### PR TITLE
GPU: support single-coin invalid data tails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Apple MPS single-coin EMA Anchor and Trailing Martingale optimization now accepts invalid
+  candles after the coin's final valid candle when HSL is disabled and the tail remains below
+  exact Rust's 1,400-candle forced-delist threshold. Metal keeps the tail non-tradable and records
+  balance-only account equity like exact Rust. HSL tails, forced-delist closes, and multi-coin
+  invalid tails continue to fail closed.
+
 - Apple MPS multi-coin EMA Anchor optimization now supports any positive integer
   `backtest.candle_interval_minutes` for long-only, short-only, and fused long+short runs. Global
   and static per-coin minute spans, Forager spans, HSL decay, and cooldowns are converted to

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -360,7 +360,12 @@ The supported slice is intentionally narrow:
   market paths: the proxy projects adverse slippage and taker fees and keeps a conservative
   zero-loss envelope for ordinary and exposure-repair closes, while exact Rust applies the shared
   peak-balance allowance to every validation.
-- no invalid candle tail after the selected coin's final valid candle
+- single-coin runs with HSL disabled may include invalid candles after the selected coin's final
+  valid candle while the tail remains below exact Rust's 1,400-candle forced-delist threshold;
+  Metal treats those candles as non-tradable, excludes the open position's unrealized PnL, and
+  continues balance-only equity and elapsed-time accounting through the prepared endpoint
+- single-coin HSL tails, forced-delist tails, and any multi-coin invalid tail remain fail-closed
+  until their hard-stop and forced-close semantics are modeled
 
 Unsupported combinations fail before optimization begins. Dual-side multi-coin EMA Anchor and
 Trailing Martingale use fused shared-account Metal kernels in hedge and one-way modes. Every

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -178,14 +178,17 @@ mod tests {
     fn assert_directional_recovery_sampling_contract(source: &str) {
         assert_eq!(source.matches("device float* recovery_samples").count(), 2);
         assert!(source.contains("#ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED"));
-        assert!(source.contains("const int recovery_stride = sizes[7]"));
-        assert!(source.contains("const int recovery_sample_count = sizes[8]"));
+        assert!(source.contains("const int last_valid = sizes[7]"));
+        assert!(source.contains("const int recovery_stride = sizes[8]"));
+        assert!(source.contains("const int recovery_sample_count = sizes[9]"));
         assert!(source.contains("int recovery_start_k = -1"));
         assert!(source.contains("const bool recovery_terminal = liq || k == T - 2"));
         assert!(source.contains("(recovery_elapsed + recovery_stride - 1) / recovery_stride"));
         assert!(source.contains("int(b) * recovery_sample_count + sample_index"));
         assert!(source.contains("const bool rolling_pnl_overflowed ="));
         assert!(source.contains("= RECOVERY_FAIL_CLOSED_SENTINEL;"));
+        assert!(source.contains("const bool after_valid_tail = k > last_valid"));
+        assert!(source.contains("(valid || after_valid_tail)"));
     }
 
     #[test]

--- a/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
@@ -1032,9 +1032,10 @@ inline void passivbot_single_coin_impl(
     const int D = sizes[2];
     const int P = sizes[3];
     const int first_valid = sizes[4];
+    const int last_valid = sizes[7];
 #ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
-    const int recovery_stride = sizes[7];
-    const int recovery_sample_count = sizes[8];
+    const int recovery_stride = sizes[8];
+    const int recovery_sample_count = sizes[9];
 #endif
     if (b >= uint(B)) return;
 
@@ -1760,9 +1761,13 @@ inline void passivbot_single_coin_impl(
             }
         }
 
-        float long_unreal = long_side.psize > 0.0f
+        // Exact Rust keeps sampling account equity through a short invalid
+        // tail, but excludes positions whose coin is no longer valid.  Such a
+        // tail is non-tradable and therefore contributes balance-only equity.
+        const bool after_valid_tail = k > last_valid;
+        float long_unreal = valid && long_side.psize > 0.0f
             ? long_side.psize * c_mult * (close - long_side.pprice) : 0.0f;
-        float short_unreal = short_side.psize > 0.0f
+        float short_unreal = valid && short_side.psize > 0.0f
             ? short_side.psize * c_mult * (short_side.pprice - close) : 0.0f;
         float equity = balance + long_unreal + short_unreal;
         const bool rolling_pnl_overflowed =
@@ -1872,7 +1877,7 @@ inline void passivbot_single_coin_impl(
                 try_restart_hsl(short_hsl, kf, equity);
             }
         }
-        bool active = eq_started && alive && valid;
+        bool active = eq_started && alive && (valid || after_valid_tail);
         if (active) {
             if (first_eq_k < 0.0f) first_eq_k = kf;
             last_eq_k = kf;

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -1629,9 +1629,10 @@ inline void passivbot_single_coin_impl(
     const int D = sizes[2];
     const int P = sizes[3];
     const int first_valid = sizes[4];
+    const int last_valid = sizes[7];
 #ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
-    const int recovery_stride = sizes[7];
-    const int recovery_sample_count = sizes[8];
+    const int recovery_stride = sizes[8];
+    const int recovery_sample_count = sizes[9];
 #endif
     if (b >= uint(B)) return;
 
@@ -3594,9 +3595,13 @@ inline void passivbot_single_coin_impl(
             }
         }
 
-        float long_unreal = long_side.psize > 0.0f
+        // Exact Rust keeps sampling account equity through a short invalid
+        // tail, but excludes positions whose coin is no longer valid.  Such a
+        // tail is non-tradable and therefore contributes balance-only equity.
+        const bool after_valid_tail = k > last_valid;
+        float long_unreal = valid && long_side.psize > 0.0f
             ? long_side.psize * c_mult * (close - long_side.pprice) : 0.0f;
-        float short_unreal = short_side.psize > 0.0f
+        float short_unreal = valid && short_side.psize > 0.0f
             ? short_side.psize * c_mult * (short_side.pprice - close) : 0.0f;
         float equity = balance + long_unreal + short_unreal;
         const bool rolling_pnl_overflowed =
@@ -3706,7 +3711,7 @@ inline void passivbot_single_coin_impl(
                 try_restart_hsl(short_hsl, kf, equity);
             }
         }
-        bool active = eq_started && alive && valid;
+        bool active = eq_started && alive && (valid || after_valid_tail);
         if (active) {
             if (first_eq_k < 0.0f) first_eq_k = kf;
             last_eq_k = kf;

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -952,6 +952,23 @@ class MpsEmaAnchorRunner:
             self._recovery_buffers[batch_size].fill_(float("nan"))
         return self._recovery_buffers[batch_size]
 
+    def _single_coin_size_values(
+        self, batch_size: int, parameter_count: int
+    ) -> list[int]:
+        values = [
+            int(batch_size),
+            self.n,
+            self.n_days,
+            int(parameter_count),
+            self.run_config.first_valid_idx,
+            self.rolling_capacity,
+            self.pnl_lookback_bars,
+            self.run_config.last_valid_idx,
+        ]
+        if self.recovery_distribution_enabled:
+            values.extend([self.recovery_stride, self.n_recovery_samples])
+        return values
+
     def run(self, params: np.ndarray, *, profile: bool = False) -> dict:
         started = time.perf_counter()
         matrix = self._pack_params(params)
@@ -969,20 +986,9 @@ class MpsEmaAnchorRunner:
         )
         sizes_key = (batch_size, int(matrix.shape[1]))
         if sizes_key not in self._sizes:
-            size_values = [
-                batch_size,
-                self.n,
-                self.n_days,
-                matrix.shape[1],
-                self.run_config.first_valid_idx,
-                self.rolling_capacity,
-                self.pnl_lookback_bars,
-                self.run_config.last_valid_idx,
-            ]
-            if self.recovery_distribution_enabled:
-                size_values.extend(
-                    [self.recovery_stride, self.n_recovery_samples]
-                )
+            size_values = self._single_coin_size_values(
+                batch_size, int(matrix.shape[1])
+            )
             self._sizes[sizes_key] = torch.tensor(
                 size_values,
                 dtype=torch.int32,
@@ -1920,19 +1926,9 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
         )
         sizes_key = (batch_size, int(matrix.shape[1]))
         if sizes_key not in self._sizes:
-            size_values = [
-                batch_size,
-                self.n,
-                self.n_days,
-                matrix.shape[1],
-                self.run_config.first_valid_idx,
-                self.rolling_capacity,
-                self.pnl_lookback_bars,
-            ]
-            if self.recovery_distribution_enabled:
-                size_values.extend(
-                    [self.recovery_stride, self.n_recovery_samples]
-                )
+            size_values = self._single_coin_size_values(
+                batch_size, int(matrix.shape[1])
+            )
             self._sizes[sizes_key] = torch.tensor(
                 size_values,
                 dtype=torch.int32,

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -977,6 +977,7 @@ class MpsEmaAnchorRunner:
                 self.run_config.first_valid_idx,
                 self.rolling_capacity,
                 self.pnl_lookback_bars,
+                self.run_config.last_valid_idx,
             ]
             if self.recovery_distribution_enabled:
                 size_values.extend(

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -655,6 +655,43 @@ def _require_complete_valid_tail(last_valid_idx: int, candle_count: int) -> None
         )
 
 
+def _require_no_forced_delist_tail(last_valid_idx: int, candle_count: int) -> None:
+    """Accept ordinary invalid tails but reject Rust's forced-delist boundary.
+
+    Exact Rust treats a coin as delisted, and force-closes its open positions,
+    when at least 1,400 prepared candles follow its final valid candle.  The
+    single-coin kernels model shorter invalid tails as non-tradable balance-only
+    equity samples; forced delist fills are a separate parity surface.
+    """
+
+    last_valid_idx = int(last_valid_idx)
+    candle_count = int(candle_count)
+    if last_valid_idx < 0 or last_valid_idx >= candle_count:
+        raise ValueError(
+            "GPU single-coin proxy requires last_valid_idx within the prepared "
+            f"candle range; last_valid_idx={last_valid_idx}, "
+            f"candle_count={candle_count}"
+        )
+    if last_valid_idx + 1400 < candle_count:
+        raise ValueError(
+            "GPU single-coin proxy does not yet model Rust forced-delist closes "
+            "when at least 1,400 prepared candles follow the final valid candle; "
+            f"last_valid_idx={last_valid_idx}, candle_count={candle_count}"
+        )
+
+
+def _require_supported_single_coin_valid_tail(
+    last_valid_idx: int, candle_count: int, *, hsl_enabled: bool
+) -> None:
+    _require_no_forced_delist_tail(last_valid_idx, candle_count)
+    if bool(hsl_enabled) and int(last_valid_idx) != int(candle_count) - 1:
+        raise ValueError(
+            "MPS single-coin HSL does not yet model hard-stop state updates "
+            "after the coin's final valid candle; "
+            f"last_valid_idx={last_valid_idx}, candle_count={candle_count}"
+        )
+
+
 def _require_no_internal_invalid_hsl_candles(
     high, low, close, *, first_valid_idx: int, last_valid_idx: int
 ) -> None:
@@ -1192,10 +1229,6 @@ class MpsSingleCoinProxy:
         candle_interval_minutes = _single_coin_candle_interval_minutes(
             backtest_params
         )
-        _require_complete_valid_tail(
-            int(backtest_params["last_valid_indices"][0]), len(hlcvs)
-        )
-
         long_bot = payload.bot_params_list[0]["long"]
         short_bot = payload.bot_params_list[0]["short"]
         self.enabled = {
@@ -1222,6 +1255,11 @@ class MpsSingleCoinProxy:
             for side, bot in (("long", long_bot), ("short", short_bot))
             if self.enabled[side] and bool(bot.get("hsl_enabled"))
         ]
+        _require_supported_single_coin_valid_tail(
+            int(backtest_params["last_valid_indices"][0]),
+            len(hlcvs),
+            hsl_enabled=bool(hsl_enabled_sides),
+        )
         any_configured_hsl = any(
             bool(bot.get("hsl_enabled")) for bot in (long_bot, short_bot)
         )

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -3502,6 +3502,101 @@ def test_mps_single_coin_five_minute_shader_smoke(strategy_kind):
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
 @pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_single_coin_short_invalid_tail_uses_balance_only_equity(
+    strategy_kind, side
+):
+    from optimization.gpu.mps_kernel import (
+        MpsEmaAnchorRunner,
+        MpsTrailingMartingaleRunner,
+    )
+
+    count = 10
+    last_valid = 6
+    close = np.full(count, np.nan)
+    high = np.full(count, np.nan)
+    low = np.full(count, np.nan)
+    close[: last_valid + 1] = 100.0
+    high[: last_valid + 1] = 100.0
+    low[: last_valid + 1] = 100.0
+    if side == "long":
+        low[3] = 98.0
+        high[last_valid] = 80.0
+        low[last_valid] = 80.0
+        close[last_valid] = 80.0
+    else:
+        high[3] = 102.0
+        high[last_valid] = 120.0
+        low[last_valid] = 120.0
+        close[last_valid] = 120.0
+    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    market = ProxyMarket(0.001, 0.01, 0.001, 5.0, 1.0, 0.0)
+    run = ProxyRun(
+        1_000.0,
+        1,
+        1,
+        int(timestamps[0]),
+        int(timestamps[0]),
+        int(timestamps[0]),
+        60_000,
+        0.05,
+        0,
+        last_valid,
+    )
+    data = build_mps_data(high, low, close, timestamps, run, market)
+    if strategy_kind == "ema_anchor":
+        row = _single_coin_param_row(
+            {
+                "base_qty_pct": 0.1,
+                "ema_span_0": 2.0,
+                "ema_span_1": 3.0,
+                "entry_double_down_factor": 0.0,
+                "offset": 0.01,
+                "offset_psize_weight": 0.0,
+                "offset_volatility_1h_weight": 0.0,
+                "offset_volatility_1m_weight": 0.0,
+                "offset_volatility_ema_span_1h": 2.0,
+                "offset_volatility_ema_span_1m": 2.0,
+                "entry_cooldown_minutes": 100.0,
+                "total_wallet_exposure_limit": 1.0,
+                "we_excess_allowance_pct": 0.0,
+                "we_excess_allowance_legacy_raw": 0.0,
+                "twel_entry_gate_enabled": 1.0,
+                "twel_enforcer_threshold": 1.0,
+                "twel_enforcer_enabled": 0.0,
+            },
+            EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS,
+        )
+        runner_cls = MpsEmaAnchorRunner
+    else:
+        row = _tm_single_row(initial_ema_dist=0.01)
+        row[
+            TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS.index(
+                "entry_cooldown_minutes"
+            )
+        ] = 100.0
+        runner_cls = MpsTrailingMartingaleRunner
+
+    output = runner_cls(
+        market,
+        run,
+        data,
+        long_enabled=side == "long",
+        short_enabled=side == "short",
+    ).run(np.asarray([row + row], dtype=np.float64))
+    torch.mps.synchronize()
+
+    size_key = "psize" if side == "long" else "short_psize"
+    assert output[size_key].item() > 0.0
+    assert output["day_end_eq"][0, 0].item() == pytest.approx(
+        output["balance"].item()
+    )
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
 def test_mps_single_coin_active_fill_day_bucket_uses_elapsed_time(
     strategy_kind,
 ):

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -266,6 +266,40 @@ def test_trailing_martingale_no_hsl_specialization_keeps_base_scalar_abi(
     assert runner.hsl_raw_drawdown_enabled is False
 
 
+@pytest.mark.parametrize("recovery_enabled", [False, True])
+@pytest.mark.parametrize("runner_name", ["ema_anchor", "trailing_martingale"])
+def test_single_coin_size_buffer_packs_last_valid_before_recovery_fields(
+    runner_name, recovery_enabled
+):
+    from optimization.gpu.mps_kernel import (
+        MpsEmaAnchorRunner,
+        MpsTrailingMartingaleRunner,
+    )
+
+    runner_cls = (
+        MpsEmaAnchorRunner
+        if runner_name == "ema_anchor"
+        else MpsTrailingMartingaleRunner
+    )
+    runner = object.__new__(runner_cls)
+    runner.n = 17
+    runner.n_days = 2
+    runner.run_config = ProxyRun(
+        1_000.0, 1, 1, 0, 0, 0, 60_000, 0.05, 3, 11
+    )
+    runner.rolling_capacity = 9
+    runner.pnl_lookback_bars = 7
+    runner.recovery_distribution_enabled = recovery_enabled
+    runner.recovery_stride = 60
+    runner.n_recovery_samples = 4
+
+    actual = runner._single_coin_size_values(5, 13)
+
+    assert actual == [5, 17, 2, 13, 3, 9, 7, 11] + (
+        [60, 4] if recovery_enabled else []
+    )
+
+
 def test_trailing_martingale_runner_accepts_ordinary_market_execution(monkeypatch):
     from optimization.gpu.mps_kernel import MpsEmaAnchorRunner
     from optimization.gpu.mps_kernel import MpsTrailingMartingaleRunner

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -46,10 +46,12 @@ from optimization.gpu.service import (
     _prepared_single_coin_side_enabled,
     _require_multicoin_metric_topology,
     _require_complete_valid_tail,
+    _require_no_forced_delist_tail,
     _require_no_internal_invalid_account_recovery_candles,
     _require_no_internal_invalid_hsl_candles,
     _require_no_internal_invalid_multicoin_hsl_candles,
     _require_no_internal_invalid_single_coin_recovery_candles,
+    _require_supported_single_coin_valid_tail,
     _refresh_hedged_multicoin_hsl_at_portfolio_cutoff,
     _single_coin_candle_interval_minutes,
     _single_coin_exposure_params,
@@ -1190,11 +1192,30 @@ def test_multicoin_proxy_constructs_fused_shared_account_runner(
     assert constructed["kwargs"]["filter_by_min_effective_cost"] is True
 
 
-def test_gpu_proxy_requires_complete_valid_tail():
+def test_gpu_multicoin_proxy_requires_complete_valid_tail():
     _require_complete_valid_tail(99, 100)
 
     with pytest.raises(ValueError, match="force-realizes open positions"):
         _require_complete_valid_tail(98, 100)
+
+
+def test_gpu_single_coin_proxy_accepts_short_invalid_tail_only():
+    _require_no_forced_delist_tail(99, 100)
+    _require_no_forced_delist_tail(98, 100)
+    _require_no_forced_delist_tail(0, 1400)
+
+    with pytest.raises(ValueError, match="forced-delist closes"):
+        _require_no_forced_delist_tail(0, 1401)
+    with pytest.raises(ValueError, match="within the prepared candle range"):
+        _require_no_forced_delist_tail(100, 100)
+
+
+def test_gpu_single_coin_hsl_still_requires_complete_valid_tail():
+    _require_supported_single_coin_valid_tail(98, 100, hsl_enabled=False)
+    _require_supported_single_coin_valid_tail(99, 100, hsl_enabled=True)
+
+    with pytest.raises(ValueError, match="HSL does not yet model"):
+        _require_supported_single_coin_valid_tail(98, 100, hsl_enabled=True)
 
 
 def test_gpu_hsl_requires_contiguous_valid_candles():


### PR DESCRIPTION
## Summary
- allow Apple MPS single-coin EMA Anchor and Trailing Martingale proxies to continue through short invalid tails
- mirror exact Rust by keeping tail candles non-tradable, excluding invalid-coin unrealized PnL, and continuing balance-only equity/time sampling
- keep single-coin HSL tails, Rust forced-delist tails, and all multi-coin invalid tails fail-closed

## Scope and safety
- exact Rust remains authoritative for persisted optimizer results and drift validation
- GPU support remains additive; CPU optimization, backtesting, and bot operation are unchanged
- tails with at least 1,400 prepared candles after the last valid candle are rejected until forced-delist closes are modeled

## Validation
- full `tests/optimization` suite
- physical Apple MPS `tests/optimization/test_gpu_mps.py tests/optimization/test_gpu_service.py`
- physical MPS EMA Anchor and Trailing Martingale long/short invalid-tail kernel cases
- end-to-end EMA Anchor optimizer smoke: 8 generations, 512 Metal proxy evaluations, 64 exact Rust validations, 61-minute invalid tail
- end-to-end Trailing Martingale optimizer smoke: 8 generations, 512 Metal proxy evaluations, 64 exact Rust validations, 61-minute invalid tail
- `cargo test --no-default-features` (267 passed)
- `git diff --check`