### PR TITLE
GPU: support HSL through single-coin data tails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Apple MPS single-coin HSL optimization now continues hard-stop sampling, rolling-PnL expiry,
+  tier accounting, and restart checks through supported invalid candle tails. Tail candles remain
+  non-tradable and cannot satisfy stale blocking orders. Forced-delist tails and multi-coin invalid
+  tails remain fail-closed.
+
 - Apple MPS single-coin EMA Anchor and Trailing Martingale optimization now accepts invalid
   candles after the coin's final valid candle when HSL is disabled and the tail remains below
   exact Rust's 1,400-candle forced-delist threshold. Metal keeps the tail non-tradable and records

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -360,12 +360,14 @@ The supported slice is intentionally narrow:
   market paths: the proxy projects adverse slippage and taker fees and keeps a conservative
   zero-loss envelope for ordinary and exposure-repair closes, while exact Rust applies the shared
   peak-balance allowance to every validation.
-- single-coin runs with HSL disabled may include invalid candles after the selected coin's final
-  valid candle while the tail remains below exact Rust's 1,400-candle forced-delist threshold;
-  Metal treats those candles as non-tradable, excludes the open position's unrealized PnL, and
-  continues balance-only equity and elapsed-time accounting through the prepared endpoint
-- single-coin HSL tails, forced-delist tails, and any multi-coin invalid tail remain fail-closed
-  until their hard-stop and forced-close semantics are modeled
+- single-coin runs may include invalid candles after the selected coin's final valid candle while
+  the tail remains below exact Rust's 1,400-candle forced-delist threshold; Metal treats those
+  candles as non-tradable, excludes the open position's unrealized PnL, and continues balance-only
+  equity and elapsed-time accounting through the prepared endpoint. HSL-enabled runs also continue
+  hard-stop sampling, rolling-PnL expiry, tier accounting, and restart checks without treating stale
+  orders as blocking
+- forced-delist tails and any multi-coin invalid tail remain fail-closed until their hard-stop and
+  forced-close semantics are modeled
 
 Unsupported combinations fail before optimization begins. Dual-side multi-coin EMA Anchor and
 Trailing Martingale use fused shared-account Metal kernels in hedge and one-way modes. Every

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -189,6 +189,9 @@ mod tests {
         assert!(source.contains("= RECOVERY_FAIL_CLOSED_SENTINEL;"));
         assert!(source.contains("const bool after_valid_tail = k > last_valid"));
         assert!(source.contains("(valid || after_valid_tail)"));
+        assert!(source.contains("const bool hsl_step = gen || (eq_started && after_valid_tail)"));
+        assert!(source.contains("bool long_blocking_orders = valid &&"));
+        assert!(source.contains("bool short_blocking_orders = valid &&"));
     }
 
     #[test]

--- a/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
@@ -1785,12 +1785,13 @@ inline void passivbot_single_coin_impl(
             alive = false;
             liq_day = di;
         }
-        if (gen && valid && alive && balance > 0.0f && equity > liq_floor) {
-            bool long_blocking_orders = long_hsl_mode != 3 && (
+        const bool hsl_step = gen || (eq_started && after_valid_tail);
+        if (hsl_step && alive && balance > 0.0f && equity > liq_floor) {
+            bool long_blocking_orders = valid && long_hsl_mode != 3 && (
                 long_side.entry_qty > 0.0f || long_side.close_qty > 0.0f
                     || long_side.secondary_close_qty > 0.0f
             );
-            bool short_blocking_orders = short_hsl_mode != 3 && (
+            bool short_blocking_orders = valid && short_hsl_mode != 3 && (
                 short_side.entry_qty > 0.0f || short_side.close_qty > 0.0f
                     || short_side.secondary_close_qty > 0.0f
             );

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -3619,12 +3619,13 @@ inline void passivbot_single_coin_impl(
             alive = false;
             liq_day = di;
         }
-        if (gen && valid && alive && balance > 0.0f && equity > liq_floor) {
-            bool long_blocking_orders = long_hsl_mode != 3 && (
+        const bool hsl_step = gen || (eq_started && after_valid_tail);
+        if (hsl_step && alive && balance > 0.0f && equity > liq_floor) {
+            bool long_blocking_orders = valid && long_hsl_mode != 3 && (
                 long_side.entry_qty > 0.0f || long_side.close_qty > 0.0f
                     || long_side.secondary_close_qty > 0.0f
             );
-            bool short_blocking_orders = short_hsl_mode != 3 && (
+            bool short_blocking_orders = valid && short_hsl_mode != 3 && (
                 short_side.entry_qty > 0.0f || short_side.close_qty > 0.0f
                     || short_side.secondary_close_qty > 0.0f
             );

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -680,18 +680,6 @@ def _require_no_forced_delist_tail(last_valid_idx: int, candle_count: int) -> No
         )
 
 
-def _require_supported_single_coin_valid_tail(
-    last_valid_idx: int, candle_count: int, *, hsl_enabled: bool
-) -> None:
-    _require_no_forced_delist_tail(last_valid_idx, candle_count)
-    if bool(hsl_enabled) and int(last_valid_idx) != int(candle_count) - 1:
-        raise ValueError(
-            "MPS single-coin HSL does not yet model hard-stop state updates "
-            "after the coin's final valid candle; "
-            f"last_valid_idx={last_valid_idx}, candle_count={candle_count}"
-        )
-
-
 def _require_no_internal_invalid_hsl_candles(
     high, low, close, *, first_valid_idx: int, last_valid_idx: int
 ) -> None:
@@ -1255,10 +1243,9 @@ class MpsSingleCoinProxy:
             for side, bot in (("long", long_bot), ("short", short_bot))
             if self.enabled[side] and bool(bot.get("hsl_enabled"))
         ]
-        _require_supported_single_coin_valid_tail(
+        _require_no_forced_delist_tail(
             int(backtest_params["last_valid_indices"][0]),
             len(hlcvs),
-            hsl_enabled=bool(hsl_enabled_sides),
         )
         any_configured_hsl = any(
             bool(bot.get("hsl_enabled")) for bot in (long_bot, short_bot)

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -3537,8 +3537,9 @@ def test_mps_single_coin_five_minute_shader_smoke(strategy_kind):
 )
 @pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
 @pytest.mark.parametrize("side", ["long", "short"])
+@pytest.mark.parametrize("hsl_enabled", [False, True])
 def test_mps_single_coin_short_invalid_tail_uses_balance_only_equity(
-    strategy_kind, side
+    strategy_kind, side, hsl_enabled
 ):
     from optimization.gpu.mps_kernel import (
         MpsEmaAnchorRunner,
@@ -3602,6 +3603,7 @@ def test_mps_single_coin_short_invalid_tail_uses_balance_only_equity(
             EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS,
         )
         runner_cls = MpsEmaAnchorRunner
+        keys = EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS
     else:
         row = _tm_single_row(initial_ema_dist=0.01)
         row[
@@ -3610,6 +3612,27 @@ def test_mps_single_coin_short_invalid_tail_uses_balance_only_equity(
             )
         ] = 100.0
         runner_cls = MpsTrailingMartingaleRunner
+        keys = TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS
+
+    if hsl_enabled:
+        for key, value in {
+            "hsl_enabled": 1.0,
+            "hsl_red_threshold": 0.005,
+            "hsl_ema_span_minutes": 1.0,
+            "hsl_cooldown_minutes_after_red": 0.0,
+            "hsl_no_restart_drawdown_threshold": 1.0,
+            "hsl_restart_policy": 2.0,
+            "hsl_tier_ratio_yellow": 0.5,
+            "hsl_tier_ratio_orange": 0.75,
+            "hsl_orange_graceful_stop": 0.0,
+            "hsl_signal_mode": 0.0,
+            "hsl_slot_count": 1.0,
+        }.items():
+            row[keys.index(key)] = value
+
+    runner_kwargs = {}
+    if strategy_kind == "trailing_martingale":
+        runner_kwargs["hsl_enabled"] = hsl_enabled
 
     output = runner_cls(
         market,
@@ -3617,6 +3640,7 @@ def test_mps_single_coin_short_invalid_tail_uses_balance_only_equity(
         data,
         long_enabled=side == "long",
         short_enabled=side == "short",
+        **runner_kwargs,
     ).run(np.asarray([row + row], dtype=np.float64))
     torch.mps.synchronize()
 
@@ -3625,6 +3649,121 @@ def test_mps_single_coin_short_invalid_tail_uses_balance_only_equity(
     assert output["day_end_eq"][0, 0].item() == pytest.approx(
         output["balance"].item()
     )
+    if hsl_enabled:
+        expected_hsl_samples = (
+            (output["last_eq_ts"] - output["first_eq_ts"]) / 60_000.0 + 1.0
+        )
+        assert output["hsl_tier_samples_total"].item() == pytest.approx(
+            expected_hsl_samples.item()
+        )
+        assert output["hsl_tier_samples_red"].item() > 0.0
+        assert (
+            output["hsl_tier_samples_red"].item()
+            < output["hsl_tier_samples_total"].item()
+        )
+        assert output[f"hsl_triggers_{side}"].item() == 0.0
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_single_coin_hsl_can_restart_during_invalid_tail(
+    strategy_kind, side
+):
+    from optimization.gpu.mps_kernel import (
+        MpsEmaAnchorRunner,
+        MpsTrailingMartingaleRunner,
+    )
+
+    count = 15
+    last_valid = 10
+    close = np.full(count, np.nan)
+    close[:8] = 100.0
+    close[8 : last_valid + 1] = 70.0 if side == "long" else 130.0
+    high = np.where(np.isfinite(close), close * 1.02, np.nan)
+    low = np.where(np.isfinite(close), close * 0.98, np.nan)
+    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    market = ProxyMarket(0.001, 0.01, 0.001, 0.0, 1.0, 0.0)
+    run = ProxyRun(
+        1_000.0,
+        1,
+        1,
+        int(timestamps[0]),
+        int(timestamps[0]),
+        int(timestamps[0]),
+        60_000,
+        0.05,
+        0,
+        last_valid,
+    )
+    data = build_mps_data(high, low, close, timestamps, run, market)
+    if strategy_kind == "trailing_martingale":
+        row = _tm_single_row(initial_ema_dist=0.0)
+        row[6] = 0.5
+        row[7] = 0.5
+        row[16] = 0.5
+        keys = TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS
+        runner_cls = MpsTrailingMartingaleRunner
+    else:
+        row = _single_coin_param_row(
+            {
+                "base_qty_pct": 0.5,
+                "ema_span_0": 2.0,
+                "ema_span_1": 3.0,
+                "entry_double_down_factor": 1.0,
+                "offset": 0.0,
+                "offset_psize_weight": 0.0,
+                "offset_volatility_1h_weight": 0.0,
+                "offset_volatility_1m_weight": 0.0,
+                "offset_volatility_ema_span_1h": 2.0,
+                "offset_volatility_ema_span_1m": 2.0,
+                "entry_cooldown_minutes": 0.0,
+                "total_wallet_exposure_limit": 1.0,
+                "we_excess_allowance_pct": 0.0,
+                "we_excess_allowance_legacy_raw": 0.0,
+                "twel_entry_gate_enabled": 1.0,
+                "twel_enforcer_threshold": 1.0,
+                "twel_enforcer_enabled": 0.0,
+            },
+            EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS,
+        )
+        keys = EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS
+        runner_cls = MpsEmaAnchorRunner
+    for key, value in {
+        "hsl_enabled": 1.0,
+        "hsl_red_threshold": 0.01,
+        "hsl_ema_span_minutes": 1.0,
+        "hsl_cooldown_minutes_after_red": 2.0,
+        "hsl_no_restart_drawdown_threshold": 1.0,
+        "hsl_restart_policy": 0.0,
+        "hsl_tier_ratio_yellow": 0.5,
+        "hsl_tier_ratio_orange": 0.75,
+        "hsl_orange_graceful_stop": 0.0,
+        "hsl_signal_mode": 0.0,
+        "hsl_slot_count": 1.0,
+    }.items():
+        row[keys.index(key)] = value
+
+    runner_kwargs = {}
+    if strategy_kind == "trailing_martingale":
+        runner_kwargs["hsl_enabled"] = True
+    output = runner_cls(
+        market,
+        run,
+        data,
+        long_enabled=side == "long",
+        short_enabled=side == "short",
+        **runner_kwargs,
+    ).run(np.asarray([row + row], dtype=np.float64))
+    torch.mps.synchronize()
+
+    size_key = "psize" if side == "long" else "short_psize"
+    assert output[size_key].item() == 0.0
+    assert output[f"hsl_triggers_{side}"].item() == 1.0
+    assert output[f"hsl_restarts_{side}"].item() == 1.0
+    assert output["last_eq_ts"].item() > last_valid * run.interval_ms
 
 
 @pytest.mark.skipif(

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -51,7 +51,6 @@ from optimization.gpu.service import (
     _require_no_internal_invalid_hsl_candles,
     _require_no_internal_invalid_multicoin_hsl_candles,
     _require_no_internal_invalid_single_coin_recovery_candles,
-    _require_supported_single_coin_valid_tail,
     _refresh_hedged_multicoin_hsl_at_portfolio_cutoff,
     _single_coin_candle_interval_minutes,
     _single_coin_exposure_params,
@@ -1208,14 +1207,6 @@ def test_gpu_single_coin_proxy_accepts_short_invalid_tail_only():
         _require_no_forced_delist_tail(0, 1401)
     with pytest.raises(ValueError, match="within the prepared candle range"):
         _require_no_forced_delist_tail(100, 100)
-
-
-def test_gpu_single_coin_hsl_still_requires_complete_valid_tail():
-    _require_supported_single_coin_valid_tail(98, 100, hsl_enabled=False)
-    _require_supported_single_coin_valid_tail(99, 100, hsl_enabled=True)
-
-    with pytest.raises(ValueError, match="HSL does not yet model"):
-        _require_supported_single_coin_valid_tail(98, 100, hsl_enabled=True)
 
 
 def test_gpu_hsl_requires_contiguous_valid_candles():


### PR DESCRIPTION
## Summary
- continue single-coin HSL controller sampling, rolling-PnL expiry, tier accounting, and restart checks through supported invalid candle tails
- keep invalid tail candles non-tradable and prevent stale pre-tail orders from blocking HSL transitions
- remove the obsolete HSL tail guard while retaining forced-delist and multi-coin fail-closed boundaries
- add physical-MPS coverage for EMA Anchor and Trailing Martingale, long/short, HSL on/off, and restart during an invalid tail

## Validation
- physical Apple MPS: `pytest -q tests/optimization/test_gpu_mps.py tests/optimization/test_gpu_service.py`
- `pytest -q tests/optimization`
- `cargo test --no-default-features` (267 passed)
- end-to-end HSL-enabled single-coin GPU optimize smokes for dual-side EMA Anchor and Trailing Martingale over a prepared 61-minute invalid tail
- `git diff --check`

## Boundaries
- exact Rust remains authoritative
- forced-delist tails and all multi-coin invalid tails remain fail-closed
- CPU optimization and bot/backtest behavior are unchanged

## Formatting note
- repository-wide `cargo fmt --all -- --check` still reports pre-existing formatting drift in `passivbot-rust/src/gpu.rs`; the assertion added here is in rustfmt's expected form
