### PR TITLE
Add per-side HSL raw tail metrics to MPS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Apple MPS HSL optimization now supports per-side
+  `drawdown_worst_mean_1pct_strategy_eq_{long,short}` scoring and limits for EMA Anchor and
+  Trailing Martingale across single-coin, one-sided multi-coin, and fused dual-side multi-coin
+  topologies. The opt-in Metal proxy reduces full-resolution controller drawdowns to one worst
+  sample per observed day, then applies a bounded logarithmic tail histogram; exact Rust
+  validation and rolling drift gates remain authoritative.
+
 - Apple MPS multi-coin EMA Anchor and Trailing Martingale optimization now supports staggered
   ordinary invalid candle tails when at least one prepared coin remains valid through the endpoint,
   every tail stays below exact Rust's forced-delist threshold, and at least one candle whose packed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ All notable user-facing changes will be documented in this file.
   Trailing Martingale across single-coin, one-sided multi-coin, and fused dual-side multi-coin
   topologies. The opt-in Metal proxy reduces full-resolution controller drawdowns to one worst
   sample per observed day, then applies a bounded logarithmic tail histogram; exact Rust
-  validation and rolling drift gates remain authoritative.
+  retains each controller sample's timestamp for matching daily reduction, while exact validation
+  and rolling drift gates remain authoritative.
 
 - Apple MPS multi-coin EMA Anchor and Trailing Martingale optimization now supports staggered
   ordinary invalid candle tails when at least one prepared coin remains valid through the endpoint,

--- a/docs/equity_hard_stop_loss_reference.md
+++ b/docs/equity_hard_stop_loss_reference.md
@@ -138,6 +138,7 @@ These are the main parity surfaces that should be reviewed together:
    - Dual-side multi-coin Trailing Martingale uses a fused shared-account strategy kernel for unified, pside, and coin signals, including shared lifecycle/panic-loss metrics and per-coin HSL overrides in coin mode
    - Apple MPS exports the worst EMA-smoothed strategy-equity drawdown for long and short HSL controllers; the account metric is the same `max(long, short)` reduction as exact Rust
    - Apple MPS exports the raw worst strategy-equity drawdown for each long and short HSL controller through opt-in bounded peak-and-maximum state; exact Rust validation remains authoritative for proxy-fill drift
+   - Apple MPS exports the raw mean-worst-1% daily strategy-equity drawdown for each long and short HSL controller through opt-in daily-worst state and a bounded logarithmic tail histogram; exact Rust validation and rolling drift gates remain authoritative
    - Apple MPS exports each HSL controller's longest strict strategy-equity time-to-exceed interval as `peak_recovery_{hours,days}_strategy_eq_{long,short}`, including an unrecovered tail through the backtest end
 
 ### Confirmed Gaps / Risks

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -176,9 +176,13 @@ The supported slice is intentionally narrow:
   `peak_recovery_hours_strategy_eq_{long,short}` and
   `peak_recovery_days_strategy_eq_{long,short}` retain the longest interval until strategy equity
   strictly exceeds its prior controller peak, including an unrecovered tail through the backtest
-  end. Raw per-side `drawdown_worst_strategy_eq_{long,short}` is also available through an opt-in
-  bounded peak-and-maximum accumulator, with exact Rust validation retaining authority over the
-  approximate fill path. Single-coin, one-sided multi-coin, and fused shared-account dual-side
+  end. Raw per-side `drawdown_worst_strategy_eq_{long,short}` and
+  `drawdown_worst_mean_1pct_strategy_eq_{long,short}` are also available through opt-in bounded
+  accumulators. The latter first retains each observed day's worst full-resolution controller
+  drawdown and then applies the same logarithmic tail approximation used by the EMA-smoothed
+  metric; only its partially selected cutoff bin is approximate. Exact Rust validation retains
+  authority over both the proxy fill path and tail reduction. Single-coin, one-sided multi-coin,
+  and fused shared-account dual-side
   multi-coin EMA Anchor and Trailing Martingale also support the global
   `strategy_eq_recovery_days_{mean,median,p95,p99,mean_worst_5pct,mean_worst_1pct}` metrics. The
   strategy kernels emit opt-in candidate-relative hourly strategy-equity samples plus mandatory
@@ -1290,6 +1294,7 @@ over all exchanges before scoring.
 | `drawdown_worst_strategy_eq` | Worst drawdown on collateral-agnostic strategy equity |
 | `drawdown_worst_ema_strategy_eq` | Worst EMA-smoothed strategy-equity drawdown, shared as `max(long, short)` |
 | `drawdown_worst_mean_1pct_strategy_eq` | Mean of worst 1% daily worst strategy-equity drawdowns, computed from full-resolution strategy-equity drawdowns before daily reduction |
+| `drawdown_worst_mean_1pct_strategy_eq_{long,short}` | Mean of worst 1% daily worst strategy-equity drawdowns for the long or short HSL controller |
 | `drawdown_worst_mean_1pct_ema_strategy_eq` | Mean of worst 1% EMA-smoothed strategy-equity drawdown samples, shared as `max(long, short)` |
 | `expected_shortfall_1pct` | Mean of worst 1% daily losses (CVaR) |
 | `equity_balance_diff_neg_max` / `pos_max` | Largest divergence between equity and account balance (negative side tracks only drawdowns below balance; positive side tracks only run-ups above balance) |

--- a/passivbot-rust/src/backtest.rs
+++ b/passivbot-rust/src/backtest.rs
@@ -696,6 +696,7 @@ pub struct Backtest<'a> {
     hard_stop_plot_events_pside: [Vec<HardStopPlotEvent>; 2],
     strategy_equity_series: Vec<f64>,
     strategy_equity_series_pside: [Vec<f64>; 2],
+    strategy_equity_timestamps_ms_pside: [Vec<u64>; 2],
     peak_strategy_equity_series: Vec<f64>,
     peak_strategy_equity_series_pside: [Vec<f64>; 2],
     hard_stop_no_restart_peak_strategy_equity: f64,
@@ -2255,6 +2256,7 @@ impl<'a> Backtest<'a> {
             hard_stop_plot_events_pside: [Vec::new(), Vec::new()],
             strategy_equity_series: Vec::new(),
             strategy_equity_series_pside: [Vec::new(), Vec::new()],
+            strategy_equity_timestamps_ms_pside: [Vec::new(), Vec::new()],
             peak_strategy_equity_series: Vec::new(),
             peak_strategy_equity_series_pside: [Vec::new(), Vec::new()],
             hard_stop_no_restart_peak_strategy_equity: 0.0,
@@ -3494,6 +3496,7 @@ impl<'a> Backtest<'a> {
         let strategy_equity = baseline_balance + strategy_pnl;
         let peak_strategy_equity = (baseline_balance + peak_strategy_pnl).max(strategy_equity);
         self.strategy_equity_series_pside[pside].push(strategy_equity);
+        self.strategy_equity_timestamps_ms_pside[pside].push(timestamp_ms);
         self.peak_strategy_equity_series_pside[pside].push(peak_strategy_equity);
         Ok(())
     }
@@ -3620,6 +3623,7 @@ impl<'a> Backtest<'a> {
             .map(|state| state.drawdown_ema)
             .unwrap_or(step.drawdown_raw);
         self.strategy_equity_series_pside[pside].push(strategy_equity);
+        self.strategy_equity_timestamps_ms_pside[pside].push(timestamp_ms);
         self.peak_strategy_equity_series_pside[pside].push(peak_strategy_equity);
         self.hard_stop_drawdown_timestamps_ms_pside[pside].push(timestamp_ms);
         self.hard_stop_drawdown_samples_pside[pside].push(step.drawdown_raw);
@@ -5568,6 +5572,7 @@ impl<'a> Backtest<'a> {
         &self,
         strategy_equity_series: &[f64],
         drawdown_ema_samples: Option<&[f64]>,
+        strategy_equity_timestamps_ms: Option<&[u64]>,
     ) -> StrategyEquityMetrics {
         let sample_count = strategy_equity_series
             .len()
@@ -5578,6 +5583,16 @@ impl<'a> Backtest<'a> {
         let timestamps_offset = self.equities.timestamps_ms.len() - sample_count;
         let series = &strategy_equity_series[strategy_equity_series.len() - sample_count..];
         let timestamps = &self.equities.timestamps_ms[timestamps_offset..];
+        let daily_metric_timestamps = strategy_equity_timestamps_ms
+            .map(|values| {
+                assert_eq!(
+                    values.len(),
+                    strategy_equity_series.len(),
+                    "per-side strategy-equity timestamps must align with samples"
+                );
+                &values[values.len() - sample_count..]
+            })
+            .unwrap_or(timestamps);
         let drawdowns = calc_strategy_equity_drawdowns(series);
         let drawdown_emas = drawdown_ema_samples.map(|samples| {
             let ema_sample_count = sample_count.min(samples.len());
@@ -5586,6 +5601,7 @@ impl<'a> Backtest<'a> {
 
         let compute_metrics = |series: &[f64],
                                timestamps_ms: &[u64],
+                               daily_metric_timestamps_ms: &[u64],
                                drawdowns: &[f64],
                                drawdown_emas: Option<&[f64]>| {
             let equity_metrics = analyze_equity_series(series, timestamps_ms);
@@ -5593,7 +5609,7 @@ impl<'a> Backtest<'a> {
                 .iter()
                 .fold(0.0_f64, |max_dd, &x| max_dd.max(x.abs()));
             let daily_worst_drawdowns =
-                daily_worst_positive_drawdowns(drawdowns, timestamps_ms, series.len());
+                daily_worst_positive_drawdowns(drawdowns, daily_metric_timestamps_ms, series.len());
             let drawdown_worst_mean_1pct = mean_worst_1pct_abs(&daily_worst_drawdowns);
             let strategy_eq_underwater_pct_mean = mean_abs(&daily_worst_drawdowns);
             let strategy_eq_underwater_pct_median = median_abs(&daily_worst_drawdowns);
@@ -5627,7 +5643,13 @@ impl<'a> Backtest<'a> {
             }
         };
 
-        let full = compute_metrics(series, timestamps, &drawdowns, drawdown_emas);
+        let full = compute_metrics(
+            series,
+            timestamps,
+            daily_metric_timestamps,
+            &drawdowns,
+            drawdown_emas,
+        );
         let recovery = calc_strategy_eq_recovery_days(series, timestamps);
         let peak_recovery_days_strategy_eq = recovery.max;
         let peak_recovery_hours_strategy_eq = peak_recovery_days_strategy_eq * 24.0;
@@ -5653,11 +5675,13 @@ impl<'a> Backtest<'a> {
                 break;
             }
             let subset_timestamps = &timestamps[start_idx..];
+            let subset_daily_metric_timestamps = &daily_metric_timestamps[start_idx..];
             let subset_drawdowns = &drawdowns[start_idx..];
             let subset_drawdown_emas = drawdown_emas.map(|values| &values[start_idx..]);
             let mut subset_metric = compute_metrics(
                 subset_series,
                 subset_timestamps,
+                subset_daily_metric_timestamps,
                 subset_drawdowns,
                 subset_drawdown_emas,
             );
@@ -5720,7 +5744,7 @@ impl<'a> Backtest<'a> {
     }
 
     fn strategy_equity_metrics(&self) -> StrategyEquityMetrics {
-        self.strategy_equity_metrics_from_series(&self.strategy_equity_series, None)
+        self.strategy_equity_metrics_from_series(&self.strategy_equity_series, None, None)
     }
 
     pub fn strategy_equity_metrics_for_analysis(&self) -> StrategyEquityMetricsBundle {
@@ -5737,6 +5761,7 @@ impl<'a> Backtest<'a> {
                 self.strategy_equity_metrics_from_series(
                     &self.strategy_equity_series_pside[LONG],
                     Some(&self.hard_stop_drawdown_ema_samples_pside[LONG]),
+                    Some(&self.strategy_equity_timestamps_ms_pside[LONG]),
                 )
             } else {
                 StrategyEquityMetrics::default()
@@ -5745,6 +5770,7 @@ impl<'a> Backtest<'a> {
                 self.strategy_equity_metrics_from_series(
                     &self.strategy_equity_series_pside[SHORT],
                     Some(&self.hard_stop_drawdown_ema_samples_pside[SHORT]),
+                    Some(&self.strategy_equity_timestamps_ms_pside[SHORT]),
                 )
             } else {
                 StrategyEquityMetrics::default()
@@ -8556,6 +8582,10 @@ mod tests {
         bt.update_hard_stop_state(1).unwrap();
 
         assert_eq!(bt.strategy_equity_series_pside[LONG].len(), 2);
+        assert_eq!(
+            bt.strategy_equity_timestamps_ms_pside[LONG],
+            vec![0, 60_000]
+        );
         assert_eq!(bt.peak_strategy_equity_series_pside[LONG].len(), 2);
         assert_eq!(
             bt.hard_stop_drawdown_timestamps_ms_pside[LONG],
@@ -9359,7 +9389,7 @@ mod tests {
     }
 
     #[test]
-    fn hard_stop_ema_metrics_use_runtime_side_series_and_shared_max() {
+    fn hard_stop_side_metrics_use_runtime_series_shared_max_and_sample_timestamps() {
         let hlcvs = Array3::from_shape_vec((4, 1, 4), vec![1.0; 4 * 1 * 4]).unwrap();
         let btc_usd_prices = Array1::from_vec(vec![20_000.0; 4]);
 
@@ -9426,10 +9456,12 @@ mod tests {
 
         bt.equities.timestamps_ms = vec![0, 60_000, 120_000, 180_000];
         bt.strategy_equity_series_pside[LONG] = vec![100.0, 90.0, 90.0, 90.0];
+        bt.strategy_equity_timestamps_ms_pside[LONG] = vec![0, 60_000, 120_000, 180_000];
         bt.peak_strategy_equity_series_pside[LONG] = vec![100.0, 100.0, 100.0, 100.0];
         bt.hard_stop_drawdown_samples_pside[LONG] = vec![0.0, 0.10, 0.10, 0.10];
         bt.hard_stop_drawdown_ema_samples_pside[LONG] = vec![0.0, 0.10, 0.10, 0.10];
         bt.strategy_equity_series_pside[SHORT] = vec![100.0, 90.0, 100.0, 90.0];
+        bt.strategy_equity_timestamps_ms_pside[SHORT] = vec![0, 60_000, 120_000, 180_000];
         bt.peak_strategy_equity_series_pside[SHORT] = vec![100.0, 100.0, 100.0, 100.0];
         bt.hard_stop_drawdown_samples_pside[SHORT] = vec![0.0, 0.10, 0.0, 0.10];
         bt.hard_stop_drawdown_ema_samples_pside[SHORT] = vec![0.0, 0.01, 0.005, 0.02];
@@ -9459,6 +9491,35 @@ mod tests {
                 .abs()
                 < 1e-12
         );
+
+        // Reproduce a halted-controller tail-alignment edge over 200 days.
+        // The raw stresses of 90% late on day 0 and 80% early on day 1 are
+        // separate daily worst samples with their true controller timestamps.
+        // Tail-aligning the shortened series to account timestamps merges both
+        // into one day and changes the worst-1% mean from 85% to 50%.
+        let day_ms = 86_400_000_u64;
+        let mut actual_timestamps = Vec::with_capacity(600);
+        let mut series = Vec::with_capacity(600);
+        for day in 0..200_u64 {
+            actual_timestamps.extend([day * day_ms, day * day_ms + 60_000, day * day_ms + 120_000]);
+            let peak = 100.0 + day as f64;
+            let first_drawdown = if day == 1 { 0.8 } else { 0.1 };
+            let second_drawdown = if day == 0 { 0.9 } else { 0.1 };
+            series.extend([
+                peak,
+                peak * (1.0 - first_drawdown),
+                peak * (1.0 - second_drawdown),
+            ]);
+        }
+        bt.equities.timestamps_ms = actual_timestamps.clone();
+        bt.equities.timestamps_ms.push(200 * day_ms);
+
+        let actual =
+            bt.strategy_equity_metrics_from_series(&series, None, Some(&actual_timestamps));
+        let legacy_tail_aligned = bt.strategy_equity_metrics_from_series(&series, None, None);
+
+        assert!((actual.drawdown_worst_mean_1pct_strategy_eq - 0.85).abs() < 1e-9);
+        assert!((legacy_tail_aligned.drawdown_worst_mean_1pct_strategy_eq - 0.50).abs() < 1e-9);
     }
 
     #[test]

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -154,6 +154,12 @@ mod tests {
                 .count(),
             1
         );
+        assert_eq!(
+            source
+                .matches("inline float hsl_strategy_equity_drawdown_mean_worst_1pct(")
+                .count(),
+            1
+        );
         for signature in [
             "inline HslDrawdownEmaTailStats init_hsl_drawdown_ema_tail_stats(",
             "inline int hsl_drawdown_ema_tail_bin(",
@@ -164,6 +170,7 @@ mod tests {
         }
         assert!(source.contains("#define PASSIVBOT_HSL_EMA_TAIL_ENABLED 0"));
         assert!(source.contains("#define PASSIVBOT_HSL_RAW_DRAWDOWN_ENABLED 0"));
+        assert!(source.contains("#define PASSIVBOT_HSL_RAW_TAIL_ENABLED 0"));
         assert_eq!(
             source
                 .matches("inline float hsl_strategy_equity_drawdown_max(")
@@ -376,7 +383,7 @@ mod tests {
         assert!(source.contains("constant int DAILY_COLS = 8"));
         assert!(source.contains("constant int SCALAR_COLS = 66"));
         assert!(source.contains("constant int SCALAR_COLS = 68"));
-        assert!(source.contains("constant int SCALAR_COLS = 70"));
+        assert!(source.contains("constant int SCALAR_COLS = 72"));
         assert!(source.contains("record_gross_pnl"));
         assert!(source.contains("scalars[so + 44] = loss_sum"));
         assert!(source.contains("scalars[so + 45] = position_unchanged_max_min * interval_ms"));
@@ -492,10 +499,10 @@ mod tests {
         assert!(source.contains("day_min_balance"));
         assert!(source.contains("constant int SCALAR_COLS = 61"));
         assert!(source.contains("constant int SCALAR_COLS = 63"));
-        assert!(source.contains("constant int SCALAR_COLS = 65"));
+        assert!(source.contains("constant int SCALAR_COLS = 67"));
         assert!(source.contains("constant int FUSED_SCALAR_COLS = 66"));
         assert!(source.contains("constant int FUSED_SCALAR_COLS = 68"));
-        assert!(source.contains("constant int FUSED_SCALAR_COLS = 70"));
+        assert!(source.contains("constant int FUSED_SCALAR_COLS = 72"));
         assert_eq!(source.matches("struct EmaMulticoinSideState").count(), 1);
         assert_eq!(source.matches("struct EmaMulticoinSideConfig").count(), 1);
         assert_eq!(source.matches("struct EmaMulticoinFillState").count(), 1);
@@ -697,7 +704,7 @@ mod tests {
         assert!(source.contains("try_restart_hsl("));
         assert!(source.contains("constant int SCALAR_COLS = 66"));
         assert!(source.contains("constant int SCALAR_COLS = 68"));
-        assert!(source.contains("constant int SCALAR_COLS = 70"));
+        assert!(source.contains("constant int SCALAR_COLS = 72"));
         assert!(source.contains("record_gross_pnl"));
         assert!(source.contains("scalars[so + 44] = loss_sum"));
         assert!(source.contains("scalars[so + 45] = position_unchanged_max_min * interval_ms"));
@@ -937,10 +944,10 @@ mod tests {
         assert!(source.contains("never reuse the equity-derived liquidation floor"));
         assert!(source.contains("constant int SCALAR_COLS = 61"));
         assert!(source.contains("constant int SCALAR_COLS = 63"));
-        assert!(source.contains("constant int SCALAR_COLS = 65"));
+        assert!(source.contains("constant int SCALAR_COLS = 67"));
         assert!(source.contains("constant int FUSED_SCALAR_COLS = 66"));
         assert!(source.contains("constant int FUSED_SCALAR_COLS = 68"));
-        assert!(source.contains("constant int FUSED_SCALAR_COLS = 70"));
+        assert!(source.contains("constant int FUSED_SCALAR_COLS = 72"));
         assert_eq!(
             source
                 .matches("struct TrailingMartingaleMulticoinSideState")

--- a/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
@@ -2,7 +2,9 @@
 using namespace metal;
 
 constant int DAILY_COLS = 8;
-#if PASSIVBOT_HSL_RAW_DRAWDOWN_ENABLED
+#if PASSIVBOT_HSL_RAW_TAIL_ENABLED
+constant int SCALAR_COLS = 72;
+#elif PASSIVBOT_HSL_RAW_DRAWDOWN_ENABLED
 constant int SCALAR_COLS = 70;
 #elif PASSIVBOT_HSL_EMA_TAIL_ENABLED
 constant int SCALAR_COLS = 68;
@@ -1822,7 +1824,8 @@ inline void passivbot_single_coin_impl(
                     starting_balance + (
                         unified_hsl ? realized_pnl_cumsum_last
                             : realized_pnl_cumsum_long
-                    ) + (unified_hsl ? long_unreal + short_unreal : long_unreal)
+                    ) + (unified_hsl ? long_unreal + short_unreal : long_unreal),
+                    di
                 );
             }
             if (short_hsl_sample_enabled) {
@@ -1831,7 +1834,8 @@ inline void passivbot_single_coin_impl(
                     starting_balance + (
                         unified_hsl ? realized_pnl_cumsum_last
                             : realized_pnl_cumsum_short
-                    ) + (unified_hsl ? long_unreal + short_unreal : short_unreal)
+                    ) + (unified_hsl ? long_unreal + short_unreal : short_unreal),
+                    di
                 );
             }
             bool hsl_update_valid = update_dual_side_hsl(
@@ -2117,6 +2121,14 @@ inline void passivbot_single_coin_impl(
 #if PASSIVBOT_HSL_RAW_DRAWDOWN_ENABLED
     scalars[so + 68] = hsl_strategy_equity_drawdown_max(long_hsl_strategy_eq);
     scalars[so + 69] = hsl_strategy_equity_drawdown_max(short_hsl_strategy_eq);
+#endif
+#if PASSIVBOT_HSL_RAW_TAIL_ENABLED
+    scalars[so + 70] = hsl_strategy_equity_drawdown_mean_worst_1pct(
+        long_hsl_strategy_eq
+    );
+    scalars[so + 71] = hsl_strategy_equity_drawdown_mean_worst_1pct(
+        short_hsl_strategy_eq
+    );
 #endif
 }
 

--- a/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
@@ -7,7 +7,10 @@ constant int COIN_COLS = 13;
 constant int OVERRIDE_COLS = 29;
 constant int HSL_OVERRIDE_START = 19;
 constant int DAILY_COLS = 9;
-#if PASSIVBOT_HSL_RAW_DRAWDOWN_ENABLED
+#if PASSIVBOT_HSL_RAW_TAIL_ENABLED
+constant int SCALAR_COLS = 67;
+constant int FUSED_SCALAR_COLS = 72;
+#elif PASSIVBOT_HSL_RAW_DRAWDOWN_ENABLED
 constant int SCALAR_COLS = 65;
 constant int FUSED_SCALAR_COLS = 70;
 #elif PASSIVBOT_HSL_EMA_TAIL_ENABLED
@@ -597,6 +600,7 @@ inline bool update_ema_multicoin_dual_side_hsl(
     constant float* bars,
     constant float* coin_settings,
     int k,
+    int day_index,
     int coin_count,
     float starting_balance,
     float interval_ms,
@@ -747,7 +751,8 @@ inline bool update_ema_multicoin_dual_side_hsl(
 #endif
             update_hsl_strategy_equity_stats(
                 long_side.hsl_strategy_eq,
-                starting_balance + account.realized_pnl_long + long_unrealized
+                starting_balance + account.realized_pnl_long + long_unrealized,
+                day_index
             );
         }
         if (short_strategy_eq_enabled) {
@@ -758,7 +763,8 @@ inline bool update_ema_multicoin_dual_side_hsl(
 #endif
             update_hsl_strategy_equity_stats(
                 short_side.hsl_strategy_eq,
-                starting_balance + account.realized_pnl_short + short_unrealized
+                starting_balance + account.realized_pnl_short + short_unrealized,
+                day_index
             );
         }
         return true;
@@ -774,7 +780,8 @@ inline bool update_ema_multicoin_dual_side_hsl(
             long_side.hsl_strategy_eq,
             starting_balance + (
                 unified ? account.realized_pnl_total : account.realized_pnl_long
-            ) + (unified ? long_unrealized + short_unrealized : long_unrealized)
+            ) + (unified ? long_unrealized + short_unrealized : long_unrealized),
+            day_index
         );
     }
     if (short_strategy_eq_enabled) {
@@ -782,7 +789,8 @@ inline bool update_ema_multicoin_dual_side_hsl(
             short_side.hsl_strategy_eq,
             starting_balance + (
                 unified ? account.realized_pnl_total : account.realized_pnl_short
-            ) + (unified ? long_unrealized + short_unrealized : short_unrealized)
+            ) + (unified ? long_unrealized + short_unrealized : short_unrealized),
+            day_index
         );
     }
     if (!update_joint_pside_hsl(
@@ -2979,7 +2987,8 @@ inline void passivbot_ema_anchor_multicoin_impl(
 #endif
                 update_hsl_strategy_equity_stats(
                     side.hsl_strategy_eq,
-                    starting_balance + realized_pnl_cumsum_last + unrealized
+                    starting_balance + realized_pnl_cumsum_last + unrealized,
+                    day_index
                 );
             }
             if (hsl_sample_enabled) {
@@ -3206,6 +3215,13 @@ inline void passivbot_ema_anchor_multicoin_impl(
         : hsl_strategy_equity_drawdown_max(side.hsl_strategy_eq);
     scalars[scalar_offset + 64] = short_side
         ? hsl_strategy_equity_drawdown_max(side.hsl_strategy_eq) : 0.0f;
+#endif
+#if PASSIVBOT_HSL_RAW_TAIL_ENABLED
+    scalars[scalar_offset + 65] = short_side ? 0.0f
+        : hsl_strategy_equity_drawdown_mean_worst_1pct(side.hsl_strategy_eq);
+    scalars[scalar_offset + 66] = short_side
+        ? hsl_strategy_equity_drawdown_mean_worst_1pct(side.hsl_strategy_eq)
+        : 0.0f;
 #endif
 }
 
@@ -3846,7 +3862,7 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
             bool hsl_valid = update_ema_multicoin_dual_side_hsl(
                 long_side, long_config, long_effective_n_positions,
                 short_side, short_config, short_effective_n_positions,
-                account, bars, coin_settings, k, C,
+                account, bars, coin_settings, k, day_index, C,
                 starting_balance, interval_ms,
                 sample_enabled, sampled_tier
             );
@@ -4118,6 +4134,16 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
     scalars[scalar_offset + 69] = hsl_strategy_equity_drawdown_max(
         short_side.hsl_strategy_eq
     );
+#endif
+#if PASSIVBOT_HSL_RAW_TAIL_ENABLED
+    scalars[scalar_offset + 70]
+        = hsl_strategy_equity_drawdown_mean_worst_1pct(
+            long_side.hsl_strategy_eq
+        );
+    scalars[scalar_offset + 71]
+        = hsl_strategy_equity_drawdown_mean_worst_1pct(
+            short_side.hsl_strategy_eq
+        );
 #endif
 }
 

--- a/passivbot-rust/src/gpu/mps_hsl_common.metal
+++ b/passivbot-rust/src/gpu/mps_hsl_common.metal
@@ -11,6 +11,10 @@
 #define PASSIVBOT_HSL_RAW_DRAWDOWN_ENABLED 0
 #endif
 
+#ifndef PASSIVBOT_HSL_RAW_TAIL_ENABLED
+#define PASSIVBOT_HSL_RAW_TAIL_ENABLED 0
+#endif
+
 #define HSL_EMA_TAIL_BINS 32
 
 constant int HSL_SIGNAL_UNIFIED = 0;
@@ -235,6 +239,13 @@ struct HslStrategyEquityStats {
 #if PASSIVBOT_HSL_RAW_DRAWDOWN_ENABLED
     float drawdown_max;
 #endif
+#if PASSIVBOT_HSL_RAW_TAIL_ENABLED
+    int current_drawdown_day;
+    float current_day_drawdown_worst;
+    float completed_day_count;
+    float daily_drawdown_counts[HSL_EMA_TAIL_BINS];
+    float daily_drawdown_sums[HSL_EMA_TAIL_BINS];
+#endif
 };
 
 inline HslStrategyEquityStats init_hsl_strategy_equity_stats() {
@@ -247,12 +258,44 @@ inline HslStrategyEquityStats init_hsl_strategy_equity_stats() {
 #if PASSIVBOT_HSL_RAW_DRAWDOWN_ENABLED
     stats.drawdown_max = 0.0f;
 #endif
+#if PASSIVBOT_HSL_RAW_TAIL_ENABLED
+    stats.current_drawdown_day = -1;
+    stats.current_day_drawdown_worst = 0.0f;
+    stats.completed_day_count = 0.0f;
+    for (int i = 0; i < HSL_EMA_TAIL_BINS; ++i) {
+        stats.daily_drawdown_counts[i] = 0.0f;
+        stats.daily_drawdown_sums[i] = 0.0f;
+    }
+#endif
     return stats;
+}
+
+inline int hsl_drawdown_tail_bin(float value) {
+    // Cover fourteen octaves over [2^-14, 1) so low-drawdown Pareto members
+    // remain rankable without increasing thread-local state. Edge bins retain
+    // smaller values and overflow respectively. Actual sums are not clamped,
+    // so values outside the covered range keep their magnitude.
+    float scaled = (log2(fmax(value, 0.00006103515625f)) + 14.0f)
+        * 2.2857142857142856f;
+    return clamp(int(floor(scaled)), 0, HSL_EMA_TAIL_BINS - 1);
+}
+
+inline void flush_hsl_strategy_equity_daily_drawdown(
+    thread HslStrategyEquityStats& stats
+) {
+#if PASSIVBOT_HSL_RAW_TAIL_ENABLED
+    if (stats.current_drawdown_day < 0) return;
+    int bin = hsl_drawdown_tail_bin(stats.current_day_drawdown_worst);
+    stats.completed_day_count += 1.0f;
+    stats.daily_drawdown_counts[bin] += 1.0f;
+    stats.daily_drawdown_sums[bin] += stats.current_day_drawdown_worst;
+#endif
 }
 
 inline void update_hsl_strategy_equity_stats(
     thread HslStrategyEquityStats& stats,
-    float strategy_equity
+    float strategy_equity,
+    int day_index
 ) {
     if (!isfinite(strategy_equity)) return;
     const float sample_k = stats.initialized
@@ -262,6 +305,10 @@ inline void update_hsl_strategy_equity_stats(
         stats.peak = strategy_equity;
         stats.peak_sample_k = sample_k;
         stats.last_sample_k = sample_k;
+#if PASSIVBOT_HSL_RAW_TAIL_ENABLED
+        stats.current_drawdown_day = day_index;
+        stats.current_day_drawdown_worst = 0.0f;
+#endif
         return;
     }
     stats.last_sample_k = sample_k;
@@ -273,10 +320,22 @@ inline void update_hsl_strategy_equity_stats(
         stats.peak_sample_k = sample_k;
     }
 #if PASSIVBOT_HSL_RAW_DRAWDOWN_ENABLED
-    stats.drawdown_max = fmax(
-        stats.drawdown_max,
-        (stats.peak - strategy_equity) / fmax(fabs(stats.peak), 1.0e-12f)
-    );
+    float drawdown = (stats.peak - strategy_equity)
+        / fmax(fabs(stats.peak), 1.0e-12f);
+    stats.drawdown_max = fmax(stats.drawdown_max, drawdown);
+#endif
+#if PASSIVBOT_HSL_RAW_TAIL_ENABLED
+    float daily_drawdown = (stats.peak - strategy_equity)
+        / fmax(fabs(stats.peak), 1.0e-12f);
+    if (day_index > stats.current_drawdown_day) {
+        flush_hsl_strategy_equity_daily_drawdown(stats);
+        stats.current_drawdown_day = day_index;
+        stats.current_day_drawdown_worst = daily_drawdown;
+    } else {
+        stats.current_day_drawdown_worst = fmax(
+            stats.current_day_drawdown_worst, daily_drawdown
+        );
+    }
 #endif
 }
 
@@ -285,6 +344,34 @@ inline float hsl_strategy_equity_drawdown_max(
 ) {
 #if PASSIVBOT_HSL_RAW_DRAWDOWN_ENABLED
     return stats.drawdown_max;
+#else
+    return 0.0f;
+#endif
+}
+
+inline float hsl_strategy_equity_drawdown_mean_worst_1pct(
+    thread HslStrategyEquityStats& stats
+) {
+#if PASSIVBOT_HSL_RAW_TAIL_ENABLED
+    float sample_count = stats.completed_day_count
+        + (stats.current_drawdown_day >= 0 ? 1.0f : 0.0f);
+    if (!(sample_count > 0.0f)) return 0.0f;
+    float worst_n = fmax(floor(sample_count * 0.01f), 1.0f);
+    float remaining = worst_n;
+    float total = 0.0f;
+    int current_bin = stats.current_drawdown_day >= 0
+        ? hsl_drawdown_tail_bin(stats.current_day_drawdown_worst) : -1;
+    for (int i = HSL_EMA_TAIL_BINS - 1; i >= 0 && remaining > 0.0f; --i) {
+        float count = stats.daily_drawdown_counts[i]
+            + (i == current_bin ? 1.0f : 0.0f);
+        if (!(count > 0.0f)) continue;
+        float sum = stats.daily_drawdown_sums[i]
+            + (i == current_bin ? stats.current_day_drawdown_worst : 0.0f);
+        float take = fmin(count, remaining);
+        total += sum * (take / count);
+        remaining -= take;
+    }
+    return total / worst_n;
 #else
     return 0.0f;
 #endif
@@ -332,13 +419,7 @@ inline HslDrawdownEmaTailStats init_hsl_drawdown_ema_tail_stats() {
 }
 
 inline int hsl_drawdown_ema_tail_bin(float value) {
-    // Cover fourteen octaves over [2^-14, 1) so low-drawdown Pareto members
-    // remain rankable without increasing thread-local state. Edge bins retain
-    // smaller values and overflow respectively. Actual sums are not clamped,
-    // so values outside the covered range keep their magnitude.
-    float scaled = (log2(fmax(value, 0.00006103515625f)) + 14.0f)
-        * 2.2857142857142856f;
-    return clamp(int(floor(scaled)), 0, HSL_EMA_TAIL_BINS - 1);
+    return hsl_drawdown_tail_bin(value);
 }
 
 inline void update_hsl_drawdown_ema_tail_stats(

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -2,7 +2,9 @@
 using namespace metal;
 
 constant int DAILY_COLS = 8;
-#if PASSIVBOT_HSL_RAW_DRAWDOWN_ENABLED
+#if PASSIVBOT_HSL_RAW_TAIL_ENABLED
+constant int SCALAR_COLS = 72;
+#elif PASSIVBOT_HSL_RAW_DRAWDOWN_ENABLED
 constant int SCALAR_COLS = 70;
 #elif PASSIVBOT_HSL_EMA_TAIL_ENABLED
 constant int SCALAR_COLS = 68;
@@ -3656,7 +3658,8 @@ inline void passivbot_single_coin_impl(
                     starting_balance + (
                         unified_hsl ? realized_pnl_cumsum_last
                             : realized_pnl_cumsum_long
-                    ) + (unified_hsl ? long_unreal + short_unreal : long_unreal)
+                    ) + (unified_hsl ? long_unreal + short_unreal : long_unreal),
+                    di
                 );
             }
             if (short_hsl_sample_enabled) {
@@ -3665,7 +3668,8 @@ inline void passivbot_single_coin_impl(
                     starting_balance + (
                         unified_hsl ? realized_pnl_cumsum_last
                             : realized_pnl_cumsum_short
-                    ) + (unified_hsl ? long_unreal + short_unreal : short_unreal)
+                    ) + (unified_hsl ? long_unreal + short_unreal : short_unreal),
+                    di
                 );
             }
             bool hsl_update_valid = update_dual_side_hsl(
@@ -3951,6 +3955,14 @@ inline void passivbot_single_coin_impl(
 #if PASSIVBOT_HSL_RAW_DRAWDOWN_ENABLED
     scalars[so + 68] = hsl_strategy_equity_drawdown_max(long_hsl_strategy_eq);
     scalars[so + 69] = hsl_strategy_equity_drawdown_max(short_hsl_strategy_eq);
+#endif
+#if PASSIVBOT_HSL_RAW_TAIL_ENABLED
+    scalars[so + 70] = hsl_strategy_equity_drawdown_mean_worst_1pct(
+        long_hsl_strategy_eq
+    );
+    scalars[so + 71] = hsl_strategy_equity_drawdown_mean_worst_1pct(
+        short_hsl_strategy_eq
+    );
 #endif
 }
 

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
@@ -9,7 +9,10 @@ constant int GATE_INITIAL_OVERRIDE_COL = 44;
 constant int GATE_REENTRY_OVERRIDE_COL = 45;
 constant int COIN_COLS = 13;
 constant int DAILY_COLS = 9;
-#if PASSIVBOT_HSL_RAW_DRAWDOWN_ENABLED
+#if PASSIVBOT_HSL_RAW_TAIL_ENABLED
+constant int SCALAR_COLS = 67;
+constant int FUSED_SCALAR_COLS = 72;
+#elif PASSIVBOT_HSL_RAW_DRAWDOWN_ENABLED
 constant int SCALAR_COLS = 65;
 constant int FUSED_SCALAR_COLS = 70;
 #elif PASSIVBOT_HSL_EMA_TAIL_ENABLED
@@ -2469,6 +2472,7 @@ inline bool update_tm_multicoin_dual_side_hsl(
     constant float* bars,
     constant float* coin_settings,
     int k,
+    int day_index,
     int coin_count,
     float starting_balance,
     float interval_ms,
@@ -2619,7 +2623,8 @@ inline bool update_tm_multicoin_dual_side_hsl(
 #endif
             update_hsl_strategy_equity_stats(
                 long_side.hsl_strategy_eq,
-                starting_balance + account.realized_pnl_long + long_unrealized
+                starting_balance + account.realized_pnl_long + long_unrealized,
+                day_index
             );
         }
         if (short_strategy_eq_enabled) {
@@ -2630,7 +2635,8 @@ inline bool update_tm_multicoin_dual_side_hsl(
 #endif
             update_hsl_strategy_equity_stats(
                 short_side.hsl_strategy_eq,
-                starting_balance + account.realized_pnl_short + short_unrealized
+                starting_balance + account.realized_pnl_short + short_unrealized,
+                day_index
             );
         }
         return true;
@@ -2646,7 +2652,8 @@ inline bool update_tm_multicoin_dual_side_hsl(
             long_side.hsl_strategy_eq,
             starting_balance + (
                 unified ? account.realized_pnl_total : account.realized_pnl_long
-            ) + (unified ? long_unrealized + short_unrealized : long_unrealized)
+            ) + (unified ? long_unrealized + short_unrealized : long_unrealized),
+            day_index
         );
     }
     if (short_strategy_eq_enabled) {
@@ -2654,7 +2661,8 @@ inline bool update_tm_multicoin_dual_side_hsl(
             short_side.hsl_strategy_eq,
             starting_balance + (
                 unified ? account.realized_pnl_total : account.realized_pnl_short
-            ) + (unified ? long_unrealized + short_unrealized : short_unrealized)
+            ) + (unified ? long_unrealized + short_unrealized : short_unrealized),
+            day_index
         );
     }
     if (!update_joint_pside_hsl(
@@ -5034,7 +5042,7 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
             bool hsl_valid = update_tm_multicoin_dual_side_hsl(
                 long_side, long_config, long_effective_n_positions,
                 short_side, short_config, short_effective_n_positions,
-                account, bars, coin_settings, k, C,
+                account, bars, coin_settings, k, day_index, C,
                 starting_balance, interval_ms,
                 sample_enabled, sampled_tier
             );
@@ -5306,6 +5314,16 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
     scalars[scalar_offset + 69] = hsl_strategy_equity_drawdown_max(
         short_side.hsl_strategy_eq
     );
+#endif
+#if PASSIVBOT_HSL_RAW_TAIL_ENABLED
+    scalars[scalar_offset + 70]
+        = hsl_strategy_equity_drawdown_mean_worst_1pct(
+            long_side.hsl_strategy_eq
+        );
+    scalars[scalar_offset + 71]
+        = hsl_strategy_equity_drawdown_mean_worst_1pct(
+            short_side.hsl_strategy_eq
+        );
 #endif
 }
 
@@ -5722,7 +5740,8 @@ inline void passivbot_trailing_martingale_multicoin_impl(
 #endif
                 update_hsl_strategy_equity_stats(
                     side.hsl_strategy_eq,
-                    starting_balance + realized_pnl_cumsum_last + unrealized
+                    starting_balance + realized_pnl_cumsum_last + unrealized,
+                    day_index
                 );
             }
             if (hsl_sample_enabled) {
@@ -5947,6 +5966,13 @@ inline void passivbot_trailing_martingale_multicoin_impl(
         : hsl_strategy_equity_drawdown_max(side.hsl_strategy_eq);
     scalars[scalar_offset + 64] = short_side
         ? hsl_strategy_equity_drawdown_max(side.hsl_strategy_eq) : 0.0f;
+#endif
+#if PASSIVBOT_HSL_RAW_TAIL_ENABLED
+    scalars[scalar_offset + 65] = short_side ? 0.0f
+        : hsl_strategy_equity_drawdown_mean_worst_1pct(side.hsl_strategy_eq);
+    scalars[scalar_offset + 66] = short_side
+        ? hsl_strategy_equity_drawdown_mean_worst_1pct(side.hsl_strategy_eq)
+        : 0.0f;
 #endif
 }
 

--- a/src/config/scoring.py
+++ b/src/config/scoring.py
@@ -85,6 +85,8 @@ DEFAULT_OBJECTIVE_GOALS = {
     "drawdown_worst_mean_1pct_ema_strategy_eq_long": "min",
     "drawdown_worst_mean_1pct_ema_strategy_eq_short": "min",
     "drawdown_worst_mean_1pct_strategy_eq": "min",
+    "drawdown_worst_mean_1pct_strategy_eq_long": "min",
+    "drawdown_worst_mean_1pct_strategy_eq_short": "min",
     "strategy_eq_underwater_pct_mean": "min",
     "strategy_eq_underwater_pct_median": "min",
     "strategy_eq_recovery_days_mean": "min",

--- a/src/optimization/gpu/metrics.py
+++ b/src/optimization/gpu/metrics.py
@@ -57,6 +57,8 @@ SUPPORTED_METRICS = (
     "calmar_ratio_strategy_eq",
     "calmar_ratio_strategy_eq_w",
     "drawdown_worst_mean_1pct_strategy_eq",
+    "drawdown_worst_mean_1pct_strategy_eq_long",
+    "drawdown_worst_mean_1pct_strategy_eq_short",
     "drawdown_worst_strategy_eq_long",
     "drawdown_worst_strategy_eq_short",
     "drawdown_worst_mean_1pct_ema_strategy_eq",
@@ -265,6 +267,8 @@ _HARD_STOP_EMA_DRAWDOWN_METRICS = {
 _HARD_STOP_RAW_DRAWDOWN_METRICS = {
     "drawdown_worst_strategy_eq_long",
     "drawdown_worst_strategy_eq_short",
+    "drawdown_worst_mean_1pct_strategy_eq_long",
+    "drawdown_worst_mean_1pct_strategy_eq_short",
 }
 _HARD_STOP_EMA_TAIL_METRICS = {
     "drawdown_worst_mean_1pct_ema_strategy_eq",
@@ -1381,9 +1385,14 @@ def _hard_stop_ema_drawdown_metrics(out: dict) -> dict:
 
 
 def _hard_stop_raw_drawdown_metrics(out: dict) -> dict:
-    """Expose per-side worst raw HSL strategy-equity drawdown."""
+    """Expose per-side raw HSL strategy-equity drawdown summaries."""
 
-    required = {"hsl_drawdown_raw_max_long", "hsl_drawdown_raw_max_short"}
+    required = {
+        "hsl_drawdown_raw_max_long",
+        "hsl_drawdown_raw_max_short",
+        "hsl_drawdown_raw_mean_worst_1pct_long",
+        "hsl_drawdown_raw_mean_worst_1pct_short",
+    }
     if missing := required.difference(out):
         raise RuntimeError(
             "MPS directional HSL raw-drawdown outputs are missing from proxy "
@@ -1395,6 +1404,12 @@ def _hard_stop_raw_drawdown_metrics(out: dict) -> dict:
         ].to(torch.float64),
         "drawdown_worst_strategy_eq_short": out[
             "hsl_drawdown_raw_max_short"
+        ].to(torch.float64),
+        "drawdown_worst_mean_1pct_strategy_eq_long": out[
+            "hsl_drawdown_raw_mean_worst_1pct_long"
+        ].to(torch.float64),
+        "drawdown_worst_mean_1pct_strategy_eq_short": out[
+            "hsl_drawdown_raw_mean_worst_1pct_short"
         ].to(torch.float64),
     }
 

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -32,18 +32,22 @@ MPS_MULTICOIN_DAILY_COLS = 9
 MPS_SCALAR_COLS = 32
 MPS_MULTICOIN_BASE_SCALAR_COLS = 61
 MPS_MULTICOIN_EMA_TAIL_SCALAR_COLS = 63
-MPS_MULTICOIN_SCALAR_COLS = 65
+MPS_MULTICOIN_RAW_DRAWDOWN_SCALAR_COLS = 65
+MPS_MULTICOIN_SCALAR_COLS = 67
 MPS_DIRECTIONAL_BASE_SCALAR_COLS = 66
 MPS_DIRECTIONAL_EMA_TAIL_SCALAR_COLS = 68
-MPS_DIRECTIONAL_SCALAR_COLS = 70
+MPS_DIRECTIONAL_RAW_DRAWDOWN_SCALAR_COLS = 70
+MPS_DIRECTIONAL_SCALAR_COLS = 72
 MPS_MULTICOIN_FUSED_BASE_SCALAR_COLS = 66
 MPS_MULTICOIN_FUSED_EMA_TAIL_SCALAR_COLS = 68
-MPS_MULTICOIN_FUSED_SCALAR_COLS = 70
+MPS_MULTICOIN_FUSED_RAW_DRAWDOWN_SCALAR_COLS = 70
+MPS_MULTICOIN_FUSED_SCALAR_COLS = 72
 MPS_DIRECTIONAL_HSL_ROLLING_CAPACITY = 2048
 MPS_STRATEGY_EQ_RECOVERY_METRIC_COLS = 7
 
 _HSL_EMA_TAIL_DEFINE = "#define PASSIVBOT_HSL_EMA_TAIL_ENABLED 1\n"
 _HSL_RAW_DRAWDOWN_DEFINE = "#define PASSIVBOT_HSL_RAW_DRAWDOWN_ENABLED 1\n"
+_HSL_RAW_TAIL_DEFINE = "#define PASSIVBOT_HSL_RAW_TAIL_ENABLED 1\n"
 _RECOVERY_DISTRIBUTION_DEFINE = (
     "#define PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED 1\n"
 )
@@ -62,13 +66,20 @@ def _with_hsl_features(
     *,
     ema_tail_enabled: bool,
     raw_drawdown_enabled: bool,
+    raw_tail_enabled: bool,
 ) -> str:
+    if raw_tail_enabled and not raw_drawdown_enabled:
+        raise ValueError("HSL raw-tail metrics require raw-drawdown metrics")
     source = _with_hsl_ema_tail(source, ema_tail_enabled)
-    if not raw_drawdown_enabled:
-        return source
-    if "#ifndef PASSIVBOT_HSL_RAW_DRAWDOWN_ENABLED" not in source:
-        raise RuntimeError("MPS source is missing the HSL raw-drawdown feature guard")
-    return _HSL_RAW_DRAWDOWN_DEFINE + source
+    if raw_drawdown_enabled:
+        if "#ifndef PASSIVBOT_HSL_RAW_DRAWDOWN_ENABLED" not in source:
+            raise RuntimeError("MPS source is missing the HSL raw-drawdown feature guard")
+        source = _HSL_RAW_DRAWDOWN_DEFINE + source
+    if raw_tail_enabled:
+        if "#ifndef PASSIVBOT_HSL_RAW_TAIL_ENABLED" not in source:
+            raise RuntimeError("MPS source is missing the HSL raw-tail feature guard")
+        source = _HSL_RAW_TAIL_DEFINE + source
+    return source
 
 
 def _with_recovery_distribution(source: str, enabled: bool) -> str:
@@ -292,6 +303,7 @@ def _scalar_column_or_zero(scalars, index: int):
 def _shader_library(
     hsl_ema_tail_enabled: bool = False,
     hsl_raw_drawdown_enabled: bool = False,
+    hsl_raw_tail_enabled: bool = False,
     recovery_distribution_enabled: bool = False,
 ):
     if not torch.backends.mps.is_available():
@@ -304,6 +316,7 @@ def _shader_library(
                 passivbot_rust.mps_ema_anchor_source_py(),
                 ema_tail_enabled=hsl_ema_tail_enabled,
                 raw_drawdown_enabled=hsl_raw_drawdown_enabled,
+                raw_tail_enabled=hsl_raw_tail_enabled,
             ),
             recovery_distribution_enabled,
         )
@@ -314,6 +327,7 @@ def _shader_library(
 def _trailing_martingale_shader_library(
     hsl_ema_tail_enabled: bool = False,
     hsl_raw_drawdown_enabled: bool = False,
+    hsl_raw_tail_enabled: bool = False,
     recovery_distribution_enabled: bool = False,
 ):
     if not torch.backends.mps.is_available():
@@ -326,6 +340,7 @@ def _trailing_martingale_shader_library(
                 passivbot_rust.mps_trailing_martingale_source_py(),
                 ema_tail_enabled=hsl_ema_tail_enabled,
                 raw_drawdown_enabled=hsl_raw_drawdown_enabled,
+                raw_tail_enabled=hsl_raw_tail_enabled,
             ),
             recovery_distribution_enabled,
         )
@@ -368,6 +383,7 @@ def _trailing_martingale_short_no_hsl_shader_library(
 def _ema_anchor_multicoin_shader_library(
     hsl_ema_tail_enabled: bool = False,
     hsl_raw_drawdown_enabled: bool = False,
+    hsl_raw_tail_enabled: bool = False,
     recovery_distribution_enabled: bool = False,
 ):
     if not torch.backends.mps.is_available():
@@ -380,6 +396,7 @@ def _ema_anchor_multicoin_shader_library(
                 passivbot_rust.mps_ema_anchor_multicoin_source_py(),
                 ema_tail_enabled=hsl_ema_tail_enabled,
                 raw_drawdown_enabled=hsl_raw_drawdown_enabled,
+                raw_tail_enabled=hsl_raw_tail_enabled,
             ),
             recovery_distribution_enabled,
         )
@@ -390,6 +407,7 @@ def _ema_anchor_multicoin_shader_library(
 def _trailing_martingale_multicoin_shader_library(
     hsl_ema_tail_enabled: bool = False,
     hsl_raw_drawdown_enabled: bool = False,
+    hsl_raw_tail_enabled: bool = False,
     recovery_distribution_enabled: bool = False,
 ):
     if not torch.backends.mps.is_available():
@@ -402,6 +420,7 @@ def _trailing_martingale_multicoin_shader_library(
                 passivbot_rust.mps_trailing_martingale_multicoin_source_py(),
                 ema_tail_enabled=hsl_ema_tail_enabled,
                 raw_drawdown_enabled=hsl_raw_drawdown_enabled,
+                raw_tail_enabled=hsl_raw_tail_enabled,
             ),
             recovery_distribution_enabled,
         )
@@ -578,6 +597,12 @@ def _decode_outputs(daily, scalars, gaps) -> dict:
         ),
         "hsl_drawdown_raw_max_long": _scalar_column_or_zero(scalars, 63),
         "hsl_drawdown_raw_max_short": _scalar_column_or_zero(scalars, 64),
+        "hsl_drawdown_raw_mean_worst_1pct_long": _scalar_column_or_zero(
+            scalars, 65
+        ),
+        "hsl_drawdown_raw_mean_worst_1pct_short": _scalar_column_or_zero(
+            scalars, 66
+        ),
     }
 
 
@@ -602,6 +627,12 @@ def _decode_multicoin_fused_outputs(daily, scalars, gaps) -> dict:
             ),
             "hsl_drawdown_raw_max_long": _scalar_column_or_zero(scalars, 68),
             "hsl_drawdown_raw_max_short": _scalar_column_or_zero(scalars, 69),
+            "hsl_drawdown_raw_mean_worst_1pct_long": _scalar_column_or_zero(
+                scalars, 70
+            ),
+            "hsl_drawdown_raw_mean_worst_1pct_short": _scalar_column_or_zero(
+                scalars, 71
+            ),
         }
     )
     return output
@@ -702,6 +733,12 @@ def _decode_directional_outputs(daily, scalars, gaps) -> dict:
         ),
         "hsl_drawdown_raw_max_long": _scalar_column_or_zero(scalars, 68),
         "hsl_drawdown_raw_max_short": _scalar_column_or_zero(scalars, 69),
+        "hsl_drawdown_raw_mean_worst_1pct_long": _scalar_column_or_zero(
+            scalars, 70
+        ),
+        "hsl_drawdown_raw_mean_worst_1pct_short": _scalar_column_or_zero(
+            scalars, 71
+        ),
     }
 
 
@@ -728,6 +765,7 @@ class MpsEmaAnchorRunner:
         pnl_lookback_bars: int = 0,
         hsl_ema_tail_enabled: bool = False,
         hsl_raw_drawdown_enabled: bool = False,
+        hsl_raw_tail_enabled: bool = False,
         recovery_distribution_enabled: bool = False,
     ):
         self.market = market
@@ -782,6 +820,7 @@ class MpsEmaAnchorRunner:
         self.pnl_lookback_bars = pnl_lookback_bars
         self.hsl_ema_tail_enabled = bool(hsl_ema_tail_enabled)
         self.hsl_raw_drawdown_enabled = bool(hsl_raw_drawdown_enabled)
+        self.hsl_raw_tail_enabled = bool(hsl_raw_tail_enabled)
         self.recovery_distribution_enabled = bool(recovery_distribution_enabled)
         self.rolling_capacity = (
             MPS_DIRECTIONAL_HSL_ROLLING_CAPACITY
@@ -902,11 +941,15 @@ class MpsEmaAnchorRunner:
                         (
                             batch_size,
                             MPS_DIRECTIONAL_SCALAR_COLS
-                            if self.hsl_raw_drawdown_enabled
+                            if self.hsl_raw_tail_enabled
                             else (
-                                MPS_DIRECTIONAL_EMA_TAIL_SCALAR_COLS
-                                if self.hsl_ema_tail_enabled
-                                else MPS_DIRECTIONAL_BASE_SCALAR_COLS
+                                MPS_DIRECTIONAL_RAW_DRAWDOWN_SCALAR_COLS
+                                if self.hsl_raw_drawdown_enabled
+                                else (
+                                    MPS_DIRECTIONAL_EMA_TAIL_SCALAR_COLS
+                                    if self.hsl_ema_tail_enabled
+                                    else MPS_DIRECTIONAL_BASE_SCALAR_COLS
+                                )
                             ),
                         ),
                         dtype=torch.float32,
@@ -998,6 +1041,7 @@ class MpsEmaAnchorRunner:
         library = _shader_library(
             self.hsl_ema_tail_enabled,
             self.hsl_raw_drawdown_enabled,
+            self.hsl_raw_tail_enabled,
             self.recovery_distribution_enabled,
         )
         compiled = time.perf_counter()
@@ -1067,6 +1111,7 @@ class MpsEmaAnchorMulticoinRunner:
         hsl_panic_market: bool = False,
         hsl_ema_tail_enabled: bool = False,
         hsl_raw_drawdown_enabled: bool = False,
+        hsl_raw_tail_enabled: bool = False,
         recovery_distribution_enabled: bool = False,
     ):
         if side not in {"long", "short"}:
@@ -1077,13 +1122,20 @@ class MpsEmaAnchorMulticoinRunner:
         self.collect_coin_fill_counts = bool(collect_coin_fill_counts)
         self.hsl_ema_tail_enabled = bool(hsl_ema_tail_enabled)
         self.hsl_raw_drawdown_enabled = bool(hsl_raw_drawdown_enabled)
+        self.hsl_raw_tail_enabled = bool(hsl_raw_tail_enabled)
         self.recovery_distribution_enabled = bool(recovery_distribution_enabled)
         fused = self.scalar_cols == MPS_MULTICOIN_FUSED_SCALAR_COLS
-        if self.hsl_raw_drawdown_enabled:
+        if self.hsl_raw_tail_enabled:
             self.scalar_cols = (
                 MPS_MULTICOIN_FUSED_SCALAR_COLS
                 if fused
                 else MPS_MULTICOIN_SCALAR_COLS
+            )
+        elif self.hsl_raw_drawdown_enabled:
+            self.scalar_cols = (
+                MPS_MULTICOIN_FUSED_RAW_DRAWDOWN_SCALAR_COLS
+                if fused
+                else MPS_MULTICOIN_RAW_DRAWDOWN_SCALAR_COLS
             )
         elif self.hsl_ema_tail_enabled:
             self.scalar_cols = (
@@ -1328,6 +1380,7 @@ class MpsEmaAnchorMulticoinRunner:
         return _ema_anchor_multicoin_shader_library(
             self.hsl_ema_tail_enabled,
             self.hsl_raw_drawdown_enabled,
+            self.hsl_raw_tail_enabled,
             self.recovery_distribution_enabled,
         )
 
@@ -1450,6 +1503,7 @@ class MpsEmaAnchorMulticoinFusedRunner(MpsEmaAnchorMulticoinRunner):
         hsl_panic_market_short: bool = False,
         hsl_ema_tail_enabled: bool = False,
         hsl_raw_drawdown_enabled: bool = False,
+        hsl_raw_tail_enabled: bool = False,
         recovery_distribution_enabled: bool = False,
         hedge_mode: bool = True,
     ):
@@ -1468,6 +1522,7 @@ class MpsEmaAnchorMulticoinFusedRunner(MpsEmaAnchorMulticoinRunner):
             hsl_panic_market=hsl_panic_market_long,
             hsl_ema_tail_enabled=hsl_ema_tail_enabled,
             hsl_raw_drawdown_enabled=hsl_raw_drawdown_enabled,
+            hsl_raw_tail_enabled=hsl_raw_tail_enabled,
             recovery_distribution_enabled=recovery_distribution_enabled,
         )
         if short_coin_overrides is None:
@@ -1619,6 +1674,7 @@ class MpsTrailingMartingaleMulticoinRunner(MpsEmaAnchorMulticoinRunner):
         hsl_panic_market: bool = False,
         hsl_ema_tail_enabled: bool = False,
         hsl_raw_drawdown_enabled: bool = False,
+        hsl_raw_tail_enabled: bool = False,
         recovery_distribution_enabled: bool = False,
     ):
         super().__init__(
@@ -1636,6 +1692,7 @@ class MpsTrailingMartingaleMulticoinRunner(MpsEmaAnchorMulticoinRunner):
             hsl_panic_market=hsl_panic_market,
             hsl_ema_tail_enabled=hsl_ema_tail_enabled,
             hsl_raw_drawdown_enabled=hsl_raw_drawdown_enabled,
+            hsl_raw_tail_enabled=hsl_raw_tail_enabled,
             recovery_distribution_enabled=recovery_distribution_enabled,
         )
 
@@ -1661,6 +1718,7 @@ class MpsTrailingMartingaleMulticoinRunner(MpsEmaAnchorMulticoinRunner):
         return _trailing_martingale_multicoin_shader_library(
             self.hsl_ema_tail_enabled,
             self.hsl_raw_drawdown_enabled,
+            self.hsl_raw_tail_enabled,
             self.recovery_distribution_enabled,
         )
 
@@ -1733,6 +1791,7 @@ class MpsTrailingMartingaleMulticoinFusedRunner(
         hsl_panic_market_short: bool = False,
         hsl_ema_tail_enabled: bool = False,
         hsl_raw_drawdown_enabled: bool = False,
+        hsl_raw_tail_enabled: bool = False,
         recovery_distribution_enabled: bool = False,
         hedge_mode: bool = True,
     ):
@@ -1751,6 +1810,7 @@ class MpsTrailingMartingaleMulticoinFusedRunner(
             hsl_panic_market=hsl_panic_market_long,
             hsl_ema_tail_enabled=hsl_ema_tail_enabled,
             hsl_raw_drawdown_enabled=hsl_raw_drawdown_enabled,
+            hsl_raw_tail_enabled=hsl_raw_tail_enabled,
             recovery_distribution_enabled=recovery_distribution_enabled,
         )
         if short_coin_overrides is None:
@@ -1875,6 +1935,7 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
         if self.shader_topology != "generic":
             self.hsl_ema_tail_enabled = False
             self.hsl_raw_drawdown_enabled = False
+            self.hsl_raw_tail_enabled = False
 
     def _shader_library(self):
         if self.shader_topology == "long_no_hsl":
@@ -1888,6 +1949,7 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
         return _trailing_martingale_shader_library(
             self.hsl_ema_tail_enabled,
             self.hsl_raw_drawdown_enabled,
+            self.hsl_raw_tail_enabled,
             self.recovery_distribution_enabled,
         )
 

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -125,6 +125,8 @@ DIRECTIONAL_HSL_OUTPUT_KEYS = {
     "hsl_drawdown_ema_mean_worst_1pct_short",
     "hsl_drawdown_raw_max_long",
     "hsl_drawdown_raw_max_short",
+    "hsl_drawdown_raw_mean_worst_1pct_long",
+    "hsl_drawdown_raw_mean_worst_1pct_short",
 }
 
 
@@ -342,6 +344,10 @@ _HSL_EMA_TAIL_METRICS = {
 _HSL_RAW_DRAWDOWN_METRICS = {
     "drawdown_worst_strategy_eq_long",
     "drawdown_worst_strategy_eq_short",
+}
+_HSL_RAW_TAIL_METRICS = {
+    "drawdown_worst_mean_1pct_strategy_eq_long",
+    "drawdown_worst_mean_1pct_strategy_eq_short",
 }
 _STRATEGY_EQ_RECOVERY_DISTRIBUTION_METRICS = {
     "strategy_eq_recovery_days_mean",
@@ -984,6 +990,8 @@ def _combine_hedged_multicoin_hsl_outputs(long: dict, short: dict) -> dict:
         "hsl_drawdown_ema_mean_worst_1pct_short",
         "hsl_drawdown_raw_max_long",
         "hsl_drawdown_raw_max_short",
+        "hsl_drawdown_raw_mean_worst_1pct_long",
+        "hsl_drawdown_raw_mean_worst_1pct_short",
         "hsl_strategy_eq_recovery_max_ms_long",
         "hsl_strategy_eq_recovery_max_ms_short",
     ):
@@ -1500,7 +1508,11 @@ class MpsSingleCoinProxy:
                 self.needed_metrics & _HSL_EMA_TAIL_METRICS
             ),
             hsl_raw_drawdown_enabled=bool(
-                self.needed_metrics & _HSL_RAW_DRAWDOWN_METRICS
+                self.needed_metrics
+                & (_HSL_RAW_DRAWDOWN_METRICS | _HSL_RAW_TAIL_METRICS)
+            ),
+            hsl_raw_tail_enabled=bool(
+                self.needed_metrics & _HSL_RAW_TAIL_METRICS
             ),
             recovery_distribution_enabled=bool(
                 self.needed_metrics & _STRATEGY_EQ_RECOVERY_DISTRIBUTION_METRICS
@@ -2316,7 +2328,11 @@ class MpsMulticoinProxy:
                 self.needed_metrics & _HSL_EMA_TAIL_METRICS
             ),
             "hsl_raw_drawdown_enabled": bool(
-                self.needed_metrics & _HSL_RAW_DRAWDOWN_METRICS
+                self.needed_metrics
+                & (_HSL_RAW_DRAWDOWN_METRICS | _HSL_RAW_TAIL_METRICS)
+            ),
+            "hsl_raw_tail_enabled": bool(
+                self.needed_metrics & _HSL_RAW_TAIL_METRICS
             ),
             "recovery_distribution_enabled": bool(
                 self.needed_metrics

--- a/tests/optimization/test_gpu_metrics.py
+++ b/tests/optimization/test_gpu_metrics.py
@@ -1080,6 +1080,8 @@ def test_hard_stop_raw_drawdown_metrics_map_each_side():
         {
             "hsl_drawdown_raw_max_long": torch.tensor([0.17, 0.0]),
             "hsl_drawdown_raw_max_short": torch.tensor([0.08, 0.23]),
+            "hsl_drawdown_raw_mean_worst_1pct_long": torch.tensor([0.12, 0.0]),
+            "hsl_drawdown_raw_mean_worst_1pct_short": torch.tensor([0.06, 0.19]),
         }
     )
 
@@ -1089,6 +1091,12 @@ def test_hard_stop_raw_drawdown_metrics_map_each_side():
     assert metrics["drawdown_worst_strategy_eq_short"].tolist() == pytest.approx(
         [0.08, 0.23]
     )
+    assert metrics[
+        "drawdown_worst_mean_1pct_strategy_eq_long"
+    ].tolist() == pytest.approx([0.12, 0.0])
+    assert metrics[
+        "drawdown_worst_mean_1pct_strategy_eq_short"
+    ].tolist() == pytest.approx([0.06, 0.19])
 
 
 def test_hard_stop_raw_drawdown_metrics_fail_closed_without_outputs():
@@ -1099,7 +1107,11 @@ def test_hard_stop_raw_drawdown_metrics_fail_closed_without_outputs():
 
     with pytest.raises(RuntimeError, match="hsl_drawdown_raw_max_short"):
         _hard_stop_raw_drawdown_metrics(
-            {"hsl_drawdown_raw_max_long": torch.tensor([0.1])}
+            {
+                "hsl_drawdown_raw_max_long": torch.tensor([0.1]),
+                "hsl_drawdown_raw_mean_worst_1pct_long": torch.tensor([0.08]),
+                "hsl_drawdown_raw_mean_worst_1pct_short": torch.tensor([0.05]),
+            }
         )
 
 

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -142,7 +142,7 @@ def test_decode_multicoin_fused_outputs_maps_directional_reductions():
     daily = torch.zeros((1, 1, 9), dtype=torch.float32)
     daily[:, :, 1].fill_(float("inf"))
     daily[:, :, 5].fill_(float("inf"))
-    scalars = torch.arange(70, dtype=torch.float32).reshape(1, 70)
+    scalars = torch.arange(72, dtype=torch.float32).reshape(1, 72)
     gaps = torch.zeros((1, 128), dtype=torch.int32)
 
     output = _decode_multicoin_fused_outputs(daily, scalars, gaps)
@@ -170,6 +170,12 @@ def test_decode_multicoin_fused_outputs_maps_directional_reductions():
     )
     assert torch.equal(output["hsl_drawdown_raw_max_long"], scalars[:, 68])
     assert torch.equal(output["hsl_drawdown_raw_max_short"], scalars[:, 69])
+    assert torch.equal(
+        output["hsl_drawdown_raw_mean_worst_1pct_long"], scalars[:, 70]
+    )
+    assert torch.equal(
+        output["hsl_drawdown_raw_mean_worst_1pct_short"], scalars[:, 71]
+    )
 
 
 def test_hsl_ema_tail_source_variant_is_opt_in_and_guarded():
@@ -187,14 +193,55 @@ def test_hsl_raw_drawdown_source_variant_is_opt_in_and_guarded():
     source = "#ifndef PASSIVBOT_HSL_RAW_DRAWDOWN_ENABLED\nbody"
 
     assert _with_hsl_features(
-        source, ema_tail_enabled=False, raw_drawdown_enabled=False
+        source,
+        ema_tail_enabled=False,
+        raw_drawdown_enabled=False,
+        raw_tail_enabled=False,
     ) is source
     assert _with_hsl_features(
-        source, ema_tail_enabled=False, raw_drawdown_enabled=True
+        source,
+        ema_tail_enabled=False,
+        raw_drawdown_enabled=True,
+        raw_tail_enabled=False,
     ) == ("#define PASSIVBOT_HSL_RAW_DRAWDOWN_ENABLED 1\n" + source)
     with pytest.raises(RuntimeError, match="raw-drawdown feature guard"):
         _with_hsl_features(
-            "body", ema_tail_enabled=False, raw_drawdown_enabled=True
+            "body",
+            ema_tail_enabled=False,
+            raw_drawdown_enabled=True,
+            raw_tail_enabled=False,
+        )
+    with pytest.raises(ValueError, match="require raw-drawdown"):
+        _with_hsl_features(
+            source,
+            ema_tail_enabled=False,
+            raw_drawdown_enabled=False,
+            raw_tail_enabled=True,
+        )
+
+
+def test_hsl_raw_tail_source_variant_is_separately_opt_in_and_guarded():
+    source = (
+        "#ifndef PASSIVBOT_HSL_RAW_DRAWDOWN_ENABLED\n"
+        "#ifndef PASSIVBOT_HSL_RAW_TAIL_ENABLED\nbody"
+    )
+
+    assert _with_hsl_features(
+        source,
+        ema_tail_enabled=False,
+        raw_drawdown_enabled=True,
+        raw_tail_enabled=True,
+    ) == (
+        "#define PASSIVBOT_HSL_RAW_TAIL_ENABLED 1\n"
+        "#define PASSIVBOT_HSL_RAW_DRAWDOWN_ENABLED 1\n"
+        + source
+    )
+    with pytest.raises(RuntimeError, match="raw-tail feature guard"):
+        _with_hsl_features(
+            "#ifndef PASSIVBOT_HSL_RAW_DRAWDOWN_ENABLED\nbody",
+            ema_tail_enabled=False,
+            raw_drawdown_enabled=True,
+            raw_tail_enabled=True,
         )
 
 
@@ -250,6 +297,7 @@ def test_trailing_martingale_no_hsl_specialization_keeps_base_scalar_abi(
         self.hsl_raw_drawdown_enabled = bool(
             kwargs["hsl_raw_drawdown_enabled"]
         )
+        self.hsl_raw_tail_enabled = bool(kwargs["hsl_raw_tail_enabled"])
 
     monkeypatch.setattr(MpsEmaAnchorRunner, "__init__", fake_base_init)
     runner = MpsTrailingMartingaleRunner(
@@ -259,11 +307,13 @@ def test_trailing_martingale_no_hsl_specialization_keeps_base_scalar_abi(
         hsl_enabled=False,
         hsl_ema_tail_enabled=True,
         hsl_raw_drawdown_enabled=True,
+        hsl_raw_tail_enabled=True,
     )
 
     assert runner.shader_topology == "long_no_hsl"
     assert runner.hsl_ema_tail_enabled is False
     assert runner.hsl_raw_drawdown_enabled is False
+    assert runner.hsl_raw_tail_enabled is False
 
 
 @pytest.mark.parametrize("recovery_enabled", [False, True])
@@ -309,6 +359,7 @@ def test_trailing_martingale_runner_accepts_ordinary_market_execution(monkeypatc
         self.short_enabled = False
         self.hsl_ema_tail_enabled = False
         self.hsl_raw_drawdown_enabled = False
+        self.hsl_raw_tail_enabled = False
         self.recovery_distribution_enabled = False
 
     monkeypatch.setattr(MpsEmaAnchorRunner, "__init__", fake_base_init)
@@ -441,14 +492,14 @@ kernel void passivbot_hsl_strategy_equity_recovery_probe(
     if (b > 0) return;
     HslStrategyEquityStats stats = init_hsl_strategy_equity_stats();
     for (int k = 0; k < 7; ++k) {
-        update_hsl_strategy_equity_stats(stats, samples[k]);
+        update_hsl_strategy_equity_stats(stats, samples[k], 0);
     }
     output[0] = hsl_strategy_equity_recovery_max_steps(stats);
     HslStrategyEquityStats resumed = init_hsl_strategy_equity_stats();
-    update_hsl_strategy_equity_stats(resumed, samples[0]);
-    update_hsl_strategy_equity_stats(resumed, samples[2]);
-    update_hsl_strategy_equity_stats(resumed, samples[3]);
-    update_hsl_strategy_equity_stats(resumed, samples[4]);
+    update_hsl_strategy_equity_stats(resumed, samples[0], 0);
+    update_hsl_strategy_equity_stats(resumed, samples[2], 0);
+    update_hsl_strategy_equity_stats(resumed, samples[3], 0);
+    update_hsl_strategy_equity_stats(resumed, samples[4], 0);
     output[1] = hsl_strategy_equity_recovery_max_steps(resumed);
 }
 """
@@ -530,9 +581,10 @@ kernel void passivbot_hsl_strategy_equity_raw_drawdown_probe(
     if (b > 0) return;
     HslStrategyEquityStats stats = init_hsl_strategy_equity_stats();
     for (int k = 0; k < 5; ++k) {
-        update_hsl_strategy_equity_stats(stats, samples[k]);
+        update_hsl_strategy_equity_stats(stats, samples[k], k / 2);
     }
     output[0] = hsl_strategy_equity_drawdown_max(stats);
+    output[1] = hsl_strategy_equity_drawdown_mean_worst_1pct(stats);
 }
 """
     samples = torch.tensor(
@@ -540,11 +592,12 @@ kernel void passivbot_hsl_strategy_equity_raw_drawdown_probe(
         dtype=torch.float32,
         device="mps",
     )
-    output = torch.zeros(1, dtype=torch.float32, device="mps")
+    output = torch.zeros(2, dtype=torch.float32, device="mps")
     source = _with_hsl_features(
         passivbot_rust.mps_ema_anchor_source_py(),
         ema_tail_enabled=False,
         raw_drawdown_enabled=True,
+        raw_tail_enabled=True,
     )
     library = torch.mps.compile_shader(source + probe_kernel)
     library.passivbot_hsl_strategy_equity_raw_drawdown_probe(
@@ -552,7 +605,11 @@ kernel void passivbot_hsl_strategy_equity_raw_drawdown_probe(
     )
     torch.mps.synchronize()
 
-    assert output.item() == pytest.approx(0.2, abs=1.0e-6)
+    assert output[0].item() == pytest.approx(0.2, abs=1.0e-6)
+    # The two intraday lows reduce to daily worst values of 0.1 and 0.2;
+    # the open terminal day contributes zero. With three observed days, Rust's
+    # floor(1%) contract retains the single worst day.
+    assert output[1].item() == pytest.approx(0.2, abs=1.0e-6)
 
 
 @pytest.mark.skipif(
@@ -2022,7 +2079,7 @@ kernel void passivbot_tm_multicoin_dual_hsl_phase_probe(
         bool valid = update_tm_multicoin_dual_side_hsl(
             long_side, long_config, long_slots,
             short_side, short_config, short_slots,
-            account, selected_bars, coin_settings, k, 1,
+                account, selected_bars, coin_settings, k, 0, 1,
             100.0f, 60000.0f, sample_enabled, sampled_tier
         );
         all_valid = all_valid && valid;
@@ -2189,7 +2246,7 @@ kernel void passivbot_ema_multicoin_dual_hsl_phase_probe(
         bool valid = update_ema_multicoin_dual_side_hsl(
             long_side, long_config, long_slots,
             short_side, short_config, short_slots,
-            account, selected_bars, coin_settings, k, 1,
+                account, selected_bars, coin_settings, k, 0, 1,
             100.0f, 60000.0f, sample_enabled, sampled_tier
         );
         all_valid = all_valid && valid;
@@ -6704,6 +6761,7 @@ def test_mps_ema_anchor_multicoin_directional_shader_smoke(side):
         passivbot_rust.mps_ema_anchor_multicoin_source_py(),
         ema_tail_enabled=True,
         raw_drawdown_enabled=True,
+        raw_tail_enabled=True,
     )
     assert "kernel void passivbot_ema_anchor_multicoin" in source
     assert "kernel void passivbot_ema_anchor_multicoin_long" in source
@@ -8425,9 +8483,10 @@ def test_mps_ema_anchor_multicoin_fused_kernel_smoke_all_hsl_modes():
         passivbot_rust.mps_ema_anchor_multicoin_source_py(),
         ema_tail_enabled=True,
         raw_drawdown_enabled=True,
+        raw_tail_enabled=True,
     )
     assert "kernel void passivbot_ema_anchor_multicoin_fused" in source
-    assert "constant int FUSED_SCALAR_COLS = 70" in source
+    assert "constant int FUSED_SCALAR_COLS = 72" in source
 
     count = 512
     coin_count = 3
@@ -8558,7 +8617,7 @@ def test_mps_ema_anchor_multicoin_fused_kernel_smoke_all_hsl_modes():
     )
     daily[:, :, 1].fill_(float("inf"))
     daily[:, :, 5].fill_(float("inf"))
-    scalars = torch.zeros((batch_size, 70), dtype=torch.float32, device="mps")
+    scalars = torch.zeros((batch_size, 72), dtype=torch.float32, device="mps")
     gaps = torch.zeros((batch_size, 128), dtype=torch.int32, device="mps")
     coin_fill_counts = torch.zeros(
         (batch_size, coin_count), dtype=torch.float32, device="mps"
@@ -8630,6 +8689,7 @@ def test_mps_ema_anchor_multicoin_fused_kernel_smoke_all_hsl_modes():
         collect_coin_fill_counts=True,
         hsl_ema_tail_enabled=True,
         hsl_raw_drawdown_enabled=True,
+        hsl_raw_tail_enabled=True,
         recovery_distribution_enabled=True,
     )
     torch.testing.assert_close(runner.settings, run_settings)
@@ -8673,6 +8733,12 @@ def test_mps_ema_anchor_multicoin_fused_kernel_smoke_all_hsl_modes():
     )
     torch.testing.assert_close(
         runner_output["hsl_drawdown_raw_max_short"], scalars[:, 69]
+    )
+    torch.testing.assert_close(
+        runner_output["hsl_drawdown_raw_mean_worst_1pct_long"], scalars[:, 70]
+    )
+    torch.testing.assert_close(
+        runner_output["hsl_drawdown_raw_mean_worst_1pct_short"], scalars[:, 71]
     )
     assert runner_output["alive"].cpu().tolist() == [
         True,
@@ -8845,7 +8911,7 @@ def test_mps_ema_anchor_multicoin_fused_kernel_smoke_all_hsl_modes():
     )
     override_daily[:, :, 1].fill_(float("inf"))
     override_daily[:, :, 5].fill_(float("inf"))
-    override_scalars = torch.zeros((1, 70), dtype=torch.float32, device="mps")
+    override_scalars = torch.zeros((1, 72), dtype=torch.float32, device="mps")
     override_gaps = torch.zeros((1, 128), dtype=torch.int32, device="mps")
     override_coin_fills = torch.zeros(
         (1, coin_count), dtype=torch.float32, device="mps"
@@ -8992,9 +9058,10 @@ def test_mps_trailing_martingale_multicoin_fused_kernel_smoke_all_hsl_modes():
         passivbot_rust.mps_trailing_martingale_multicoin_source_py(),
         ema_tail_enabled=True,
         raw_drawdown_enabled=True,
+        raw_tail_enabled=True,
     )
     assert "kernel void passivbot_trailing_martingale_multicoin_fused" in source
-    assert "constant int FUSED_SCALAR_COLS = 70" in source
+    assert "constant int FUSED_SCALAR_COLS = 72" in source
 
     count = 512
     coin_count = 3
@@ -9154,7 +9221,7 @@ def test_mps_trailing_martingale_multicoin_fused_kernel_smoke_all_hsl_modes():
     )
     daily[:, :, 1].fill_(float("inf"))
     daily[:, :, 5].fill_(float("inf"))
-    scalars = torch.zeros((batch_size, 70), dtype=torch.float32, device="mps")
+    scalars = torch.zeros((batch_size, 72), dtype=torch.float32, device="mps")
     gaps = torch.zeros((batch_size, 128), dtype=torch.int32, device="mps")
     coin_fill_counts = torch.zeros(
         (batch_size, coin_count), dtype=torch.float32, device="mps"
@@ -9224,6 +9291,7 @@ def test_mps_trailing_martingale_multicoin_fused_kernel_smoke_all_hsl_modes():
         collect_coin_fill_counts=True,
         hsl_ema_tail_enabled=True,
         hsl_raw_drawdown_enabled=True,
+        hsl_raw_tail_enabled=True,
         recovery_distribution_enabled=True,
     )
     torch.testing.assert_close(runner.settings, run_settings)
@@ -9455,7 +9523,7 @@ def test_mps_trailing_martingale_multicoin_fused_kernel_smoke_all_hsl_modes():
     )
     override_daily[:, :, 1].fill_(float("inf"))
     override_daily[:, :, 5].fill_(float("inf"))
-    override_scalars = torch.zeros((1, 70), dtype=torch.float32, device="mps")
+    override_scalars = torch.zeros((1, 72), dtype=torch.float32, device="mps")
     override_gaps = torch.zeros((1, 128), dtype=torch.int32, device="mps")
     override_coin_fills = torch.zeros(
         (1, coin_count), dtype=torch.float32, device="mps"
@@ -12127,6 +12195,7 @@ def test_mps_single_coin_hsl_panics_and_permanently_halts(strategy_kind, side):
         pnl_lookback_bars=5,
         hsl_ema_tail_enabled=True,
         hsl_raw_drawdown_enabled=True,
+        hsl_raw_tail_enabled=True,
     ).run(np.asarray(rows, dtype=np.float64))
     market_runner = runner_cls(
         market,
@@ -12209,6 +12278,9 @@ def test_mps_single_coin_hsl_panics_and_permanently_halts(strategy_kind, side):
     assert output[f"hsl_strategy_eq_recovery_max_ms_{side}"][1].item() > 0.0
     assert output[f"hsl_drawdown_ema_mean_worst_1pct_{side}"][1].item() > 0.0
     assert output[f"hsl_drawdown_raw_max_{side}"][1].item() > 0.0
+    assert output[
+        f"hsl_drawdown_raw_mean_worst_1pct_{side}"
+    ][1].item() > 0.0
     assert output[
         f"hsl_drawdown_ema_mean_worst_1pct_{'short' if side == 'long' else 'long'}"
     ][1].item() == 0.0
@@ -12348,6 +12420,7 @@ def test_mps_dual_side_single_coin_hsl_respects_signal_scope(
         short_enabled=True,
         hsl_ema_tail_enabled=True,
         hsl_raw_drawdown_enabled=True,
+        hsl_raw_tail_enabled=True,
     ).run(rows)
     torch.mps.synchronize()
 
@@ -12368,6 +12441,8 @@ def test_mps_dual_side_single_coin_hsl_respects_signal_scope(
     assert output["hsl_drawdown_ema_mean_worst_1pct_short"][2].item() > 0.0
     assert output["hsl_drawdown_raw_max_long"][2].item() > 0.0
     assert output["hsl_drawdown_raw_max_short"][2].item() > 0.0
+    assert output["hsl_drawdown_raw_mean_worst_1pct_long"][2].item() > 0.0
+    assert output["hsl_drawdown_raw_mean_worst_1pct_short"][2].item() > 0.0
     if signal_mode == "unified":
         assert output["hsl_panic_loss_drawdown_count"][2].item() >= 1.0
     else:

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -560,6 +560,8 @@ def test_directional_hsl_output_contract_retains_lifecycle_and_panic_scalars():
         "hsl_strategy_eq_recovery_max_ms_short",
         "hsl_drawdown_ema_mean_worst_1pct_long",
         "hsl_drawdown_ema_mean_worst_1pct_short",
+        "hsl_drawdown_raw_mean_worst_1pct_long",
+        "hsl_drawdown_raw_mean_worst_1pct_short",
     } <= DIRECTIONAL_HSL_OUTPUT_KEYS
 
 
@@ -606,6 +608,9 @@ def test_combine_hedged_multicoin_hsl_outputs_reduces_pside_episodes():
         output[f"hsl_drawdown_ema_mean_worst_1pct_{side}"] = torch.tensor(
             [0.18 if side == "long" else 0.09]
         )
+        output[f"hsl_drawdown_raw_mean_worst_1pct_{side}"] = torch.tensor(
+            [0.16 if side == "long" else 0.07]
+        )
         return output
 
     combined = _combine_hedged_multicoin_hsl_outputs(
@@ -640,6 +645,12 @@ def test_combine_hedged_multicoin_hsl_outputs_reduces_pside_episodes():
     assert combined["hsl_drawdown_ema_mean_worst_1pct_short"].item() == pytest.approx(
         0.09
     )
+    assert combined["hsl_drawdown_raw_mean_worst_1pct_long"].item() == pytest.approx(
+        0.16
+    )
+    assert combined["hsl_drawdown_raw_mean_worst_1pct_short"].item() == pytest.approx(
+        0.07
+    )
     assert combined["hsl_tier_samples_total"].item() == 10.0
     assert combined["hsl_tier_samples_red"].item() == 8.0
     assert combined["hsl_tier_samples_orange"].item() == 2.0
@@ -662,7 +673,7 @@ def test_combine_hedged_multicoin_hsl_outputs_reduces_pside_episodes():
     assert panic["hard_stop_panic_close_loss_drawdown_pct_mean"].item() == (
         pytest.approx(0.8 / 3.0)
     )
-    assert len(DIRECTIONAL_HSL_OUTPUT_KEYS) == 33
+    assert len(DIRECTIONAL_HSL_OUTPUT_KEYS) == 35
 
 
 def test_refresh_hedged_multicoin_hsl_replays_only_cutoff_candidates():
@@ -971,13 +982,15 @@ def test_multicoin_proxy_routes_dual_side_batch_through_fused_runner(
         "needed_metrics",
         "tail_enabled",
         "raw_drawdown_enabled",
+        "raw_tail_enabled",
         "recovery_distribution_enabled",
     ),
     [
-        ({"hard_stop_time_in_red_pct"}, False, False, False),
-        ({"drawdown_worst_mean_1pct_ema_strategy_eq"}, True, False, False),
-        ({"drawdown_worst_strategy_eq_long"}, False, True, False),
-        ({"strategy_eq_recovery_days_p99"}, False, False, True),
+        ({"hard_stop_time_in_red_pct"}, False, False, False, False),
+        ({"drawdown_worst_mean_1pct_ema_strategy_eq"}, True, False, False, False),
+        ({"drawdown_worst_strategy_eq_long"}, False, True, False, False),
+        ({"drawdown_worst_mean_1pct_strategy_eq_long"}, False, True, True, False),
+        ({"strategy_eq_recovery_days_p99"}, False, False, False, True),
     ],
 )
 def test_multicoin_proxy_constructs_fused_shared_account_runner(
@@ -990,6 +1003,7 @@ def test_multicoin_proxy_constructs_fused_shared_account_runner(
     needed_metrics,
     tail_enabled,
     raw_drawdown_enabled,
+    raw_tail_enabled,
     recovery_distribution_enabled,
 ):
     torch = pytest.importorskip("torch")
@@ -1183,6 +1197,7 @@ def test_multicoin_proxy_constructs_fused_shared_account_runner(
         constructed["kwargs"]["hsl_raw_drawdown_enabled"]
         is raw_drawdown_enabled
     )
+    assert constructed["kwargs"]["hsl_raw_tail_enabled"] is raw_tail_enabled
     assert (
         constructed["kwargs"]["recovery_distribution_enabled"]
         is recovery_distribution_enabled

--- a/tests/test_config_scoring.py
+++ b/tests/test_config_scoring.py
@@ -51,6 +51,8 @@ def test_default_objective_goal_recognizes_strategy_eq_recovery_metrics():
     assert default_objective_goal("drawdown_worst_ema_strategy_eq") == "min"
     assert default_objective_goal("drawdown_worst_ema_strategy_eq_long") == "min"
     assert default_objective_goal("drawdown_worst_ema_strategy_eq_short") == "min"
+    assert default_objective_goal("drawdown_worst_mean_1pct_strategy_eq_long") == "min"
+    assert default_objective_goal("drawdown_worst_mean_1pct_strategy_eq_short") == "min"
     assert default_objective_goal("strategy_eq_recovery_days_mean") == "min"
     assert default_objective_goal("strategy_eq_recovery_days_median") == "min"
     assert default_objective_goal("strategy_eq_recovery_days_p95") == "min"


### PR DESCRIPTION
## Summary
- add Apple MPS proxy support for drawdown_worst_mean_1pct_strategy_eq_long and short
- preserve exact Rust authority with per-day worst reduction and a bounded 32-bin logarithmic tail histogram
- compile the added histogram state only when either new metric is requested, preserving the existing raw-max kernel ABI and cost
- support EMA Anchor and Trailing Martingale across directional, one-sided multicoin, and fused dual-side multicoin kernels

## Validation
- full physical Apple MPS test_gpu_mps.py
- full tests/optimization plus tests/test_config_scoring.py
- cargo test --manifest-path passivbot-rust/Cargo.toml --no-default-features: 267 passed
- cargo check --manifest-path passivbot-rust/Cargo.toml --tests
- rebuilt and fingerprint-verified Python Rust extension
- physical XMR Trailing Martingale optimizer smoke: 32 generations, 512 proxy evaluations, 64 exact validations, both new side metrics nonzero, no drift halt

## Notes
- exact Rust remains authoritative for persisted candidates and rolling drift gates
- no CPU optimizer, backtest, or bot behavior is changed