### PR TITLE
GPU: support single-coin forced delists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Apple MPS single-coin EMA Anchor and Trailing Martingale optimization now mirrors exact Rust's
+  forced-delist close when at least 1,400 prepared candles follow a coin's final valid candle,
+  including adverse market slippage, directional price rounding, taker fees, panic-loss and fill
+  accounting, position-duration finalization, pending-order clearing, and balance-only tail
+  accounting. Multi-coin forced delists remain fail-closed.
+
 - Apple MPS HSL optimization now supports per-side
   `drawdown_worst_mean_1pct_strategy_eq_{long,short}` scoring and limits for EMA Anchor and
   Trailing Martingale across single-coin, one-sided multi-coin, and fused dual-side multi-coin
@@ -18,8 +24,8 @@ All notable user-facing changes will be documented in this file.
   float32 H/L/C values remain finite and positive inside the declared valid ranges covers every
   timestep after coverage begins. Tailed coins become non-tradable, contribute no unrealized PnL,
   and cannot leave stale orders blocking HSL, while portfolio and coin HSL controllers continue
-  through the surviving timeline. Forced-delist tails, all-coins-ended tails, and all-invalid gaps
-  remain fail-closed.
+  through the surviving timeline. Multi-coin forced-delist tails, all-coins-ended tails, and
+  all-invalid gaps remain fail-closed.
 
 - Fixed live bot startup on Windows without symlink privileges by writing a visible pointer to the
   timestamped run log instead of failing while creating the stable log alias. Built-in monitor
@@ -27,14 +33,14 @@ All notable user-facing changes will be documented in this file.
 
 - Apple MPS single-coin HSL optimization now continues hard-stop sampling, rolling-PnL expiry,
   tier accounting, and restart checks through supported invalid candle tails. Tail candles remain
-  non-tradable and cannot satisfy stale blocking orders. Forced-delist tails and multi-coin invalid
+  non-tradable and cannot satisfy stale blocking orders. Multi-coin forced-delist and all-coins-ended
   tails remain fail-closed.
 
 - Apple MPS single-coin EMA Anchor and Trailing Martingale optimization now accepts invalid
-  candles after the coin's final valid candle when HSL is disabled and the tail remains below
-  exact Rust's 1,400-candle forced-delist threshold. Metal keeps the tail non-tradable and records
-  balance-only account equity like exact Rust. HSL tails, forced-delist closes, and multi-coin
-  invalid tails continue to fail closed.
+  candles after the coin's final valid candle when HSL is disabled. Metal keeps shorter tails
+  non-tradable and records balance-only account equity like exact Rust; the forced-delist boundary
+  is covered by the expanded support above. Unsupported multi-coin invalid-tail combinations
+  continue to fail closed.
 
 - Apple MPS multi-coin EMA Anchor optimization now supports any positive integer
   `backtest.candle_interval_minutes` for long-only, short-only, and fused long+short runs. Global

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -364,12 +364,15 @@ The supported slice is intentionally narrow:
   market paths: the proxy projects adverse slippage and taker fees and keeps a conservative
   zero-loss envelope for ordinary and exposure-repair closes, while exact Rust applies the shared
   peak-balance allowance to every validation.
-- single-coin runs may include invalid candles after the selected coin's final valid candle while
-  the tail remains below exact Rust's 1,400-candle forced-delist threshold; Metal treats those
-  candles as non-tradable, excludes the open position's unrealized PnL, and continues balance-only
-  equity and elapsed-time accounting through the prepared endpoint. HSL-enabled runs also continue
-  hard-stop sampling, rolling-PnL expiry, tier accounting, and restart checks without treating stale
-  orders as blocking
+- single-coin runs may include invalid candles after the selected coin's final valid candle. A
+  shorter tail remains non-tradable, excludes the open position's unrealized PnL, and continues
+  balance-only equity and elapsed-time accounting through the prepared endpoint. When at least
+  1,400 prepared candles follow the final valid candle, Metal mirrors exact Rust's forced delist:
+  it closes any open long and short at that candle with adverse market slippage, directional price
+  rounding, and the taker fee, records the panic fill and position/fill aggregates, clears pending
+  orders, and then continues the same balance-only tail. HSL-enabled runs also continue hard-stop
+  sampling, rolling-PnL expiry, tier accounting, and restart checks without treating stale orders
+  as blocking
 - multi-coin runs may include staggered invalid tails while at least one prepared coin remains
   valid through the endpoint, every tail stays below exact Rust's 1,400-candle forced-delist
   threshold, and at least one candle whose packed float32 H/L/C values remain finite and positive
@@ -377,9 +380,9 @@ The supported slice is intentionally narrow:
   begins. Tailed coins are non-tradable, contribute no unrealized PnL, and cannot leave stale orders
   blocking HSL; dynamic tradability, portfolio/coin HSL, equity, and elapsed-time accounting
   continue on the surviving timeline
-- forced-delist tails, multi-coin histories in which every coin ends before the prepared endpoint,
-  and histories with an all-invalid gap after coverage begins remain fail-closed until their
-  forced-close and all-invalid time-accounting semantics are modeled
+- multi-coin forced-delist tails, multi-coin histories in which every coin ends before the prepared
+  endpoint, and histories with an all-invalid gap after coverage begins remain fail-closed until
+  their forced-close and all-invalid time-accounting semantics are modeled
 
 Unsupported combinations fail before optimization begins. Dual-side multi-coin EMA Anchor and
 Trailing Martingale use fused shared-account Metal kernels in hedge and one-way modes. Every

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -290,6 +290,13 @@ mod tests {
         assert!(source.contains("const int pnl_lookback_bars"));
         assert!(source.contains("device float2* rolling_pnl_values"));
         assert!(source.contains("device int2* rolling_pnl_indices"));
+        assert_eq!(source.matches("force_close_delisted_position(").count(), 3);
+        assert!(source.contains("const bool forced_delist = valid && k == last_valid"));
+        assert!(source.contains("last_valid + 1400 < T"));
+        assert!(source.contains("close, !is_long, market_order_slippage_pct, price_step"));
+        assert!(source.contains("const float fee = close_qty * close_price * c_mult * taker_fee"));
+        assert!(source.contains("record_hsl_panic_fill("));
+        assert!(source.contains("if (gen && !forced_delist_closed_any)"));
     }
 
     #[test]

--- a/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
@@ -1013,6 +1013,92 @@ inline void gate_generated_close(
     }
 }
 
+inline bool force_close_delisted_position(
+    thread float& psize,
+    thread float& pprice,
+    thread float& pos_open_k,
+    thread HslState& hsl,
+    bool is_long,
+    float close,
+    float other_unrealized,
+    float price_step,
+    float c_mult,
+    float taker_fee,
+    float market_order_slippage_pct,
+    float kf,
+    thread float& balance,
+    thread float& realized_pnl_cumsum_last,
+    thread float& realized_pnl_cumsum_max,
+    thread float& realized_pnl_cumsum_long,
+    thread float& realized_pnl_cumsum_short,
+    thread float& day_fill_count,
+    thread float& fill_count,
+    thread float& fill_count_entry,
+    thread float& fill_count_long,
+    thread float& pnl_recovery_peak,
+    thread float& pnl_recovery_peak_k,
+    thread float& pnl_recovery_max_min,
+    thread HslRollingPnlWindow& rolling_pnl,
+    device float2* rolling_pnl_values,
+    device int2* rolling_pnl_indices,
+    int rolling_base,
+    int rolling_capacity,
+    int pnl_lookback_bars,
+    bool coin_hsl_rolling,
+    thread float& profit_sum,
+    thread float& loss_sum,
+    thread float& side_profit_sum,
+    thread float& side_loss_sum,
+    thread float& held_max_min,
+    thread float& held_sum_min,
+    thread float& held_count,
+    thread float& day_volume
+) {
+    if (!(psize > 0.0f && pprice > 0.0f)) return false;
+    const float close_price = ordinary_market_fill_price(
+        close, !is_long, market_order_slippage_pct, price_step
+    );
+    const float close_qty = psize;
+    const float pnl = close_qty * c_mult * (
+        is_long ? close_price - pprice : pprice - close_price
+    );
+    const float fee = close_qty * close_price * c_mult * taker_fee;
+    const float net_pnl = pnl - fee;
+    const float own_unrealized = close_qty * c_mult * (
+        is_long ? close - pprice : pprice - close
+    );
+    record_hsl_panic_fill(
+        hsl, net_pnl, balance + own_unrealized + other_unrealized
+    );
+    record_directional_gross_pnl(
+        pnl, profit_sum, loss_sum, side_profit_sum, side_loss_sum
+    );
+    balance += net_pnl;
+    record_realized_net(
+        net_pnl, realized_pnl_cumsum_last, realized_pnl_cumsum_max,
+        realized_pnl_cumsum_long, realized_pnl_cumsum_short,
+        day_fill_count, fill_count, fill_count_entry, fill_count_long,
+        pnl_recovery_peak, pnl_recovery_peak_k, pnl_recovery_max_min, kf,
+        false, is_long
+    );
+    record_hsl_rolling_pnl(
+        rolling_pnl, rolling_pnl_values, rolling_pnl_indices,
+        rolling_base, rolling_capacity, int(kf), pnl_lookback_bars,
+        coin_hsl_rolling, net_pnl
+    );
+    if (pos_open_k >= 0.0f) {
+        const float held_min = kf - pos_open_k;
+        held_max_min = fmax(held_max_min, held_min);
+        held_sum_min += held_min;
+        held_count += 1.0f;
+    }
+    day_volume += close_qty * close_price / balance;
+    psize = 0.0f;
+    pprice = 0.0f;
+    pos_open_k = -1.0f;
+    return true;
+}
+
 inline void passivbot_single_coin_impl(
     constant float* bars,
     constant int* flags,
@@ -1442,6 +1528,58 @@ inline void passivbot_single_coin_impl(
             short_side.entry_qty = 0.0f;
         }
 
+        // Exact Rust generates this candle's bundles first, then force-closes and
+        // clears both bundles.  Closing here and suppressing only that dead order
+        // generation is equivalent while retaining `gen` for equity/HSL sampling.
+        const bool forced_delist = valid && k == last_valid
+            && last_valid + 1400 < T;
+        bool forced_delist_closed_any = false;
+        if (forced_delist && alive && balance > 0.0f) {
+            float short_unrealized = short_side.psize > 0.0f
+                ? short_side.psize * c_mult * (short_side.pprice - close)
+                : 0.0f;
+            bool forced_long_close = force_close_delisted_position(
+                long_side.psize, long_side.pprice, long_side.pos_open_k,
+                long_hsl, true, close, short_unrealized, price_step,
+                c_mult, taker_fee, market_order_slippage_pct, kf, balance,
+                realized_pnl_cumsum_last, realized_pnl_cumsum_max,
+                realized_pnl_cumsum_long, realized_pnl_cumsum_short,
+                day_fill_count, fill_count, fill_count_entry, fill_count_long,
+                pnl_recovery_peak, pnl_recovery_peak_k, pnl_recovery_max_min,
+                long_rolling_pnl, rolling_pnl_values, rolling_pnl_indices,
+                long_rolling_base, rolling_capacity, pnl_lookback_bars,
+                long_coin_hsl_rolling, profit_sum, loss_sum, profit_sum_long,
+                loss_sum_long, held_max_min, held_sum_min, held_count, day_volume
+            );
+            float long_unrealized = long_side.psize > 0.0f
+                ? long_side.psize * c_mult * (close - long_side.pprice)
+                : 0.0f;
+            bool forced_short_close = force_close_delisted_position(
+                short_side.psize, short_side.pprice, short_side.pos_open_k,
+                short_hsl, false, close, long_unrealized, price_step,
+                c_mult, taker_fee, market_order_slippage_pct, kf, balance,
+                realized_pnl_cumsum_last, realized_pnl_cumsum_max,
+                realized_pnl_cumsum_long, realized_pnl_cumsum_short,
+                day_fill_count, fill_count, fill_count_entry, fill_count_long,
+                pnl_recovery_peak, pnl_recovery_peak_k, pnl_recovery_max_min,
+                short_rolling_pnl, rolling_pnl_values, rolling_pnl_indices,
+                short_rolling_base, rolling_capacity, pnl_lookback_bars,
+                short_coin_hsl_rolling, profit_sum, loss_sum, profit_sum_short,
+                loss_sum_short, held_max_min, held_sum_min, held_count, day_volume
+            );
+            long_close_fill = long_close_fill || forced_long_close;
+            short_close_fill = short_close_fill || forced_short_close;
+            forced_delist_closed_any = forced_long_close || forced_short_close;
+            if (forced_delist_closed_any) {
+                long_side.entry_qty = 0.0f;
+                long_side.close_qty = 0.0f;
+                long_side.secondary_close_qty = 0.0f;
+                short_side.entry_qty = 0.0f;
+                short_side.close_qty = 0.0f;
+                short_side.secondary_close_qty = 0.0f;
+            }
+        }
+
         if (long_close_fill || long_entry_fill) {
             if (long_position_last_fill_k >= 0.0f) {
                 position_unchanged_max_min = fmax(
@@ -1487,7 +1625,7 @@ inline void passivbot_single_coin_impl(
         eq_started = eq_started || gen;
         int long_hsl_mode = hsl_mode(long_hsl, long_side.psize > 0.0f);
         int short_hsl_mode = hsl_mode(short_hsl, short_side.psize > 0.0f);
-        if (gen) {
+        if (gen && !forced_delist_closed_any) {
             long_side.close_is_panic = false;
             short_side.close_is_panic = false;
             if (long_side.psize > 0.0f || short_side.psize > 0.0f) {

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -1610,6 +1610,92 @@ inline bool recursive_strategy_close_would_expand(
     return false;
 }
 
+inline bool force_close_delisted_position(
+    thread float& psize,
+    thread float& pprice,
+    thread float& pos_open_k,
+    thread HslState& hsl,
+    bool is_long,
+    float close,
+    float other_unrealized,
+    float price_step,
+    float c_mult,
+    float taker_fee,
+    float market_order_slippage_pct,
+    float kf,
+    thread float& balance,
+    thread float& realized_pnl_cumsum_last,
+    thread float& realized_pnl_cumsum_max,
+    thread float& realized_pnl_cumsum_long,
+    thread float& realized_pnl_cumsum_short,
+    thread float& day_fill_count,
+    thread float& fill_count,
+    thread float& fill_count_entry,
+    thread float& fill_count_long,
+    thread float& pnl_recovery_peak,
+    thread float& pnl_recovery_peak_k,
+    thread float& pnl_recovery_max_min,
+    thread HslRollingPnlWindow& rolling_pnl,
+    device float2* rolling_pnl_values,
+    device int2* rolling_pnl_indices,
+    int rolling_base,
+    int rolling_capacity,
+    int pnl_lookback_bars,
+    bool coin_hsl_rolling,
+    thread float& profit_sum,
+    thread float& loss_sum,
+    thread float& side_profit_sum,
+    thread float& side_loss_sum,
+    thread float& held_max_min,
+    thread float& held_sum_min,
+    thread float& held_count,
+    thread float& day_volume
+) {
+    if (!(psize > 0.0f && pprice > 0.0f)) return false;
+    const float close_price = ordinary_market_fill_price(
+        close, !is_long, market_order_slippage_pct, price_step
+    );
+    const float close_qty = psize;
+    const float pnl = close_qty * c_mult * (
+        is_long ? close_price - pprice : pprice - close_price
+    );
+    const float fee = close_qty * close_price * c_mult * taker_fee;
+    const float net_pnl = pnl - fee;
+    const float own_unrealized = close_qty * c_mult * (
+        is_long ? close - pprice : pprice - close
+    );
+    record_hsl_panic_fill(
+        hsl, net_pnl, balance + own_unrealized + other_unrealized
+    );
+    record_directional_gross_pnl(
+        pnl, profit_sum, loss_sum, side_profit_sum, side_loss_sum
+    );
+    balance += net_pnl;
+    record_realized_net(
+        net_pnl, realized_pnl_cumsum_last, realized_pnl_cumsum_max,
+        realized_pnl_cumsum_long, realized_pnl_cumsum_short,
+        day_fill_count, fill_count, fill_count_entry, fill_count_long,
+        pnl_recovery_peak, pnl_recovery_peak_k, pnl_recovery_max_min, kf,
+        false, is_long
+    );
+    record_hsl_rolling_pnl(
+        rolling_pnl, rolling_pnl_values, rolling_pnl_indices,
+        rolling_base, rolling_capacity, int(kf), pnl_lookback_bars,
+        coin_hsl_rolling, net_pnl
+    );
+    if (pos_open_k >= 0.0f) {
+        const float held_min = kf - pos_open_k;
+        held_max_min = fmax(held_max_min, held_min);
+        held_sum_min += held_min;
+        held_count += 1.0f;
+    }
+    day_volume += close_qty * close_price / balance;
+    psize = 0.0f;
+    pprice = 0.0f;
+    pos_open_k = -1.0f;
+    return true;
+}
+
 inline void passivbot_single_coin_impl(
     constant float* bars,
     constant int* flags,
@@ -3308,6 +3394,58 @@ inline void passivbot_single_coin_impl(
             short_side.entry_qty = 0.0f;
         }
 
+        // Exact Rust generates this candle's bundles first, then force-closes and
+        // clears both bundles.  Closing here and suppressing only that dead order
+        // generation is equivalent while retaining `gen` for equity/HSL sampling.
+        const bool forced_delist = valid && k == last_valid
+            && last_valid + 1400 < T;
+        bool forced_delist_closed_any = false;
+        if (forced_delist && alive && balance > 0.0f) {
+            float short_unrealized = short_side.psize > 0.0f
+                ? short_side.psize * c_mult * (short_side.pprice - close)
+                : 0.0f;
+            bool forced_long_close = force_close_delisted_position(
+                long_side.psize, long_side.pprice, long_side.pos_open_k,
+                long_hsl, true, close, short_unrealized, price_step,
+                c_mult, taker_fee, market_order_slippage_pct, kf, balance,
+                realized_pnl_cumsum_last, realized_pnl_cumsum_max,
+                realized_pnl_cumsum_long, realized_pnl_cumsum_short,
+                day_fill_count, fill_count, fill_count_entry, fill_count_long,
+                pnl_recovery_peak, pnl_recovery_peak_k, pnl_recovery_max_min,
+                long_rolling_pnl, rolling_pnl_values, rolling_pnl_indices,
+                long_rolling_base, rolling_capacity, pnl_lookback_bars,
+                long_coin_hsl_rolling, profit_sum, loss_sum, profit_sum_long,
+                loss_sum_long, held_max_min, held_sum_min, held_count, day_volume
+            );
+            float long_unrealized = long_side.psize > 0.0f
+                ? long_side.psize * c_mult * (close - long_side.pprice)
+                : 0.0f;
+            bool forced_short_close = force_close_delisted_position(
+                short_side.psize, short_side.pprice, short_side.pos_open_k,
+                short_hsl, false, close, long_unrealized, price_step,
+                c_mult, taker_fee, market_order_slippage_pct, kf, balance,
+                realized_pnl_cumsum_last, realized_pnl_cumsum_max,
+                realized_pnl_cumsum_long, realized_pnl_cumsum_short,
+                day_fill_count, fill_count, fill_count_entry, fill_count_long,
+                pnl_recovery_peak, pnl_recovery_peak_k, pnl_recovery_max_min,
+                short_rolling_pnl, rolling_pnl_values, rolling_pnl_indices,
+                short_rolling_base, rolling_capacity, pnl_lookback_bars,
+                short_coin_hsl_rolling, profit_sum, loss_sum, profit_sum_short,
+                loss_sum_short, held_max_min, held_sum_min, held_count, day_volume
+            );
+            long_close_fill = long_close_fill || forced_long_close;
+            short_close_fill = short_close_fill || forced_short_close;
+            forced_delist_closed_any = forced_long_close || forced_short_close;
+            if (forced_delist_closed_any) {
+                long_side.entry_qty = 0.0f;
+                long_side.close_qty = 0.0f;
+                long_side.secondary_close_qty = 0.0f;
+                short_side.entry_qty = 0.0f;
+                short_side.close_qty = 0.0f;
+                short_side.secondary_close_qty = 0.0f;
+            }
+        }
+
         if (long_close_fill || long_entry_fill) {
             if (long_position_last_fill_k >= 0.0f) {
                 position_unchanged_max_min = fmax(
@@ -3365,7 +3503,7 @@ inline void passivbot_single_coin_impl(
         eq_started = eq_started || gen;
         int long_hsl_mode = hsl_mode(long_hsl, long_side.psize > 0.0f);
         int short_hsl_mode = hsl_mode(short_hsl, short_side.psize > 0.0f);
-        if (gen) {
+        if (gen && !forced_delist_closed_any) {
             long_side.close_is_panic = false;
             short_side.close_is_panic = false;
             if (long_side.psize > 0.0f || short_side.psize > 0.0f) {

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -652,13 +652,15 @@ def _hsl_params(bot: dict, *, signal_mode: str) -> dict[str, float]:
     }
 
 
-def _require_no_forced_delist_tail(last_valid_idx: int, candle_count: int) -> None:
-    """Accept ordinary invalid tails but reject Rust's forced-delist boundary.
+def _require_no_multicoin_forced_delist_tail(
+    last_valid_idx: int, candle_count: int
+) -> None:
+    """Keep multicoin forced-delists fail closed until that kernel models them.
 
     Exact Rust treats a coin as delisted, and force-closes its open positions,
     when at least 1,400 prepared candles follow its final valid candle.  The
-    single-coin kernels model shorter invalid tails as non-tradable balance-only
-    equity samples; forced delist fills are a separate parity surface.
+    single-coin kernels model that close, but multicoin forced-delist fills are
+    a separate parity surface.
     """
 
     last_valid_idx = int(last_valid_idx)
@@ -671,7 +673,7 @@ def _require_no_forced_delist_tail(last_valid_idx: int, candle_count: int) -> No
         )
     if last_valid_idx + 1400 < candle_count:
         raise ValueError(
-            "GPU proxy does not yet model Rust forced-delist closes "
+            "GPU multicoin proxy does not yet model Rust forced-delist closes "
             "when at least 1,400 prepared candles follow the final valid candle; "
             f"last_valid_idx={last_valid_idx}, candle_count={candle_count}"
         )
@@ -714,7 +716,7 @@ def _require_supported_multicoin_valid_tails(
             and last_valid_idx == candle_count - 1
         ):
             continue
-        _require_no_forced_delist_tail(last_valid_idx, candle_count)
+        _require_no_multicoin_forced_delist_tail(last_valid_idx, candle_count)
         if not 0 <= first_valid_idx <= last_valid_idx:
             raise ValueError(
                 "GPU multicoin proxy requires each first_valid_idx within its "
@@ -1337,10 +1339,6 @@ class MpsSingleCoinProxy:
             for side, bot in (("long", long_bot), ("short", short_bot))
             if self.enabled[side] and bool(bot.get("hsl_enabled"))
         ]
-        _require_no_forced_delist_tail(
-            int(backtest_params["last_valid_indices"][0]),
-            len(hlcvs),
-        )
         any_configured_hsl = any(
             bool(bot.get("hsl_enabled")) for bot in (long_bot, short_bot)
         )

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -3633,16 +3633,17 @@ def test_mps_single_coin_five_minute_shader_smoke(strategy_kind):
 @pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
 @pytest.mark.parametrize("side", ["long", "short"])
 @pytest.mark.parametrize("hsl_enabled", [False, True])
-def test_mps_single_coin_short_invalid_tail_uses_balance_only_equity(
-    strategy_kind, side, hsl_enabled
+@pytest.mark.parametrize("forced_delist", [False, True])
+def test_mps_single_coin_invalid_tail_matches_forced_delist_boundary(
+    strategy_kind, side, hsl_enabled, forced_delist
 ):
     from optimization.gpu.mps_kernel import (
         MpsEmaAnchorRunner,
         MpsTrailingMartingaleRunner,
     )
 
-    count = 10
     last_valid = 6
+    count = last_valid + 1401 if forced_delist else 10
     close = np.full(count, np.nan)
     high = np.full(count, np.nan)
     low = np.full(count, np.nan)
@@ -3740,7 +3741,12 @@ def test_mps_single_coin_short_invalid_tail_uses_balance_only_equity(
     torch.mps.synchronize()
 
     size_key = "psize" if side == "long" else "short_psize"
-    assert output[size_key].item() > 0.0
+    if forced_delist:
+        assert output[size_key].item() == 0.0
+        assert output["fill_count"].item() >= 2.0
+        assert output["hsl_panic_close_loss_sum"].item() > 0.0
+    else:
+        assert output[size_key].item() > 0.0
     assert output["day_end_eq"][0, 0].item() == pytest.approx(
         output["balance"].item()
     )
@@ -3756,7 +3762,207 @@ def test_mps_single_coin_short_invalid_tail_uses_balance_only_equity(
             output["hsl_tier_samples_red"].item()
             < output["hsl_tier_samples_total"].item()
         )
-        assert output[f"hsl_triggers_{side}"].item() == 0.0
+        if not forced_delist:
+            assert output[f"hsl_triggers_{side}"].item() == 0.0
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
+def test_mps_single_coin_forced_delist_closes_both_hedged_sides(strategy_kind):
+    from optimization.gpu.mps_kernel import (
+        MpsEmaAnchorRunner,
+        MpsTrailingMartingaleRunner,
+    )
+
+    last_valid = 6
+    count = last_valid + 1401
+    close = np.full(count, np.nan)
+    high = np.full(count, np.nan)
+    low = np.full(count, np.nan)
+    close[: last_valid + 1] = 100.0
+    high[: last_valid + 1] = 100.0
+    low[: last_valid + 1] = 100.0
+    high[3] = 102.0
+    low[3] = 98.0
+    close[last_valid] = 90.0
+    high[last_valid] = 90.0
+    low[last_valid] = 90.0
+    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    market = ProxyMarket(0.001, 0.01, 0.001, 5.0, 1.0, 0.0)
+    run = ProxyRun(
+        1_000.0,
+        1,
+        1,
+        int(timestamps[0]),
+        int(timestamps[0]),
+        int(timestamps[0]),
+        60_000,
+        0.05,
+        0,
+        last_valid,
+    )
+    data = build_mps_data(high, low, close, timestamps, run, market)
+    if strategy_kind == "ema_anchor":
+        row = _single_coin_param_row(
+            {
+                "base_qty_pct": 0.1,
+                "ema_span_0": 2.0,
+                "ema_span_1": 3.0,
+                "entry_double_down_factor": 0.0,
+                "offset": 0.01,
+                "offset_psize_weight": 0.0,
+                "offset_volatility_1h_weight": 0.0,
+                "offset_volatility_1m_weight": 0.0,
+                "offset_volatility_ema_span_1h": 2.0,
+                "offset_volatility_ema_span_1m": 2.0,
+                "entry_cooldown_minutes": 100.0,
+                "total_wallet_exposure_limit": 1.0,
+                "we_excess_allowance_pct": 0.0,
+                "we_excess_allowance_legacy_raw": 0.0,
+                "twel_entry_gate_enabled": 1.0,
+                "twel_enforcer_threshold": 1.0,
+                "twel_enforcer_enabled": 0.0,
+            },
+            EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS,
+        )
+        runner_cls = MpsEmaAnchorRunner
+        runner_kwargs = {}
+    else:
+        row = _tm_single_row(initial_ema_dist=0.01)
+        row[
+            TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS.index(
+                "entry_cooldown_minutes"
+            )
+        ] = 100.0
+        runner_cls = MpsTrailingMartingaleRunner
+        runner_kwargs = {"hsl_enabled": False}
+
+    output = runner_cls(
+        market,
+        run,
+        data,
+        long_enabled=True,
+        short_enabled=True,
+        hedge_mode=True,
+        **runner_kwargs,
+    ).run(np.asarray([row + row], dtype=np.float64))
+    torch.mps.synchronize()
+
+    assert output["psize"].item() == 0.0
+    assert output["short_psize"].item() == 0.0
+    assert output["fill_count"].item() >= 4.0
+    assert output["fill_count_long"].item() >= 2.0
+    assert output["fill_count"].item() - output["fill_count_long"].item() >= 2.0
+    assert output["loss_sum_long"].item() > 0.0
+    assert output["profit_sum_short"].item() > 0.0
+    assert output["hsl_panic_close_loss_sum"].item() > 0.0
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
+def test_mps_single_coin_service_dispatches_forced_delist_tail(strategy_kind):
+    from backtest import run_backtest
+    from config.schema import get_template_config
+    from optimization.gpu.service import MpsSingleCoinProxy
+
+    last_valid = 6
+    count = last_valid + 1401
+    hlcvs = np.full((count, 1, 4), np.nan, dtype=np.float64)
+    hlcvs[: last_valid + 1, 0] = [100.0, 100.0, 100.0, 1.0]
+    hlcvs[3, 0, 1] = 98.0
+    hlcvs[last_valid, 0] = [80.0, 80.0, 80.0, 1.0]
+    timestamps = (
+        1_700_000_000_000
+        + np.arange(count, dtype=np.int64) * 60_000
+    )
+    market_settings = {
+        "BTC": {
+            "qty_step": 0.001,
+            "price_step": 0.01,
+            "min_qty": 0.001,
+            "min_cost": 5.0,
+            "c_mult": 1.0,
+            "maker": 0.0,
+            "taker": 0.001,
+            "exchange": "bybit",
+            "first_valid_index": 0,
+            "last_valid_index": last_valid,
+            "warmup_minutes": 1,
+        },
+        "__meta__": {
+            "requested_start_ts": int(timestamps[0]),
+            "requested_start_date": "2023-11-14",
+            "warmup_minutes_requested": 1,
+        },
+    }
+    config = get_template_config()
+    config["live"]["strategy_kind"] = strategy_kind
+    config["live"]["max_warmup_minutes"] = 1
+    config["live"]["approved_coins"] = {"long": ["BTC"], "short": []}
+    config["backtest"]["coins"] = {"bybit": ["BTC"]}
+    config["backtest"]["exchanges"] = ["bybit"]
+    for side, enabled in (("long", True), ("short", False)):
+        risk = config["bot"][side]["risk"]
+        risk["total_wallet_exposure_limit"] = 1.0 if enabled else 0.0
+        risk["n_positions"] = 1 if enabled else 0
+        risk["we_excess_allowance_pct"] = 0.0
+        risk["position_exposure_enforcer_enabled"] = False
+        risk["total_exposure_enforcer_enabled"] = False
+        config["bot"][side]["hsl"]["enabled"] = False
+        config["bot"][side]["unstuck"]["enabled"] = False
+    if strategy_kind == "ema_anchor":
+        config["bot"]["long"]["strategy"]["ema_anchor"].update(
+            {
+                "base_qty_pct": 0.1,
+                "ema_span_0": 2.0,
+                "ema_span_1": 3.0,
+                "offset": 0.01,
+                "offset_psize_weight": 0.0,
+            }
+        )
+    else:
+        strategy = config["bot"]["long"]["strategy"]["trailing_martingale"]
+        strategy["ema_span_0"] = 2.0
+        strategy["ema_span_1"] = 3.0
+        strategy["entry"]["initial_qty_pct"] = 0.1
+        strategy["entry"]["initial_ema_dist"] = 0.01
+
+    proxy = MpsSingleCoinProxy(
+        config=config,
+        hlcvs=hlcvs,
+        mss=market_settings,
+        btc=np.full(count, 50_000.0),
+        timestamps=timestamps,
+        exchange="bybit",
+        batch_size=1,
+        needed_metrics={
+            "backtest_completion_ratio",
+            "fills_count",
+            "hard_stop_panic_close_loss_sum",
+        },
+    )
+    result = proxy.evaluate([{}])[0]
+    exact_fills, _, exact_analysis = run_backtest(
+        hlcvs,
+        market_settings,
+        config,
+        "bybit",
+        np.full(count, 50_000.0),
+        timestamps,
+    )
+
+    assert result["fills_count"] == 2.0
+    assert result["fills_count"] == exact_analysis["fills_count"]
+    assert len(exact_fills) == exact_analysis["fills_count"]
+    assert result["hard_stop_panic_close_loss_sum"] > 0.0
+    assert result["hard_stop_panic_close_loss_sum"] == pytest.approx(
+        exact_analysis["hard_stop_panic_close_loss_sum"], rel=1.0e-5
+    )
+    assert result["backtest_completion_ratio"] > 0.99
 
 
 @pytest.mark.skipif(

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -45,7 +45,7 @@ from optimization.gpu.service import (
     _position_exposure_enforcer_params,
     _prepared_single_coin_side_enabled,
     _require_multicoin_metric_topology,
-    _require_no_forced_delist_tail,
+    _require_no_multicoin_forced_delist_tail,
     _require_no_internal_invalid_account_recovery_candles,
     _require_no_internal_invalid_hsl_candles,
     _require_no_internal_invalid_multicoin_hsl_candles,
@@ -1279,15 +1279,15 @@ def test_gpu_multicoin_proxy_rejects_all_invalid_after_float32_packing(
     _require_supported_multicoin_valid_tails(hlcvs, [0, 0], [59, 99])
 
 
-def test_gpu_single_coin_proxy_accepts_short_invalid_tail_only():
-    _require_no_forced_delist_tail(99, 100)
-    _require_no_forced_delist_tail(98, 100)
-    _require_no_forced_delist_tail(0, 1400)
+def test_gpu_multicoin_forced_delist_tail_gate_preserves_rust_boundary():
+    _require_no_multicoin_forced_delist_tail(99, 100)
+    _require_no_multicoin_forced_delist_tail(98, 100)
+    _require_no_multicoin_forced_delist_tail(0, 1400)
 
     with pytest.raises(ValueError, match="forced-delist closes"):
-        _require_no_forced_delist_tail(0, 1401)
+        _require_no_multicoin_forced_delist_tail(0, 1401)
     with pytest.raises(ValueError, match="within the prepared candle range"):
-        _require_no_forced_delist_tail(100, 100)
+        _require_no_multicoin_forced_delist_tail(100, 100)
 
 
 def test_gpu_hsl_requires_contiguous_valid_candles():


### PR DESCRIPTION
## Summary
- mirror exact Rust forced-delist closes in the Apple MPS single-coin EMA Anchor and Trailing Martingale kernels
- preserve adverse market slippage, directional tick rounding, taker fees, panic-loss/realized-PnL/fill/holding/volume accounting, and dual-side order clearing
- keep multi-coin forced-delist tails explicitly fail-closed for the next slice
- document the expanded support boundary and add source, service, direct-kernel, hedged-side, HSL, and exact-Rust parity regressions

## Safety and ownership
- exact Rust remains authoritative; this only broadens the MPS proxy screening surface
- CPU optimization/backtesting paths are unchanged
- unsupported multi-coin forced-delist inputs continue to fail before optimization

## Validation
- `cargo test --manifest-path passivbot-rust/Cargo.toml --no-default-features` (267 passed)
- `cargo check --manifest-path passivbot-rust/Cargo.toml --tests`
- `PYTHONPATH=src python -m pytest tests/optimization tests/test_config_scoring.py -q`
- rebuilt and source-fingerprint-verified the Rust extension
- full physical Apple M3/MPS `tests/optimization/test_gpu_mps.py -q`
- focused service-level MPS tests compare forced-delist fill count and panic-loss sum with exact Rust for both supported strategies