### PR TITLE
GPU: support multi-coin forced delists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,15 @@ All notable user-facing changes will be documented in this file.
   forced-delist close when at least 1,400 prepared candles follow a coin's final valid candle,
   including adverse market slippage, directional price rounding, taker fees, panic-loss and fill
   accounting, position-duration finalization, pending-order clearing, and balance-only tail
-  accounting. Multi-coin forced delists remain fail-closed.
+  accounting. Multi-coin forced delists are covered by the expanded support below.
+
+- Apple MPS multi-coin EMA Anchor and Trailing Martingale optimization now mirrors per-coin exact
+  Rust forced delists for long-only, short-only, and fused long+short runs while another coin keeps
+  the prepared timeline alive. Metal preserves ordinary-fill and order-generation chronology,
+  closes long before short using adverse market slippage, directional price rounding, and taker
+  fees, records panic-loss, realized-PnL, fill, duration, and HSL equity effects, and clears both
+  sides' pending orders for the delisted coin. Exact Rust remains authoritative. All-coins-ended
+  tails and all-invalid gaps remain fail-closed.
 
 - Apple MPS HSL optimization now supports per-side
   `drawdown_worst_mean_1pct_strategy_eq_{long,short}` scoring and limits for EMA Anchor and
@@ -20,12 +28,12 @@ All notable user-facing changes will be documented in this file.
 
 - Apple MPS multi-coin EMA Anchor and Trailing Martingale optimization now supports staggered
   ordinary invalid candle tails when at least one prepared coin remains valid through the endpoint,
-  every tail stays below exact Rust's forced-delist threshold, and at least one candle whose packed
-  float32 H/L/C values remain finite and positive inside the declared valid ranges covers every
-  timestep after coverage begins. Tailed coins become non-tradable, contribute no unrealized PnL,
-  and cannot leave stale orders blocking HSL, while portfolio and coin HSL controllers continue
-  through the surviving timeline. Multi-coin forced-delist tails, all-coins-ended tails, and
-  all-invalid gaps remain fail-closed.
+  and at least one candle whose packed float32 H/L/C values remain finite and positive inside the
+  declared valid ranges covers every timestep after coverage begins. Tailed coins become
+  non-tradable, contribute no unrealized PnL, and cannot leave stale orders blocking HSL, while
+  portfolio and coin HSL controllers continue through the surviving timeline. Forced-delist tails
+  are covered by the expanded support above; all-coins-ended tails and all-invalid gaps remain
+  fail-closed.
 
 - Fixed live bot startup on Windows without symlink privileges by writing a visible pointer to the
   timestamped run log instead of failing while creating the stable log alias. Built-in monitor
@@ -33,8 +41,8 @@ All notable user-facing changes will be documented in this file.
 
 - Apple MPS single-coin HSL optimization now continues hard-stop sampling, rolling-PnL expiry,
   tier accounting, and restart checks through supported invalid candle tails. Tail candles remain
-  non-tradable and cannot satisfy stale blocking orders. Multi-coin forced-delist and all-coins-ended
-  tails remain fail-closed.
+  non-tradable and cannot satisfy stale blocking orders. Multi-coin all-coins-ended tails remain
+  fail-closed.
 
 - Apple MPS single-coin EMA Anchor and Trailing Martingale optimization now accepts invalid
   candles after the coin's final valid candle when HSL is disabled. Metal keeps shorter tails

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,9 @@ All notable user-facing changes will be documented in this file.
   the prepared timeline alive. Metal preserves ordinary-fill and order-generation chronology,
   closes long before short using adverse market slippage, directional price rounding, and taker
   fees, records panic-loss, realized-PnL, fill, duration, and HSL equity effects, and clears both
-  sides' pending orders for the delisted coin. Exact Rust remains authoritative. All-coins-ended
-  tails and all-invalid gaps remain fail-closed.
+  sides' pending orders for the delisted coin. Forced-delist final candles that cannot be represented
+  as finite positive float32 H/L/C fail before dispatch. Exact Rust remains authoritative.
+  All-coins-ended tails and all-invalid gaps remain fail-closed.
 
 - Apple MPS HSL optimization now supports per-side
   `drawdown_worst_mean_1pct_strategy_eq_{long,short}` scoring and limits for EMA Anchor and

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -374,15 +374,17 @@ The supported slice is intentionally narrow:
   sampling, rolling-PnL expiry, tier accounting, and restart checks without treating stale orders
   as blocking
 - multi-coin runs may include staggered invalid tails while at least one prepared coin remains
-  valid through the endpoint, every tail stays below exact Rust's 1,400-candle forced-delist
-  threshold, and at least one candle whose packed float32 H/L/C values remain finite and positive
-  inside the coins' declared first-to-last-valid ranges covers every timestep after coverage
-  begins. Tailed coins are non-tradable, contribute no unrealized PnL, and cannot leave stale orders
-  blocking HSL; dynamic tradability, portfolio/coin HSL, equity, and elapsed-time accounting
+  valid through the endpoint and at least one candle whose packed float32 H/L/C values remain
+  finite and positive inside the coins' declared first-to-last-valid ranges covers every timestep
+  after coverage begins. Tailed coins are non-tradable, contribute no unrealized PnL, and cannot
+  leave stale orders blocking HSL. When a tail crosses exact Rust's 1,400-candle forced-delist
+  boundary, Metal closes that coin's long and then short with the same adverse market execution,
+  taker-fee, panic-loss, fill, duration, and realized-PnL accounting, then clears both sides' pending
+  orders for that coin. Dynamic tradability, portfolio/coin HSL, equity, and elapsed-time accounting
   continue on the surviving timeline
-- multi-coin forced-delist tails, multi-coin histories in which every coin ends before the prepared
-  endpoint, and histories with an all-invalid gap after coverage begins remain fail-closed until
-  their forced-close and all-invalid time-accounting semantics are modeled
+- multi-coin histories in which every coin ends before the prepared endpoint and histories with an
+  all-invalid gap after coverage begins remain fail-closed until their all-invalid time-accounting
+  semantics are modeled
 
 Unsupported combinations fail before optimization begins. Dual-side multi-coin EMA Anchor and
 Trailing Martingale use fused shared-account Metal kernels in hedge and one-way modes. Every

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -380,8 +380,9 @@ The supported slice is intentionally narrow:
   leave stale orders blocking HSL. When a tail crosses exact Rust's 1,400-candle forced-delist
   boundary, Metal closes that coin's long and then short with the same adverse market execution,
   taker-fee, panic-loss, fill, duration, and realized-PnL accounting, then clears both sides' pending
-  orders for that coin. Dynamic tradability, portfolio/coin HSL, equity, and elapsed-time accounting
-  continue on the surviving timeline
+  orders for that coin. Each such coin's final H/L/C must remain finite and positive after float32
+  packing; an unrepresentable final candle fails before dispatch. Dynamic tradability,
+  portfolio/coin HSL, equity, and elapsed-time accounting continue on the surviving timeline
 - multi-coin histories in which every coin ends before the prepared endpoint and histories with an
   all-invalid gap after coverage begins remain fail-closed until their all-invalid time-accounting
   semantics are modeled

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -134,6 +134,11 @@ mod tests {
         assert!(source.contains("h.drawdown_ema_max = fmax("));
         assert!(source.contains("output.drawdown_ema_max_long"));
         assert!(source.contains("output.drawdown_ema_max_short"));
+        let panic_loss_aggregation = source
+            .find("output.panic_close_loss_sum += h.panic_close_loss_sum")
+            .unwrap();
+        let enabled_gate = source.find("if (!h.enabled) return;").unwrap();
+        assert!(panic_loss_aggregation < enabled_gate);
         assert_eq!(source.matches("struct HslStrategyEquityStats").count(), 1);
         assert_eq!(source.matches("struct HslDrawdownEmaTailStats").count(), 1);
         assert_eq!(
@@ -343,9 +348,17 @@ mod tests {
 
     #[test]
     fn multicoin_kernels_route_every_fill_through_joint_account_state() {
-        for (body, expected_account_record_sites) in [
-            (MPS_EMA_ANCHOR_MULTICOIN_BODY, 2),
-            (MPS_TRAILING_MARTINGALE_MULTICOIN_BODY, 2),
+        for (body, expected_account_record_sites, helper_prefix) in [
+            (
+                MPS_EMA_ANCHOR_MULTICOIN_BODY,
+                2,
+                "force_close_ema_multicoin_delisted",
+            ),
+            (
+                MPS_TRAILING_MARTINGALE_MULTICOIN_BODY,
+                2,
+                "force_close_tm_multicoin_delisted",
+            ),
         ] {
             assert!(body.contains(
                 "JointPortfolioAccount account = init_joint_portfolio_account(starting_balance)"
@@ -363,6 +376,11 @@ mod tests {
             assert!(!body.contains("float balance = starting_balance"));
             assert!(!body.contains("balance += net_pnl"));
             assert!(!body.contains("balance -= fee"));
+            assert!(body.contains(&format!("{helper_prefix}_one_side(")));
+            assert!(body.contains(&format!("{helper_prefix}_fused(")));
+            assert!(body.contains("last_valid + 1400 >= timestep_count"));
+            assert!(body.contains("ordinary_market_fill_price("));
+            assert!(body.contains("record_hsl_panic_fill("));
         }
     }
 
@@ -612,7 +630,7 @@ mod tests {
             MPS_EMA_ANCHOR_MULTICOIN_BODY
                 .matches("advance_coin_hsl_equity_after_close_fill(")
                 .count(),
-            1
+            2
         );
         assert_eq!(
             MPS_EMA_ANCHOR_MULTICOIN_BODY
@@ -662,7 +680,12 @@ mod tests {
         assert_eq!(
             source
                 .matches("coin_fill_counts[candidate_index * coin_count + c] += 1.0f")
-                .count(),
+                .count()
+                + source
+                    .matches(
+                        "coin_fill_counts[candidate_index * coin_count + coin] += 1.0f",
+                    )
+                    .count(),
             2
         );
         assert!(source.contains("close_tick[c] <= fill_ticks[tick_offset + 0]"));
@@ -1071,7 +1094,7 @@ mod tests {
             MPS_TRAILING_MARTINGALE_MULTICOIN_BODY
                 .matches("record_tm_multicoin_close_fill(")
                 .count(),
-            4
+            5
         );
         assert_eq!(
             MPS_TRAILING_MARTINGALE_MULTICOIN_BODY
@@ -1083,7 +1106,7 @@ mod tests {
             MPS_TRAILING_MARTINGALE_MULTICOIN_BODY
                 .matches("finalize_tm_multicoin_close_position(")
                 .count(),
-            2
+            3
         );
         assert_eq!(
             MPS_TRAILING_MARTINGALE_MULTICOIN_BODY
@@ -1097,7 +1120,7 @@ mod tests {
             MPS_TRAILING_MARTINGALE_MULTICOIN_BODY
                 .matches("update_tm_multicoin_position_fill_timestamp(")
                 .count(),
-            2
+            3
         );
         assert_eq!(
             MPS_TRAILING_MARTINGALE_MULTICOIN_BODY
@@ -1109,7 +1132,7 @@ mod tests {
             MPS_TRAILING_MARTINGALE_MULTICOIN_BODY
                 .matches("advance_coin_hsl_equity_after_close_fill(")
                 .count(),
-            1
+            2
         );
         assert_eq!(
             MPS_TRAILING_MARTINGALE_MULTICOIN_BODY

--- a/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
@@ -230,6 +230,63 @@ inline void record_ema_multicoin_gross_pnl(
     }
 }
 
+inline void record_ema_multicoin_close_fill(
+    thread EmaMulticoinSideState& side,
+    thread JointPortfolioAccount& account,
+    thread EmaMulticoinFillState& fills,
+    device float* coin_fill_counts,
+    int candidate_index,
+    int coin_count,
+    int coin,
+    int k,
+    float gross_pnl,
+    float net_pnl,
+    float qty,
+    float position_price,
+    float mark_price,
+    float c_mult,
+    bool short_side,
+    bool is_hsl_panic,
+    bool collect_coin_fill_counts,
+    thread float& hsl_equity_before_fills
+) {
+    const bool coin_hsl_mode =
+        side.hsl.signal_mode == HSL_SIGNAL_COIN;
+    if (is_hsl_panic) {
+        if (coin_hsl_mode) {
+            record_hsl_panic_fill(
+                side.coin_hsl[coin], net_pnl, hsl_equity_before_fills
+            );
+        } else {
+            record_hsl_panic_fill(
+                side.hsl, net_pnl, hsl_equity_before_fills
+            );
+        }
+    }
+    record_ema_multicoin_gross_pnl(gross_pnl, fills, short_side);
+    record_realized_net(
+        net_pnl, account,
+        fills.day_fill_count, fills.fill_count,
+        fills.fill_count_entry, fills.fill_count_long,
+        fills.pnl_recovery_peak, fills.pnl_recovery_peak_k,
+        fills.pnl_recovery_max_min, float(k), false, !short_side
+    );
+    side.coin_realized_pnl[coin] += net_pnl;
+    if (coin_hsl_mode) {
+        record_coin_hsl_realized_fill(
+            side.coin_hsl[coin], side.coin_realized_pnl[coin]
+        );
+        advance_coin_hsl_equity_after_close_fill(
+            hsl_equity_before_fills,
+            net_pnl, qty, position_price, mark_price,
+            c_mult, short_side
+        );
+    }
+    if (collect_coin_fill_counts) {
+        coin_fill_counts[candidate_index * coin_count + coin] += 1.0f;
+    }
+}
+
 inline EmaMulticoinSideConfig load_ema_multicoin_side_config(
     constant float* params,
     int po
@@ -2492,40 +2549,13 @@ inline bool process_ema_multicoin_side_fills(
                     * (market_execution ? taker_fee : maker_fee);
             bool is_hsl_panic = !use_secondary
                 && close_is_hsl_panic[c];
-            if (is_hsl_panic) {
-                if (coin_hsl_mode) {
-                    record_hsl_panic_fill(
-                        coin_hsl[c], net_pnl, hsl_equity_before_fills
-                    );
-                } else {
-                    record_hsl_panic_fill(
-                        hsl, net_pnl, hsl_equity_before_fills
-                    );
-                }
-            }
-            record_ema_multicoin_gross_pnl(pnl, fills, short_side);
-            record_realized_net(
-                net_pnl, account,
-                fills.day_fill_count, fills.fill_count,
-                fills.fill_count_entry, fills.fill_count_long,
-                fills.pnl_recovery_peak, fills.pnl_recovery_peak_k,
-                fills.pnl_recovery_max_min, float(k),
-                false, !short_side
+            record_ema_multicoin_close_fill(
+                side, account, fills, coin_fill_counts,
+                candidate_index, coin_count, c, k, pnl, net_pnl,
+                adjusted, pprice[c], close, c_mult, short_side,
+                is_hsl_panic, collect_coin_fill_counts,
+                hsl_equity_before_fills
             );
-            coin_realized_pnl[c] += net_pnl;
-            if (coin_hsl_mode) {
-                record_coin_hsl_realized_fill(
-                    coin_hsl[c], coin_realized_pnl[c]
-                );
-                advance_coin_hsl_equity_after_close_fill(
-                    hsl_equity_before_fills,
-                    net_pnl, adjusted, pprice[c], close,
-                    c_mult, short_side
-                );
-            }
-            if (collect_coin_fill_counts) {
-                coin_fill_counts[candidate_index * coin_count + c] += 1.0f;
-            }
             float new_size = fmax(
                 round_step(psize[c] - adjusted, qty_step), 0.0f
             );
@@ -2619,6 +2649,174 @@ inline bool process_ema_multicoin_side_fills(
         }
     }
     return any_fill;
+}
+
+inline void clear_ema_multicoin_coin_orders(
+    thread EmaMulticoinSideState& side,
+    int coin
+) {
+    side.entry_qty[coin] = 0.0f;
+    side.close_qty[coin] = 0.0f;
+    side.secondary_close_qty[coin] = 0.0f;
+    side.twel_close_qty[coin] = 0.0f;
+    side.unstuck_close_qty[coin] = 0.0f;
+    side.entry_tick[coin] = 0;
+    side.close_tick[coin] = 0;
+    side.secondary_close_tick[coin] = 0;
+    side.twel_close_tick[coin] = 0;
+    side.unstuck_close_tick[coin] = 0;
+    side.entry_market[coin] = false;
+    side.close_market[coin] = false;
+    side.secondary_close_market[coin] = false;
+    side.close_is_protective_reducer[coin] = false;
+    side.close_is_unstuck_reducer[coin] = false;
+    side.close_is_hsl_panic[coin] = false;
+}
+
+inline bool force_close_ema_multicoin_delisted_position(
+    thread EmaMulticoinSideState& side,
+    thread JointPortfolioAccount& account,
+    thread EmaMulticoinFillState& fills,
+    constant float* bars,
+    constant float* coin_settings,
+    device float* coin_fill_counts,
+    int candidate_index,
+    int k,
+    int coin_count,
+    int coin,
+    bool short_side,
+    bool collect_coin_fill_counts,
+    float market_order_slippage_pct,
+    thread float& hsl_equity_before_close
+) {
+    if (!(side.psize[coin] > 0.0f && side.pprice[coin] > 0.0f)) {
+        return false;
+    }
+    const int coin_offset = coin * COIN_COLS;
+    const int bar_offset = (k * coin_count + coin) * 4;
+    const float close = bars[bar_offset + 2];
+    if (!finite_positive(close)) return false;
+    const float price_step = coin_settings[coin_offset + 1];
+    const float c_mult = coin_settings[coin_offset + 4];
+    const float taker_fee = coin_settings[coin_offset + 11];
+    const float close_price = ordinary_market_fill_price(
+        close, short_side, market_order_slippage_pct, price_step
+    );
+    const float close_qty = side.psize[coin];
+    const float position_price = side.pprice[coin];
+    const float pnl = close_qty * c_mult * (
+        short_side
+            ? position_price - close_price
+            : close_price - position_price
+    );
+    const float net_pnl = pnl
+        - close_qty * close_price * c_mult * taker_fee;
+    const bool coin_hsl_mode =
+        side.hsl.signal_mode == HSL_SIGNAL_COIN;
+    record_ema_multicoin_close_fill(
+        side, account, fills, coin_fill_counts,
+        candidate_index, coin_count, coin, k, pnl, net_pnl,
+        close_qty, position_price, close, c_mult, short_side,
+        true, collect_coin_fill_counts, hsl_equity_before_close
+    );
+    if (!coin_hsl_mode) {
+        advance_coin_hsl_equity_after_close_fill(
+            hsl_equity_before_close,
+            net_pnl, close_qty, position_price, close,
+            c_mult, short_side
+        );
+    }
+    side.psize[coin] = 0.0f;
+    side.pprice[coin] = 0.0f;
+    if (side.position_open_k[coin] >= 0.0f) {
+        const float held_min = float(k) - side.position_open_k[coin];
+        fills.held_max_min = fmax(fills.held_max_min, held_min);
+        fills.held_sum_min += held_min;
+        fills.held_count += 1.0f;
+    }
+    side.position_open_k[coin] = -1.0f;
+    fills.day_volume += close_qty * close_price * c_mult / account.balance;
+    if (side.position_last_fill_k[coin] >= 0.0f) {
+        fills.position_unchanged_max_min = fmax(
+            fills.position_unchanged_max_min,
+            float(k) - side.position_last_fill_k[coin]
+        );
+    }
+    side.position_last_fill_k[coin] = -1.0f;
+    return true;
+}
+
+inline bool force_close_ema_multicoin_delisted_one_side(
+    thread EmaMulticoinSideState& side,
+    thread JointPortfolioAccount& account,
+    thread EmaMulticoinFillState& fills,
+    constant float* bars,
+    constant float* coin_settings,
+    device float* coin_fill_counts,
+    int candidate_index,
+    int k,
+    int timestep_count,
+    int coin_count,
+    bool short_side,
+    bool collect_coin_fill_counts,
+    float market_order_slippage_pct,
+    thread float& hsl_equity_before_close
+) {
+    bool any_close = false;
+    for (int c = 0; c < coin_count; ++c) {
+        const int last_valid = int(coin_settings[c * COIN_COLS + 7]);
+        if (k != last_valid || last_valid + 1400 >= timestep_count) continue;
+        const bool closed = force_close_ema_multicoin_delisted_position(
+            side, account, fills, bars, coin_settings, coin_fill_counts,
+            candidate_index, k, coin_count, c, short_side,
+            collect_coin_fill_counts, market_order_slippage_pct,
+            hsl_equity_before_close
+        );
+        if (closed) clear_ema_multicoin_coin_orders(side, c);
+        any_close = any_close || closed;
+    }
+    return any_close;
+}
+
+inline bool force_close_ema_multicoin_delisted_fused(
+    thread EmaMulticoinSideState& long_side,
+    thread EmaMulticoinSideState& short_side,
+    thread JointPortfolioAccount& account,
+    thread EmaMulticoinFillState& fills,
+    constant float* bars,
+    constant float* coin_settings,
+    device float* coin_fill_counts,
+    int candidate_index,
+    int k,
+    int timestep_count,
+    int coin_count,
+    bool collect_coin_fill_counts,
+    float market_order_slippage_pct,
+    thread float& hsl_equity_before_close
+) {
+    bool any_close = false;
+    for (int c = 0; c < coin_count; ++c) {
+        const int last_valid = int(coin_settings[c * COIN_COLS + 7]);
+        if (k != last_valid || last_valid + 1400 >= timestep_count) continue;
+        const bool long_closed = force_close_ema_multicoin_delisted_position(
+            long_side, account, fills, bars, coin_settings, coin_fill_counts,
+            candidate_index, k, coin_count, c, false,
+            collect_coin_fill_counts, market_order_slippage_pct,
+            hsl_equity_before_close
+        );
+        const bool short_closed = force_close_ema_multicoin_delisted_position(
+            short_side, account, fills, bars, coin_settings, coin_fill_counts,
+            candidate_index, k, coin_count, c, true,
+            collect_coin_fill_counts, market_order_slippage_pct,
+            hsl_equity_before_close
+        );
+        if (long_closed || short_closed) {
+            clear_ema_multicoin_coin_orders(long_side, c);
+            clear_ema_multicoin_coin_orders(short_side, c);
+        }
+        any_close = any_close || long_closed || short_closed;
+    }
+    return any_close;
 }
 
 inline void passivbot_ema_anchor_multicoin_impl(
@@ -2798,20 +2996,6 @@ inline void passivbot_ema_anchor_multicoin_impl(
             collect_coin_fill_counts, market_order_slippage_pct,
             hsl_panic_market, hsl_equity_before_fills
         );
-        if (any_fill) {
-            day_has_fill = 1.0f;
-            if (last_fill_k >= 0.0f) {
-                float gap = float(k) - last_fill_k;
-                int bin = clamp(
-                    int(log(fmax(gap, 0.0f) + 1.0f) * log_bin_scale), 0, 127
-                );
-                gap_hist[int(b) * GAP_BINS + bin] += 1;
-                gap_max_min = fmax(gap_max_min, gap);
-            }
-            if (first_fill_k < 0.0f) first_fill_k = float(k);
-            last_fill_k = float(k);
-        }
-
         update_ema_multicoin_side_indicators(
             side, config, bars, hour_log_ranges,
             coin_settings, k, C
@@ -2880,6 +3064,34 @@ inline void passivbot_ema_anchor_multicoin_impl(
                 market_orders_allowed, market_order_near_touch_threshold,
                 market_order_slippage_pct, max_realized_loss_pct
             );
+        }
+
+        float forced_delist_equity =
+            accumulate_ema_multicoin_side_unrealized_pnl(
+                side, bars, coin_settings, k, C, short_side, balance
+            );
+        bool forced_delist_fill = false;
+        if (alive && balance > 0.0f) {
+            forced_delist_fill = force_close_ema_multicoin_delisted_one_side(
+                side, account, fills, bars, coin_settings,
+                coin_fill_counts, int(b), k, T, C, short_side,
+                collect_coin_fill_counts, market_order_slippage_pct,
+                forced_delist_equity
+            );
+        }
+        any_fill = any_fill || forced_delist_fill;
+        if (any_fill) {
+            day_has_fill = 1.0f;
+            if (last_fill_k >= 0.0f) {
+                float gap = float(k) - last_fill_k;
+                int bin = clamp(
+                    int(log(fmax(gap, 0.0f) + 1.0f) * log_bin_scale), 0, 127
+                );
+                gap_hist[int(b) * GAP_BINS + bin] += 1;
+                gap_max_min = fmax(gap_max_min, gap);
+            }
+            if (first_fill_k < 0.0f) first_fill_k = float(k);
+            last_fill_k = float(k);
         }
 
         float unrealized = 0.0f;
@@ -3610,20 +3822,6 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
             short_hsl_panic_market, short_hsl_equity_before_fills
         );
         bool any_fill = long_fill || short_fill;
-        if (any_fill) {
-            day_has_fill = 1.0f;
-            if (last_fill_k >= 0.0f) {
-                float gap = float(k) - last_fill_k;
-                int bin = clamp(
-                    int(log(fmax(gap, 0.0f) + 1.0f) * log_bin_scale),
-                    0, 127
-                );
-                gap_hist[int(b) * GAP_BINS + bin] += 1;
-                gap_max_min = fmax(gap_max_min, gap);
-            }
-            if (first_fill_k < 0.0f) first_fill_k = float(k);
-            last_fill_k = float(k);
-        }
 
         update_ema_multicoin_side_indicators(
             long_side, long_config, bars, hour_log_ranges,
@@ -3812,6 +4010,42 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
                 market_orders_allowed, market_order_near_touch_threshold,
                 market_order_slippage_pct, max_realized_loss_pct
             );
+        }
+
+        float forced_delist_equity = account.balance;
+        forced_delist_equity =
+            accumulate_ema_multicoin_side_unrealized_pnl(
+                long_side, bars, coin_settings, k, C, false,
+                forced_delist_equity
+            );
+        forced_delist_equity =
+            accumulate_ema_multicoin_side_unrealized_pnl(
+                short_side, bars, coin_settings, k, C, true,
+                forced_delist_equity
+            );
+        bool forced_delist_fill = false;
+        if (alive && account.balance > 0.0f) {
+            forced_delist_fill = force_close_ema_multicoin_delisted_fused(
+                long_side, short_side, account, fills,
+                bars, coin_settings, coin_fill_counts,
+                int(b), k, T, C, collect_coin_fill_counts,
+                market_order_slippage_pct, forced_delist_equity
+            );
+        }
+        any_fill = any_fill || forced_delist_fill;
+        if (any_fill) {
+            day_has_fill = 1.0f;
+            if (last_fill_k >= 0.0f) {
+                float gap = float(k) - last_fill_k;
+                int bin = clamp(
+                    int(log(fmax(gap, 0.0f) + 1.0f) * log_bin_scale),
+                    0, 127
+                );
+                gap_hist[int(b) * GAP_BINS + bin] += 1;
+                gap_max_min = fmax(gap_max_min, gap);
+            }
+            if (first_fill_k < 0.0f) first_fill_k = float(k);
+            last_fill_k = float(k);
         }
 
         float long_unrealized = 0.0f;

--- a/passivbot-rust/src/gpu/mps_hsl_common.metal
+++ b/passivbot-rust/src/gpu/mps_hsl_common.metal
@@ -945,6 +945,23 @@ inline void accumulate_hsl_output(
     bool short_side,
     float last_equity_k
 ) {
+    // Forced delist closes are panic fills even when HSL itself is disabled.
+    // Exact Rust reports their loss metrics independently of controller
+    // enablement, so retain those fields before filtering HSL-only telemetry.
+    output.panic_close_loss_sum += h.panic_close_loss_sum;
+    output.panic_close_loss_max = fmax(
+        output.panic_close_loss_max, h.panic_close_loss_max
+    );
+    if (h.panic_loss_drawdown_count > 0.0f) {
+        output.panic_loss_drawdown_min = output.panic_loss_drawdown_count > 0.0f
+            ? fmin(output.panic_loss_drawdown_min, h.panic_loss_drawdown_min)
+            : h.panic_loss_drawdown_min;
+    }
+    output.panic_loss_drawdown_sum += h.panic_loss_drawdown_sum;
+    output.panic_loss_drawdown_max = fmax(
+        output.panic_loss_drawdown_max, h.panic_loss_drawdown_max
+    );
+    output.panic_loss_drawdown_count += h.panic_loss_drawdown_count;
     if (!h.enabled) return;
     float terminal_count = h.halted
         && h.current_halt_start_k >= 0.0f && last_equity_k >= 0.0f
@@ -978,20 +995,6 @@ inline void accumulate_hsl_output(
     output.flatten_time_count += h.flatten_time_count;
     output.restart_retrigger_count += h.restart_retrigger_count;
     output.halt_to_restart_equity_loss += h.halt_to_restart_equity_loss;
-    output.panic_close_loss_sum += h.panic_close_loss_sum;
-    output.panic_close_loss_max = fmax(
-        output.panic_close_loss_max, h.panic_close_loss_max
-    );
-    if (h.panic_loss_drawdown_count > 0.0f) {
-        output.panic_loss_drawdown_min = output.panic_loss_drawdown_count > 0.0f
-            ? fmin(output.panic_loss_drawdown_min, h.panic_loss_drawdown_min)
-            : h.panic_loss_drawdown_min;
-    }
-    output.panic_loss_drawdown_sum += h.panic_loss_drawdown_sum;
-    output.panic_loss_drawdown_max = fmax(
-        output.panic_loss_drawdown_max, h.panic_loss_drawdown_max
-    );
-    output.panic_loss_drawdown_count += h.panic_loss_drawdown_count;
 }
 
 inline void write_hsl_output_aggregate(

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
@@ -1276,6 +1276,183 @@ inline void update_tm_multicoin_position_fill_timestamp(
         side.psize[coin] > 0.0f ? float(k) : -1.0f;
 }
 
+inline void clear_tm_multicoin_coin_orders(
+    thread TrailingMartingaleMulticoinSideState& side,
+    int coin
+) {
+    side.entry_qty[coin] = 0.0f;
+    side.entry_strategy_qty[coin] = 0.0f;
+    side.entry_gen_balance[coin] = 0.0f;
+    side.entry_gen_allowed_wel[coin] = 0.0f;
+    side.entry_gen_market_price[coin] = 0.0f;
+    side.entry_gen_psize[coin] = 0.0f;
+    side.entry_gen_pprice[coin] = 0.0f;
+    side.entry_gate_suffix_partial_qty[coin] = 0.0f;
+    side.entry_gate_suffix_keep_count[coin] = 0;
+    side.entry_gate_suffix_partial_rank[coin] = -1;
+    side.entry_tick[coin] = 0;
+    side.entry_gen_initial_tick[coin] = 0;
+    side.entry_gen_touch_tick[coin] = 0;
+    side.entry_order_type[coin] = 0;
+    side.entry_recursive_market_mode[coin] = false;
+    side.entry_market[coin] = false;
+    side.close_qty[coin] = 0.0f;
+    side.secondary_close_qty[coin] = 0.0f;
+    side.twel_close_qty[coin] = 0.0f;
+    side.unstuck_close_qty[coin] = 0.0f;
+    side.close_gen_balance[coin] = 0.0f;
+    side.close_gen_allowed_wel[coin] = 0.0f;
+    side.close_gen_market_price[coin] = 0.0f;
+    side.close_grid_gen_psize[coin] = 0.0f;
+    side.close_grid_prefix_qty[coin] = 0.0f;
+    side.close_tick[coin] = 0;
+    side.secondary_close_tick[coin] = 0;
+    side.twel_close_tick[coin] = 0;
+    side.unstuck_close_tick[coin] = 0;
+    side.close_grid_max_rungs[coin] = 500;
+    side.close_grid_prefix_tick[coin] = 0;
+    side.close_reconstruct_after_reducer[coin] = false;
+    side.close_recursive_market_mode[coin] = false;
+    side.close_market[coin] = false;
+    side.secondary_close_market[coin] = false;
+    side.close_is_exposure_reducer[coin] = false;
+    side.close_is_unstuck_reducer[coin] = false;
+    side.close_is_hsl_panic[coin] = false;
+}
+
+inline bool force_close_tm_multicoin_delisted_position(
+    thread TrailingMartingaleMulticoinSideState& side,
+    thread JointPortfolioAccount& account,
+    thread TrailingMartingaleMulticoinFillState& fills,
+    constant float* bars,
+    constant float* coin_settings,
+    device float* coin_fill_counts,
+    int candidate_index,
+    int k,
+    int coin_count,
+    int coin,
+    bool short_side,
+    bool collect_coin_fill_counts,
+    float market_order_slippage_pct,
+    thread float& hsl_equity_before_close
+) {
+    if (!(side.psize[coin] > 0.0f && side.pprice[coin] > 0.0f)) {
+        return false;
+    }
+    const int coin_offset = coin * COIN_COLS;
+    const int bar_offset = (k * coin_count + coin) * 4;
+    const float close = bars[bar_offset + 2];
+    if (!finite_positive(close)) return false;
+    const float price_step = coin_settings[coin_offset + 1];
+    const float c_mult = coin_settings[coin_offset + 4];
+    const float taker_fee = coin_settings[coin_offset + 11];
+    const float close_price = ordinary_market_fill_price(
+        close, short_side, market_order_slippage_pct, price_step
+    );
+    const float close_qty = side.psize[coin];
+    const float position_price = side.pprice[coin];
+    const float pnl = close_qty * c_mult * (
+        short_side
+            ? position_price - close_price
+            : close_price - position_price
+    );
+    const float net_pnl = pnl
+        - close_qty * close_price * c_mult * taker_fee;
+    const bool coin_hsl_mode =
+        side.hsl.signal_mode == HSL_SIGNAL_COIN;
+    record_tm_multicoin_close_fill(
+        side, account, fills, coin_fill_counts,
+        candidate_index, coin_count, coin, k, pnl, net_pnl,
+        close_qty, position_price, close, c_mult, short_side,
+        true, collect_coin_fill_counts, hsl_equity_before_close
+    );
+    if (!coin_hsl_mode) {
+        advance_coin_hsl_equity_after_close_fill(
+            hsl_equity_before_close,
+            net_pnl, close_qty, position_price, close,
+            c_mult, short_side
+        );
+    }
+    side.psize[coin] = 0.0f;
+    fills.day_volume += close_qty * close_price * c_mult / account.balance;
+    finalize_tm_multicoin_close_position(side, fills, coin, k);
+    update_tm_multicoin_position_fill_timestamp(side, fills, coin, k);
+    return true;
+}
+
+inline bool force_close_tm_multicoin_delisted_one_side(
+    thread TrailingMartingaleMulticoinSideState& side,
+    thread JointPortfolioAccount& account,
+    thread TrailingMartingaleMulticoinFillState& fills,
+    constant float* bars,
+    constant float* coin_settings,
+    device float* coin_fill_counts,
+    int candidate_index,
+    int k,
+    int timestep_count,
+    int coin_count,
+    bool short_side,
+    bool collect_coin_fill_counts,
+    float market_order_slippage_pct,
+    thread float& hsl_equity_before_close
+) {
+    bool any_close = false;
+    for (int c = 0; c < coin_count; ++c) {
+        const int last_valid = int(coin_settings[c * COIN_COLS + 7]);
+        if (k != last_valid || last_valid + 1400 >= timestep_count) continue;
+        const bool closed = force_close_tm_multicoin_delisted_position(
+            side, account, fills, bars, coin_settings, coin_fill_counts,
+            candidate_index, k, coin_count, c, short_side,
+            collect_coin_fill_counts, market_order_slippage_pct,
+            hsl_equity_before_close
+        );
+        if (closed) clear_tm_multicoin_coin_orders(side, c);
+        any_close = any_close || closed;
+    }
+    return any_close;
+}
+
+inline bool force_close_tm_multicoin_delisted_fused(
+    thread TrailingMartingaleMulticoinSideState& long_side,
+    thread TrailingMartingaleMulticoinSideState& short_side,
+    thread JointPortfolioAccount& account,
+    thread TrailingMartingaleMulticoinFillState& fills,
+    constant float* bars,
+    constant float* coin_settings,
+    device float* coin_fill_counts,
+    int candidate_index,
+    int k,
+    int timestep_count,
+    int coin_count,
+    bool collect_coin_fill_counts,
+    float market_order_slippage_pct,
+    thread float& hsl_equity_before_close
+) {
+    bool any_close = false;
+    for (int c = 0; c < coin_count; ++c) {
+        const int last_valid = int(coin_settings[c * COIN_COLS + 7]);
+        if (k != last_valid || last_valid + 1400 >= timestep_count) continue;
+        const bool long_closed = force_close_tm_multicoin_delisted_position(
+            long_side, account, fills, bars, coin_settings, coin_fill_counts,
+            candidate_index, k, coin_count, c, false,
+            collect_coin_fill_counts, market_order_slippage_pct,
+            hsl_equity_before_close
+        );
+        const bool short_closed = force_close_tm_multicoin_delisted_position(
+            short_side, account, fills, bars, coin_settings, coin_fill_counts,
+            candidate_index, k, coin_count, c, true,
+            collect_coin_fill_counts, market_order_slippage_pct,
+            hsl_equity_before_close
+        );
+        if (long_closed || short_closed) {
+            clear_tm_multicoin_coin_orders(long_side, c);
+            clear_tm_multicoin_coin_orders(short_side, c);
+        }
+        any_close = any_close || long_closed || short_closed;
+    }
+    return any_close;
+}
+
 inline bool process_tm_multicoin_side_fills(
     thread TrailingMartingaleMulticoinSideState& side,
     thread const TrailingMartingaleMulticoinSideConfig& config,
@@ -4789,20 +4966,6 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
             short_hsl_panic_market, short_hsl_equity_before_fills
         );
         bool any_fill = long_fill || short_fill;
-        if (any_fill) {
-            day_has_fill = 1.0f;
-            if (last_fill_k >= 0.0f) {
-                float gap = float(k) - last_fill_k;
-                int bin = clamp(
-                    int(log(fmax(gap, 0.0f) + 1.0f) * log_bin_scale),
-                    0, 127
-                );
-                gap_hist[int(b) * GAP_BINS + bin] += 1;
-                gap_max_min = fmax(gap_max_min, gap);
-            }
-            if (first_fill_k < 0.0f) first_fill_k = float(k);
-            last_fill_k = float(k);
-        }
 
         update_tm_multicoin_side_indicators(
             long_side, long_config, bars, hour_log_ranges,
@@ -4992,6 +5155,42 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
         if (filter_by_min_effective_cost
             && (long_can_generate || short_can_generate)) {
             min_cost_exact_open_uncertain = true;
+        }
+
+        float forced_delist_equity = account.balance;
+        forced_delist_equity =
+            accumulate_tm_multicoin_side_unrealized_pnl(
+                long_side, bars, coin_settings, k, C, false,
+                forced_delist_equity
+            );
+        forced_delist_equity =
+            accumulate_tm_multicoin_side_unrealized_pnl(
+                short_side, bars, coin_settings, k, C, true,
+                forced_delist_equity
+            );
+        bool forced_delist_fill = false;
+        if (alive && account.balance > 0.0f) {
+            forced_delist_fill = force_close_tm_multicoin_delisted_fused(
+                long_side, short_side, account, fills,
+                bars, coin_settings, coin_fill_counts,
+                int(b), k, T, C, collect_coin_fill_counts,
+                market_order_slippage_pct, forced_delist_equity
+            );
+        }
+        any_fill = any_fill || forced_delist_fill;
+        if (any_fill) {
+            day_has_fill = 1.0f;
+            if (last_fill_k >= 0.0f) {
+                float gap = float(k) - last_fill_k;
+                int bin = clamp(
+                    int(log(fmax(gap, 0.0f) + 1.0f) * log_bin_scale),
+                    0, 127
+                );
+                gap_hist[int(b) * GAP_BINS + bin] += 1;
+                gap_max_min = fmax(gap_max_min, gap);
+            }
+            if (first_fill_k < 0.0f) first_fill_k = float(k);
+            last_fill_k = float(k);
         }
 
         float long_unrealized = 0.0f;
@@ -5554,20 +5753,6 @@ inline void passivbot_trailing_martingale_multicoin_impl(
             market_order_near_touch_threshold,
             hsl_panic_market, hsl_equity_before_fills
         );
-        if (any_fill) {
-            day_has_fill = 1.0f;
-            if (last_fill_k >= 0.0f) {
-                float gap = float(k) - last_fill_k;
-                int bin = clamp(
-                    int(log(fmax(gap, 0.0f) + 1.0f) * log_bin_scale), 0, 127
-                );
-                gap_hist[int(b) * GAP_BINS + bin] += 1;
-                gap_max_min = fmax(gap_max_min, gap);
-            }
-            if (first_fill_k < 0.0f) first_fill_k = float(k);
-            last_fill_k = float(k);
-        }
-
         update_tm_multicoin_side_indicators(
             side, config, bars, hour_log_ranges, coin_settings, k, C
         );
@@ -5633,6 +5818,34 @@ inline void passivbot_trailing_martingale_multicoin_impl(
             if (filter_by_min_effective_cost) {
                 min_cost_exact_open_uncertain = true;
             }
+        }
+
+        float forced_delist_equity =
+            accumulate_tm_multicoin_side_unrealized_pnl(
+                side, bars, coin_settings, k, C, short_side, balance
+            );
+        bool forced_delist_fill = false;
+        if (alive && balance > 0.0f) {
+            forced_delist_fill = force_close_tm_multicoin_delisted_one_side(
+                side, account, fills, bars, coin_settings,
+                coin_fill_counts, int(b), k, T, C, short_side,
+                collect_coin_fill_counts, market_order_slippage_pct,
+                forced_delist_equity
+            );
+        }
+        any_fill = any_fill || forced_delist_fill;
+        if (any_fill) {
+            day_has_fill = 1.0f;
+            if (last_fill_k >= 0.0f) {
+                float gap = float(k) - last_fill_k;
+                int bin = clamp(
+                    int(log(fmax(gap, 0.0f) + 1.0f) * log_bin_scale), 0, 127
+                );
+                gap_hist[int(b) * GAP_BINS + bin] += 1;
+                gap_max_min = fmax(gap_max_min, gap);
+            }
+            if (first_fill_k < 0.0f) first_fill_k = float(k);
+            last_fill_k = float(k);
         }
 
         float unrealized = 0.0f;

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -652,37 +652,10 @@ def _hsl_params(bot: dict, *, signal_mode: str) -> dict[str, float]:
     }
 
 
-def _require_no_multicoin_forced_delist_tail(
-    last_valid_idx: int, candle_count: int
-) -> None:
-    """Keep multicoin forced-delists fail closed until that kernel models them.
-
-    Exact Rust treats a coin as delisted, and force-closes its open positions,
-    when at least 1,400 prepared candles follow its final valid candle.  The
-    single-coin kernels model that close, but multicoin forced-delist fills are
-    a separate parity surface.
-    """
-
-    last_valid_idx = int(last_valid_idx)
-    candle_count = int(candle_count)
-    if last_valid_idx < 0 or last_valid_idx >= candle_count:
-        raise ValueError(
-            "GPU proxy requires last_valid_idx within the prepared "
-            f"candle range; last_valid_idx={last_valid_idx}, "
-            f"candle_count={candle_count}"
-        )
-    if last_valid_idx + 1400 < candle_count:
-        raise ValueError(
-            "GPU multicoin proxy does not yet model Rust forced-delist closes "
-            "when at least 1,400 prepared candles follow the final valid candle; "
-            f"last_valid_idx={last_valid_idx}, candle_count={candle_count}"
-        )
-
-
 def _require_supported_multicoin_valid_tails(
     hlcvs, first_valid_indices, last_valid_indices
 ) -> None:
-    """Accept staggered ordinary tails with continuous portfolio time coverage."""
+    """Accept staggered tails with continuous portfolio time coverage."""
 
     values = np.asarray(hlcvs)
     if values.ndim != 3 or values.shape[2] < 3:
@@ -716,8 +689,7 @@ def _require_supported_multicoin_valid_tails(
             and last_valid_idx == candle_count - 1
         ):
             continue
-        _require_no_multicoin_forced_delist_tail(last_valid_idx, candle_count)
-        if not 0 <= first_valid_idx <= last_valid_idx:
+        if not 0 <= first_valid_idx <= last_valid_idx < candle_count:
             raise ValueError(
                 "GPU multicoin proxy requires each first_valid_idx within its "
                 "prepared valid range; "
@@ -2131,8 +2103,8 @@ class MpsMulticoinProxy:
                         config["bot"][side].get("risk", {}), side=side
                     )
                 )
-            first_strategy.update(_unstuck_params(config["bot"][side]))
             base_bot = flatten_shared_bot_side(config["bot"][side])
+            first_strategy.update(_unstuck_params(base_bot))
             first_strategy.update(_hsl_params(base_bot, signal_mode=signal_mode))
             missing = [
                 key for key in self.param_keys if key not in first_strategy

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -734,6 +734,18 @@ def _require_supported_multicoin_valid_tails(
     actual_valid = np.all(
         np.isfinite(packed_hlc) & (packed_hlc > 0.0), axis=2
     )
+    for coin, last_valid_idx in enumerate(tails):
+        if (
+            last_valid_idx + 1400 < candle_count
+            and not actual_valid[last_valid_idx, coin]
+        ):
+            raise ValueError(
+                "GPU multicoin proxy requires each forced-delist final "
+                "candle's packed float32 H/L/C values to remain finite and "
+                "positive; "
+                f"coin={coin}, last_valid_idx={last_valid_idx}, "
+                f"packed_hlc={packed_hlc[last_valid_idx, coin].tolist()}"
+            )
     actual_coverage = np.any(within_declared_window & actual_valid, axis=1)
     coverage_start = min(first for first, _ in windows)
     missing = np.flatnonzero(~actual_coverage[coverage_start:])

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -3969,6 +3969,149 @@ def test_mps_single_coin_service_dispatches_forced_delist_tail(strategy_kind):
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
 @pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
+@pytest.mark.parametrize("topology", ["long", "short", "fused"])
+def test_mps_multicoin_service_dispatches_forced_delist_tail(
+    strategy_kind, topology
+):
+    from backtest import run_backtest
+    from config.schema import get_template_config
+    from optimization.gpu.service import MpsMulticoinProxy
+
+    last_valid = 6
+    count = last_valid + 1401
+    hlcvs = np.full((count, 2, 4), np.nan, dtype=np.float64)
+    hlcvs[: last_valid + 1, 0] = [100.0, 100.0, 100.0, 1.0]
+    hlcvs[:, 1] = [200.0, 200.0, 200.0, 1.0]
+    if topology in {"long", "fused"}:
+        hlcvs[3, 0, 1] = 80.0
+    if topology in {"short", "fused"}:
+        hlcvs[3, 0, 0] = 120.0
+    delist_close = {
+        "long": 50.0,
+        "short": 150.0,
+        "fused": 100.0,
+    }[topology]
+    hlcvs[last_valid, 0] = [
+        delist_close,
+        delist_close,
+        delist_close,
+        1.0,
+    ]
+    timestamps = (
+        1_700_000_000_000
+        + np.arange(count, dtype=np.int64) * 60_000
+    )
+    market_settings = {
+        coin: {
+            "qty_step": 0.001,
+            "price_step": 0.01,
+            "min_qty": 0.001,
+            "min_cost": 5.0,
+            "c_mult": 1.0,
+            "maker": 0.0,
+            "taker": 0.001,
+            "exchange": "bybit",
+            "first_valid_index": 0,
+            "last_valid_index": last,
+            "warmup_minutes": 1,
+        }
+        for coin, last in (("BTC", last_valid), ("ETH", count - 1))
+    }
+    market_settings["__meta__"] = {
+        "requested_start_ts": int(timestamps[0]),
+        "requested_start_date": "2023-11-14",
+        "warmup_minutes_requested": 1,
+    }
+    config = get_template_config()
+    config["live"]["strategy_kind"] = strategy_kind
+    config["live"]["max_warmup_minutes"] = 1
+    enabled_sides = (
+        ("long", "short") if topology == "fused" else (topology,)
+    )
+    config["live"]["approved_coins"] = {
+        side: ["BTC"] if side in enabled_sides else []
+        for side in ("long", "short")
+    }
+    config["live"]["hedge_mode"] = topology == "fused"
+    config["backtest"]["coins"] = {"bybit": ["BTC", "ETH"]}
+    config["backtest"]["exchanges"] = ["bybit"]
+    for side in ("long", "short"):
+        enabled = side in enabled_sides
+        risk = config["bot"][side]["risk"]
+        risk["total_wallet_exposure_limit"] = 0.1 if enabled else 0.0
+        risk["n_positions"] = 1 if enabled else 0
+        risk["entry_cooldown_minutes"] = 100.0
+        risk["we_excess_allowance_pct"] = 0.0
+        risk["position_exposure_enforcer_enabled"] = False
+        risk["total_exposure_enforcer_enabled"] = False
+        config["bot"][side]["hsl"]["enabled"] = False
+        config["bot"][side]["unstuck"]["enabled"] = False
+    for side in enabled_sides:
+        if strategy_kind == "ema_anchor":
+            config["bot"][side]["strategy"]["ema_anchor"].update(
+                {
+                    "base_qty_pct": 1.0,
+                    "ema_span_0": 2.0,
+                    "ema_span_1": 3.0,
+                    "offset": 0.1,
+                    "offset_psize_weight": 0.0,
+                }
+            )
+        else:
+            strategy = config["bot"][side]["strategy"][
+                "trailing_martingale"
+            ]
+            strategy["ema_span_0"] = 2.0
+            strategy["ema_span_1"] = 3.0
+            strategy["entry"]["initial_qty_pct"] = 1.0
+            strategy["entry"]["initial_ema_dist"] = 0.1
+            strategy["entry"]["double_down_factor"] = 0.0
+            strategy["close"]["threshold_base_pct"] = 0.5
+
+    proxy = MpsMulticoinProxy(
+        config=config,
+        hlcvs=hlcvs,
+        mss=market_settings,
+        btc=np.full(count, 50_000.0),
+        timestamps=timestamps,
+        exchange="bybit",
+        batch_size=1,
+        needed_metrics={
+            "backtest_completion_ratio",
+            "fills_count",
+            "hard_stop_panic_close_loss_sum",
+        },
+    )
+    result = proxy.evaluate([{}])[0]
+    exact_fills, _, exact_analysis = run_backtest(
+        hlcvs,
+        market_settings,
+        config,
+        "bybit",
+        np.full(count, 50_000.0),
+        timestamps,
+    )
+    expected_fills = 4.0 if topology == "fused" else 2.0
+    assert result["fills_count"] == expected_fills
+    assert result["fills_count"] == exact_analysis["fills_count"]
+    assert len(exact_fills) == exact_analysis["fills_count"]
+    exact_order_types = {row[13] for row in exact_fills}
+    expected_panic_types = {
+        f"close_panic_{side}" for side in enabled_sides
+    }
+    assert expected_panic_types <= exact_order_types
+    if topology != "fused":
+        assert exact_analysis["hard_stop_panic_close_loss_sum"] > 0.0
+        assert result["hard_stop_panic_close_loss_sum"] == pytest.approx(
+            exact_analysis["hard_stop_panic_close_loss_sum"], rel=5.0e-4
+        )
+    assert result["backtest_completion_ratio"] > 0.99
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
 @pytest.mark.parametrize("side", ["long", "short"])
 def test_mps_single_coin_hsl_can_restart_during_invalid_tail(
     strategy_kind, side
@@ -4398,11 +4541,12 @@ def test_mps_tm_multicoin_aggregated_interval_fused_smoke(interval_minutes):
 )
 @pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
 @pytest.mark.parametrize("topology", ["long", "short", "fused"])
+@pytest.mark.parametrize("forced_delist", [False, True])
 def test_mps_multicoin_staggered_tail_keeps_balance_only_equity_and_hsl(
-    strategy_kind, topology
+    strategy_kind, topology, forced_delist
 ):
-    count = 12
     last_valid = 6
+    count = last_valid + 1401 if forced_delist else 12
     closes = np.full((count, 2), 100.0)
     # Keep a positive packed mark after the explicit validity window so this
     # exercises the index boundary rather than relying on NaNs becoming zero.
@@ -4423,12 +4567,17 @@ def test_mps_multicoin_staggered_tail_keeps_balance_only_equity_and_hsl(
         fused_runner_cls = MpsTrailingMartingaleMulticoinFusedRunner
     overrides = np.full((2, override_cols), np.nan, dtype=np.float32)
     overrides[1, wallet_exposure_column] = 0.0
+    markets = [
+        ProxyMarket(0.001, 0.01, 0.001, 0.0, 1.0, 0.0, 0.02)
+        for _ in range(2)
+    ]
     fixture_side = topology if topology != "fused" else "long"
     runner, row, run, data = _multicoin_exposure_fixture(
         strategy_kind,
         fixture_side,
         coin_overrides=overrides,
         count=count,
+        markets=markets,
         closes=closes,
         highs=highs,
         lows=lows,
@@ -4472,9 +4621,15 @@ def test_mps_multicoin_staggered_tail_keeps_balance_only_equity_and_hsl(
 
     assert output["balance"].item() > 0.0
     if topology in {"long", "fused"}:
-        assert output["psize"].item() > 0.0
+        assert (output["psize"].item() == 0.0) is forced_delist
     if topology in {"short", "fused"}:
-        assert output["short_psize"].item() > 0.0
+        assert (output["short_psize"].item() == 0.0) is forced_delist
+    expected_min_fills = 4.0 if topology == "fused" else 2.0
+    if forced_delist:
+        assert output["fill_count"].item() >= expected_min_fills
+        assert output["hsl_panic_close_loss_sum"].item() > 0.0
+    else:
+        assert output["hsl_panic_close_loss_sum"].item() == 0.0
     assert output["day_end_eq"][0, 0].item() == pytest.approx(
         output["balance"].item()
     )

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -1286,6 +1286,24 @@ def test_gpu_multicoin_valid_tail_gate_rejects_out_of_range_last_index():
         )
 
 
+@pytest.mark.parametrize(
+    "unrepresentable_close",
+    [np.nextafter(0.0, 1.0), np.finfo(np.float64).max],
+)
+def test_gpu_multicoin_forced_delist_requires_representable_final_candle(
+    unrepresentable_close,
+):
+    hlcvs = np.ones((1401, 2, 4), dtype=np.float64)
+    hlcvs[0, 0, 2] = unrepresentable_close
+
+    with pytest.raises(ValueError, match="forced-delist final candle"):
+        _require_supported_multicoin_valid_tails(
+            hlcvs,
+            [0, 0],
+            [0, 1400],
+        )
+
+
 def test_gpu_hsl_requires_contiguous_valid_candles():
     high = np.array([100.0, np.nan, 100.0])
     low = np.array([99.0, np.nan, 99.0])

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -45,7 +45,6 @@ from optimization.gpu.service import (
     _position_exposure_enforcer_params,
     _prepared_single_coin_side_enabled,
     _require_multicoin_metric_topology,
-    _require_no_multicoin_forced_delist_tail,
     _require_no_internal_invalid_account_recovery_candles,
     _require_no_internal_invalid_hsl_candles,
     _require_no_internal_invalid_multicoin_hsl_candles,
@@ -1206,7 +1205,7 @@ def test_multicoin_proxy_constructs_fused_shared_account_runner(
     assert constructed["kwargs"]["filter_by_min_effective_cost"] is True
 
 
-def test_gpu_multicoin_proxy_accepts_staggered_ordinary_valid_tails():
+def test_gpu_multicoin_proxy_accepts_staggered_valid_and_forced_delist_tails():
     hlcvs = np.ones((100, 2, 4), dtype=np.float64)
     _require_supported_multicoin_valid_tails(hlcvs, [0, 0], [99, 98])
     _require_supported_multicoin_valid_tails(hlcvs, [0, 50], [49, 99])
@@ -1214,12 +1213,11 @@ def test_gpu_multicoin_proxy_accepts_staggered_ordinary_valid_tails():
 
     with pytest.raises(ValueError, match="at least one coin to remain valid"):
         _require_supported_multicoin_valid_tails(hlcvs, [0, 0], [98, 97])
-    with pytest.raises(ValueError, match="forced-delist closes"):
-        _require_supported_multicoin_valid_tails(
-            np.ones((1401, 2, 4), dtype=np.float64),
-            [0, 0],
-            [1400, 0],
-        )
+    _require_supported_multicoin_valid_tails(
+        np.ones((1401, 2, 4), dtype=np.float64),
+        [0, 0],
+        [1400, 0],
+    )
     with pytest.raises(ValueError, match="at least one prepared coin"):
         _require_supported_multicoin_valid_tails(
             np.ones((100, 0, 4), dtype=np.float64), [], []
@@ -1279,15 +1277,13 @@ def test_gpu_multicoin_proxy_rejects_all_invalid_after_float32_packing(
     _require_supported_multicoin_valid_tails(hlcvs, [0, 0], [59, 99])
 
 
-def test_gpu_multicoin_forced_delist_tail_gate_preserves_rust_boundary():
-    _require_no_multicoin_forced_delist_tail(99, 100)
-    _require_no_multicoin_forced_delist_tail(98, 100)
-    _require_no_multicoin_forced_delist_tail(0, 1400)
-
-    with pytest.raises(ValueError, match="forced-delist closes"):
-        _require_no_multicoin_forced_delist_tail(0, 1401)
-    with pytest.raises(ValueError, match="within the prepared candle range"):
-        _require_no_multicoin_forced_delist_tail(100, 100)
+def test_gpu_multicoin_valid_tail_gate_rejects_out_of_range_last_index():
+    with pytest.raises(ValueError, match="prepared valid range"):
+        _require_supported_multicoin_valid_tails(
+            np.ones((100, 2, 4), dtype=np.float64),
+            [0, 0],
+            [100, 99],
+        )
 
 
 def test_gpu_hsl_requires_contiguous_valid_candles():


### PR DESCRIPTION
## Summary

- mirror exact Rust per-coin forced delists in the Apple MPS multi-coin EMA Anchor and Trailing Martingale kernels
- preserve exact candle chronology, long-before-short close ordering, adverse market execution, taker fees, realized-PnL/HSL accounting, and pending-order clearing
- allow staggered forced-delist tails while another coin covers the prepared endpoint; keep all-coins-ended tails and all-invalid gaps fail-closed
- retain forced-panic loss telemetry even when the HSL controller itself is disabled
- normalize grouped bot configuration before packing multi-coin unstuck parameters

## Validation

- `./passivbot-rust/cargotest.sh` — 267 passed
- `cargo check --manifest-path passivbot-rust/Cargo.toml --no-default-features`
- `python -m pytest tests/optimization -q` — full optimizer suite passed, including physical Apple MPS tests
- final physical MPS forced-delist matrix — 18 passed across EMA Anchor and Trailing Martingale; long, short, and fused; ordinary and forced tails; HSL and exact Rust service checks
- `python -m mkdocs build`

`mkdocs build --strict` remains blocked by the repository's two pre-existing missing `../CHANGELOG.md` links in the v8.0.0 and v8.1.0 release notes; the ordinary docs build passes.
