### PR TITLE
GPU: support multi-coin all-invalid time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Apple MPS multi-coin EMA Anchor and Trailing Martingale optimization now continues through
+  declared periods where no prepared coin is valid, including gaps between disjoint coin histories
+  and tails after every coin has ended. Long-only, short-only, and fused long+short kernels keep
+  exact Rust's balance-only equity, HSL, exposure, restart, daily, recovery, and elapsed-time
+  accounting after tracking begins, but do not activate tracking from tradability seen only before
+  the requested-start guard. Validity still blocks fills, orders, and unrealized PnL. A timestep
+  covered by a declared valid range but lacking any finite positive packed float32 H/L/C remains
+  fail-closed.
+
 - Apple MPS single-coin EMA Anchor and Trailing Martingale optimization now mirrors exact Rust's
   forced-delist close when at least 1,400 prepared candles follow a coin's final valid candle,
   including adverse market slippage, directional price rounding, taker fees, panic-loss and fill
@@ -17,7 +26,7 @@ All notable user-facing changes will be documented in this file.
   fees, records panic-loss, realized-PnL, fill, duration, and HSL equity effects, and clears both
   sides' pending orders for the delisted coin. Forced-delist final candles that cannot be represented
   as finite positive float32 H/L/C fail before dispatch. Exact Rust remains authoritative.
-  All-coins-ended tails and all-invalid gaps remain fail-closed.
+  All-coins-ended tails and declared all-invalid gaps are covered by the expanded support above.
 
 - Apple MPS HSL optimization now supports per-side
   `drawdown_worst_mean_1pct_strategy_eq_{long,short}` scoring and limits for EMA Anchor and
@@ -33,8 +42,8 @@ All notable user-facing changes will be documented in this file.
   declared valid ranges covers every timestep after coverage begins. Tailed coins become
   non-tradable, contribute no unrealized PnL, and cannot leave stale orders blocking HSL, while
   portfolio and coin HSL controllers continue through the surviving timeline. Forced-delist tails
-  are covered by the expanded support above; all-coins-ended tails and all-invalid gaps remain
-  fail-closed.
+  are covered by the expanded support above, as are all-coins-ended tails and declared all-invalid
+  gaps.
 
 - Fixed live bot startup on Windows without symlink privileges by writing a visible pointer to the
   timestamped run log instead of failing while creating the stable log alias. Built-in monitor
@@ -42,14 +51,13 @@ All notable user-facing changes will be documented in this file.
 
 - Apple MPS single-coin HSL optimization now continues hard-stop sampling, rolling-PnL expiry,
   tier accounting, and restart checks through supported invalid candle tails. Tail candles remain
-  non-tradable and cannot satisfy stale blocking orders. Multi-coin all-coins-ended tails remain
-  fail-closed.
+  non-tradable and cannot satisfy stale blocking orders. Multi-coin all-coins-ended tails are
+  covered by the expanded support above.
 
 - Apple MPS single-coin EMA Anchor and Trailing Martingale optimization now accepts invalid
   candles after the coin's final valid candle when HSL is disabled. Metal keeps shorter tails
   non-tradable and records balance-only account equity like exact Rust; the forced-delist boundary
-  is covered by the expanded support above. Unsupported multi-coin invalid-tail combinations
-  continue to fail closed.
+  and multi-coin invalid-time behavior are covered by the expanded support above.
 
 - Apple MPS multi-coin EMA Anchor optimization now supports any positive integer
   `backtest.candle_interval_minutes` for long-only, short-only, and fused long+short runs. Global

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -383,9 +383,14 @@ The supported slice is intentionally narrow:
   orders for that coin. Each such coin's final H/L/C must remain finite and positive after float32
   packing; an unrepresentable final candle fails before dispatch. Dynamic tradability,
   portfolio/coin HSL, equity, and elapsed-time accounting continue on the surviving timeline
-- multi-coin histories in which every coin ends before the prepared endpoint and histories with an
-  all-invalid gap after coverage begins remain fail-closed until their all-invalid time-accounting
-  semantics are modeled
+- multi-coin histories may also contain declared all-invalid gaps between disjoint coin histories or
+  a tail after every coin has ended. Once portfolio equity tracking starts, Metal continues exact
+  Rust's balance-only equity, HSL, exposure, restart, daily, recovery, and elapsed-time accounting
+  through those periods. Tradability observed only before the warmup/requested-start guard does not
+  activate tracking inside a later gap; the next eligible coin does. Per-coin validity still blocks
+  fills, order generation, and unrealized PnL. If one or more coins are declared valid for a timestep
+  but every corresponding packed float32 H/L/C candle is non-finite or non-positive, the input
+  remains fail-closed before dispatch
 
 Unsupported combinations fail before optimization begins. Dual-side multi-coin EMA Anchor and
 Trailing Martingale use fused shared-account Metal kernels in hedge and one-way modes. Every

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -554,7 +554,8 @@ mod tests {
         assert!(source.contains("candle_eligibility_changed"));
         assert!(source.contains("candle_eligibility_mask"));
         assert_eq!(source.matches("if (!managed_candidate) continue;").count(), 3);
-        assert!(source.contains("any_valid = any_valid || valid;"));
+        assert!(!source.contains("any_valid"));
+        assert!(source.contains("declared all-invalid gaps and"));
         assert!(source.contains("update_ema_multicoin_dual_side_hsl("));
         assert!(source.contains("if (long_side.hsl.signal_mode != short_side.hsl.signal_mode)"));
         assert!(source.contains("update_joint_pside_hsl("));
@@ -608,6 +609,13 @@ mod tests {
             "generate_ema_multicoin_side_orders(\n                side, config, account"
         ));
         assert!(source.contains("side.max_tradable_seen = max("));
+        assert_eq!(source.matches("const bool past_activation_guard").count(), 2);
+        assert_eq!(
+            source
+                .matches("!post_fill_balance_depleted && past_activation_guard")
+                .count(),
+            2
+        );
         assert!(source.contains(
             "side.previous_effective_n_positions = effective_n_positions"
         ));
@@ -695,7 +703,9 @@ mod tests {
         assert!(source.contains(
             "const bool post_fill_balance_depleted = isfinite(balance) && balance <= 0.0f"
         ));
-        assert!(source.contains("if (alive && !post_fill_balance_depleted)"));
+        assert!(source.contains(
+            "if (alive && !post_fill_balance_depleted && past_activation_guard)"
+        ));
         assert!(source.contains("const float score_hysteresis = fmax(run_settings[4], 0.0f)"));
         assert!(source.contains("incumbent[c] = selected[c] && psize[c] <= 0.0f"));
         assert!(source.contains("if (!selected[c] || incumbent[c] || !survivor[c]) continue"));
@@ -1034,7 +1044,8 @@ mod tests {
         assert!(source.contains("candle_eligibility_changed"));
         assert!(source.contains("candle_eligibility_mask"));
         assert_eq!(source.matches("if (!managed_candidate) continue;").count(), 3);
-        assert!(source.contains("any_valid = any_valid || valid;"));
+        assert!(!source.contains("any_valid"));
+        assert!(source.contains("declared all-invalid gaps and"));
         assert!(source.contains("update_tm_multicoin_dual_side_hsl("));
         assert!(source.contains("update_tm_multicoin_side_selection("));
         assert!(source.contains("generate_tm_multicoin_side_orders("));
@@ -1086,6 +1097,13 @@ mod tests {
         assert!(source.contains("thread int* entry_tick = side.entry_tick"));
         assert!(source.contains("thread bool* selected = side.selected"));
         assert!(source.contains("thread int& max_tradable_seen = side.max_tradable_seen"));
+        assert_eq!(source.matches("const bool past_activation_guard").count(), 2);
+        assert_eq!(
+            source
+                .matches("!post_fill_balance_depleted && past_activation_guard")
+                .count(),
+            2
+        );
         assert!(source.contains("side.previous_effective_n_positions"));
         assert!(source.contains("load_hsl(params, po, 48)"));
         assert!(source.contains("write_one_side_hsl_outputs("));
@@ -1200,7 +1218,9 @@ mod tests {
         assert!(source.contains(
             "const bool post_fill_balance_depleted = isfinite(balance) && balance <= 0.0f"
         ));
-        assert!(source.contains("if (alive && !post_fill_balance_depleted)"));
+        assert!(source.contains(
+            "if (alive && !post_fill_balance_depleted && past_activation_guard)"
+        ));
         assert!(source.contains("market_price * 0.9995f / price_step"));
         assert!(source.matches("clamped_market_price(").count() >= 4);
         assert!(source.contains("finalized_twel_reducer_qty = ordinary_can_accompany_reducer"));

--- a/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
@@ -3005,7 +3005,9 @@ inline void passivbot_ema_anchor_multicoin_impl(
             bars, coin_settings, coin_overrides, k, C
         );
         const bool post_fill_balance_depleted = isfinite(balance) && balance <= 0.0f;
-        if (alive && !post_fill_balance_depleted) {
+        const bool past_activation_guard =
+            k > max(global_warmup, 1) && k >= requested_start_k;
+        if (alive && !post_fill_balance_depleted && past_activation_guard) {
             side.max_tradable_seen = max(
                 side.max_tradable_seen, tradable_count
             );
@@ -3014,7 +3016,7 @@ inline void passivbot_ema_anchor_multicoin_impl(
             n_positions, side.max_tradable_seen
         );
         const bool can_generate = alive && effective_n_positions > 0
-            && k > max(global_warmup, 1) && k >= requested_start_k;
+            && past_activation_guard;
         equity_started = equity_started || can_generate;
         bool has_hsl_position = ema_multicoin_side_has_position(side, C);
         int current_hsl_mode = coin_hsl_mode
@@ -3096,7 +3098,6 @@ inline void passivbot_ema_anchor_multicoin_impl(
 
         float unrealized = 0.0f;
         float position_cost = 0.0f;
-        bool any_valid = false;
         bool has_open_position = false;
         bool has_blocking_orders = false;
         for (int c = 0; c < C; ++c) {
@@ -3109,7 +3110,6 @@ inline void passivbot_ema_anchor_multicoin_impl(
             bool mark_valid = k >= int(coin_settings[coin_offset + 6])
                 && k <= int(coin_settings[coin_offset + 7])
                 && isfinite(close);
-            any_valid = any_valid || valid;
             if (psize[c] > 0.0f) {
                 has_open_position = true;
                 position_cost += psize[c] * pprice[c]
@@ -3130,7 +3130,11 @@ inline void passivbot_ema_anchor_multicoin_impl(
             }
         }
         float equity = balance + unrealized;
-        if (can_generate && any_valid && alive
+        // Exact Rust keeps advancing balance-only equity and HSL time once
+        // portfolio tracking starts, including declared all-invalid gaps and
+        // tails. Per-coin validity still blocks fills, orders, and unrealized
+        // PnL above.
+        if (can_generate && alive
             && balance > 0.0f && equity > liquidation_floor) {
             int sampled_hsl_tier = 0;
 #if PASSIVBOT_HSL_EMA_TAIL_ENABLED
@@ -3217,7 +3221,7 @@ inline void passivbot_ema_anchor_multicoin_impl(
                 try_restart_hsl(hsl, float(k), equity);
             }
         }
-        bool active = equity_started && alive && any_valid;
+        bool active = equity_started && alive;
         if (active) {
             if (first_eq_k < 0.0f) first_eq_k = float(k);
             last_eq_k = float(k);
@@ -3839,7 +3843,9 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
         );
         const bool post_fill_balance_depleted =
             isfinite(account.balance) && account.balance <= 0.0f;
-        if (alive && !post_fill_balance_depleted) {
+        const bool past_activation_guard =
+            k > max(global_warmup, 1) && k >= requested_start_k;
+        if (alive && !post_fill_balance_depleted && past_activation_guard) {
             long_side.max_tradable_seen = max(
                 long_side.max_tradable_seen, long_tradable_count
             );
@@ -3853,12 +3859,10 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
         const int short_effective_n_positions = min(
             short_config.n_positions, short_side.max_tradable_seen
         );
-        const bool past_warmup =
-            k > max(global_warmup, 1) && k >= requested_start_k;
         const bool long_can_generate = alive
-            && long_effective_n_positions > 0 && past_warmup;
+            && long_effective_n_positions > 0 && past_activation_guard;
         const bool short_can_generate = alive
-            && short_effective_n_positions > 0 && past_warmup;
+            && short_effective_n_positions > 0 && past_activation_guard;
         equity_started = equity_started
             || long_can_generate || short_can_generate;
 
@@ -4051,7 +4055,6 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
         float long_unrealized = 0.0f;
         float short_unrealized = 0.0f;
         float net_position_cost = 0.0f;
-        bool any_valid = false;
         for (int c = 0; c < C; ++c) {
             int coin_offset = c * COIN_COLS;
             int bar_offset = (k * C + c) * 4;
@@ -4062,7 +4065,6 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
             bool mark_valid = k >= int(coin_settings[coin_offset + 6])
                 && k <= int(coin_settings[coin_offset + 7])
                 && isfinite(close);
-            any_valid = any_valid || valid;
             float c_mult = coin_settings[coin_offset + 4];
             if (long_side.psize[c] > 0.0f) {
                 net_position_cost += long_side.psize[c]
@@ -4084,8 +4086,12 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
         float equity = joint_portfolio_equity(
             account, long_unrealized, short_unrealized
         );
+        // Exact Rust keeps advancing balance-only equity and HSL time once
+        // portfolio tracking starts, including declared all-invalid gaps and
+        // tails. Per-coin validity still blocks fills, orders, and unrealized
+        // PnL above.
         bool can_sample_hsl = (long_can_generate || short_can_generate)
-            && any_valid && alive
+            && alive
             && joint_portfolio_can_generate(
                 account, equity, liquidation_floor
             );
@@ -4116,8 +4122,7 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
             }
         }
 
-        bool active = equity_started && any_valid
-            && (alive || hsl_validation_failed);
+        bool active = equity_started && (alive || hsl_validation_failed);
         if (active) {
             if (first_eq_k < 0.0f) first_eq_k = float(k);
             last_eq_k = float(k);

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
@@ -4983,7 +4983,9 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
         );
         const bool post_fill_balance_depleted =
             isfinite(account.balance) && account.balance <= 0.0f;
-        if (alive && !post_fill_balance_depleted) {
+        const bool past_activation_guard =
+            k > max(global_warmup, 1) && k >= requested_start_k;
+        if (alive && !post_fill_balance_depleted && past_activation_guard) {
             long_side.max_tradable_seen = max(
                 long_side.max_tradable_seen, long_tradable_count
             );
@@ -4997,12 +4999,10 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
         const int short_effective_n_positions = min(
             short_config.n_positions, short_side.max_tradable_seen
         );
-        const bool past_warmup =
-            k > max(global_warmup, 1) && k >= requested_start_k;
         const bool long_can_generate = alive
-            && long_effective_n_positions > 0 && past_warmup;
+            && long_effective_n_positions > 0 && past_activation_guard;
         const bool short_can_generate = alive
-            && short_effective_n_positions > 0 && past_warmup;
+            && short_effective_n_positions > 0 && past_activation_guard;
         equity_started = equity_started
             || long_can_generate || short_can_generate;
 
@@ -5196,7 +5196,6 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
         float long_unrealized = 0.0f;
         float short_unrealized = 0.0f;
         float net_position_cost = 0.0f;
-        bool any_valid = false;
         for (int c = 0; c < C; ++c) {
             int coin_offset = c * COIN_COLS;
             int bar_offset = (k * C + c) * 4;
@@ -5207,7 +5206,6 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
             bool mark_valid = k >= int(coin_settings[coin_offset + 6])
                 && k <= int(coin_settings[coin_offset + 7])
                 && isfinite(close);
-            any_valid = any_valid || valid;
             float c_mult = coin_settings[coin_offset + 4];
             if (long_side.psize[c] > 0.0f) {
                 net_position_cost += long_side.psize[c]
@@ -5229,8 +5227,12 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
         float equity = joint_portfolio_equity(
             account, long_unrealized, short_unrealized
         );
+        // Exact Rust keeps advancing balance-only equity and HSL time once
+        // portfolio tracking starts, including declared all-invalid gaps and
+        // tails. Per-coin validity still blocks fills, orders, and unrealized
+        // PnL above.
         bool can_sample_hsl = (long_can_generate || short_can_generate)
-            && any_valid && alive
+            && alive
             && joint_portfolio_can_generate(
                 account, equity, liquidation_floor
             );
@@ -5261,8 +5263,7 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
             }
         }
 
-        bool active = equity_started && any_valid
-            && (alive || hsl_validation_failed);
+        bool active = equity_started && (alive || hsl_validation_failed);
         if (active) {
             if (first_eq_k < 0.0f) first_eq_k = float(k);
             last_eq_k = float(k);
@@ -5761,12 +5762,14 @@ inline void passivbot_trailing_martingale_multicoin_impl(
             bars, coin_settings, coin_overrides, k, C
         );
         const bool post_fill_balance_depleted = isfinite(balance) && balance <= 0.0f;
-        if (alive && !post_fill_balance_depleted) {
+        const bool past_activation_guard =
+            k > max(global_warmup, 1) && k >= requested_start_k;
+        if (alive && !post_fill_balance_depleted && past_activation_guard) {
             max_tradable_seen = max(max_tradable_seen, tradable_count);
         }
         const int effective_n_positions = min(n_positions, max_tradable_seen);
         const bool can_generate = alive && effective_n_positions > 0
-            && k > max(global_warmup, 1) && k >= requested_start_k;
+            && past_activation_guard;
         equity_started = equity_started || can_generate;
         bool has_hsl_position = tm_multicoin_side_has_position(side, C);
         int current_hsl_mode = coin_hsl_mode
@@ -5850,7 +5853,6 @@ inline void passivbot_trailing_martingale_multicoin_impl(
 
         float unrealized = 0.0f;
         float position_cost = 0.0f;
-        bool any_valid = false;
         bool has_open_position = false;
         bool has_blocking_orders = false;
         for (int c = 0; c < C; ++c) {
@@ -5863,7 +5865,6 @@ inline void passivbot_trailing_martingale_multicoin_impl(
             bool mark_valid = k >= int(coin_settings[coin_offset + 6])
                 && k <= int(coin_settings[coin_offset + 7])
                 && isfinite(close);
-            any_valid = any_valid || valid;
             if (psize[c] > 0.0f) {
                 has_open_position = true;
                 position_cost += psize[c] * pprice[c]
@@ -5884,7 +5885,11 @@ inline void passivbot_trailing_martingale_multicoin_impl(
             }
         }
         float equity = balance + unrealized;
-        if (can_generate && any_valid && alive
+        // Exact Rust keeps advancing balance-only equity and HSL time once
+        // portfolio tracking starts, including declared all-invalid gaps and
+        // tails. Per-coin validity still blocks fills, orders, and unrealized
+        // PnL above.
+        if (can_generate && alive
             && balance > 0.0f && equity > liquidation_floor) {
             int sampled_hsl_tier = 0;
 #if PASSIVBOT_HSL_EMA_TAIL_ENABLED
@@ -5971,7 +5976,7 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                 try_restart_hsl(hsl, float(k), equity);
             }
         }
-        bool active = equity_started && alive && any_valid;
+        bool active = equity_started && alive;
         if (active) {
             if (first_eq_k < 0.0f) first_eq_k = float(k);
             last_eq_k = float(k);

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -655,7 +655,7 @@ def _hsl_params(bot: dict, *, signal_mode: str) -> dict[str, float]:
 def _require_supported_multicoin_valid_tails(
     hlcvs, first_valid_indices, last_valid_indices
 ) -> None:
-    """Accept staggered tails with continuous portfolio time coverage."""
+    """Validate declared multi-coin coverage and packed candle integrity."""
 
     values = np.asarray(hlcvs)
     if values.ndim != 3 or values.shape[2] < 3:
@@ -702,24 +702,6 @@ def _require_supported_multicoin_valid_tails(
             "GPU multicoin proxy requires at least one coin with a non-empty "
             "prepared valid range"
         )
-    if max(last for _, last in windows) != int(candle_count) - 1:
-        raise ValueError(
-            "GPU multicoin proxy requires at least one coin to remain valid through "
-            "the prepared endpoint while all-coins-ended tail accounting is not yet "
-            f"modeled; last_valid_indices={tails}, candle_count={candle_count}"
-        )
-    windows.sort()
-    covered_through = windows[0][1]
-    for first_valid_idx, last_valid_idx in windows[1:]:
-        if first_valid_idx > covered_through + 1:
-            raise ValueError(
-                "GPU multicoin proxy does not yet model an all-invalid gap after "
-                "portfolio equity tracking may begin; "
-                f"gap_start={covered_through + 1}, "
-                f"gap_end={first_valid_idx - 1}, "
-                f"valid_windows={windows}"
-            )
-        covered_through = max(covered_through, last_valid_idx)
     candle_indices = np.arange(candle_count, dtype=np.int64)[:, None]
     within_declared_window = (
         (candle_indices >= np.asarray(starts, dtype=np.int64)[None, :])
@@ -746,14 +728,19 @@ def _require_supported_multicoin_valid_tails(
                 f"coin={coin}, last_valid_idx={last_valid_idx}, "
                 f"packed_hlc={packed_hlc[last_valid_idx, coin].tolist()}"
             )
+    declared_coverage = np.any(within_declared_window, axis=1)
     actual_coverage = np.any(within_declared_window & actual_valid, axis=1)
-    coverage_start = min(first for first, _ in windows)
-    missing = np.flatnonzero(~actual_coverage[coverage_start:])
+    # Declared all-invalid gaps and tails are valid portfolio time: exact Rust
+    # keeps sampling balance-only equity, HSL, exposure, and elapsed-time
+    # metrics while no coin is tradeable.  A declared-valid minute whose every
+    # packed H/L/C is unusable remains a malformed required input and fails
+    # closed rather than being reclassified as an intentional gap.
+    missing = np.flatnonzero(declared_coverage & ~actual_coverage)
     if missing.size:
-        missing_idx = coverage_start + int(missing[0])
+        missing_idx = int(missing[0])
         raise ValueError(
-            "GPU multicoin proxy does not yet model an all-invalid candle after "
-            "portfolio equity tracking may begin; "
+            "GPU multicoin proxy requires at least one finite positive packed "
+            "H/L/C candle whenever a coin is declared valid; "
             f"candle_index={missing_idx}, valid_windows={windows}"
         )
 

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -4112,6 +4112,147 @@ def test_mps_multicoin_service_dispatches_forced_delist_tail(
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
 @pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
+@pytest.mark.parametrize("topology", ["long", "short", "fused"])
+@pytest.mark.parametrize(
+    ("count", "first_valid_indices", "last_valid_indices"),
+    [
+        (12, (0, 0), (6, 7)),
+        (12, (0, 9), (6, 11)),
+        (1408, (0, 0), (6, 7)),
+    ],
+    ids=[
+        "all-coins-ended-tail",
+        "gap-between-coin-histories",
+        "all-coins-forced-delisted",
+    ],
+)
+def test_mps_multicoin_service_matches_exact_declared_all_invalid_time(
+    strategy_kind, topology, count, first_valid_indices, last_valid_indices
+):
+    from backtest import run_backtest
+    from config.schema import get_template_config
+    from optimization.gpu.service import MpsMulticoinProxy
+
+    hlcvs = np.full((count, 2, 4), 100.0, dtype=np.float64)
+    hlcvs[:, :, 3] = 1.0
+    if topology in {"long", "fused"}:
+        hlcvs[3, 0, 1] = 80.0
+    if topology in {"short", "fused"}:
+        hlcvs[3, 0, 0] = 120.0
+    timestamps = (
+        1_700_000_000_000
+        + np.arange(count, dtype=np.int64) * 60_000
+    )
+    market_settings = {
+        coin: {
+            "qty_step": 0.001,
+            "price_step": 0.01,
+            "min_qty": 0.001,
+            "min_cost": 5.0,
+            "c_mult": 1.0,
+            "maker": 0.0,
+            "taker": 0.001,
+            "exchange": "bybit",
+            "first_valid_index": first,
+            "last_valid_index": last,
+            "warmup_minutes": 1,
+        }
+        for coin, first, last in zip(
+            ("BTC", "ETH"), first_valid_indices, last_valid_indices
+        )
+    }
+    market_settings["__meta__"] = {
+        "requested_start_ts": int(timestamps[0]),
+        "requested_start_date": "2023-11-14",
+        "warmup_minutes_requested": 1,
+    }
+    config = get_template_config()
+    config["live"]["strategy_kind"] = strategy_kind
+    config["live"]["max_warmup_minutes"] = 1
+    enabled_sides = (
+        ("long", "short") if topology == "fused" else (topology,)
+    )
+    config["live"]["approved_coins"] = {
+        side: ["BTC"] if side in enabled_sides else []
+        for side in ("long", "short")
+    }
+    config["live"]["hedge_mode"] = topology == "fused"
+    config["backtest"]["coins"] = {"bybit": ["BTC", "ETH"]}
+    config["backtest"]["exchanges"] = ["bybit"]
+    for side in ("long", "short"):
+        enabled = side in enabled_sides
+        risk = config["bot"][side]["risk"]
+        risk["total_wallet_exposure_limit"] = 0.1 if enabled else 0.0
+        risk["n_positions"] = 1 if enabled else 0
+        risk["entry_cooldown_minutes"] = 100.0
+        risk["we_excess_allowance_pct"] = 0.0
+        risk["position_exposure_enforcer_enabled"] = False
+        risk["total_exposure_enforcer_enabled"] = False
+        config["bot"][side]["hsl"]["enabled"] = enabled
+        config["bot"][side]["hsl"]["red_threshold"] = 0.9
+        config["bot"][side]["hsl"]["ema_span_minutes"] = 1.0
+        config["bot"][side]["unstuck"]["enabled"] = False
+    for side in enabled_sides:
+        if strategy_kind == "ema_anchor":
+            config["bot"][side]["strategy"]["ema_anchor"].update(
+                {
+                    "base_qty_pct": 1.0,
+                    "ema_span_0": 2.0,
+                    "ema_span_1": 3.0,
+                    "offset": 0.1,
+                    "offset_psize_weight": 0.0,
+                }
+            )
+        else:
+            strategy = config["bot"][side]["strategy"][
+                "trailing_martingale"
+            ]
+            strategy["ema_span_0"] = 2.0
+            strategy["ema_span_1"] = 3.0
+            strategy["entry"]["initial_qty_pct"] = 1.0
+            strategy["entry"]["initial_ema_dist"] = 0.1
+            strategy["entry"]["double_down_factor"] = 0.0
+            strategy["close"]["threshold_base_pct"] = 0.5
+
+    proxy = MpsMulticoinProxy(
+        config=config,
+        hlcvs=hlcvs,
+        mss=market_settings,
+        btc=np.full(count, 50_000.0),
+        timestamps=timestamps,
+        exchange="bybit",
+        batch_size=1,
+        needed_metrics={
+            "backtest_completion_ratio",
+            "fills_count",
+            "position_held_days_max",
+        },
+    )
+    result = proxy.evaluate([{}])[0]
+    exact_fills, _, exact_analysis = run_backtest(
+        hlcvs,
+        market_settings,
+        config,
+        "bybit",
+        np.full(count, 50_000.0),
+        timestamps,
+    )
+
+    assert result["fills_count"] == exact_analysis["fills_count"]
+    assert len(exact_fills) == exact_analysis["fills_count"]
+    # The synthetic exact helper retains the template's calendar date span,
+    # whereas the proxy receives this prepared span directly. The
+    # proxy must nevertheless cover the all-invalid tail through its endpoint.
+    assert result["backtest_completion_ratio"] > 0.9
+    assert result["position_held_days_max"] == pytest.approx(
+        exact_analysis["position_held_days_max"], rel=1.0e-5
+    )
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
 @pytest.mark.parametrize("side", ["long", "short"])
 def test_mps_single_coin_hsl_can_restart_during_invalid_tail(
     strategy_kind, side
@@ -4282,6 +4423,7 @@ def _multicoin_exposure_fixture(
     market_orders_allowed=False,
     market_order_near_touch_threshold=0.001,
     hsl_panic_market=False,
+    requested_start_index=0,
     return_context=False,
     interval_minutes=1,
 ):
@@ -4319,8 +4461,8 @@ def _multicoin_exposure_fixture(
             1_000.0,
             1,
             max(1, first_valid_indices[coin]),
-            int(timestamps[0]),
-            int(timestamps[0]),
+            int(timestamps[requested_start_index]),
+            int(timestamps[requested_start_index]),
             int(timestamps[0]),
             interval_ms,
             liquidation_threshold,
@@ -4635,6 +4777,180 @@ def test_mps_multicoin_staggered_tail_keeps_balance_only_equity_and_hsl(
     )
     assert output["last_eq_ts"].item() > last_valid * run.interval_ms
     assert output["hsl_tier_samples_total"].item() > last_valid
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
+@pytest.mark.parametrize("topology", ["long", "short", "fused"])
+@pytest.mark.parametrize(
+    (
+        "first_valid_indices",
+        "last_valid_indices",
+        "invalid_start",
+        "invalid_end",
+        "requested_start_index",
+        "expected_first_eq_index",
+    ),
+    [
+        ((0, 0), (6, 7), 8, 10, 0, 2),
+        ((0, 9), (6, 11), 7, 8, 0, 2),
+        ((0, 9), (6, 11), 7, 8, 7, 9),
+    ],
+    ids=[
+        "all-coins-ended-tail",
+        "gap-after-tracking-start",
+        "gap-crosses-requested-start",
+    ],
+)
+def test_mps_multicoin_all_invalid_time_keeps_equity_and_hsl_clock(
+    strategy_kind,
+    topology,
+    first_valid_indices,
+    last_valid_indices,
+    invalid_start,
+    invalid_end,
+    requested_start_index,
+    expected_first_eq_index,
+):
+    count = 12
+    assert all(
+        not any(
+            first <= k <= last
+            for first, last in zip(first_valid_indices, last_valid_indices)
+        )
+        for k in range(invalid_start, invalid_end + 1)
+    )
+    closes = np.full((count, 2), 100.0)
+    highs = closes.copy()
+    lows = closes.copy()
+    highs[3, :] = 101.0
+    lows[3, :] = 99.0
+    fixture_side = topology if topology != "fused" else "long"
+    runner, row, run, data = _multicoin_exposure_fixture(
+        strategy_kind,
+        fixture_side,
+        count=count,
+        closes=closes,
+        highs=highs,
+        lows=lows,
+        first_valid_indices=first_valid_indices,
+        last_valid_indices=last_valid_indices,
+        requested_start_index=requested_start_index,
+        return_context=True,
+    )
+    if strategy_kind == "ema_anchor":
+        keys = EMA_ANCHOR_MULTICOIN_PARAM_KEYS
+        fused_runner_cls = MpsEmaAnchorMulticoinFusedRunner
+    else:
+        keys = TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS
+        fused_runner_cls = MpsTrailingMartingaleMulticoinFusedRunner
+    for key, value in {
+        "hsl_enabled": 1.0,
+        "hsl_red_threshold": 0.9,
+        "hsl_ema_span_minutes": 1.0,
+        "hsl_cooldown_minutes_after_red": 0.0,
+        "hsl_no_restart_drawdown_threshold": 1.0,
+        "hsl_restart_policy": 1.0,
+        "hsl_tier_ratio_yellow": 0.5,
+        "hsl_tier_ratio_orange": 0.75,
+        "hsl_orange_graceful_stop": 0.0,
+        "hsl_signal_mode": 0.0,
+        "hsl_slot_count": 1.0,
+    }.items():
+        row[keys.index(key)] = value
+
+    if topology == "fused":
+        runner = fused_runner_cls(run, data)
+        params = np.asarray([row + row], dtype=np.float64)
+    else:
+        params = np.asarray([row], dtype=np.float64)
+    output = runner.run(params)
+    torch.mps.synchronize()
+
+    assert output["balance"].item() > 0.0
+    assert output["first_eq_ts"].item() == pytest.approx(
+        expected_first_eq_index * run.interval_ms
+    )
+    assert output["last_eq_ts"].item() >= invalid_end * run.interval_ms
+    expected_hsl_samples = (
+        output["last_eq_ts"].item() - output["first_eq_ts"].item()
+    ) / run.interval_ms + 1.0
+    assert output["hsl_tier_samples_total"].item() == pytest.approx(
+        expected_hsl_samples
+    )
+    day_samples = output["day_end_eq"][0]
+    assert torch.isfinite(day_samples).any().item()
+    assert day_samples[torch.isfinite(day_samples)][-1].item() == pytest.approx(
+        output["balance"].item()
+    )
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
+@pytest.mark.parametrize("adverse_side", ["long", "short"])
+def test_mps_multicoin_fused_hsl_restarts_during_all_coins_ended_tail(
+    strategy_kind, adverse_side
+):
+    count = 15
+    last_valid = 10
+    adverse_close = 70.0 if adverse_side == "long" else 130.0
+    closes = np.full((count, 2), 100.0)
+    closes[8:, 0] = adverse_close
+    highs = closes * 1.02
+    lows = closes * 0.98
+    if strategy_kind == "ema_anchor":
+        keys = EMA_ANCHOR_MULTICOIN_PARAM_KEYS
+        override_cols = EMA_ANCHOR_COIN_OVERRIDE_COLS
+        wallet_exposure_column = 11
+        fused_runner_cls = MpsEmaAnchorMulticoinFusedRunner
+    else:
+        keys = TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS
+        override_cols = TRAILING_MARTINGALE_COIN_OVERRIDE_COLS
+        wallet_exposure_column = 24
+        fused_runner_cls = MpsTrailingMartingaleMulticoinFusedRunner
+    overrides = np.full((2, override_cols), np.nan, dtype=np.float32)
+    overrides[1, wallet_exposure_column] = 0.0
+    _, row, run, data = _multicoin_exposure_fixture(
+        strategy_kind,
+        "long",
+        coin_overrides=overrides,
+        count=count,
+        closes=closes,
+        highs=highs,
+        lows=lows,
+        last_valid_indices=(last_valid, last_valid),
+        return_context=True,
+    )
+    for key, value in {
+        "hsl_enabled": 1.0,
+        "hsl_red_threshold": 0.01,
+        "hsl_ema_span_minutes": 1.0,
+        "hsl_cooldown_minutes_after_red": 2.0,
+        "hsl_no_restart_drawdown_threshold": 1.0,
+        "hsl_restart_policy": 0.0,
+        "hsl_tier_ratio_yellow": 0.5,
+        "hsl_tier_ratio_orange": 0.75,
+        "hsl_orange_graceful_stop": 0.0,
+        "hsl_signal_mode": 1.0,
+        "hsl_slot_count": 1.0,
+    }.items():
+        row[keys.index(key)] = value
+
+    output = fused_runner_cls(
+        run,
+        data,
+        long_coin_overrides=overrides,
+        short_coin_overrides=overrides,
+    ).run(np.asarray([row + row], dtype=np.float64))
+    torch.mps.synchronize()
+
+    assert output[f"hsl_triggers_{adverse_side}"].item() == 1.0
+    assert output[f"hsl_restarts_{adverse_side}"].item() == 1.0
+    assert output["last_eq_ts"].item() > last_valid * run.interval_ms
 
 
 @pytest.mark.skipif(

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -1205,14 +1205,13 @@ def test_multicoin_proxy_constructs_fused_shared_account_runner(
     assert constructed["kwargs"]["filter_by_min_effective_cost"] is True
 
 
-def test_gpu_multicoin_proxy_accepts_staggered_valid_and_forced_delist_tails():
+def test_gpu_multicoin_proxy_accepts_staggered_valid_gaps_and_ended_tails():
     hlcvs = np.ones((100, 2, 4), dtype=np.float64)
     _require_supported_multicoin_valid_tails(hlcvs, [0, 0], [99, 98])
     _require_supported_multicoin_valid_tails(hlcvs, [0, 50], [49, 99])
     _require_supported_multicoin_valid_tails(hlcvs, [100, 0], [99, 99])
-
-    with pytest.raises(ValueError, match="at least one coin to remain valid"):
-        _require_supported_multicoin_valid_tails(hlcvs, [0, 0], [98, 97])
+    _require_supported_multicoin_valid_tails(hlcvs, [0, 0], [98, 97])
+    _require_supported_multicoin_valid_tails(hlcvs, [0, 60], [39, 99])
     _require_supported_multicoin_valid_tails(
         np.ones((1401, 2, 4), dtype=np.float64),
         [0, 0],
@@ -1232,15 +1231,6 @@ def test_gpu_multicoin_proxy_accepts_staggered_valid_and_forced_delist_tails():
         _require_supported_multicoin_valid_tails(hlcvs, [99, 0], [98, 99])
 
 
-def test_gpu_multicoin_proxy_rejects_all_invalid_gap_between_valid_windows():
-    with pytest.raises(ValueError, match=r"all-invalid gap.*gap_start=40"):
-        _require_supported_multicoin_valid_tails(
-            np.ones((100, 2, 4), dtype=np.float64),
-            [0, 60],
-            [39, 99],
-        )
-
-
 @pytest.mark.parametrize("invalid_value", [np.nan, 0.0, -1.0])
 def test_gpu_multicoin_proxy_rejects_actual_all_invalid_candle_in_windows(
     invalid_value,
@@ -1248,7 +1238,7 @@ def test_gpu_multicoin_proxy_rejects_actual_all_invalid_candle_in_windows(
     hlcvs = np.ones((100, 2, 4), dtype=np.float64)
     hlcvs[40, :, :3] = invalid_value
 
-    with pytest.raises(ValueError, match=r"all-invalid candle.*candle_index=40"):
+    with pytest.raises(ValueError, match=r"declared valid.*candle_index=40"):
         _require_supported_multicoin_valid_tails(hlcvs, [0, 0], [59, 99])
 
     # One actual finite-positive candle is sufficient to advance portfolio
@@ -1270,7 +1260,7 @@ def test_gpu_multicoin_proxy_rejects_all_invalid_after_float32_packing(
     hlcvs = np.ones((100, 2, 4), dtype=np.float64)
     hlcvs[40, :, :3] = unpackable_value
 
-    with pytest.raises(ValueError, match=r"all-invalid candle.*candle_index=40"):
+    with pytest.raises(ValueError, match=r"declared valid.*candle_index=40"):
         _require_supported_multicoin_valid_tails(hlcvs, [0, 0], [59, 99])
 
     hlcvs[40, 1, :3] = 1.0


### PR DESCRIPTION
## Summary

- continue EMA Anchor and Trailing Martingale multi-coin MPS account time through declared all-invalid gaps and ended tails
- preserve exact Rust balance-only equity, HSL, exposure, recovery, daily, restart, and elapsed-time accounting across long-only, short-only, and fused long+short kernels
- begin grow-only tradability tracking only after the warmup/requested-start guard, matching exact Rust when a gap crosses activation
- keep malformed declared-valid packed H/L/C inputs and unrepresentable forced-delist final candles fail-closed

## Validation

- full `tests/optimization` suite on physical Apple MPS
- 40-case targeted physical-MPS matrix across both strategies, all three topologies, gaps, ended tails, all-coins forced delists, requested-start activation, and fused HSL restart
- exact Rust fill-count and open-position held-time comparisons for declared gaps, ended tails, and forced-delist tails
- `cargo test --no-default-features` (267 passed)
- `cargo check --tests`
- rebuilt and fingerprint-verified PyO3 extension
- AI documentation checks and documentation build