### PR TITLE
GPU: support recovery through invalid candles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,22 @@ All notable user-facing changes will be documented in this file.
   exact Rust's balance-only equity, HSL, exposure, restart, daily, recovery, and elapsed-time
   accounting after tracking begins, but do not activate tracking from tradability seen only before
   the requested-start guard. Validity still blocks fills, orders, and unrealized PnL. A timestep
-  covered by a declared valid range but lacking any finite positive packed float32 H/L/C remains
-  fail-closed.
+  covered by a declared valid range whose raw H/L/C values are all NaN is likewise treated
+  as non-tradable balance-only time. Single-coin kernels now apply the same rule to these internal
+  gaps, and exact Rust now classifies the same row as non-tradable without triggering delist panic
+  handling during mandatory validation. Only the GPU optimizer operation explicitly admits these
+  internal gaps; retaining `optimize.backend: gpu` in a config does not relax normal backtest,
+  suite, download, or reproduction validation. Coarser GPU candle intervals ignore complete NaN
+  minutes inside mixed buckets, preserve all-gap buckets as non-tradable gaps, and retain any
+  malformed non-gap price as a fail-closed aggregate. Gap rows must be strictly internal: the
+  first-valid candle and any forced-delist endpoint remain valid finite prices, with the endpoint
+  cutoff scaled to the prepared candle interval. Directional Metal kernels clear pending orders at
+  a supported gap so they cannot fill stale pre-gap intents afterward. This enables
+  account-equity and strategy-equity recovery
+  metrics on such histories. Finite
+  non-positive, partially invalid, or float32-unrepresentable prices remain fail-closed for GPU
+  screening; HSL-enabled coins still require contiguous candles, and a forced-delist endpoint must
+  remain representable because it supplies an executable close.
 
 - Apple MPS single-coin EMA Anchor and Trailing Martingale optimization now mirrors exact Rust's
   forced-delist close when at least 1,400 prepared candles follow a coin's final valid candle,
@@ -221,9 +235,10 @@ All notable user-facing changes will be documented in this file.
   Metal postprocessor applies Rust's strict
   time-to-exceed, percentile, and worst-tail definitions for
   `strategy_eq_recovery_days_{mean,median,p95,p99,mean_worst_5pct,mean_worst_1pct}`. Exact Rust
-  validation and rolling drift gates remain authoritative. Histories with internal invalid candles
-  remain fail closed, and a bounded single-coin coin-HSL rolling-PnL overflow emits a conservative
-  full-horizon recovery penalty. Independent dual-side multi-coin summaries remain fail closed
+  validation and rolling drift gates remain authoritative. Internal all-NaN H/L/C gaps
+  contribute balance-only samples, and a bounded single-coin coin-HSL rolling-PnL overflow emits a
+  conservative full-horizon recovery penalty. Independent dual-side multi-coin summaries remain
+  fail closed
   because they cannot reconstruct one shared portfolio-equity curve.
 
 - Added raw per-side HSL strategy-equity worst-drawdown scoring and limits to Apple MPS

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -188,9 +188,20 @@ The supported slice is intentionally narrow:
   strategy kernels emit opt-in candidate-relative hourly strategy-equity samples plus mandatory
   initial and terminal/liquidation endpoints, and a bounded Metal postprocessor applies the same
   strict time-to-exceed and percentile/tail definitions as exact Rust. The hourly proxy is
-  approximate; exact Rust validation and rolling drift gates remain authoritative. Tracked
-  histories with internal invalid candles fail closed because exact Rust records balance-only
-  strategy equity at those steps. A bounded coin-HSL rolling-PnL overflow also fails closed with a
+  approximate; exact Rust validation and rolling drift gates remain authoritative. At an internal
+  gap whose raw H/L/C values are all NaN, Metal mirrors exact Rust by advancing the tracked
+  timeline with balance-only strategy equity while blocking fills, order generation, and unrealized
+  PnL. Exact Rust classifies the same row as non-tradable without treating the internal gap as a
+  delist during mandatory validation. Only the GPU optimizer operation explicitly requests this
+  input exception; a persisted GPU backend setting does not relax other commands. At coarser candle
+  intervals, complete NaN minutes are ignored inside a mixed aggregation bucket and an all-gap
+  bucket remains a non-tradable gap; malformed non-gap prices cannot be hidden by a later valid
+  minute in the same bucket. A gap must be strictly internal: first-valid candles and forced-delist
+  endpoints remain finite positive prices, and the raw endpoint guard scales with the configured
+  candle interval. Pending directional orders are cleared at a gap before the next valid candle.
+  Normal CPU input validation stays strict.
+  Finite non-positive, partially invalid, or float32-unrepresentable prices remain fail-closed
+  for GPU screening. A bounded coin-HSL rolling-PnL overflow still fails closed with a
   conservative full-horizon recovery penalty. Independent dual-side multi-coin summaries remain
   fail closed for these metrics because they cannot reconstruct one shared portfolio-equity curve.
   Compatible suites may use the supported topologies.
@@ -249,9 +260,8 @@ The supported slice is intentionally narrow:
 - canonical USD `peak_recovery_hours_equity` and `peak_recovery_days_equity` scoring and limits
   use Metal's full-resolution maximum completed peak-to-peak recovery interval. As in exact Rust,
   an unrecovered final tail is not included and a candidate without fills returns zero. Fused
-  dual-side multi-coin kernels maintain the shared portfolio equity path. These metrics also
-  require contiguous valid candles for every exposure-eligible coin on either side after that
-  coin's equity tracking starts because Rust records an equity sample on every tracked step
+  dual-side multi-coin kernels maintain the shared portfolio equity path. Internal all-NaN
+  H/L/C gaps advance this full-resolution clock with exact Rust's balance-only equity sample
 - Trailing Martingale supports `risk.position_exposure_enforcer_enabled` and a tunable
   `risk.position_exposure_enforcer_threshold` for single-coin long, short, and dual-side runs,
   one- and dual-side multi-coin runs, and compatible suites. When current position exposure
@@ -383,14 +393,16 @@ The supported slice is intentionally narrow:
   orders for that coin. Each such coin's final H/L/C must remain finite and positive after float32
   packing; an unrepresentable final candle fails before dispatch. Dynamic tradability,
   portfolio/coin HSL, equity, and elapsed-time accounting continue on the surviving timeline
-- multi-coin histories may also contain declared all-invalid gaps between disjoint coin histories or
-  a tail after every coin has ended. Once portfolio equity tracking starts, Metal continues exact
-  Rust's balance-only equity, HSL, exposure, restart, daily, recovery, and elapsed-time accounting
-  through those periods. Tradability observed only before the warmup/requested-start guard does not
-  activate tracking inside a later gap; the next eligible coin does. Per-coin validity still blocks
-  fills, order generation, and unrealized PnL. If one or more coins are declared valid for a timestep
-  but every corresponding packed float32 H/L/C candle is non-finite or non-positive, the input
-  remains fail-closed before dispatch
+- multi-coin histories may also contain declared all-invalid gaps between disjoint coin histories, a
+  tail after every coin has ended, or internal timestamps where every declared coin's raw H/L/C is
+  NaN. Once portfolio equity tracking starts, Metal continues exact Rust's balance-only
+  equity, exposure, daily, recovery, and elapsed-time accounting through those periods. Tradability
+  observed only before the warmup/requested-start guard does not activate tracking inside a later
+  gap; the next eligible coin does. Per-coin candle validity still blocks fills, order generation,
+  and unrealized PnL. Finite but non-positive, partially invalid, or float32-unrepresentable H/L/C
+  values remain fail-closed for GPU screening. HSL-enabled coins retain the
+  stricter contiguous-candle requirement documented above, and a forced-delist endpoint must remain
+  finite and positive after float32 packing because it supplies an executable close
 
 Unsupported combinations fail before optimization begins. Dual-side multi-coin EMA Anchor and
 Trailing Martingale use fused shared-account Metal kernels in hedge and one-way modes. Every

--- a/passivbot-rust/src/backtest.rs
+++ b/passivbot-rust/src/backtest.rs
@@ -1374,7 +1374,7 @@ impl<'a> Backtest<'a> {
                 } else {
                     None
                 };
-                let valid_now = self.coin_is_valid_at(idx, k);
+                let within_valid_range_now = self.coin_is_within_valid_range_at(idx, k);
 
                 let pos_long = self.positions.long[idx];
                 let pos_short = self.positions.short[idx];
@@ -1394,10 +1394,10 @@ impl<'a> Backtest<'a> {
                         }
                     }
                 } else {
-                    if !valid_now && pos_long.size != 0.0 {
+                    if !within_valid_range_now && pos_long.size != 0.0 {
                         mode_long = Some(orchestrator::TradingMode::Panic);
                     }
-                    if !valid_now && pos_short.size != 0.0 {
+                    if !within_valid_range_now && pos_short.size != 0.0 {
                         mode_short = Some(orchestrator::TradingMode::Panic);
                     }
                 }
@@ -1674,7 +1674,7 @@ impl<'a> Backtest<'a> {
             sym.long.runtime_budget = Some(self.runtime_budget[idx].long.clone());
             sym.short.runtime_budget = Some(self.runtime_budget[idx].short.clone());
 
-            let valid_now = self.coin_is_valid_at(idx, k);
+            let within_valid_range_now = self.coin_is_within_valid_range_at(idx, k);
             let mut mode_long: Option<orchestrator::TradingMode> = self.configured_mode(idx, LONG);
             let mut mode_short: Option<orchestrator::TradingMode> =
                 self.configured_mode(idx, SHORT);
@@ -1689,10 +1689,10 @@ impl<'a> Backtest<'a> {
                     }
                 }
             } else {
-                if !valid_now && pos_long.size != 0.0 {
+                if !within_valid_range_now && pos_long.size != 0.0 {
                     mode_long = Some(orchestrator::TradingMode::Panic);
                 }
-                if !valid_now && pos_short.size != 0.0 {
+                if !within_valid_range_now && pos_short.size != 0.0 {
                     mode_short = Some(orchestrator::TradingMode::Panic);
                 }
             }
@@ -2587,10 +2587,21 @@ impl<'a> Backtest<'a> {
     }
 
     #[inline(always)]
-    fn coin_is_valid_at(&self, idx: usize, k: usize) -> bool {
+    fn coin_is_within_valid_range_at(&self, idx: usize, k: usize) -> bool {
         self.coin_valid_range(idx)
             .map(|(start, end)| k >= start && k <= end)
             .unwrap_or(false)
+    }
+
+    #[inline(always)]
+    fn coin_is_valid_at(&self, idx: usize, k: usize) -> bool {
+        if !self.coin_is_within_valid_range_at(idx, k) {
+            return false;
+        }
+        let high = self.hlcvs_value(k, idx, HIGH);
+        let low = self.hlcvs_value(k, idx, LOW);
+        let close = self.hlcvs_value(k, idx, CLOSE);
+        !(high.is_nan() && low.is_nan() && close.is_nan())
     }
 
     #[inline(always)]
@@ -6398,6 +6409,77 @@ mod tests {
             Some(orchestrator::TradingMode::Normal)
         );
         assert_eq!(input.symbols[0].short.mode, None);
+    }
+
+    #[test]
+    fn all_nan_hlc_gap_is_not_valid_or_tradeable() {
+        let mut values = vec![1.0; 3 * 4];
+        values[4] = f64::NAN;
+        values[5] = f64::NAN;
+        values[6] = f64::NAN;
+        values[7] = f64::NAN;
+        let hlcvs = Array3::from_shape_vec((3, 1, 4), values).unwrap();
+        let btc_usd_prices = Array1::from_vec(vec![20_000.0; 3]);
+        let mut bp_pair = BotParamsPair::default();
+        bp_pair.long.n_positions = 1;
+        bp_pair.long.total_wallet_exposure_limit = 1.0;
+        bp_pair.long.wallet_exposure_limit = 1.0;
+        bp_pair.long.ema_span_0 = 10.0;
+        bp_pair.long.ema_span_1 = 20.0;
+        let backtest_params = BacktestParams {
+            starting_balance: 1000.0,
+            maker_fee: 0.0,
+            taker_fee: 0.00055,
+            coins: vec!["TEST".to_string()],
+            active_coin_indices: None,
+            first_timestamp_ms: 0,
+            requested_start_timestamp_ms: 0,
+            first_valid_indices: vec![0],
+            last_valid_indices: vec![2],
+            warmup_minutes: vec![0],
+            trade_start_indices: vec![0],
+            global_warmup_bars: 0,
+            btc_collateral_cap: 0.0,
+            btc_collateral_ltv_cap: None,
+            metrics_only: true,
+            skip_btc_analysis: false,
+            filter_by_min_effective_cost: false,
+            dynamic_wel_by_tradability: true,
+            hedge_mode: true,
+            forager_score_hysteresis_pct: 0.0,
+            max_realized_loss_pct: 1.0,
+            pnls_max_lookback_days: 30.0,
+            liquidation_threshold: 0.05,
+            equity_hard_stop_loss: EquityHardStopLossConfig::default(),
+            market_orders_allowed: false,
+            market_order_near_touch_threshold: 0.001,
+            market_order_slippage_pct: 0.0005,
+            candle_interval_minutes: 1,
+        };
+        let mut bt = Backtest::new(
+            hlcvs.view(),
+            btc_usd_prices.view(),
+            vec![bp_pair],
+            vec![ExchangeParams::default()],
+            &backtest_params,
+        );
+
+        assert!(bt.coin_is_valid_at(0, 0));
+        assert!(!bt.coin_is_valid_at(0, 1));
+        assert!(!bt.coin_is_tradeable_at(0, 1));
+        assert!(bt.coin_is_valid_at(0, 2));
+
+        bt.positions.long[0] = Position {
+            size: 1.0,
+            price: 1.0,
+        };
+        let input = bt.build_orchestrator_input_iter(1, None, None, 0..1);
+        assert!(!input.symbols[0].tradable);
+        assert_ne!(
+            input.symbols[0].long.mode,
+            Some(orchestrator::TradingMode::Panic),
+            "an internal data gap must not be mistaken for a delist"
+        );
     }
 
     #[test]

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -200,10 +200,21 @@ mod tests {
         assert!(source.contains("const bool rolling_pnl_overflowed ="));
         assert!(source.contains("= RECOVERY_FAIL_CLOSED_SENTINEL;"));
         assert!(source.contains("const bool after_valid_tail = k > last_valid"));
-        assert!(source.contains("(valid || after_valid_tail)"));
+        assert!(source.contains("bool active = eq_started && alive"));
+        assert!(!source
+            .contains("eq_started && alive && (valid || after_valid_tail)"));
         assert!(source.contains("const bool hsl_step = gen || (eq_started && after_valid_tail)"));
         assert!(source.contains("bool long_blocking_orders = valid &&"));
         assert!(source.contains("bool short_blocking_orders = valid &&"));
+        assert!(source.contains("if (!valid) {"));
+        assert!(
+            source.contains("clear_pending_ema_orders(long_side);")
+                || source.contains("clear_pending_tm_orders(long_side);")
+        );
+        assert!(
+            source.contains("clear_pending_ema_orders(short_side);")
+                || source.contains("clear_pending_tm_orders(short_side);")
+        );
     }
 
     #[test]

--- a/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
@@ -243,6 +243,12 @@ struct EmaSide {
     bool close_is_panic;
 };
 
+inline void clear_pending_ema_orders(thread EmaSide& side) {
+    side.entry_qty = 0.0f;
+    side.close_qty = 0.0f;
+    side.secondary_close_qty = 0.0f;
+}
+
 struct ReducerVariant {
     bool valid;
     bool is_unstuck;
@@ -1259,6 +1265,11 @@ inline void passivbot_single_coin_impl(
         const int touch_up_tick = flags[fo + 7];
         const float kf = float(k);
 
+        if (!valid) {
+            clear_pending_ema_orders(long_side);
+            clear_pending_ema_orders(short_side);
+        }
+
         if (di != cur_day) {
             if (day_touched && cur_day >= 0 && cur_day < D) {
                 int o = (int(b) * D + cur_day) * DAILY_COLS;
@@ -2020,7 +2031,10 @@ inline void passivbot_single_coin_impl(
                 try_restart_hsl(short_hsl, kf, equity);
             }
         }
-        bool active = eq_started && alive && (valid || after_valid_tail);
+        // Exact Rust records an equity sample at every tracked timestamp.
+        // Invalid candles are non-tradable and contribute balance-only equity,
+        // just like the already-supported tail after last_valid.
+        bool active = eq_started && alive;
         if (active) {
             if (first_eq_k < 0.0f) first_eq_k = kf;
             last_eq_k = kf;

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -301,6 +301,12 @@ struct TmSide {
     float min_since_open, max_since_min, max_since_open, min_since_max;
 };
 
+inline void clear_pending_tm_orders(thread TmSide& side) {
+    side.entry_qty = 0.0f;
+    side.close_qty = 0.0f;
+    side.secondary_close_qty = 0.0f;
+}
+
 struct CloseGroup {
     int ticks;
     float price;
@@ -1875,6 +1881,11 @@ inline void passivbot_single_coin_impl(
         const float touch_min_qty = as_type<float>(flags[fo + 9]);
         const int touch_min_qty_relation = flags[fo + 10];
         const float kf = float(k);
+
+        if (!valid) {
+            clear_pending_tm_orders(long_side);
+            clear_pending_tm_orders(short_side);
+        }
 
         if (di != cur_day) {
             if (day_touched && cur_day >= 0 && cur_day < D) {
@@ -3854,7 +3865,10 @@ inline void passivbot_single_coin_impl(
                 try_restart_hsl(short_hsl, kf, equity);
             }
         }
-        bool active = eq_started && alive && (valid || after_valid_tail);
+        // Exact Rust records an equity sample at every tracked timestamp.
+        // Invalid candles are non-tradable and contribute balance-only equity,
+        // just like the already-supported tail after last_valid.
+        bool active = eq_started && alive;
         if (active) {
             if (first_eq_k < 0.0f) first_eq_k = kf;
             last_eq_k = kf;

--- a/src/backtest.py
+++ b/src/backtest.py
@@ -712,6 +712,8 @@ def _validate_hlcvs_valid_windows(
     *,
     coin_indices: list[int] | None = None,
     target_chunk_bytes: int = _HLCVS_VALIDATION_TARGET_CHUNK_BYTES,
+    allow_internal_nan_gaps: bool = False,
+    candle_interval_minutes: int = 1,
 ) -> None:
     hlcvs_arr = np.asarray(hlcvs)
     if hlcvs_arr.ndim != 3 or hlcvs_arr.shape[2] < 4:
@@ -749,6 +751,36 @@ def _validate_hlcvs_valid_windows(
         start = max(0, start)
         end = min(n_rows - 1, end)
         valid_windows.append((col, start, end))
+
+    if allow_internal_nan_gaps:
+        prepared_interval_float = float(candle_interval_minutes)
+        if not prepared_interval_float.is_integer() or prepared_interval_float < 1.0:
+            raise ValueError(
+                "candle_interval_minutes must be a positive integer before "
+                f"GPU gap validation, got {candle_interval_minutes!r}"
+            )
+        prepared_interval = int(prepared_interval_float)
+        for payload_idx, (col, start, end) in enumerate(valid_windows):
+            if (
+                start <= end
+                and bool(np.isnan(hlcvs_arr[start, col, :3]).all())
+            ):
+                raise ValueError(
+                    "all-NaN H/L/C is not allowed at a first-valid boundary: "
+                    f"coin={coins_order[payload_idx]} payload_index={payload_idx} "
+                    f"source_column={col} first_valid_index={start} rows={n_rows}"
+                )
+            if (
+                start <= end
+                and end + 1400 * prepared_interval < n_rows
+                and bool(np.isnan(hlcvs_arr[end, col, :3]).all())
+            ):
+                raise ValueError(
+                    "all-NaN H/L/C is not allowed at a forced-delist endpoint: "
+                    f"coin={coins_order[payload_idx]} payload_index={payload_idx} "
+                    f"source_column={col} last_valid_index={end} rows={n_rows} "
+                    f"candle_interval_minutes={prepared_interval}"
+                )
 
     column_events: dict[int, dict[int, int]] = {}
     for col, start, end in valid_windows:
@@ -817,7 +849,16 @@ def _validate_hlcvs_valid_windows(
                 chunk_values = hlcvs_arr[chunk_start:chunk_end, :, :4][
                     :, column_indices, :
                 ]
-            finite_by_row_coin = np.isfinite(chunk_values).all(axis=2)
+            finite_fields = np.isfinite(chunk_values)
+            finite_hlc = finite_fields[:, :, :3]
+            # Exact Rust treats a declared-range row whose complete H/L/C
+            # triple is NaN as non-tradable portfolio time. Preserve that
+            # intentional gap, while continuing to reject infinities,
+            # partially invalid prices, and non-finite volume on otherwise
+            # valid rows.
+            finite_by_row_coin = finite_hlc.all(axis=2) & finite_fields[:, :, 3]
+            if allow_internal_nan_gaps:
+                finite_by_row_coin |= np.isnan(chunk_values[:, :, :3]).all(axis=2)
             chunk_count += 1
             for payload_idx, (col, start, end) in enumerate(valid_windows):
                 if first_bad_rows[payload_idx] is not None or start > end:
@@ -870,7 +911,15 @@ def _validate_hlcvs_valid_windows(
     )
 
 
-def _validate_hlcvs_valid_windows_from_mss(hlcvs, timestamps, coins, mss) -> None:
+def _validate_hlcvs_valid_windows_from_mss(
+    hlcvs,
+    timestamps,
+    coins,
+    mss,
+    *,
+    allow_internal_nan_gaps: bool = False,
+    candle_interval_minutes: int = 1,
+) -> None:
     first_valid_indices = []
     last_valid_indices = []
     for coin in coins:
@@ -883,6 +932,8 @@ def _validate_hlcvs_valid_windows_from_mss(hlcvs, timestamps, coins, mss) -> Non
         coins,
         first_valid_indices,
         last_valid_indices,
+        allow_internal_nan_gaps=allow_internal_nan_gaps,
+        candle_interval_minutes=candle_interval_minutes,
     )
 
 
@@ -2121,12 +2172,21 @@ def assert_hlcv_has_tradable_coverage(coins, mss):
         raise ValueError("HLCV data has no tradable candles after warmup")
 
 
-async def prepare_hlcvs_mss(config, exchange, *, force_refetch_gaps: bool = False):
+async def prepare_hlcvs_mss(
+    config,
+    exchange,
+    *,
+    force_refetch_gaps: bool = False,
+    allow_internal_nan_gaps: bool = False,
+):
     base_dir = require_config_value(config, "backtest.base_dir")
     results_path = oj(base_dir, exchange, "")
     warmup_map = compute_per_coin_warmup_minutes(config)
     default_warm = int(warmup_map.get("__default__", 0))
     backtest_warmup_minutes = compute_backtest_warmup_minutes(config)
+    candle_interval_minutes = config.get("backtest", {}).get(
+        "candle_interval_minutes", 1
+    ) or 1
     if exchange == "combined":
         backtest_cfg = config.setdefault("backtest", {})
         configured_exchanges = [
@@ -2159,7 +2219,14 @@ async def prepare_hlcvs_mss(config, exchange, *, force_refetch_gaps: bool = Fals
     if override_result is not None:
         cache_dir, coins, hlcvs, mss, results_path, btc_usd_prices, timestamps = override_result
         ensure_valid_index_metadata(mss, hlcvs, coins, warmup_map)
-        _validate_hlcvs_valid_windows_from_mss(hlcvs, timestamps, coins, mss)
+        _validate_hlcvs_valid_windows_from_mss(
+            hlcvs,
+            timestamps,
+            coins,
+            mss,
+            allow_internal_nan_gaps=allow_internal_nan_gaps,
+            candle_interval_minutes=candle_interval_minutes,
+        )
         warn_hlcv_valid_range_coverage(config, coins, mss, timestamps)
         assert_hlcv_has_tradable_coverage(coins, mss)
         return (
@@ -2185,7 +2252,14 @@ async def prepare_hlcvs_mss(config, exchange, *, force_refetch_gaps: bool = Fals
             )
             logging.info(f"Successfully loaded hlcvs data from cache")
             ensure_valid_index_metadata(mss, hlcvs, coins, warmup_map)
-            _validate_hlcvs_valid_windows_from_mss(hlcvs, timestamps, coins, mss)
+            _validate_hlcvs_valid_windows_from_mss(
+                hlcvs,
+                timestamps,
+                coins,
+                mss,
+                allow_internal_nan_gaps=allow_internal_nan_gaps,
+                candle_interval_minutes=candle_interval_minutes,
+            )
             warn_hlcv_valid_range_coverage(config, coins, mss, timestamps)
             assert_hlcv_has_tradable_coverage(coins, mss)
             # Pass through cached timestamps if they were stored; fall back to None otherwise
@@ -2240,7 +2314,14 @@ async def prepare_hlcvs_mss(config, exchange, *, force_refetch_gaps: bool = Fals
         )
     coins = sorted([coin for coin in mss.keys() if not coin.startswith("__")])
     ensure_valid_index_metadata(mss, hlcvs, coins, warmup_map)
-    _validate_hlcvs_valid_windows_from_mss(hlcvs, timestamps, coins, mss)
+    _validate_hlcvs_valid_windows_from_mss(
+        hlcvs,
+        timestamps,
+        coins,
+        mss,
+        allow_internal_nan_gaps=allow_internal_nan_gaps,
+        candle_interval_minutes=candle_interval_minutes,
+    )
     warn_hlcv_valid_range_coverage(config, coins, mss, timestamps)
     assert_hlcv_has_tradable_coverage(coins, mss)
     logging.info(f"Finished preparing hlcvs data for {exchange}. Shape: {hlcvs.shape}")

--- a/src/ohlcv_utils.py
+++ b/src/ohlcv_utils.py
@@ -227,7 +227,12 @@ def attempt_gap_fix_ohlcvs(
     return new_df.reset_index().rename(columns={"index": "timestamp"})
 
 
-def aggregate_hlcvs(candles_1m: np.ndarray, interval: int) -> np.ndarray:
+def aggregate_hlcvs(
+    candles_1m: np.ndarray,
+    interval: int,
+    *,
+    preserve_internal_nan_gaps: bool = False,
+) -> np.ndarray:
     """
     Aggregate 1m HLCV candles to coarser interval.
 
@@ -257,15 +262,71 @@ def aggregate_hlcvs(candles_1m: np.ndarray, interval: int) -> np.ndarray:
     truncated = candles[: n_out * interval]
     reshaped = truncated.reshape(n_out, interval, *candles.shape[1:])
     # HLCV indices: 0=high, 1=low, 2=close, 3=volume
-    aggregated = np.stack(
-        [
-            reshaped[:, :, :, 0].max(axis=1),  # high: max across interval
-            reshaped[:, :, :, 1].min(axis=1),  # low: min across interval
-            reshaped[:, -1, :, 2],  # close: last candle's close
-            reshaped[:, :, :, 3].sum(axis=1),  # volume: sum across interval
-        ],
-        axis=-1,
+    if not preserve_internal_nan_gaps:
+        aggregated = np.stack(
+            [
+                reshaped[:, :, :, 0].max(axis=1),  # high: max across interval
+                reshaped[:, :, :, 1].min(axis=1),  # low: min across interval
+                reshaped[:, -1, :, 2],  # close: last candle's close
+                reshaped[:, :, :, 3].sum(axis=1),  # volume: sum across interval
+            ],
+            axis=-1,
+        )
+        return aggregated
+
+    # A GPU optimizer may explicitly admit a minute whose H/L/C are all NaN
+    # as balance-only, non-tradable time. Ignore only those complete gaps when
+    # a coarser bucket also contains valid minutes; partial NaNs, infinities,
+    # and other malformed rows must keep propagating to downstream fail-closed
+    # validation. An all-gap bucket remains an all-NaN H/L/C gap.
+    raw_hlc = reshaped[:, :, :, :3]
+    gap_rows = np.isnan(raw_hlc).all(axis=3)
+    float32_max = float(np.finfo(np.float32).max)
+    float32_zero_rounding_boundary = float(
+        np.nextafter(np.float32(0.0), np.float32(1.0), dtype=np.float32)
+    ) / 2.0
+    malformed_rows = np.zeros_like(gap_rows)
+    for field in range(3):
+        field_values = raw_hlc[:, :, :, field]
+        malformed_rows |= (
+            ~np.isfinite(field_values)
+            | (field_values <= float32_zero_rounding_boundary)
+            | (field_values > float32_max)
+        )
+    malformed_rows &= ~gap_rows
+    malformed_buckets = malformed_rows.any(axis=1)
+    all_gap = gap_rows.all(axis=1)
+    usable_rows = ~gap_rows
+    high = np.max(
+        reshaped[:, :, :, 0],
+        axis=1,
+        where=usable_rows,
+        initial=-np.inf,
     )
+    low = np.min(
+        reshaped[:, :, :, 1],
+        axis=1,
+        where=usable_rows,
+        initial=np.inf,
+    )
+    close = np.full((n_out, candles.shape[1]), np.nan, dtype=candles.dtype)
+    for minute in range(interval):
+        usable = usable_rows[:, minute, :]
+        close[usable] = reshaped[:, minute, :, 2][usable]
+    volume = np.sum(
+        reshaped[:, :, :, 3],
+        axis=1,
+        where=usable_rows,
+        initial=0.0,
+    )
+    high[all_gap] = np.nan
+    low[all_gap] = np.nan
+    close[all_gap] = np.nan
+    # Do not let a later valid minute sanitize a malformed non-gap price.
+    # A partial-NaN aggregate is an intentional fail-closed sentinel for the
+    # post-aggregation GPU screening gate.
+    close[malformed_buckets] = np.nan
+    aggregated = np.stack([high, low, close, volume], axis=-1)
     return aggregated
 
 
@@ -274,6 +335,8 @@ def align_and_aggregate_hlcvs(
     timestamps: np.ndarray | None,
     btc_usd_prices: np.ndarray | None,
     interval: int,
+    *,
+    preserve_internal_nan_gaps: bool = False,
 ) -> tuple[np.ndarray, np.ndarray | None, np.ndarray | None, int]:
     """
     Align candles to interval boundaries (by trimming leading bars) and aggregate.
@@ -298,7 +361,11 @@ def align_and_aggregate_hlcvs(
             timestamps = timestamps[offset_bars:]
             if btc_usd_prices is not None and len(btc_usd_prices) >= offset_bars:
                 btc_usd_prices = btc_usd_prices[offset_bars:]
-    hlcvs_agg = aggregate_hlcvs(hlcvs, interval)
+    hlcvs_agg = aggregate_hlcvs(
+        hlcvs,
+        interval,
+        preserve_internal_nan_gaps=preserve_internal_nan_gaps,
+    )
     n_out = hlcvs_agg.shape[0]
     ts_agg = None
     btc_agg = None

--- a/src/optimization/gpu/model.py
+++ b/src/optimization/gpu/model.py
@@ -885,7 +885,9 @@ def build_mps_data(high, low, close, timestamps_ms, run: ProxyRun, market: Proxy
         np.isfinite(close[first_valid : last_valid + 1])
         & (close[first_valid : last_valid + 1] > 0.0)
         & np.isfinite(high[first_valid : last_valid + 1])
+        & (high[first_valid : last_valid + 1] > 0.0)
         & np.isfinite(low[first_valid : last_valid + 1])
+        & (low[first_valid : last_valid + 1] > 0.0)
     )
     indices = np.arange(n, dtype=np.int64)
     can_generate = (
@@ -989,7 +991,12 @@ def build_mps_multicoin_data(
         raise ValueError("MPS multicoin proxy requires a continuous candle timeline")
 
     bars = np.ascontiguousarray(values[:, :, :4], dtype=np.float32)
-    bars[~np.isfinite(bars)] = 0.0
+    # Preserve a non-finite close so portfolio-equity accumulation can mirror
+    # exact Rust by omitting that coin's unrealized PnL. Other non-finite
+    # fields use zero sentinels and remain blocked by candle validity.
+    for field in (0, 1, 3):
+        field_values = bars[:, :, field]
+        field_values[~np.isfinite(field_values)] = 0.0
     fill_ticks = np.empty((candle_count, coin_count, 2), dtype=np.int32)
     touch_ticks = np.empty((candle_count, coin_count, 2), dtype=np.int32)
     touch_nearest_ticks = np.empty((candle_count, coin_count), dtype=np.int32)

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -702,11 +702,6 @@ def _require_supported_multicoin_valid_tails(
             "GPU multicoin proxy requires at least one coin with a non-empty "
             "prepared valid range"
         )
-    candle_indices = np.arange(candle_count, dtype=np.int64)[:, None]
-    within_declared_window = (
-        (candle_indices >= np.asarray(starts, dtype=np.int64)[None, :])
-        & (candle_indices <= np.asarray(tails, dtype=np.int64)[None, :])
-    )
     # Validate the representation consumed by Metal. The data packer casts
     # bars to float32 and replaces non-finite packed values with zero, so a
     # finite-positive float64 value is insufficient if it overflows or
@@ -728,20 +723,37 @@ def _require_supported_multicoin_valid_tails(
                 f"coin={coin}, last_valid_idx={last_valid_idx}, "
                 f"packed_hlc={packed_hlc[last_valid_idx, coin].tolist()}"
             )
-    declared_coverage = np.any(within_declared_window, axis=1)
+    for coin, first_valid_idx in enumerate(starts):
+        if (
+            first_valid_idx < candle_count
+            and tails[coin] >= first_valid_idx
+            and not actual_valid[first_valid_idx, coin]
+        ):
+            raise ValueError(
+                "GPU multicoin proxy requires each first-valid candle's packed "
+                "float32 H/L/C values to remain finite and positive; "
+                f"coin={coin}, first_valid_idx={first_valid_idx}, "
+                f"packed_hlc={packed_hlc[first_valid_idx, coin].tolist()}"
+            )
+    candle_indices = np.arange(candle_count, dtype=np.int64)[:, None]
+    within_declared_window = (
+        (candle_indices >= np.asarray(starts, dtype=np.int64)[None, :])
+        & (candle_indices <= np.asarray(tails, dtype=np.int64)[None, :])
+    )
     actual_coverage = np.any(within_declared_window & actual_valid, axis=1)
-    # Declared all-invalid gaps and tails are valid portfolio time: exact Rust
-    # keeps sampling balance-only equity, HSL, exposure, and elapsed-time
-    # metrics while no coin is tradeable.  A declared-valid minute whose every
-    # packed H/L/C is unusable remains a malformed required input and fails
-    # closed rather than being reclassified as an intentional gap.
-    missing = np.flatnonzero(declared_coverage & ~actual_coverage)
-    if missing.size:
-        missing_idx = int(missing[0])
+    missing = np.flatnonzero(
+        np.any(within_declared_window, axis=1) & ~actual_coverage
+    )
+    for candle_index in missing:
+        declared = within_declared_window[candle_index]
+        raw_hlc = np.asarray(values[candle_index, declared, :3], dtype=np.float64)
+        if bool(np.all(np.isnan(raw_hlc))):
+            continue
         raise ValueError(
-            "GPU multicoin proxy requires at least one finite positive packed "
-            "H/L/C candle whenever a coin is declared valid; "
-            f"candle_index={missing_idx}, valid_windows={windows}"
+            "GPU multicoin proxy only supports an all-invalid internal candle "
+            "when every declared coin's raw H/L/C is NaN; infinities, finite but "
+            "non-positive or float32-unrepresentable values remain fail-closed; "
+            f"candle_index={int(candle_index)}, valid_windows={windows}"
         )
 
 
@@ -794,70 +806,89 @@ def _require_no_internal_invalid_multicoin_hsl_candles(
         )
 
 
-def _require_no_internal_invalid_account_recovery_candles(
+def _require_exact_safe_proxy_candles(
     hlcvs,
     *,
     exposure_eligible_coins,
     first_valid_indices,
     last_valid_indices,
-    tracking_start_indices,
+    require_positive_high_low: bool,
 ) -> None:
-    """Keep completed account-equity recovery aligned with Rust's per-step series."""
+    """Allow exact balance-only gaps, but reject finite unmodeled prices."""
 
     values = np.asarray(hlcvs)
     if values.ndim != 3 or values.shape[2] < 3:
         raise ValueError(
-            "MPS account-equity recovery requires HLCVs shaped [time, coin, fields]"
+            "MPS proxy requires HLCVs shaped [time, coin, fields]"
         )
+    with np.errstate(over="ignore", under="ignore", invalid="ignore"):
+        packed = np.asarray(values[:, :, :3], dtype=np.float32)
     for coin in range(values.shape[1]):
         if not bool(exposure_eligible_coins[coin]):
             continue
-        first = max(
-            0,
-            int(tracking_start_indices[coin]),
-            int(first_valid_indices[coin]),
-        )
+        first = max(0, int(first_valid_indices[coin]))
         last = min(int(last_valid_indices[coin]), values.shape[0] - 1)
         if first > last:
             continue
-        high = values[first : last + 1, coin, 0]
-        low = values[first : last + 1, coin, 1]
-        close = values[first : last + 1, coin, 2]
-        valid = (
-            np.isfinite(high)
-            & np.isfinite(low)
-            & np.isfinite(close)
-            & (close > 0.0)
+        raw_hlc = np.asarray(values[first : last + 1, coin, :3], dtype=np.float64)
+        packed_hlc = packed[first : last + 1, coin]
+        packed_valid = (
+            np.all(np.isfinite(packed_hlc), axis=1)
+            & (packed_hlc[:, 2] > 0.0)
         )
-        if not bool(np.all(valid)):
-            first_invalid = first + int(np.flatnonzero(~valid)[0])
+        if require_positive_high_low:
+            packed_valid &= (packed_hlc[:, 0] > 0.0) & (
+                packed_hlc[:, 1] > 0.0
+            )
+        exact_balance_only = np.all(np.isnan(raw_hlc), axis=1)
+        unsafe = np.flatnonzero(~(packed_valid | exact_balance_only))
+        if unsafe.size:
+            candle_index = first + int(unsafe[0])
             raise ValueError(
-                "MPS account/strategy-equity recovery metrics require contiguous "
-                "valid candles after equity tracking starts; "
-                f"coin index {coin}, invalid candle at {first_invalid}"
+                "MPS proxy only supports internal "
+                "invalid candles whose raw H/L/C values are all NaN; "
+                "infinite, finite but non-positive, partially invalid, or float32-"
+                "unrepresentable prices remain fail-closed; "
+                f"coin index {coin}, invalid candle at {candle_index}"
             )
 
 
-def _require_no_internal_invalid_single_coin_recovery_candles(
+def _require_no_unsafe_single_coin_candles(
     hlcvs,
     *,
-    needed_metrics,
     first_valid_idx: int,
     last_valid_idx: int,
-    tracking_start_idx: int,
 ) -> None:
-    recovery_metrics = (
-        _ACCOUNT_EQUITY_RECOVERY_METRICS
-        | _STRATEGY_EQ_RECOVERY_DISTRIBUTION_METRICS
-    )
-    if not set(needed_metrics) & recovery_metrics:
-        return
-    _require_no_internal_invalid_account_recovery_candles(
-        hlcvs,
+    values = np.asarray(hlcvs)
+    if (
+        values.ndim == 3
+        and values.shape[1] > 0
+        and values.shape[2] >= 3
+        and 0 <= int(first_valid_idx) < values.shape[0]
+        and bool(np.all(np.isnan(values[int(first_valid_idx), 0, :3])))
+    ):
+        raise ValueError(
+            "MPS single-coin proxy requires the first-valid candle to have "
+            f"finite positive H/L/C; first_valid_idx={first_valid_idx}"
+        )
+    if (
+        values.ndim == 3
+        and values.shape[1] > 0
+        and values.shape[2] >= 3
+        and 0 <= int(last_valid_idx) < values.shape[0]
+        and int(last_valid_idx) + 1400 < values.shape[0]
+        and bool(np.all(np.isnan(values[int(last_valid_idx), 0, :3])))
+    ):
+        raise ValueError(
+            "MPS single-coin proxy requires the forced-delist final candle "
+            f"to have finite positive H/L/C; last_valid_idx={last_valid_idx}"
+        )
+    _require_exact_safe_proxy_candles(
+        values,
         exposure_eligible_coins=[True],
         first_valid_indices=[first_valid_idx],
         last_valid_indices=[last_valid_idx],
-        tracking_start_indices=[tracking_start_idx],
+        require_positive_high_low=True,
     )
 
 
@@ -1428,12 +1459,10 @@ class MpsSingleCoinProxy:
         high = hlcvs[:, 0, 0].astype(np.float64)
         low = hlcvs[:, 0, 1].astype(np.float64)
         close = hlcvs[:, 0, 2].astype(np.float64)
-        _require_no_internal_invalid_single_coin_recovery_candles(
+        _require_no_unsafe_single_coin_candles(
             hlcvs,
-            needed_metrics=self.needed_metrics,
             first_valid_idx=self.run.first_valid_idx,
             last_valid_idx=self.run.last_valid_idx,
-            tracking_start_idx=self.run.trade_start_idx,
         )
         if hsl_enabled_sides:
             _require_no_internal_invalid_hsl_candles(
@@ -2241,27 +2270,23 @@ class MpsMulticoinProxy:
             last_valid_idx=max(run.last_valid_idx for run in runs),
             trade_start_idx=min(run.trade_start_idx for run in runs),
         )
-        if self.needed_metrics & (
-            _ACCOUNT_EQUITY_RECOVERY_METRICS
-            | _STRATEGY_EQ_RECOVERY_DISTRIBUTION_METRICS
-        ):
-            wallet_exposure_column = (
-                EMA_ANCHOR_COIN_OVERRIDE_WALLET_EXPOSURE_COLUMN
-                if self.strategy_kind == "ema_anchor"
-                else len(TRAILING_MARTINGALE_COIN_OVERRIDE_PATHS) + 1
-            )
-            exposure_eligible_coins = _multicoin_exposure_eligible_coins(
-                per_side_coin_overrides,
-                self.sides,
-                wallet_exposure_column,
-            )
-            _require_no_internal_invalid_account_recovery_candles(
-                values,
-                exposure_eligible_coins=exposure_eligible_coins,
-                first_valid_indices=backtest_params["first_valid_indices"],
-                last_valid_indices=backtest_params["last_valid_indices"],
-                tracking_start_indices=[run.trade_start_idx for run in runs],
-            )
+        wallet_exposure_column = (
+            EMA_ANCHOR_COIN_OVERRIDE_WALLET_EXPOSURE_COLUMN
+            if self.strategy_kind == "ema_anchor"
+            else len(TRAILING_MARTINGALE_COIN_OVERRIDE_PATHS) + 1
+        )
+        exposure_eligible_coins = _multicoin_exposure_eligible_coins(
+            per_side_coin_overrides,
+            self.sides,
+            wallet_exposure_column,
+        )
+        _require_exact_safe_proxy_candles(
+            values,
+            exposure_eligible_coins=exposure_eligible_coins,
+            first_valid_indices=backtest_params["first_valid_indices"],
+            last_valid_indices=backtest_params["last_valid_indices"],
+            require_positive_high_low=True,
+        )
         self.data = build_mps_multicoin_data(
             values,
             timestamps,

--- a/src/optimize.py
+++ b/src/optimize.py
@@ -269,13 +269,25 @@ def _normalize_optional_bool_flag(argv: list[str], flag: str) -> list[str]:
     return result
 
 
-def _maybe_aggregate_backtest_data(hlcvs, timestamps, btc_usd_prices, mss, config):
+def _maybe_aggregate_backtest_data(
+    hlcvs,
+    timestamps,
+    btc_usd_prices,
+    mss,
+    config,
+    *,
+    preserve_internal_nan_gaps: bool = False,
+):
     candle_interval = int(config.get("backtest", {}).get("candle_interval_minutes", 1) or 1)
     if candle_interval <= 1:
         return hlcvs, timestamps, btc_usd_prices
     n_before = hlcvs.shape[0]
     hlcvs, timestamps, btc_usd_prices, offset_bars = align_and_aggregate_hlcvs(
-        hlcvs, timestamps, btc_usd_prices, candle_interval
+        hlcvs,
+        timestamps,
+        btc_usd_prices,
+        candle_interval,
+        preserve_internal_nan_gaps=preserve_internal_nan_gaps,
     )
     logging.debug(
         "[optimize] aggregated %dm candles: %d bars -> %d bars (trimmed %d for alignment)",
@@ -381,6 +393,7 @@ def _register_exchange_data(
     btc_usd_specs: dict,
     timestamps_dict: dict,
     array_manager: SharedArrayManager,
+    preserve_internal_nan_gaps: bool = False,
 ) -> tuple[list[str], dict]:
     """
     Register one exchange's prepared data into the optimizer's shared-memory
@@ -390,7 +403,12 @@ def _register_exchange_data(
     _propagate_optimizer_dataset_override(config, exchange, coins, cache_dir, mss)
     prepared_hlcvs = hlcvs
     hlcvs, timestamps, btc_usd_prices = _maybe_aggregate_backtest_data(
-        hlcvs, timestamps, btc_usd_prices, mss, config
+        hlcvs,
+        timestamps,
+        btc_usd_prices,
+        mss,
+        config,
+        preserve_internal_nan_gaps=preserve_internal_nan_gaps,
     )
     _stamp_optimizer_warmup(config, mss, coins)
     timestamps_dict[exchange] = (
@@ -3353,6 +3371,10 @@ async def main():
         config, backtest_exchanges, prefer_backtest_coin_source_keys=True
     )
     data_config = build_optimizer_data_config(config)
+    allow_internal_nan_gaps = (
+        str(config.get("optimize", {}).get("backend", "")).strip().lower()
+        == "gpu"
+    )
     interrupted = False
     failed = False
     pool = None
@@ -3374,6 +3396,7 @@ async def main():
                 data_config,
                 suite_cfg,
                 shared_array_manager=array_manager,
+                allow_internal_nan_gaps=allow_internal_nan_gaps,
             )
             if not scenario_contexts:
                 raise ValueError("Suite configuration produced no scenarios.")
@@ -3447,13 +3470,18 @@ async def main():
                 exchange = "combined"
                 coins, mss = _register_exchange_data(
                     exchange,
-                    await prepare_hlcvs_mss(data_config, exchange),
+                    await prepare_hlcvs_mss(
+                        data_config,
+                        exchange,
+                        allow_internal_nan_gaps=allow_internal_nan_gaps,
+                    ),
                     config,
                     msss=msss,
                     hlcvs_specs=hlcvs_specs,
                     btc_usd_specs=btc_usd_specs,
                     timestamps_dict=timestamps_dict,
                     array_manager=array_manager,
+                    preserve_internal_nan_gaps=allow_internal_nan_gaps,
                 )
                 exchange_preference = defaultdict(list)
                 for coin in coins:
@@ -3462,7 +3490,13 @@ async def main():
                     logging.info(f"chose {ex} for {','.join(exchange_preference[ex])}")
             else:
                 tasks = {
-                    exchange: asyncio.create_task(prepare_hlcvs_mss(data_config, exchange))
+                    exchange: asyncio.create_task(
+                        prepare_hlcvs_mss(
+                            data_config,
+                            exchange,
+                            allow_internal_nan_gaps=allow_internal_nan_gaps,
+                        )
+                    )
                     for exchange in backtest_exchanges
                 }
                 for exchange, task in tasks.items():
@@ -3475,6 +3509,7 @@ async def main():
                         btc_usd_specs=btc_usd_specs,
                         timestamps_dict=timestamps_dict,
                         array_manager=array_manager,
+                        preserve_internal_nan_gaps=allow_internal_nan_gaps,
                     )
         exchanges = backtest_exchanges
         exchanges_fname = "combined" if len(backtest_exchanges) > 1 else "_".join(exchanges)

--- a/src/optimize_suite.py
+++ b/src/optimize_suite.py
@@ -72,6 +72,7 @@ async def prepare_suite_contexts(
     suite_cfg: Dict[str, Any],
     *,
     shared_array_manager,
+    allow_internal_nan_gaps: bool = False,
 ) -> tuple[List[ScenarioEvalContext], Dict[str, Any]]:
     """Prepare datasets and configs for every optimizer suite scenario."""
 
@@ -164,6 +165,7 @@ async def prepare_suite_contexts(
         needed_individual_exchanges=needed_individual,
         candle_interval_minutes=candle_interval,
         scenarios=scenarios,
+        allow_internal_nan_gaps=allow_internal_nan_gaps,
     )
     available_coins = set()
     for dataset in datasets.values():

--- a/src/suite_runner.py
+++ b/src/suite_runner.py
@@ -877,11 +877,23 @@ def _determine_needed_individual_exchanges(
     return needed
 
 
-def _apply_candle_aggregation(hlcvs, timestamps, btc_usd_prices, mss, interval):
+def _apply_candle_aggregation(
+    hlcvs,
+    timestamps,
+    btc_usd_prices,
+    mss,
+    interval,
+    *,
+    preserve_internal_nan_gaps: bool = False,
+):
     """Aggregate candles and update mss metadata. Returns (hlcvs, timestamps, btc_usd_prices)."""
     n_before = hlcvs.shape[0]
     hlcvs, timestamps, btc_usd_prices, offset_bars = align_and_aggregate_hlcvs(
-        hlcvs, timestamps, btc_usd_prices, int(interval)
+        hlcvs,
+        timestamps,
+        btc_usd_prices,
+        int(interval),
+        preserve_internal_nan_gaps=preserve_internal_nan_gaps,
     )
     logging.debug(
         "[suite] aggregated %dm candles: %d bars -> %d bars (trimmed %d for alignment)",
@@ -904,10 +916,20 @@ async def prepare_master_datasets(
     needed_individual_exchanges: Optional[Set[str]] = None,
     candle_interval_minutes: int = 1,
     scenarios: Optional[Sequence[SuiteScenario]] = None,
+    allow_internal_nan_gaps: bool = False,
 ) -> Dict[str, ExchangeDataset]:
     from backtest import prepare_hlcvs_mss
 
     datasets: Dict[str, ExchangeDataset] = {}
+
+    async def _prepare_dataset(config, exchange):
+        kwargs = (
+            {"allow_internal_nan_gaps": True}
+            if allow_internal_nan_gaps
+            else {}
+        )
+        return await prepare_hlcvs_mss(config, exchange, **kwargs)
+
     dataset_windows = _derive_dataset_windows(
         base_config,
         exchanges,
@@ -1010,11 +1032,16 @@ async def prepare_master_datasets(
             cache_dir,
             btc_usd_prices,
             timestamps,
-        ) = await prepare_hlcvs_mss(combined_config, "combined")
+        ) = await _prepare_dataset(combined_config, "combined")
         prepared_hlcvs = hlcvs
         if candle_interval_minutes > 1:
             hlcvs, timestamps, btc_usd_prices = _apply_candle_aggregation(
-                hlcvs, timestamps, btc_usd_prices, mss, candle_interval_minutes
+                hlcvs,
+                timestamps,
+                btc_usd_prices,
+                mss,
+                candle_interval_minutes,
+                preserve_internal_nan_gaps=allow_internal_nan_gaps,
             )
             release_materialized_payload(prepared_hlcvs)
         datasets["combined"] = _build_dataset(
@@ -1061,11 +1088,16 @@ async def prepare_master_datasets(
                     ex_cache_dir,
                     ex_btc_usd_prices,
                     ex_timestamps,
-                ) = await prepare_hlcvs_mss(exchange_config, exchange)
+                ) = await _prepare_dataset(exchange_config, exchange)
                 prepared_ex_hlcvs = ex_hlcvs
                 if candle_interval_minutes > 1:
                     ex_hlcvs, ex_timestamps, ex_btc_usd_prices = _apply_candle_aggregation(
-                        ex_hlcvs, ex_timestamps, ex_btc_usd_prices, ex_mss, candle_interval_minutes
+                        ex_hlcvs,
+                        ex_timestamps,
+                        ex_btc_usd_prices,
+                        ex_mss,
+                        candle_interval_minutes,
+                        preserve_internal_nan_gaps=allow_internal_nan_gaps,
                     )
                     release_materialized_payload(prepared_ex_hlcvs)
                 datasets[exchange] = _build_dataset(
@@ -1108,11 +1140,16 @@ async def prepare_master_datasets(
                 cache_dir,
                 btc_usd_prices,
                 timestamps,
-            ) = await prepare_hlcvs_mss(exchange_config, exchange)
+            ) = await _prepare_dataset(exchange_config, exchange)
             prepared_hlcvs = hlcvs
             if candle_interval_minutes > 1:
                 hlcvs, timestamps, btc_usd_prices = _apply_candle_aggregation(
-                    hlcvs, timestamps, btc_usd_prices, mss, candle_interval_minutes
+                    hlcvs,
+                    timestamps,
+                    btc_usd_prices,
+                    mss,
+                    candle_interval_minutes,
+                    preserve_internal_nan_gaps=allow_internal_nan_gaps,
                 )
                 release_materialized_payload(prepared_hlcvs)
             datasets[exchange] = _build_dataset(

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -3864,6 +3864,232 @@ def test_mps_single_coin_forced_delist_closes_both_hedged_sides(strategy_kind):
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
 @pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
+@pytest.mark.parametrize("topology", ["long", "short", "fused"])
+def test_mps_single_coin_recovery_samples_internal_nan_candle(
+    strategy_kind, topology
+):
+    from optimization.gpu.mps_kernel import (
+        MpsEmaAnchorRunner,
+        MpsTrailingMartingaleRunner,
+    )
+
+    count = 123
+    invalid_index = 61
+    close = np.full(count, 100.0)
+    high = close.copy()
+    low = close.copy()
+    high[invalid_index] = np.nan
+    low[invalid_index] = np.nan
+    close[invalid_index] = np.nan
+    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    market = ProxyMarket(0.001, 0.01, 0.001, 0.0, 1.0, 0.0)
+    run = ProxyRun(
+        1_000.0,
+        1,
+        1,
+        int(timestamps[0]),
+        int(timestamps[0]),
+        int(timestamps[0]),
+        60_000,
+        0.05,
+        0,
+        count - 1,
+    )
+    data = build_mps_data(high, low, close, timestamps, run, market)
+    if strategy_kind == "ema_anchor":
+        row = _single_coin_param_row(
+            {
+                "base_qty_pct": 0.1,
+                "ema_span_0": 2.0,
+                "ema_span_1": 3.0,
+                "entry_double_down_factor": 0.0,
+                "offset": 0.5,
+                "offset_psize_weight": 0.0,
+                "offset_volatility_1h_weight": 0.0,
+                "offset_volatility_1m_weight": 0.0,
+                "offset_volatility_ema_span_1h": 2.0,
+                "offset_volatility_ema_span_1m": 2.0,
+                "entry_cooldown_minutes": 0.0,
+                "total_wallet_exposure_limit": 1.0,
+                "we_excess_allowance_pct": 0.0,
+                "we_excess_allowance_legacy_raw": 0.0,
+                "twel_entry_gate_enabled": 1.0,
+                "twel_enforcer_threshold": 1.0,
+                "twel_enforcer_enabled": 0.0,
+            },
+            EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS,
+        )
+        runner_cls = MpsEmaAnchorRunner
+        runner_kwargs = {}
+    else:
+        row = _tm_single_row(initial_ema_dist=0.5)
+        runner_cls = MpsTrailingMartingaleRunner
+        runner_kwargs = {"hsl_enabled": False}
+
+    sides = ("long", "short") if topology == "fused" else (topology,)
+    output = runner_cls(
+        market,
+        run,
+        data,
+        long_enabled="long" in sides,
+        short_enabled="short" in sides,
+        hedge_mode=topology == "fused",
+        recovery_distribution_enabled=True,
+        **runner_kwargs,
+    ).run(np.asarray([row + row], dtype=np.float64))
+    torch.mps.synchronize()
+
+    samples = output["strategy_eq_recovery_samples"][0].cpu().numpy()
+    assert samples[:3].tolist() == pytest.approx([1_000.0, 1_000.0, 1_000.0])
+    assert np.isnan(samples[3:]).all()
+    assert output["last_eq_ts"].item() == pytest.approx(121 * run.interval_ms)
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
+def test_mps_single_coin_internal_nan_candle_clears_pending_entry(strategy_kind):
+    from optimization.gpu.mps_kernel import (
+        MpsEmaAnchorRunner,
+        MpsTrailingMartingaleRunner,
+    )
+
+    count = 5
+    close = np.full(count, 100.0)
+    high = close.copy()
+    low = close.copy()
+    high[2] = np.nan
+    low[2] = np.nan
+    close[2] = np.nan
+    low[3] = 50.0
+    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    market = ProxyMarket(0.001, 0.01, 0.001, 0.0, 1.0, 0.0)
+    run = ProxyRun(
+        1_000.0,
+        1,
+        1,
+        int(timestamps[0]),
+        int(timestamps[0]),
+        int(timestamps[0]),
+        60_000,
+        0.05,
+        0,
+        count - 1,
+    )
+    data = build_mps_data(high, low, close, timestamps, run, market)
+    if strategy_kind == "ema_anchor":
+        side = _single_coin_param_row(
+            {
+                "base_qty_pct": 0.1,
+                "ema_span_0": 2.0,
+                "ema_span_1": 3.0,
+                "entry_double_down_factor": 0.0,
+                "offset": 0.1,
+                "offset_psize_weight": 0.0,
+                "offset_volatility_1h_weight": 0.0,
+                "offset_volatility_1m_weight": 0.0,
+                "offset_volatility_ema_span_1h": 2.0,
+                "offset_volatility_ema_span_1m": 2.0,
+                "entry_cooldown_minutes": 0.0,
+                "total_wallet_exposure_limit": 1.0,
+                "we_excess_allowance_pct": 0.0,
+                "we_excess_allowance_legacy_raw": 0.0,
+                "twel_entry_gate_enabled": 1.0,
+                "twel_enforcer_threshold": 1.0,
+                "twel_enforcer_enabled": 0.0,
+            },
+            EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS,
+        )
+        runner_cls = MpsEmaAnchorRunner
+        runner_kwargs = {}
+    else:
+        side = _tm_single_row(initial_ema_dist=0.1)
+        runner_cls = MpsTrailingMartingaleRunner
+        runner_kwargs = {"hsl_enabled": False}
+
+    output = runner_cls(
+        market,
+        run,
+        data,
+        long_enabled=True,
+        short_enabled=False,
+        hedge_mode=False,
+        **runner_kwargs,
+    ).run(np.asarray([side + side], dtype=np.float64))
+    torch.mps.synchronize()
+
+    assert output["fill_count"].item() == 0.0
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
+@pytest.mark.parametrize("topology", ["long", "short", "fused"])
+def test_mps_multicoin_recovery_samples_all_internal_nan_candle(
+    strategy_kind, topology
+):
+    count = 123
+    invalid_index = 61
+    closes = np.full((count, 2), 100.0)
+    highs = closes.copy()
+    lows = closes.copy()
+    if topology != "fused":
+        highs[3, :] = 101.0
+        lows[3, :] = 99.0
+    highs[invalid_index, :] = np.nan
+    lows[invalid_index, :] = np.nan
+    closes[invalid_index, :] = np.nan
+    fixture_side = topology if topology != "fused" else "long"
+    runner, row, run, data = _multicoin_exposure_fixture(
+        strategy_kind,
+        fixture_side,
+        count=count,
+        closes=closes,
+        highs=highs,
+        lows=lows,
+        recovery_distribution_enabled=True,
+        return_context=True,
+    )
+    if topology == "fused":
+        runner_cls = (
+            MpsEmaAnchorMulticoinFusedRunner
+            if strategy_kind == "ema_anchor"
+            else MpsTrailingMartingaleMulticoinFusedRunner
+        )
+        runner = runner_cls(
+            run,
+            data,
+            recovery_distribution_enabled=True,
+        )
+        params = row + row
+    else:
+        params = row
+
+    assert torch.isnan(data["bars"][invalid_index, :, 2]).all().item()
+    output = runner.run(np.asarray([params], dtype=np.float64))
+    torch.mps.synchronize()
+
+    samples = output["strategy_eq_recovery_samples"][0].cpu().numpy()
+    if topology == "fused":
+        assert output["fill_count"].item() == 0.0
+    else:
+        assert output["fill_count"].item() > 0.0
+        assert (
+            output["psize"].item() > 0.0
+            or output.get("short_psize", torch.zeros(1)).item() > 0.0
+        )
+    assert np.isfinite(samples[:3]).all()
+    assert samples[1] == pytest.approx(output["balance"].item())
+    assert np.isnan(samples[3:]).all()
+    assert output["last_eq_ts"].item() == pytest.approx(121 * run.interval_ms)
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
 def test_mps_single_coin_service_dispatches_forced_delist_tail(strategy_kind):
     from backtest import run_backtest
     from config.schema import get_template_config
@@ -4423,6 +4649,7 @@ def _multicoin_exposure_fixture(
     market_orders_allowed=False,
     market_order_near_touch_threshold=0.001,
     hsl_panic_market=False,
+    recovery_distribution_enabled=False,
     requested_start_index=0,
     return_context=False,
     interval_minutes=1,
@@ -4521,6 +4748,7 @@ def _multicoin_exposure_fixture(
             market_orders_allowed=market_orders_allowed,
             market_order_near_touch_threshold=market_order_near_touch_threshold,
             hsl_panic_market=hsl_panic_market,
+            recovery_distribution_enabled=recovery_distribution_enabled,
         )
     else:
         values = {
@@ -4582,6 +4810,7 @@ def _multicoin_exposure_fixture(
             market_orders_allowed=market_orders_allowed,
             market_order_near_touch_threshold=market_order_near_touch_threshold,
             hsl_panic_market=hsl_panic_market,
+            recovery_distribution_enabled=recovery_distribution_enabled,
         )
     if return_context:
         return runner, row, runs[0], data

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -44,11 +44,11 @@ from optimization.gpu.service import (
     _multicoin_exposure_eligible_coins,
     _position_exposure_enforcer_params,
     _prepared_single_coin_side_enabled,
+    _require_exact_safe_proxy_candles,
     _require_multicoin_metric_topology,
-    _require_no_internal_invalid_account_recovery_candles,
     _require_no_internal_invalid_hsl_candles,
     _require_no_internal_invalid_multicoin_hsl_candles,
-    _require_no_internal_invalid_single_coin_recovery_candles,
+    _require_no_unsafe_single_coin_candles,
     _require_supported_multicoin_valid_tails,
     _refresh_hedged_multicoin_hsl_at_portfolio_cutoff,
     _single_coin_candle_interval_minutes,
@@ -1231,40 +1231,39 @@ def test_gpu_multicoin_proxy_accepts_staggered_valid_gaps_and_ended_tails():
         _require_supported_multicoin_valid_tails(hlcvs, [99, 0], [98, 99])
 
 
-@pytest.mark.parametrize("invalid_value", [np.nan, 0.0, -1.0])
-def test_gpu_multicoin_proxy_rejects_actual_all_invalid_candle_in_windows(
-    invalid_value,
-):
+def test_gpu_multicoin_proxy_accepts_all_nan_candle_in_windows():
     hlcvs = np.ones((100, 2, 4), dtype=np.float64)
-    hlcvs[40, :, :3] = invalid_value
+    hlcvs[40, :, :3] = np.nan
 
-    with pytest.raises(ValueError, match=r"declared valid.*candle_index=40"):
-        _require_supported_multicoin_valid_tails(hlcvs, [0, 0], [59, 99])
-
-    # One actual finite-positive candle is sufficient to advance portfolio
-    # equity time even when the other declared-valid coin is unusable.
-    hlcvs[40, 1, :3] = 1.0
     _require_supported_multicoin_valid_tails(hlcvs, [0, 0], [59, 99])
 
 
+def test_gpu_multicoin_proxy_rejects_all_nan_first_valid_candle():
+    hlcvs = np.ones((100, 2, 4), dtype=np.float64)
+    hlcvs[10, 1, :3] = np.nan
+
+    with pytest.raises(ValueError, match="first-valid candle"):
+        _require_supported_multicoin_valid_tails(hlcvs, [0, 10], [99, 99])
+
+
 @pytest.mark.parametrize(
-    "unpackable_value",
+    "unsupported_value",
     [
+        0.0,
+        -1.0,
+        np.inf,
         float(np.nextafter(0.0, 1.0)),
         float(np.finfo(np.float32).max) * 2.0,
     ],
 )
-def test_gpu_multicoin_proxy_rejects_all_invalid_after_float32_packing(
-    unpackable_value,
+def test_gpu_multicoin_proxy_rejects_finite_unmodeled_all_invalid_candle(
+    unsupported_value,
 ):
     hlcvs = np.ones((100, 2, 4), dtype=np.float64)
-    hlcvs[40, :, :3] = unpackable_value
+    hlcvs[40, :, :3] = unsupported_value
 
-    with pytest.raises(ValueError, match=r"declared valid.*candle_index=40"):
+    with pytest.raises(ValueError, match=r"finite but.*candle_index=40"):
         _require_supported_multicoin_valid_tails(hlcvs, [0, 0], [59, 99])
-
-    hlcvs[40, 1, :3] = 1.0
-    _require_supported_multicoin_valid_tails(hlcvs, [0, 0], [59, 99])
 
 
 def test_gpu_multicoin_valid_tail_gate_rejects_out_of_range_last_index():
@@ -1327,54 +1326,89 @@ def test_gpu_multicoin_hsl_requires_each_coin_to_have_contiguous_valid_candles()
     )
 
 
-def test_gpu_account_equity_recovery_requires_tracked_candles_to_be_contiguous():
+def test_gpu_proxy_accepts_only_exact_balance_only_internal_gaps():
     hlcvs = np.ones((4, 2, 4), dtype=np.float64)
     hlcvs[2, 1, :3] = np.nan
 
-    with pytest.raises(ValueError, match="coin index 1, invalid candle at 2"):
-        _require_no_internal_invalid_account_recovery_candles(
-            hlcvs,
-            exposure_eligible_coins=[True, True],
-            first_valid_indices=[0, 0],
-            last_valid_indices=[3, 3],
-            tracking_start_indices=[1, 1],
-        )
-
-    _require_no_internal_invalid_account_recovery_candles(
+    _require_exact_safe_proxy_candles(
         hlcvs,
         exposure_eligible_coins=[True, True],
         first_valid_indices=[0, 0],
         last_valid_indices=[3, 3],
-        tracking_start_indices=[1, 3],
+        require_positive_high_low=True,
     )
 
-    _require_no_internal_invalid_account_recovery_candles(
-        hlcvs,
-        exposure_eligible_coins=[True, False],
-        first_valid_indices=[0, 0],
-        last_valid_indices=[3, 3],
-        tracking_start_indices=[1, 1],
-    )
+    hlcvs[2, 1, :3] = 0.0
+    with pytest.raises(ValueError, match="coin index 1, invalid candle at 2"):
+        _require_exact_safe_proxy_candles(
+            hlcvs,
+            exposure_eligible_coins=[True, True],
+            first_valid_indices=[0, 0],
+            last_valid_indices=[3, 3],
+            require_positive_high_low=True,
+        )
+
+    hlcvs[2, 1, :3] = [np.nan, np.nan, 1.0]
+    with pytest.raises(ValueError, match="partially invalid"):
+        _require_exact_safe_proxy_candles(
+            hlcvs,
+            exposure_eligible_coins=[True, True],
+            first_valid_indices=[0, 0],
+            last_valid_indices=[3, 3],
+            require_positive_high_low=True,
+        )
+
+    hlcvs[2, 1, :3] = np.inf
+    with pytest.raises(ValueError, match="infinite"):
+        _require_exact_safe_proxy_candles(
+            hlcvs,
+            exposure_eligible_coins=[True, True],
+            first_valid_indices=[0, 0],
+            last_valid_indices=[3, 3],
+            require_positive_high_low=True,
+        )
 
 
-def test_gpu_strategy_equity_recovery_distribution_rejects_internal_invalid_candle():
+def test_gpu_single_coin_accepts_nan_gap_but_rejects_zero_for_all_metrics():
     hlcvs = np.ones((4, 1, 4), dtype=np.float64)
     hlcvs[2, 0, :3] = np.nan
+    kwargs = {
+        "first_valid_idx": 0,
+        "last_valid_idx": 3,
+    }
 
-    _require_no_internal_invalid_single_coin_recovery_candles(
-        hlcvs,
-        needed_metrics={"adg_strategy_eq"},
-        first_valid_idx=0,
-        last_valid_idx=3,
-        tracking_start_idx=1,
-    )
+    _require_no_unsafe_single_coin_candles(hlcvs, **kwargs)
+
+    hlcvs[2, 0, :3] = 0.0
     with pytest.raises(ValueError, match="invalid candle at 2"):
-        _require_no_internal_invalid_single_coin_recovery_candles(
+        _require_no_unsafe_single_coin_candles(hlcvs, **kwargs)
+
+    hlcvs[2, 0, :3] = [0.0, 1.0, 1.0]
+    with pytest.raises(ValueError, match="invalid candle at 2"):
+        _require_no_unsafe_single_coin_candles(hlcvs, **kwargs)
+
+
+def test_gpu_single_coin_rejects_nan_first_valid_candle():
+    hlcvs = np.ones((4, 1, 4), dtype=np.float64)
+    hlcvs[1, 0, :3] = np.nan
+
+    with pytest.raises(ValueError, match="first-valid candle"):
+        _require_no_unsafe_single_coin_candles(
             hlcvs,
-            needed_metrics={"strategy_eq_recovery_days_p99"},
-            first_valid_idx=0,
+            first_valid_idx=1,
             last_valid_idx=3,
-            tracking_start_idx=1,
+        )
+
+
+def test_gpu_single_coin_rejects_nan_forced_delist_endpoint():
+    hlcvs = np.ones((1402, 1, 4), dtype=np.float64)
+    hlcvs[1, 0, :3] = np.nan
+
+    with pytest.raises(ValueError, match="forced-delist final candle"):
+        _require_no_unsafe_single_coin_candles(
+            hlcvs,
+            first_valid_idx=0,
+            last_valid_idx=1,
         )
 
 

--- a/tests/optimization/test_optimize.py
+++ b/tests/optimization/test_optimize.py
@@ -2186,6 +2186,46 @@ class TestValidateArray:
         assert manager.arrays[0] is hlcvs
         assert manager.arrays[1] is btc_usd_prices
 
+    def test_register_exchange_data_preserves_gpu_nan_gaps_through_aggregation(self):
+        class RecordingArrayManager:
+            def __init__(self):
+                self.arrays = []
+
+            def create_from(self, array):
+                self.arrays.append(array)
+                return object(), array
+
+        hlcvs = np.tile(
+            np.array([10.0, 8.0, 9.0, 1.0], dtype=np.float64),
+            (6, 1, 1),
+        )
+        hlcvs[0, 0] = np.nan
+        hlcvs[2:4, 0] = np.nan
+        btc_usd_prices = np.ones(6, dtype=np.float64)
+        timestamps = np.arange(6, dtype=np.int64) * 60_000
+        mss = {"BTC": {"first_valid_index": 0, "last_valid_index": 5}}
+        config = {"backtest": {"coins": {}, "candle_interval_minutes": 2}}
+        manager = RecordingArrayManager()
+
+        with patch("optimize._stamp_optimizer_warmup"):
+            _register_exchange_data(
+                "binance",
+                (["BTC"], hlcvs, mss, None, None, btc_usd_prices, timestamps),
+                config,
+                msss={},
+                hlcvs_specs={},
+                btc_usd_specs={},
+                timestamps_dict={},
+                array_manager=manager,
+                preserve_internal_nan_gaps=True,
+            )
+
+        aggregated = manager.arrays[0]
+        np.testing.assert_allclose(aggregated[0, 0], [10.0, 8.0, 9.0, 1.0])
+        assert np.isnan(aggregated[1, 0, :3]).all()
+        assert aggregated[1, 0, 3] == 0.0
+        np.testing.assert_allclose(aggregated[2, 0], [10.0, 8.0, 9.0, 2.0])
+
     def test_register_exchange_data_propagates_dataset_replay_policy_without_bot_gates(self):
         class RecordingArrayManager:
             def create_from(self, array):

--- a/tests/optimization/test_optimize_suite_contexts.py
+++ b/tests/optimization/test_optimize_suite_contexts.py
@@ -100,7 +100,10 @@ async def test_prepare_suite_contexts_keeps_directional_scenarios_with_default_s
     ):
         return None
 
-    async def fake_prepare_master_datasets(*_args, **_kwargs):
+    captured = {}
+
+    async def fake_prepare_master_datasets(*_args, **kwargs):
+        captured["allow_internal_nan_gaps"] = kwargs["allow_internal_nan_gaps"]
         return {
             "combined": _make_lazy_dataset(
                 coins=("HYPE",),
@@ -122,9 +125,11 @@ async def test_prepare_suite_contexts_keeps_directional_scenarios_with_default_s
         config,
         suite_cfg,
         shared_array_manager=_NoSharedArrayManager(),
+        allow_internal_nan_gaps=True,
     )
 
     assert [ctx.label for ctx in contexts] == ["base", "long_only", "short_only"]
+    assert captured["allow_internal_nan_gaps"] is True
 
 
 def test_suite_evaluator_close_releases_context_and_master_attachments():

--- a/tests/test_build_backtest_payload_purity.py
+++ b/tests/test_build_backtest_payload_purity.py
@@ -14,12 +14,14 @@ from copy import deepcopy
 import numpy as np
 import pytest
 
+import backtest
 from backtest import (
     _apply_market_settings_override,
     _validate_hlcvs_valid_windows,
     build_backtest_payload,
 )
 from config_utils import get_template_config
+from ohlcv_utils import aggregate_hlcvs
 import utils
 
 
@@ -592,6 +594,218 @@ def test_hlcvs_valid_window_rejects_nonfinite_volume_inside_valid_window():
             [mss["BTC"]["first_valid_index"]],
             [mss["BTC"]["last_valid_index"]],
         )
+
+
+def test_gpu_hlcvs_validation_allows_internal_all_nan_hlc_gap_only_when_enabled():
+    start_ts = 1609459200000
+    n_minutes = 10
+    config = _base_config(candle_interval_minutes=1)
+    mss = _base_mss(start_ts)
+    mss["BTC"]["first_valid_index"] = 0
+    mss["BTC"]["last_valid_index"] = n_minutes - 1
+    hlcvs, btc, timestamps = _synthetic_1m_hlcvs(n_minutes, start_ts)
+    hlcvs[4, 0, :] = np.nan
+
+    with pytest.raises(ValueError, match=r"coin=BTC .* k=4 .* field=high"):
+        _validate_hlcvs_valid_windows(
+            hlcvs,
+            timestamps,
+            ["BTC"],
+            [mss["BTC"]["first_valid_index"]],
+            [mss["BTC"]["last_valid_index"]],
+        )
+    _validate_hlcvs_valid_windows(
+        hlcvs,
+        timestamps,
+        ["BTC"],
+        [mss["BTC"]["first_valid_index"]],
+        [mss["BTC"]["last_valid_index"]],
+        allow_internal_nan_gaps=True,
+    )
+
+    payload = build_backtest_payload(
+        hlcvs,
+        mss,
+        config,
+        "binance",
+        btc,
+        timestamps,
+    )
+
+    assert np.isnan(payload.bundle.hlcvs[4, 0, :3]).all()
+
+
+@pytest.mark.asyncio
+async def test_prepare_hlcvs_mss_requires_explicit_gpu_nan_gap_context(
+    monkeypatch, tmp_path
+):
+    start_ts = 1609459200000
+    n_minutes = 10
+    config = _base_config(candle_interval_minutes=1)
+    config["backtest"]["base_dir"] = str(tmp_path)
+    config["optimize"]["backend"] = "gpu"
+    mss = _base_mss(start_ts)
+    mss["BTC"]["first_valid_index"] = 0
+    mss["BTC"]["last_valid_index"] = n_minutes - 1
+    hlcvs, btc, timestamps = _synthetic_1m_hlcvs(n_minutes, start_ts)
+    hlcvs[4, 0, :] = np.nan
+    monkeypatch.setattr(
+        backtest,
+        "load_hlcvs_data_override",
+        lambda _config, _exchange: (
+            tmp_path,
+            ["BTC"],
+            hlcvs,
+            mss,
+            str(tmp_path),
+            btc,
+            timestamps,
+        ),
+    )
+
+    with pytest.raises(ValueError, match=r"coin=BTC .* k=4 .* field=high"):
+        await backtest.prepare_hlcvs_mss(config, "binance")
+
+    result = await backtest.prepare_hlcvs_mss(
+        config,
+        "binance",
+        allow_internal_nan_gaps=True,
+    )
+    assert np.isnan(result[1][4, 0, :3]).all()
+
+
+def test_hlcvs_valid_window_rejects_internal_all_infinite_hlc_row():
+    start_ts = 1609459200000
+    n_minutes = 10
+    mss = _base_mss(start_ts)
+    mss["BTC"]["first_valid_index"] = 0
+    mss["BTC"]["last_valid_index"] = n_minutes - 1
+    hlcvs, _btc, timestamps = _synthetic_1m_hlcvs(n_minutes, start_ts)
+    hlcvs[4, 0, :3] = np.inf
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"non-finite HLCV value inside valid backtest window: "
+            r"coin=BTC .* k=4 .* field=high"
+        ),
+    ):
+        _validate_hlcvs_valid_windows(
+            hlcvs,
+            timestamps,
+            ["BTC"],
+            [mss["BTC"]["first_valid_index"]],
+            [mss["BTC"]["last_valid_index"]],
+            allow_internal_nan_gaps=True,
+        )
+
+
+def test_gpu_gap_aggregation_ignores_only_complete_nan_hlc_rows():
+    hlcvs = np.array(
+        [
+            [[10.0, 8.0, 9.0, 2.0]],
+            [[np.nan, np.nan, np.nan, np.nan]],
+            [[12.0, 7.0, 11.0, 3.0]],
+            [[np.nan, np.nan, np.nan, np.nan]],
+            [[np.nan, np.nan, np.nan, np.nan]],
+            [[np.nan, np.nan, np.nan, np.nan]],
+        ],
+        dtype=np.float64,
+    )
+
+    aggregated = aggregate_hlcvs(
+        hlcvs,
+        3,
+        preserve_internal_nan_gaps=True,
+    )
+
+    np.testing.assert_allclose(aggregated[0, 0], [12.0, 7.0, 11.0, 5.0])
+    assert np.isnan(aggregated[1, 0, :3]).all()
+    assert aggregated[1, 0, 3] == 0.0
+
+    partial = hlcvs[:3].copy()
+    partial[1, 0] = [np.nan, 8.0, 9.0, 1.0]
+    partial_aggregated = aggregate_hlcvs(
+        partial,
+        3,
+        preserve_internal_nan_gaps=True,
+    )
+    assert np.isnan(partial_aggregated[0, 0, 0])
+    assert np.isnan(partial_aggregated[0, 0, 2])
+    assert np.isfinite(partial_aggregated[0, 0, [1, 3]]).all()
+
+
+@pytest.mark.parametrize(
+    "malformed_hlc",
+    [
+        [10.0, 8.0, 0.0],
+        [10.0, 8.0, -1.0],
+        [np.inf, 8.0, 9.0],
+        [10.0, 8.0, float(np.finfo(np.float32).max) * 2.0],
+        [10.0, 8.0, float(np.nextafter(0.0, 1.0))],
+    ],
+)
+def test_gpu_gap_aggregation_preserves_malformed_non_gap_rows(malformed_hlc):
+    hlcvs = np.array(
+        [
+            [[*malformed_hlc, 1.0]],
+            [[12.0, 7.0, 11.0, 2.0]],
+        ],
+        dtype=np.float64,
+    )
+
+    aggregated = aggregate_hlcvs(
+        hlcvs,
+        2,
+        preserve_internal_nan_gaps=True,
+    )
+
+    assert np.isnan(aggregated[0, 0, 2])
+
+
+def test_gpu_hlcvs_validation_rejects_nan_first_valid_boundary():
+    hlcvs = np.ones((4, 1, 4), dtype=np.float64)
+    hlcvs[1, 0, :3] = np.nan
+
+    with pytest.raises(ValueError, match="all-NaN H/L/C.*first-valid boundary"):
+        _validate_hlcvs_valid_windows(
+            hlcvs,
+            None,
+            ["BTC"],
+            [1],
+            [3],
+            allow_internal_nan_gaps=True,
+        )
+
+
+def test_gpu_hlcvs_validation_rejects_nan_forced_delist_endpoint():
+    hlcvs = np.ones((1402, 1, 4), dtype=np.float64)
+    hlcvs[1, 0] = np.nan
+
+    with pytest.raises(ValueError, match="all-NaN H/L/C.*forced-delist endpoint"):
+        _validate_hlcvs_valid_windows(
+            hlcvs,
+            None,
+            ["BTC"],
+            [0],
+            [1],
+            allow_internal_nan_gaps=True,
+        )
+
+
+def test_gpu_hlcvs_raw_delist_gate_scales_with_candle_interval():
+    hlcvs = np.ones((1502, 1, 4), dtype=np.float64)
+    hlcvs[1, 0, :3] = np.nan
+
+    _validate_hlcvs_valid_windows(
+        hlcvs,
+        None,
+        ["BTC"],
+        [0],
+        [1],
+        allow_internal_nan_gaps=True,
+        candle_interval_minutes=5,
+    )
 
 
 def test_build_backtest_payload_allows_sparse_nan_outside_valid_window():

--- a/tests/test_suite_runner.py
+++ b/tests/test_suite_runner.py
@@ -883,8 +883,16 @@ async def test_prepare_master_datasets_copies_materialized_arrays_directly_to_sh
     source_hlcvs = np.arange(24, dtype=np.float64).reshape(3, 2, 4)
     source_btc = np.array([10.0, 11.0, 12.0], dtype=np.float64)
     timestamps = np.array([0, 60_000, 120_000], dtype=np.int64)
+    prepare_kwargs = {}
 
-    async def fake_prepare_hlcvs_mss(config, exchange, *, force_refetch_gaps=False):
+    async def fake_prepare_hlcvs_mss(
+        config,
+        exchange,
+        *,
+        force_refetch_gaps=False,
+        **kwargs,
+    ):
+        prepare_kwargs.update(kwargs)
         return (
             ["BTC", "ETH"],
             source_hlcvs,
@@ -936,11 +944,13 @@ async def test_prepare_master_datasets_copies_materialized_arrays_directly_to_sh
         base_config,
         ["binance"],
         shared_array_manager=manager,
+        allow_internal_nan_gaps=True,
     )
 
     assert len(manager.sources) == 2
     assert np.shares_memory(manager.sources[0], source_hlcvs)
     assert np.shares_memory(manager.sources[1], source_btc)
+    assert prepare_kwargs == {"allow_internal_nan_gaps": True}
     np.testing.assert_array_equal(datasets["binance"].hlcvs, source_hlcvs)
     np.testing.assert_array_equal(datasets["binance"].btc_usd_prices, source_btc)
 


### PR DESCRIPTION
## Summary

- advance single-coin EMA Anchor and Trailing Martingale equity/recovery sampling through internal all-NaN H/L/C gaps using exact Rust's balance-only semantics
- allow equivalent multi-coin timestamps where every declared coin is all-NaN while preserving infinite, finite-unmodeled, and forced-delist fail-closed gates
- preserve NaN packed multi-coin closes so open-position unrealized PnL is omitted exactly rather than marking the position at zero
- admit the supported all-NaN gap only through the active GPU optimizer operation; persisted config values cannot relax backtest, suite, download, or reproduction validation
- make exact Rust classify the same all-NaN row as non-tradable during mandatory exact validation without mistaking an internal gap for a delist
- preserve gap semantics through coarse candle aggregation by ignoring complete gap minutes inside mixed buckets and retaining all-gap buckets as non-tradable
- remove only the obsolete blanket recovery continuity guard; HSL-enabled coins retain their separate contiguous-candle contract
- document the expanded scope and add physical-MPS coverage for long, short, and fused single-/multi-coin topologies

## Review fixes

- address the original P1 by rejecting finite zero/negative, partially invalid, and float32-unrepresentable candles instead of treating them as balance-only gaps
- address the exact-head P1 by applying that safety gate to every GPU proxy run across the entire declared window, independent of the selected equity/recovery metrics
- address the exact-head P2 by allowing all-NaN H/L/C gap rows through `build_backtest_payload` and the production data-preparation validator
- narrow supported gaps from generic non-finite values to all-NaN rows because exact Rust may fill against infinite highs/lows
- address the next exact-head P1 by narrowing the production-data exception to the GPU backend and teaching exact Rust candle-level validity about all-NaN gaps
- address the next exact-head P2 by rejecting non-positive highs and lows in single-coin GPU inputs and in the Metal validity mask
- add unit coverage for the complete fail-closed boundary and physical-MPS open-position coverage across multi-coin NaN gaps
- address the latest exact-head P1 by separating exact Rust's declared valid range from candle tradability so an open position survives an internal gap without a panic close
- address the latest operation-context P2 by threading an explicit GPU-only gap-admission flag instead of inferring permission from persisted `optimize.backend`
- address the latest aggregation P2 with gap-aware coarse aggregation that ignores only complete all-NaN H/L/C rows and lets partial corruption propagate fail-closed
- address the latest forced-delist P2 by rejecting an all-NaN declared endpoint at both raw-data and single-coin proxy boundaries
- address the next exact-head malformed-aggregation P1 by carrying any finite non-positive or float32-unrepresentable raw price into a fail-closed aggregate sentinel
- address the next exact-head stale-order P1 by clearing directional entry and close intents whenever an in-window candle is invalid
- address the next exact-head first-valid P1 at both raw preparation and post-slice single-/multi-coin service boundaries so EMA state is never seeded from a gap
- address the next exact-head interval P2 by scaling the pre-aggregation forced-delist cutoff to the configured candle interval; post-aggregation proxy gates remain authoritative

## Validation

- physical Apple MPS focused NaN-gap matrix: 12 passed
- physical Apple MPS internal-gap recovery and stale-order regressions: 8 passed
- full `tests/optimization` suite on physical Apple MPS: 1,714 passed after the final review fixes
- affected Python regression suites: 484 passed
- exact Rust internal-gap/delist regression: passed
- `cargo test --no-default-features`: 268 passed
- `cargo check --tests --no-default-features`: passed
- rebuilt Rust extension and verified exact source fingerprint
- AI docs tests/check: passed (two pre-existing word-count warnings)
- `mkdocs build`: passed (two pre-existing release-note link warnings)
- Python compileall and `git diff --check`: passed

`ruff` is not installed in the shared test virtualenv.
