### PR TITLE
GPU: support single-coin coin overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Apple MPS single-coin EMA Anchor and Trailing Martingale optimization now supports the same
+  modeled static `coin_overrides` leaves as multi-coin runs. Static values retain exact Rust's
+  last-write precedence over optimizer candidates for long-only, short-only, hedge-mode, and
+  one-way runs. Multi-coin base rows and per-coin override rows now also read the canonical risk
+  entry-cooldown payload key, preserving configured and overridden cooldowns in GPU screening.
+
 - Apple MPS multi-coin EMA Anchor and Trailing Martingale optimization now supports
   `coin_overrides.<coin>.live.forced_mode_<side>: normal` for every enabled side. Long-only,
   short-only, and fused long+short kernels reserve eligible forced-normal symbols before Forager

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable user-facing changes will be documented in this file.
   last-write precedence over optimizer candidates for long-only, short-only, hedge-mode, and
   one-way runs. Multi-coin base rows and per-coin override rows now also read the canonical risk
   entry-cooldown payload key, preserving configured and overridden cooldowns in GPU screening.
+  GPU checkpoint identity retains the resolved float64 override values before Metal packing.
 
 - Apple MPS multi-coin EMA Anchor and Trailing Martingale optimization now supports
   `coin_overrides.<coin>.live.forced_mode_<side>: normal` for every enabled side. Long-only,

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -131,13 +131,15 @@ The supported slice is intentionally narrow:
   below, while other non-bot override paths remain unsupported; combined scenarios may use
   canonical per-coin source assignments, while an individual-exchange scenario fails closed if
   an effective assignment for one of its prepared coins selects another exchange
-- static `coin_overrides` for each enabled side of multi-coin EMA-anchor and trailing-martingale
-  runs: `live.forced_mode_<side>: normal`, active-strategy parameters,
+- static `coin_overrides` for each enabled side of single- and multi-coin EMA-anchor and
+  trailing-martingale runs: `live.forced_mode_<side>: normal`, active-strategy parameters,
   `risk.entry_cooldown_minutes`, and explicit
   `wallet_exposure_limit`, `risk.we_excess_allowance_pct`, and all six `unstuck` leaves are
-  supported. Eligible forced-normal symbols reserve active slots before Forager ranking and may
-  expand the active-set cap beyond `n_positions`; the dynamic WEL denominator remains unchanged,
-  matching exact Rust. Trailing Martingale also supports per-coin
+  supported. Static single-coin values are applied after each optimizer candidate, preserving
+  exact Rust's override precedence. Eligible forced-normal symbols in multi-coin runs reserve
+  active slots before Forager ranking and may expand the active-set cap beyond `n_positions`; the
+  dynamic WEL denominator remains unchanged, matching exact Rust. Trailing Martingale also supports
+  per-coin
   `risk.position_exposure_enforcer_enabled` and
   `risk.position_exposure_enforcer_threshold`; per-coin
   `risk.we_excess_allowance_mode`, disabled sides, and other override leaves fail closed. Trailing

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -136,7 +136,8 @@ The supported slice is intentionally narrow:
   `risk.entry_cooldown_minutes`, and explicit
   `wallet_exposure_limit`, `risk.we_excess_allowance_pct`, and all six `unstuck` leaves are
   supported. Static single-coin values are applied after each optimizer candidate, preserving
-  exact Rust's override precedence. Eligible forced-normal symbols in multi-coin runs reserve
+  exact Rust's override precedence. Checkpoint identity records the resolved exact override values
+  before float32 Metal packing. Eligible forced-normal symbols in multi-coin runs reserve
   active slots before Forager ranking and may expand the active-set cap beyond `n_positions`; the
   dynamic WEL denominator remains unchanged, matching exact Rust. Trailing Martingale also supports
   per-coin

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -450,6 +450,8 @@ mod tests {
         assert!(source.contains("if (eqf >= account_peak)"));
         assert!(source.contains("constant int SIDE_PARAMS = 35"));
         assert!(source.contains("float base_wel = params[po + 34]"));
+        assert!(source.contains("side.base_wel = base_wel"));
+        assert!(source.contains("current_we / fmax(side.base_wel"));
         assert!(source.contains("struct HslState"));
         assert!(source.contains("update_hsl("));
         assert!(source.contains("try_restart_hsl("));

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -448,7 +448,8 @@ mod tests {
         assert!(source.contains("scalars[so + 68] = hsl_strategy_equity_drawdown_max("));
         assert!(source.contains("scalars[so + 69] = hsl_strategy_equity_drawdown_max("));
         assert!(source.contains("if (eqf >= account_peak)"));
-        assert!(source.contains("constant int SIDE_PARAMS = 34"));
+        assert!(source.contains("constant int SIDE_PARAMS = 35"));
+        assert!(source.contains("float base_wel = params[po + 34]"));
         assert!(source.contains("struct HslState"));
         assert!(source.contains("update_hsl("));
         assert!(source.contains("try_restart_hsl("));
@@ -750,7 +751,8 @@ mod tests {
         assert_directional_recovery_sampling_contract(source);
         assert_directional_hsl_accounting_contract(source);
         assert!(source.contains("kernel void passivbot_trailing_martingale"));
-        assert!(source.contains("constant int SIDE_PARAMS = 51"));
+        assert!(source.contains("constant int SIDE_PARAMS = 52"));
+        assert!(source.contains("float base_wel = p[o + 51]"));
         assert!(source.contains("struct HslState"));
         assert!(source.contains("update_hsl("));
         assert!(source.contains("try_restart_hsl("));

--- a/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
@@ -12,7 +12,7 @@ constant int SCALAR_COLS = 68;
 constant int SCALAR_COLS = 66;
 #endif
 constant int GAP_BINS = 128;
-constant int SIDE_PARAMS = 34;
+constant int SIDE_PARAMS = 35;
 #ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
 constant float RECOVERY_FAIL_CLOSED_SENTINEL = -3.402823466e+38f;
 #endif
@@ -287,9 +287,16 @@ inline EmaSide load_side(constant float* params, int po, float seed_close) {
     side.twel = params[po + 11];
     float allowance_pct = fmax(params[po + 12], 0.0f);
     bool legacy_raw_allowance = params[po + 13] > 0.5f;
-    side.allowed_wel = side.twel * (
-        1.0f + (legacy_raw_allowance ? allowance_pct : 0.0f)
-    );
+    float base_wel = params[po + 34];
+    if (!(isfinite(base_wel) && base_wel >= 0.0f)) base_wel = side.twel;
+    float effective_allowance_pct = allowance_pct;
+    if (!legacy_raw_allowance) {
+        float max_effective = base_wel > 0.0f
+            ? fmax(side.twel / base_wel - 1.0f, 0.0f) : 0.0f;
+        effective_allowance_pct = fmin(allowance_pct, max_effective);
+    }
+    side.allowed_wel = base_wel > 0.0f
+        ? base_wel * (1.0f + effective_allowance_pct) : 0.0f;
     bool twel_entry_gate_enabled = params[po + 14] > 0.5f;
     float twel_threshold = params[po + 15];
     float gate_cap = side.twel;

--- a/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
@@ -209,6 +209,7 @@ struct EmaSide {
     float w1m;
     float cooldown_min;
     float twel;
+    float base_wel;
     float allowed_wel;
     float entry_cap;
     float twel_enforcer_threshold;
@@ -289,6 +290,7 @@ inline EmaSide load_side(constant float* params, int po, float seed_close) {
     bool legacy_raw_allowance = params[po + 13] > 0.5f;
     float base_wel = params[po + 34];
     if (!(isfinite(base_wel) && base_wel >= 0.0f)) base_wel = side.twel;
+    side.base_wel = base_wel;
     float effective_allowance_pct = allowance_pct;
     if (!legacy_raw_allowance) {
         float max_effective = base_wel > 0.0f
@@ -830,7 +832,7 @@ inline void generate_long_orders(
     float current_cost_we = side.psize > 0.0f && balance > 0.0f
         ? side.psize * side.pprice * c_mult / balance : 0.0f;
     float swer = side.psize > 0.0f && balance > 0.0f
-        ? current_we / fmax(side.twel, 1.0e-12f) : 0.0f;
+        ? current_we / fmax(side.base_wel, 1.0e-12f) : 0.0f;
     float inv_shift = swer * side.psize_weight;
 
     int bid_ticks = min(
@@ -916,7 +918,8 @@ inline void generate_short_orders(
     float mult = fmax(1.0f + side.vol1h * side.w1h + side.vol1m * side.w1m, 1.0f);
     float eff_off = side.offset * mult;
     float swer = side.psize > 0.0f && balance > 0.0f
-        ? -side.psize * price_now * c_mult / balance / fmax(side.twel, 1.0e-12f)
+        ? -side.psize * price_now * c_mult / balance
+            / fmax(side.base_wel, 1.0e-12f)
         : 0.0f;
     float current_cost_we = side.psize > 0.0f && balance > 0.0f
         ? side.psize * side.pprice * c_mult / balance : 0.0f;

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -12,7 +12,7 @@ constant int SCALAR_COLS = 68;
 constant int SCALAR_COLS = 66;
 #endif
 constant int GAP_BINS = 128;
-constant int SIDE_PARAMS = 51;
+constant int SIDE_PARAMS = 52;
 #ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
 constant float RECOVERY_FAIL_CLOSED_SENTINEL = -3.402823466e+38f;
 #endif
@@ -422,9 +422,16 @@ inline TmSide load_side(constant float* p, int o, float seed) {
     s.gate_reentry = p[o + 26] > 0.5f;
     float allowance_pct = fmax(p[o + 27], 0.0f);
     bool legacy_raw_allowance = p[o + 28] > 0.5f;
-    s.allowed_wel = s.twel * (
-        1.0f + (legacy_raw_allowance ? allowance_pct : 0.0f)
-    );
+    float base_wel = p[o + 51];
+    if (!(isfinite(base_wel) && base_wel >= 0.0f)) base_wel = s.twel;
+    float effective_allowance_pct = allowance_pct;
+    if (!legacy_raw_allowance) {
+        float max_effective = base_wel > 0.0f
+            ? fmax(s.twel / base_wel - 1.0f, 0.0f) : 0.0f;
+        effective_allowance_pct = fmin(allowance_pct, max_effective);
+    }
+    s.allowed_wel = base_wel > 0.0f
+        ? base_wel * (1.0f + effective_allowance_pct) : 0.0f;
     s.twel_entry_gate_enabled = p[o + 29] > 0.5f;
     float twel_threshold = p[o + 30];
     float gate_cap = s.twel;

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -1242,13 +1242,13 @@ def _validate_gpu_coin_overrides(
     if not overrides:
         return
     if (
-        coin_count <= 1
+        coin_count < 1
         or strategy_kind not in {"ema_anchor", "trailing_martingale"}
         or not enabled_sides
     ):
         raise ValueError(
-            "GPU coin_overrides currently require a supported multi-coin strategy "
-            "with at least one enabled side"
+            "GPU coin_overrides require a prepared supported strategy with at "
+            "least one enabled side"
         )
     enabled_sides = set(enabled_sides)
     from optimization.gpu.model import (
@@ -1344,8 +1344,9 @@ def _validate_gpu_coin_overrides(
             config.get("live", {}).get("hsl_signal_mode", "unified")
         ).strip().lower()
         fused_dual_side = len(enabled_sides) == 2
-        if signal_mode != "coin" or not (
-            len(enabled_sides) == 1 or fused_dual_side
+        if coin_count > 1 and (
+            signal_mode != "coin"
+            or not (len(enabled_sides) == 1 or fused_dual_side)
         ):
             raise ValueError(
                 "GPU per-coin HSL overrides require live.hsl_signal_mode=coin "

--- a/src/optimization/gpu/model.py
+++ b/src/optimization/gpu/model.py
@@ -301,6 +301,7 @@ EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS = (
     *TOTAL_EXPOSURE_ENFORCER_PARAM_KEYS,
     *UNSTUCK_PARAM_KEYS,
     *HSL_PARAM_KEYS,
+    "wallet_exposure_limit",
 )
 
 EMA_ANCHOR_MULTICOIN_PARAM_KEYS = (
@@ -355,6 +356,7 @@ TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS = (
     *TOTAL_EXPOSURE_ENFORCER_PARAM_KEYS,
     *UNSTUCK_PARAM_KEYS,
     *HSL_PARAM_KEYS,
+    "wallet_exposure_limit",
 )
 
 TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS = (
@@ -499,7 +501,11 @@ def flatten_trailing_martingale_params(strategy: dict, risk: dict) -> dict:
         "volatility_ema_span_1h": strategy.get("volatility_ema_span_1h"),
         "volatility_ema_span_1m": strategy.get("volatility_ema_span_1m"),
         "entry_cooldown_minutes": float(
-            risk.get("entry_cooldown_minutes", 0.0) or 0.0
+            risk.get(
+                "risk_entry_cooldown_minutes",
+                risk.get("entry_cooldown_minutes", 0.0),
+            )
+            or 0.0
         ),
         "total_wallet_exposure_limit": float(
             risk["total_wallet_exposure_limit"]

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -127,6 +127,28 @@ def _pack_tm_parameter_matrix(
     return matrix
 
 
+def _upgrade_legacy_single_coin_wel_params(
+    params: np.ndarray, *, side_width: int
+) -> np.ndarray:
+    """Append the exact-default WEL sentinel to legacy two-side rows."""
+
+    if params.ndim != 2:
+        return params
+    legacy_width = side_width - 1
+    if params.shape[1] != legacy_width * 2:
+        return params
+    sentinel = np.full((params.shape[0], 1), -1.0, dtype=params.dtype)
+    return np.concatenate(
+        (
+            params[:, :legacy_width],
+            sentinel,
+            params[:, legacy_width:],
+            sentinel,
+        ),
+        axis=1,
+    )
+
+
 def _scale_directional_minute_parameters(
     params: np.ndarray,
     keys: tuple[str, ...],
@@ -911,6 +933,9 @@ class MpsEmaAnchorRunner:
         self.last_profile: dict[str, float] = {}
 
     def _pack_params(self, params: np.ndarray) -> np.ndarray:
+        params = _upgrade_legacy_single_coin_wel_params(
+            params, side_width=len(EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS)
+        )
         expected = len(EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS) * 2
         if params.ndim != 2 or params.shape[1] != expected:
             got = params.shape[1] if params.ndim == 2 else params.shape
@@ -1954,6 +1979,10 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
         )
 
     def _pack_params(self, params: np.ndarray) -> np.ndarray:
+        params = _upgrade_legacy_single_coin_wel_params(
+            params,
+            side_width=len(TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS),
+        )
         expected = len(TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS) * 2
         if params.ndim != 2 or params.shape[1] != expected:
             got = params.shape[1] if params.ndim == 2 else params.shape

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -1438,6 +1438,10 @@ class MpsSingleCoinProxy:
                 side: per_side_override_contracts[side]["values"]
                 for side in ("long", "short")
             },
+            "exact_overrides_by_side": {
+                side: per_side_override_contracts[side]["exact_overrides"]
+                for side in ("long", "short")
+            },
             "proxy_mode": "single-coin-exact-last-v1",
         }
 
@@ -1722,8 +1726,10 @@ def _build_multicoin_ema_coin_overrides(
         np.nan,
         dtype=np.float32,
     )
+    exact_overrides = []
     for coin_index, coin in enumerate(coins):
         patch = resolve_override(config, mss, exchange, coin) or {}
+        exact_overrides.append(copy.deepcopy(patch))
         side_patch = patch.get("bot", {}).get(side, {})
         strategy_patch = side_patch.get("strategy", {}).get("ema_anchor", {}) or {}
         effective_strategy = payload.strategy_params_list[coin_index][side]
@@ -1779,6 +1785,7 @@ def _build_multicoin_ema_coin_overrides(
         "exchange": exchange,
         "coins": coins,
         "side": side,
+        "exact_overrides": exact_overrides,
         "values": [
             [None if not np.isfinite(value) else float(value) for value in row]
             for row in matrix
@@ -1809,9 +1816,11 @@ def _build_multicoin_tm_coin_overrides(
         np.nan,
         dtype=np.float32,
     )
+    exact_overrides = []
     missing = object()
     for coin_index, coin in enumerate(coins):
         patch = resolve_override(config, mss, exchange, coin) or {}
+        exact_overrides.append(copy.deepcopy(patch))
         side_patch = patch.get("bot", {}).get(side, {})
         strategy_patch = (
             side_patch.get("strategy", {}).get("trailing_martingale", {}) or {}
@@ -1920,6 +1929,7 @@ def _build_multicoin_tm_coin_overrides(
         "exchange": exchange,
         "coins": coins,
         "side": side,
+        "exact_overrides": exact_overrides,
         "values": [
             [None if not np.isfinite(value) else float(value) for value in row]
             for row in matrix
@@ -2362,6 +2372,10 @@ class MpsMulticoinProxy:
                 "sides": list(self.sides),
                 "values_by_side": {
                     side: per_side_override_contracts[side]["values"]
+                    for side in self.sides
+                },
+                "exact_overrides_by_side": {
+                    side: per_side_override_contracts[side]["exact_overrides"]
                     for side in self.sides
                 },
                 "proxy_mode": (

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -37,6 +37,7 @@ from optimization.gpu.model import (
     TRAILING_MARTINGALE_COIN_OVERRIDE_WEL_ENFORCER_ENABLED_COLUMN,
     TRAILING_MARTINGALE_COIN_OVERRIDE_WEL_ENFORCER_THRESHOLD_COLUMN,
     TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS,
+    UNSTUCK_PARAM_KEYS,
     build_mps_data,
     build_mps_multicoin_data,
     encode_hsl_panic_order_type,
@@ -1356,6 +1357,10 @@ class MpsSingleCoinProxy:
             )
         hsl_panic_market = {}
         self.base_params = {}
+        configured_total_wallet_exposure_limits = {
+            side: float(bot["total_wallet_exposure_limit"])
+            for side, bot in (("long", long_bot), ("short", short_bot))
+        }
         for side, bot in (("long", long_bot), ("short", short_bot)):
             panic_close_order_type = str(
                 bot.get("hsl_panic_close_order_type", "limit")
@@ -1393,6 +1398,9 @@ class MpsSingleCoinProxy:
                 )
                 strategy.update(_unstuck_params(bot))
                 strategy.update(_hsl_params(bot, signal_mode=signal_mode))
+            strategy["wallet_exposure_limit"] = float(
+                bot.get("wallet_exposure_limit", -1.0)
+            )
             missing = [key for key in self.param_keys if key not in strategy]
             if missing:
                 raise ValueError(
@@ -1400,6 +1408,38 @@ class MpsSingleCoinProxy:
                     f"parameters: {missing}"
                 )
             self.base_params[side] = strategy
+
+        coins = list(backtest_params.get("coins") or [])
+        if len(coins) != 1:
+            raise ValueError(
+                "GPU single-coin payload coin identity disagrees with prepared "
+                f"data: coins={coins}"
+            )
+        self.static_coin_override_params = {}
+        per_side_override_contracts = {}
+        for side in ("long", "short"):
+            values, contract = _build_single_coin_override_params(
+                config=config,
+                mss=mss,
+                exchange=exchange,
+                coin=coins[0],
+                payload=payload,
+                side=side,
+                strategy_kind=self.strategy_kind,
+            )
+            self.static_coin_override_params[side] = values
+            self.base_params[side].update(values)
+            per_side_override_contracts[side] = contract
+        self.coin_override_contract = {
+            "exchange": exchange,
+            "coins": coins,
+            "sides": [side for side, enabled in self.enabled.items() if enabled],
+            "values_by_side": {
+                side: per_side_override_contracts[side]["values"]
+                for side in ("long", "short")
+            },
+            "proxy_mode": "single-coin-exact-last-v1",
+        }
 
         self.checkpoint_contract = _gpu_proxy_execution_checkpoint_contract(
             strategy_kind=self.strategy_kind,
@@ -1413,7 +1453,7 @@ class MpsSingleCoinProxy:
         )
 
         self.base_total_wallet_exposure_limits = {
-            side: float(self.base_params[side]["total_wallet_exposure_limit"])
+            side: configured_total_wallet_exposure_limits[side]
             for side in ("long", "short")
         }
         self.base_n_positions = {
@@ -1546,6 +1586,9 @@ class MpsSingleCoinProxy:
                         for key, value in candidate.items()
                         if key.startswith(f"{side}_")
                     }
+                )
+                merged.update(
+                    getattr(self, "static_coin_override_params", {}).get(side, {})
                 )
                 row.extend(float(merged[key]) for key in self.param_keys)
             rows.append(row)
@@ -1691,7 +1734,7 @@ def _build_multicoin_ema_coin_overrides(
         risk_patch = side_patch.get("risk", {}) or {}
         if "entry_cooldown_minutes" in risk_patch:
             matrix[coin_index, EMA_ANCHOR_COIN_OVERRIDE_COOLDOWN_COLUMN] = float(
-                effective_bot.get("entry_cooldown_minutes", 0.0) or 0.0
+                effective_bot.get("risk_entry_cooldown_minutes", 0.0) or 0.0
             )
         # Exact payload construction keeps per-side universe eligibility in
         # entry_eligible and uses a zero WEL sentinel for an ineligible coin.
@@ -1815,7 +1858,7 @@ def _build_multicoin_tm_coin_overrides(
                 coin_index,
                 TRAILING_MARTINGALE_COIN_OVERRIDE_COOLDOWN_COLUMN,
             ] = float(
-                effective_bot.get("entry_cooldown_minutes", 0.0) or 0.0
+                effective_bot.get("risk_entry_cooldown_minutes", 0.0) or 0.0
             )
         if not bool(effective_bot.get("entry_eligible", True)) or (
             "wallet_exposure_limit" in side_patch
@@ -1883,6 +1926,110 @@ def _build_multicoin_tm_coin_overrides(
         ],
     }
     return matrix, contract
+
+
+def _build_single_coin_override_params(
+    *,
+    config: dict,
+    mss: dict,
+    exchange: str,
+    coin: str,
+    payload,
+    side: str,
+    strategy_kind: str,
+) -> tuple[dict[str, float], dict]:
+    """Map the shared exact-last override ABI onto one directional row."""
+
+    if strategy_kind == "ema_anchor":
+        matrix, contract = _build_multicoin_ema_coin_overrides(
+            config=config,
+            mss=mss,
+            exchange=exchange,
+            coins=[coin],
+            payload=payload,
+            side=side,
+        )
+        columns = {
+            key: column
+            for column, key in enumerate(EMA_ANCHOR_COIN_OVERRIDE_STRATEGY_KEYS)
+        }
+        columns.update(
+            {
+                "entry_cooldown_minutes": EMA_ANCHOR_COIN_OVERRIDE_COOLDOWN_COLUMN,
+                "wallet_exposure_limit": (
+                    EMA_ANCHOR_COIN_OVERRIDE_WALLET_EXPOSURE_COLUMN
+                ),
+                "we_excess_allowance_pct": (
+                    EMA_ANCHOR_COIN_OVERRIDE_ALLOWANCE_PCT_COLUMN
+                ),
+            }
+        )
+        unstuck_start = EMA_ANCHOR_COIN_OVERRIDE_UNSTUCK_START_COLUMN
+        hsl_start = EMA_ANCHOR_COIN_OVERRIDE_HSL_START_COLUMN
+    elif strategy_kind == "trailing_martingale":
+        matrix, contract = _build_multicoin_tm_coin_overrides(
+            config=config,
+            mss=mss,
+            exchange=exchange,
+            coins=[coin],
+            payload=payload,
+            side=side,
+        )
+        columns = {
+            key: column
+            for column, (key, _path) in enumerate(
+                TRAILING_MARTINGALE_COIN_OVERRIDE_PATHS
+            )
+        }
+        columns.update(
+            {
+                "entry_cooldown_minutes": (
+                    TRAILING_MARTINGALE_COIN_OVERRIDE_COOLDOWN_COLUMN
+                ),
+                "wallet_exposure_limit": (
+                    TRAILING_MARTINGALE_COIN_OVERRIDE_WALLET_EXPOSURE_COLUMN
+                ),
+                "we_excess_allowance_pct": (
+                    TRAILING_MARTINGALE_COIN_OVERRIDE_ALLOWANCE_PCT_COLUMN
+                ),
+                "wel_enforcer_enabled": (
+                    TRAILING_MARTINGALE_COIN_OVERRIDE_WEL_ENFORCER_ENABLED_COLUMN
+                ),
+                "wel_enforcer_threshold": (
+                    TRAILING_MARTINGALE_COIN_OVERRIDE_WEL_ENFORCER_THRESHOLD_COLUMN
+                ),
+                "gate_initial": (
+                    TRAILING_MARTINGALE_COIN_OVERRIDE_GATE_INITIAL_COLUMN
+                ),
+                "gate_reentry": (
+                    TRAILING_MARTINGALE_COIN_OVERRIDE_GATE_REENTRY_COLUMN
+                ),
+            }
+        )
+        unstuck_start = TRAILING_MARTINGALE_COIN_OVERRIDE_UNSTUCK_START_COLUMN
+        hsl_start = TRAILING_MARTINGALE_COIN_OVERRIDE_HSL_START_COLUMN
+    else:
+        raise ValueError(f"unsupported single-coin strategy {strategy_kind!r}")
+
+    columns.update(
+        {key: unstuck_start + offset for offset, key in enumerate(UNSTUCK_PARAM_KEYS)}
+    )
+    columns.update(
+        {
+            key: hsl_start + offset
+            for offset, (key, _path) in enumerate(HSL_COIN_OVERRIDE_PATHS)
+            if key != "hsl_panic_market"
+        }
+    )
+    row = matrix[0]
+    return (
+        {
+            key: float(row[column])
+            for key, column in columns.items()
+            if np.isfinite(row[column])
+        },
+        contract,
+    )
 
 
 class MpsMulticoinProxy:
@@ -2099,7 +2246,7 @@ class MpsMulticoinProxy:
             first_strategy.update(
                 {
                     "entry_cooldown_minutes": float(
-                        first_bot.get("entry_cooldown_minutes", 0.0) or 0.0
+                        first_bot.get("risk_entry_cooldown_minutes", 0.0) or 0.0
                     ),
                     "total_wallet_exposure_limit": float(
                         first_bot["total_wallet_exposure_limit"]

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -2696,14 +2696,31 @@ def test_gpu_multicoin_coin_hsl_overrides_accept_fused_dual_side(
     )
 
 
-def test_gpu_coin_overrides_reject_single_coin_scope():
+def test_gpu_coin_overrides_accept_single_coin_scope():
     config = _long_only_ema_config()
     config["coin_overrides"] = {
         "BTC": {"bot": {"long": {"wallet_exposure_limit": 0.5}}}
     }
 
-    with pytest.raises(ValueError, match="require a supported multi-coin strategy"):
-        _validate_scope(config, _Evaluator())
+    assert _validate_scope(config, _Evaluator()) == "bybit"
+
+
+@pytest.mark.parametrize("signal_mode", ["unified", "pside", "coin"])
+def test_gpu_single_coin_accepts_hsl_coin_override_for_every_signal_mode(
+    signal_mode,
+):
+    config = _long_only_ema_config()
+    config["live"]["hsl_signal_mode"] = signal_mode
+    config["coin_overrides"] = {
+        "BTC": {"bot": {"long": {"hsl": {"red_threshold": 0.2}}}}
+    }
+
+    _validate_gpu_coin_overrides(
+        config,
+        strategy_kind="ema_anchor",
+        enabled_sides=["long"],
+        coin_count=1,
+    )
 
 
 @pytest.mark.parametrize("side", ["long", "short"])

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -5040,6 +5040,41 @@ def test_gpu_checkpoint_signature_tracks_realized_loss_gate_contract():
     )
 
 
+def test_gpu_checkpoint_signature_tracks_exact_coin_override_precision():
+    active = [("long_offset", 0, Bound(0.01, 0.1, 0.01))]
+    scoring = [{"goal": "max", "metric": "adg_strategy_eq"}]
+    config = _long_only_ema_config()
+    first = 0.4
+    second = float(np.nextafter(first, 1.0))
+    packed = float(np.float32(first))
+    assert packed == float(np.float32(second))
+
+    def signature(exact_value):
+        proxy = SimpleNamespace(
+            coin_override_contract={
+                "values": [[packed]],
+                "exact_overrides": [
+                    {
+                        "bot": {
+                            "long": {
+                                "strategy": {
+                                    "ema_anchor": {"offset": exact_value}
+                                }
+                            }
+                        }
+                    }
+                ],
+            }
+        )
+        return _checkpoint_signature(
+            active,
+            scoring,
+            runtime_contract=_gpu_runtime_checkpoint_contract(config, proxy),
+        )
+
+    assert signature(first) != signature(second)
+
+
 def test_gpu_checkpoint_signature_tracks_hedge_mode_contract():
     active = [("long_offset", 0, Bound(0.01, 0.1, 0.01))]
     scoring = [{"goal": "max", "metric": "adg_strategy_eq"}]

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -213,6 +213,83 @@ kernel void passivbot_single_coin_wel_probe(
     assert output[1].item() == pytest.approx(expected_allowed_wel)
 
 
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize(
+    ("side", "expected_entry_ticks"),
+    [("long", 97.0), ("short", 103.0)],
+)
+def test_mps_ema_inventory_ratio_uses_single_coin_base_wel(
+    side, expected_entry_ticks
+):
+    import passivbot_rust
+
+    values = {key: 0.0 for key in EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS}
+    values.update(
+        {
+            "base_qty_pct": 0.1,
+            "ema_span_0": 2.0,
+            "ema_span_1": 3.0,
+            "offset_psize_weight": 0.1,
+            "total_wallet_exposure_limit": 0.9,
+            "twel_enforcer_threshold": 1.0,
+            "wallet_exposure_limit": 0.4,
+        }
+    )
+    params = torch.tensor(
+        [values[key] for key in EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS],
+        dtype=torch.float32,
+        device="mps",
+    )
+    output = torch.zeros(2, dtype=torch.float32, device="mps")
+    generator = (
+        "generate_long_orders" if side == "long" else "generate_short_orders"
+    )
+    probe_kernel = f"""
+kernel void passivbot_ema_base_wel_inventory_probe(
+    constant float* packed,
+    device float* result,
+    uint b [[thread_position_in_grid]]
+) {{
+    if (b > 0) return;
+    EmaSide state = load_side(packed, 0, 100.0f);
+    state.psize = 1.0f;
+    state.pprice = 100.0f;
+    {generator}(
+        state,
+        1000.0f,
+        100.0f,
+        100,
+        100,
+        0.001f,
+        1.0f,
+        0.001f,
+        0.0f,
+        1.0f,
+        0.0f,
+        false,
+        false,
+        0.0f
+    );
+    result[0] = float(state.entry_ticks);
+    result[1] = state.base_wel;
+}}
+"""
+    library = torch.mps.compile_shader(
+        passivbot_rust.mps_ema_anchor_source_py() + probe_kernel
+    )
+    library.passivbot_ema_base_wel_inventory_probe(
+        params, output, threads=(1, 1, 1)
+    )
+    torch.mps.synchronize()
+
+    # With current WE=0.1, exact Rust's base-WEL ratio is 0.1 / 0.4 = 0.25.
+    # Dividing by TWEL=0.9 instead would produce ticks 98/102.
+    assert output[0].item() == expected_entry_ticks
+    assert output[1].item() == pytest.approx(0.4)
+
+
 @pytest.mark.parametrize(
     "value", [0.0, 0.05, 0.999999999, float(np.nextafter(1.0, 0.0))]
 )

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -43,6 +43,7 @@ from optimization.gpu.mps_kernel import (
     _scale_ema_multicoin_coin_overrides,
     _scale_tm_multicoin_coin_overrides,
     _scale_single_coin_minute_parameters,
+    _upgrade_legacy_single_coin_wel_params,
     _with_hsl_ema_tail,
     _with_hsl_features,
     _with_recovery_distribution,
@@ -123,6 +124,93 @@ def test_tm_parameter_packing_preserves_positive_underflow_mode_per_side():
     assert packed[0, width + close_column] == np.finfo(np.float32).tiny
     assert packed[0, close_column] == 0.0
     assert packed[0, width + entry_column] == 0.0
+
+
+@pytest.mark.parametrize("side_width", [35, 52])
+def test_legacy_single_coin_rows_gain_per_side_wallet_exposure_sentinel(
+    side_width,
+):
+    legacy_width = side_width - 1
+    params = np.arange(legacy_width * 2, dtype=np.float64).reshape(1, -1)
+
+    upgraded = _upgrade_legacy_single_coin_wel_params(
+        params, side_width=side_width
+    )
+
+    assert upgraded.shape == (1, side_width * 2)
+    assert upgraded[0, :legacy_width].tolist() == params[
+        0, :legacy_width
+    ].tolist()
+    assert upgraded[0, legacy_width] == -1.0
+    assert upgraded[0, side_width:-1].tolist() == params[
+        0, legacy_width:
+    ].tolist()
+    assert upgraded[0, -1] == -1.0
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
+@pytest.mark.parametrize(
+    ("base_wel", "allowance_pct", "legacy_raw", "expected_allowed_wel"),
+    [
+        (0.4, 0.25, False, 0.5),
+        (0.4, 2.0, False, 0.9),
+        (0.4, 2.0, True, 1.2),
+        (-1.0, 0.25, False, 0.9),
+    ],
+)
+def test_mps_single_coin_wallet_exposure_override_keeps_twel_separate(
+    strategy_kind,
+    base_wel,
+    allowance_pct,
+    legacy_raw,
+    expected_allowed_wel,
+):
+    import passivbot_rust
+
+    if strategy_kind == "ema_anchor":
+        keys = EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS
+        source = passivbot_rust.mps_ema_anchor_source_py()
+        side_type = "EmaSide"
+    else:
+        keys = TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS
+        source = passivbot_rust.mps_trailing_martingale_source_py()
+        side_type = "TmSide"
+    values = {key: float(index + 1) for index, key in enumerate(keys)}
+    values.update(
+        {
+            "total_wallet_exposure_limit": 0.9,
+            "wallet_exposure_limit": base_wel,
+            "we_excess_allowance_pct": allowance_pct,
+            "we_excess_allowance_legacy_raw": float(legacy_raw),
+        }
+    )
+    params = torch.tensor(
+        [values[key] for key in keys], dtype=torch.float32, device="mps"
+    )
+    output = torch.zeros(2, dtype=torch.float32, device="mps")
+    probe_kernel = f"""
+kernel void passivbot_single_coin_wel_probe(
+    constant float* packed,
+    device float* result,
+    uint b [[thread_position_in_grid]]
+) {{
+    if (b > 0) return;
+    {side_type} side = load_side(packed, 0, 100.0f);
+    result[0] = side.twel;
+    result[1] = side.allowed_wel;
+}}
+"""
+    library = torch.mps.compile_shader(source + probe_kernel)
+    library.passivbot_single_coin_wel_probe(
+        params, output, threads=(1, 1, 1)
+    )
+    torch.mps.synchronize()
+
+    assert output[0].item() == pytest.approx(0.9)
+    assert output[1].item() == pytest.approx(expected_allowed_wel)
 
 
 @pytest.mark.parametrize(
@@ -3172,7 +3260,12 @@ _HSL_DISABLED_VALUES = {
 
 
 def _single_coin_param_row(values, keys):
-    merged = {**_UNSTUCK_DISABLED_VALUES, **_HSL_DISABLED_VALUES, **values}
+    merged = {
+        **_UNSTUCK_DISABLED_VALUES,
+        **_HSL_DISABLED_VALUES,
+        "wallet_exposure_limit": -1.0,
+        **values,
+    }
     return [merged[key] for key in keys]
 
 
@@ -4209,6 +4302,207 @@ def test_mps_single_coin_service_dispatches_forced_delist_tail(strategy_kind):
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
 @pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
+@pytest.mark.parametrize(
+    ("topology", "hedge_mode"),
+    [
+        ("long", False),
+        ("short", False),
+        ("fused", True),
+        ("fused", False),
+    ],
+)
+def test_mps_single_coin_overrides_shadow_candidates_and_track_exact(
+    strategy_kind, topology, hedge_mode
+):
+    from backtest import run_backtest
+    from config.schema import get_template_config
+    from optimization.gpu.service import MpsSingleCoinProxy
+
+    count = 80
+    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    hlcvs = np.empty((count, 1, 4), dtype=np.float64)
+    hlcvs[:, 0] = [110.0, 90.0, 100.0, 1.0]
+    market_settings = {
+        "ETH": {
+            "qty_step": 0.001,
+            "price_step": 0.01,
+            "min_qty": 0.001,
+            "min_cost": 0.0,
+            "c_mult": 1.0,
+            "maker": 0.0,
+            "taker": 0.0,
+            "exchange": "bybit",
+            "first_valid_index": 0,
+            "last_valid_index": count - 1,
+            "warmup_minutes": 1,
+        },
+        "__meta__": {
+            "requested_start_ts": int(timestamps[0]),
+            "requested_start_date": "2023-11-14",
+            "warmup_minutes_requested": 1,
+        },
+    }
+    enabled_sides = (
+        ("long", "short") if topology == "fused" else (topology,)
+    )
+    config = get_template_config()
+    config["live"]["strategy_kind"] = strategy_kind
+    config["live"]["max_warmup_minutes"] = 1
+    config["live"]["approved_coins"] = {
+        side: ["ETH"] if side in enabled_sides else []
+        for side in ("long", "short")
+    }
+    config["live"]["hedge_mode"] = hedge_mode
+    config["backtest"]["coins"] = {"bybit": ["ETH"]}
+    config["backtest"]["exchanges"] = ["bybit"]
+    for side in ("long", "short"):
+        enabled = side in enabled_sides
+        risk = config["bot"][side]["risk"]
+        risk["total_wallet_exposure_limit"] = 0.9 if enabled else 0.0
+        risk["n_positions"] = 1 if enabled else 0
+        risk["entry_cooldown_minutes"] = 0.0
+        risk["we_excess_allowance_pct"] = 0.0
+        risk["total_exposure_entry_gate_enabled"] = False
+        risk["position_exposure_enforcer_enabled"] = False
+        risk["total_exposure_enforcer_enabled"] = False
+        config["bot"][side]["hsl"]["enabled"] = False
+        config["bot"][side]["unstuck"]["enabled"] = False
+
+    side_overrides = {}
+    candidate = {}
+    for side in enabled_sides:
+        if strategy_kind == "ema_anchor":
+            strategy = config["bot"][side]["strategy"]["ema_anchor"]
+            strategy.update(
+                {
+                    "base_qty_pct": 0.1,
+                    "ema_span_0": 2.0,
+                    "ema_span_1": 3.0,
+                    "entry_double_down_factor": 0.0,
+                    "offset": 0.4,
+                    "offset_psize_weight": 0.0,
+                }
+            )
+            strategy_patch = {"offset": 0.01}
+            candidate[f"{side}_offset"] = 0.4
+            locked_key = "offset"
+            locked_value = 0.01
+        else:
+            strategy = config["bot"][side]["strategy"][
+                "trailing_martingale"
+            ]
+            strategy["ema_span_0"] = 2.0
+            strategy["ema_span_1"] = 3.0
+            strategy["entry"]["initial_qty_pct"] = 0.1
+            strategy["entry"]["initial_ema_dist"] = 0.4
+            strategy["entry"]["double_down_factor"] = 0.0
+            strategy["close"]["threshold_base_pct"] = 0.01
+            strategy_patch = {
+                "entry": {"initial_ema_dist": 0.01},
+            }
+            candidate[f"{side}_entry_initial_ema_dist"] = 0.4
+            locked_key = "entry_initial_ema_dist"
+            locked_value = 0.01
+        candidate[f"{side}_entry_cooldown_minutes"] = 0.0
+        candidate[f"{side}_total_wallet_exposure_limit"] = 0.9
+        candidate[f"{side}_we_excess_allowance_pct"] = 0.0
+        candidate[f"{side}_unstuck_close_pct"] = 0.9
+        candidate[f"{side}_hsl_red_threshold"] = 0.8
+        risk_patch = {
+            "entry_cooldown_minutes": 1_000.0,
+            "we_excess_allowance_pct": 0.25,
+        }
+        if strategy_kind == "trailing_martingale":
+            risk_patch.update(
+                {
+                    "position_exposure_enforcer_enabled": False,
+                    "position_exposure_enforcer_threshold": 0.7,
+                }
+            )
+            candidate[f"{side}_wel_enforcer_enabled"] = 1.0
+            candidate[f"{side}_wel_enforcer_threshold"] = 0.9
+        side_overrides[side] = {
+            "strategy": {strategy_kind: strategy_patch},
+            "risk": risk_patch,
+            "wallet_exposure_limit": 0.4,
+            "unstuck": {"close_pct": 0.2},
+            "hsl": {"red_threshold": 0.2},
+        }
+    config["coin_overrides"] = {"ETH": {"bot": side_overrides}}
+
+    proxy = MpsSingleCoinProxy(
+        config=config,
+        hlcvs=hlcvs,
+        mss=market_settings,
+        btc=np.full(count, 50_000.0),
+        timestamps=timestamps,
+        exchange="bybit",
+        batch_size=1,
+        needed_metrics={"fills_count"},
+    )
+    parameter_matrix = proxy._parameter_matrix([candidate])
+    side_width = len(proxy.param_keys)
+    for side in enabled_sides:
+        side_offset = 0 if side == "long" else side_width
+        assert parameter_matrix[
+            0, side_offset + proxy.param_keys.index(locked_key)
+        ] == pytest.approx(locked_value)
+        assert parameter_matrix[
+            0, side_offset + proxy.param_keys.index("entry_cooldown_minutes")
+        ] == pytest.approx(1_000.0)
+        assert parameter_matrix[
+            0,
+            side_offset
+            + proxy.param_keys.index("total_wallet_exposure_limit"),
+        ] == pytest.approx(0.9)
+        assert parameter_matrix[
+            0,
+            side_offset
+            + proxy.param_keys.index("wallet_exposure_limit"),
+        ] == pytest.approx(0.4)
+        assert parameter_matrix[
+            0, side_offset + proxy.param_keys.index("we_excess_allowance_pct")
+        ] == pytest.approx(0.25)
+        assert parameter_matrix[
+            0, side_offset + proxy.param_keys.index("unstuck_close_pct")
+        ] == pytest.approx(0.2)
+        assert parameter_matrix[
+            0, side_offset + proxy.param_keys.index("hsl_red_threshold")
+        ] == pytest.approx(0.2)
+        if strategy_kind == "trailing_martingale":
+            assert parameter_matrix[
+                0, side_offset + proxy.param_keys.index("wel_enforcer_enabled")
+            ] == pytest.approx(0.0)
+            assert parameter_matrix[
+                0, side_offset + proxy.param_keys.index("wel_enforcer_threshold")
+            ] == pytest.approx(0.7)
+
+    result = proxy.evaluate([candidate])[0]
+    _, _, exact_analysis = run_backtest(
+        hlcvs,
+        market_settings,
+        config,
+        "bybit",
+        np.full(count, 50_000.0),
+        timestamps,
+    )
+
+    assert result["fills_count"] > 0.0
+    fill_count_drift = abs(
+        result["fills_count"] - exact_analysis["fills_count"]
+    )
+    # TM's float32 screening path may cross one recursive fill boundary that
+    # exact Rust's float64 path does not. The exact optimizer validation remains
+    # authoritative; this matrix is proving override dispatch and bounded drift.
+    assert fill_count_drift <= (
+        0.0 if strategy_kind == "ema_anchor" else 1.0
+    )
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
 @pytest.mark.parametrize("topology", ["long", "short", "fused"])
 def test_mps_multicoin_service_dispatches_forced_delist_tail(
     strategy_kind, topology
@@ -5006,6 +5300,8 @@ def test_mps_multicoin_forced_normal_service_matches_exact_active_symbols(
         batch_size=1,
         needed_metrics={"fills_active_symbols_count"},
     )
+    for side in enabled_sides:
+        assert proxy.base_params[side]["entry_cooldown_minutes"] == 100.0
     result = proxy.evaluate([{}])[0]
     _, _, exact_analysis = run_backtest(
         hlcvs,
@@ -7578,7 +7874,7 @@ def test_mps_ema_anchor_shader_smoke():
 
     source = passivbot_rust.mps_ema_anchor_source_py()
     assert "kernel void passivbot_ema_anchor" in source
-    assert "constant int SIDE_PARAMS = 34" in source
+    assert "constant int SIDE_PARAMS = 35" in source
     assert "total_exposure_reducer_qty" in source
     assert "secondary_close_qty" in source
     assert "realized_loss_gate_allows" in source
@@ -11435,7 +11731,7 @@ def _tm_single_row(
         unstuck_ema_dist=unstuck_ema_dist,
         unstuck_loss_allowance_pct=unstuck_loss_allowance_pct,
         unstuck_threshold=unstuck_threshold,
-    )
+    ) + [-1.0]
 
 
 @pytest.mark.skipif(
@@ -18655,7 +18951,7 @@ def test_mps_trailing_martingale_shader_contract_and_directional_smoke(
 
     source = passivbot_rust.mps_trailing_martingale_source_py()
     assert "kernel void passivbot_trailing_martingale" in source
-    assert "constant int SIDE_PARAMS = 51" in source
+    assert "constant int SIDE_PARAMS = 52" in source
     assert "s.allowed_wel" in source
     assert "s.entry_cap" in source
     assert "min_since_open" in source

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -1658,6 +1658,37 @@ def test_directional_parameter_matrix_keeps_side_values_separate():
     assert matrix[0, len(EMA_ANCHOR_PARAM_KEYS) + offset_index] == 0.25
 
 
+def test_single_coin_static_overrides_shadow_candidate_values_exact_last():
+    proxy = MpsEmaAnchorProxy.__new__(MpsEmaAnchorProxy)
+    proxy.base_params = {
+        "long": {key: 1.0 for key in EMA_ANCHOR_PARAM_KEYS},
+        "short": {key: 2.0 for key in EMA_ANCHOR_PARAM_KEYS},
+    }
+    proxy.param_keys = EMA_ANCHOR_PARAM_KEYS
+    proxy.static_coin_override_params = {
+        "long": {"offset": 0.125, "entry_cooldown_minutes": 37.0},
+        "short": {},
+    }
+
+    matrix = proxy._parameter_matrix(
+        [
+            {
+                "long_offset": 0.5,
+                "long_entry_cooldown_minutes": 5.0,
+                "short_offset": 0.25,
+            }
+        ]
+    )
+
+    offset_index = EMA_ANCHOR_PARAM_KEYS.index("offset")
+    cooldown_index = EMA_ANCHOR_PARAM_KEYS.index("entry_cooldown_minutes")
+    assert matrix[0, offset_index] == pytest.approx(0.125)
+    assert matrix[0, cooldown_index] == pytest.approx(37.0)
+    assert matrix[0, len(EMA_ANCHOR_PARAM_KEYS) + offset_index] == pytest.approx(
+        0.25
+    )
+
+
 @pytest.mark.parametrize(("side", "base"), [("long", 1.0), ("short", 2.0)])
 def test_multicoin_parameter_matrix_uses_only_enabled_side(side, base):
     proxy = MpsMulticoinEmaProxy.__new__(MpsMulticoinEmaProxy)
@@ -2010,10 +2041,15 @@ def test_multicoin_coin_overrides_pack_only_explicit_exact_values():
             {"long": strategy_override},
         ],
         bot_params_list=[
-            {"long": {"entry_cooldown_minutes": 0.0, "wallet_exposure_limit": -1.0}},
             {
                 "long": {
-                    "entry_cooldown_minutes": 15.0,
+                    "risk_entry_cooldown_minutes": 0.0,
+                    "wallet_exposure_limit": -1.0,
+                }
+            },
+            {
+                "long": {
+                    "risk_entry_cooldown_minutes": 15.0,
                     "wallet_exposure_limit": 0.4,
                     "risk_we_excess_allowance_pct": 0.25,
                     "unstuck_enabled": True,
@@ -2155,12 +2191,24 @@ def test_multicoin_coin_overrides_pack_dual_sides_independently():
         ],
         bot_params_list=[
             {
-                "long": {"entry_cooldown_minutes": 0.0, "wallet_exposure_limit": -1.0},
-                "short": {"entry_cooldown_minutes": 0.0, "wallet_exposure_limit": -1.0},
+                "long": {
+                    "risk_entry_cooldown_minutes": 0.0,
+                    "wallet_exposure_limit": -1.0,
+                },
+                "short": {
+                    "risk_entry_cooldown_minutes": 0.0,
+                    "wallet_exposure_limit": -1.0,
+                },
             },
             {
-                "long": {"entry_cooldown_minutes": 0.0, "wallet_exposure_limit": 0.4},
-                "short": {"entry_cooldown_minutes": 30.0, "wallet_exposure_limit": -1.0},
+                "long": {
+                    "risk_entry_cooldown_minutes": 0.0,
+                    "wallet_exposure_limit": 0.4,
+                },
+                "short": {
+                    "risk_entry_cooldown_minutes": 30.0,
+                    "wallet_exposure_limit": -1.0,
+                },
             },
         ],
     )
@@ -2421,14 +2469,14 @@ def test_multicoin_tm_coin_overrides_pack_only_explicit_exact_values():
         bot_params_list=[
             {
                 "long": {
-                    "entry_cooldown_minutes": 0.0,
+                    "risk_entry_cooldown_minutes": 0.0,
                     "total_wallet_exposure_limit": 1.0,
                     "wallet_exposure_limit": -1.0,
                 }
             },
             {
                 "long": {
-                    "entry_cooldown_minutes": 15.0,
+                    "risk_entry_cooldown_minutes": 15.0,
                     "total_wallet_exposure_limit": 1.0,
                     "wallet_exposure_limit": 0.4,
                     "risk_we_excess_allowance_pct": 0.25,
@@ -2639,3 +2687,30 @@ def test_trailing_martingale_flattening_rejects_unknown_gate_mode():
             },
             {"total_wallet_exposure_limit": 1.0},
         )
+
+
+def test_trailing_martingale_flattening_reads_canonical_payload_cooldown():
+    strategy = {
+        "ema_span_0": 10.0,
+        "ema_span_1": 20.0,
+        "volatility_ema_span_1h": 30.0,
+        "volatility_ema_span_1m": 40.0,
+        "entry": {"ema_gate_mode": "all"},
+        "close": {},
+    }
+    for key in TRAILING_MARTINGALE_COIN_OVERRIDE_PATHS:
+        _name, path = key
+        target = strategy
+        for part in path[:-1]:
+            target = target.setdefault(part, {})
+        target.setdefault(path[-1], 0.1)
+
+    flattened = flatten_trailing_martingale_params(
+        strategy,
+        {
+            "risk_entry_cooldown_minutes": 37.0,
+            "total_wallet_exposure_limit": 1.5,
+        },
+    )
+
+    assert flattened["entry_cooldown_minutes"] == 37.0

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -2114,6 +2114,61 @@ def test_multicoin_coin_overrides_pack_only_explicit_exact_values():
     assert np.isnan(matrix[1, 19:]).all()
     assert contract["coins"] == ["BTC", "ETH"]
     assert contract["values"][0] == [None] * EMA_ANCHOR_COIN_OVERRIDE_COLS
+    assert contract["exact_overrides"] == [
+        {},
+        config["coin_overrides"]["ETH"],
+    ]
+
+
+def test_coin_override_contract_keeps_exact_values_beyond_float32_precision():
+    first = 0.4
+    second = float(np.nextafter(first, 1.0))
+
+    def build(value):
+        config = {
+            "coin_overrides": {
+                "ETH": {
+                    "bot": {
+                        "long": {
+                            "strategy": {"ema_anchor": {"offset": value}}
+                        }
+                    }
+                }
+            }
+        }
+        payload = SimpleNamespace(
+            strategy_params_list=[{"long": {"offset": value}}],
+            bot_params_list=[
+                {
+                    "long": {
+                        "entry_eligible": True,
+                        "wallet_exposure_limit": -1.0,
+                    }
+                }
+            ],
+        )
+        return _build_multicoin_ema_coin_overrides(
+            config=config,
+            mss={"ETH": {}},
+            exchange="bybit",
+            coins=["ETH"],
+            payload=payload,
+            side="long",
+            resolve_override=lambda config, _mss, _exchange, coin: config[
+                "coin_overrides"
+            ].get(coin, {}),
+        )
+
+    first_matrix, first_contract = build(first)
+    second_matrix, second_contract = build(second)
+
+    assert np.array_equal(first_matrix, second_matrix, equal_nan=True)
+    assert first_contract["values"] == second_contract["values"]
+    assert first_contract["exact_overrides"] != second_contract["exact_overrides"]
+    first_exact = first_contract["exact_overrides"][0]["bot"]["long"]
+    second_exact = second_contract["exact_overrides"][0]["bot"]["long"]
+    assert first_exact["strategy"]["ema_anchor"]["offset"] == first
+    assert second_exact["strategy"]["ema_anchor"]["offset"] == second
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- apply modeled single-coin EMA Anchor and Trailing Martingale coin overrides after every GPU optimizer candidate, matching exact Rust last-write precedence
- keep explicit per-coin WEL separate from candidate TWEL in the directional Metal ABI, including bounded and legacy-raw allowance semantics
- read the canonical prepared risk cooldown key for single- and multi-coin proxy rows and checkpoint the single-coin override contract
- preserve legacy direct-runner row compatibility with a dynamic-WEL sentinel

## Validation
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-4/venv/bin/python -m pytest -q --tb=short tests/optimization
- cargo test --no-default-features --quiet (268 passed)
- cargo check --tests
- compiled Rust extension source fingerprint verified against 0a99e192ca030b06cd5fd74a575c3d0799e880a748493371acd520e6b10b0d5c
- /Users/eiriknarjord/repos/passivbot-4/venv/bin/python src/tools/check_ai_docs.py
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-4/venv/bin/python -m pytest -q tests/test_ai_docs.py
- /Users/eiriknarjord/repos/passivbot-4/venv/bin/mkdocs build
- git diff --check