### PR TITLE
GPU: support fixed multi-coin WEL denominators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Apple MPS multi-coin EMA Anchor and Trailing Martingale optimization now supports both wallet-
+  exposure denominator modes. With `backtest.dynamic_wel_by_tradability: false`, Metal divides
+  total wallet exposure by each side's configured `n_positions`, matching exact Rust across
+  long-only, short-only, hedge-mode, one-way, HSL, exposure repair, coin overrides, and compatible
+  suite scenarios. The existing dynamic mode continues to use its grow-only observed-tradability
+  denominator, while current Forager selection remains based on currently tradable coins in both
+  modes.
+
 - Apple MPS single-coin EMA Anchor and Trailing Martingale optimization now supports the same
   modeled static `coin_overrides` leaves as multi-coin runs. Static values retain exact Rust's
   last-write precedence over optimizer candidates for long-only, short-only, hedge-mode, and
@@ -15,7 +23,7 @@ All notable user-facing changes will be documented in this file.
   `coin_overrides.<coin>.live.forced_mode_<side>: normal` for every enabled side. Long-only,
   short-only, and fused long+short kernels reserve eligible forced-normal symbols before Forager
   ranking and expand the active-set cap when forced symbols outnumber configured positions, while
-  retaining exact Rust's separate dynamic wallet-exposure denominator, one-way initial-entry
+  retaining exact Rust's separately configured wallet-exposure denominator, one-way initial-entry
   exclusion, minimum-effective-cost gate, and per-coin HSL eligibility.
 
 - Apple MPS multi-coin EMA Anchor and Trailing Martingale optimization now continues through

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -108,9 +108,12 @@ The supported slice is intentionally narrow:
   long+short enabled for one coin
 - long-only, short-only, or dual-side hedge-mode and one-way multi-coin EMA-anchor and
   trailing-martingale runs
-  for up to 64 coins, with dynamic wallet-exposure allocation and independent per-side Forager
-  selection; non-suite dual-side runs may use different effective long and short coin universes,
-  and all multi-coin runs require `backtest.dynamic_wel_by_tradability: true`;
+  for up to 64 coins, with fixed or dynamic wallet-exposure allocation and independent per-side
+  Forager selection; non-suite dual-side runs may use different effective long and short coin
+  universes. With `backtest.dynamic_wel_by_tradability: true`, each side's WEL denominator grows
+  with the maximum observed eligible coin count up to `n_positions`; with `false`, it remains the
+  configured `n_positions`. Current Forager selection still uses the current tradable set in both
+  modes;
   `live.forager_score_hysteresis_pct` preserves flat incumbent candidates when a challenger's
   normalized Forager-score lead is within the configured gap
 - each enabled side's `n_positions` pinned to `1` and wallet-exposure limit kept positive
@@ -126,9 +129,10 @@ The supported slice is intentionally narrow:
   config overrides are supported; scenario-local `coin_overrides` for supported multi-coin
   EMA-anchor and trailing-martingale runs, starting balance, maker fee, liquidation threshold,
   taker fee, market-order slippage, minimum-effective-cost filtering, finite or all-history PnL
-  lookback, Forager hysteresis, hedge mode, HSL signal mode, ordinary-market enablement, and its
-  near-touch threshold are also supported when the resulting scenario remains within the scope
-  below, while other non-bot override paths remain unsupported; combined scenarios may use
+  lookback, Forager hysteresis, hedge mode, HSL signal mode, dynamic-WEL denominator mode,
+  ordinary-market enablement, and its near-touch threshold are also supported when the resulting
+  scenario remains within the scope below, while other non-bot override paths remain unsupported;
+  combined scenarios may use
   canonical per-coin source assignments, while an individual-exchange scenario fails closed if
   an effective assignment for one of its prepared coins selects another exchange
 - static `coin_overrides` for each enabled side of single- and multi-coin EMA-anchor and
@@ -139,7 +143,7 @@ The supported slice is intentionally narrow:
   exact Rust's override precedence. Checkpoint identity records the resolved exact override values
   before float32 Metal packing. Eligible forced-normal symbols in multi-coin runs reserve
   active slots before Forager ranking and may expand the active-set cap beyond `n_positions`; the
-  dynamic WEL denominator remains unchanged, matching exact Rust. Trailing Martingale also supports
+  configured WEL denominator mode remains unchanged, matching exact Rust. Trailing Martingale also supports
   per-coin
   `risk.position_exposure_enforcer_enabled` and
   `risk.position_exposure_enforcer_threshold`; per-coin

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -242,6 +242,7 @@ mod tests {
             "inline float float32_floor_nonnegative(",
             "inline void record_realized_net(",
             "inline void record_gross_pnl(",
+            "inline int wallet_exposure_denominator_n_positions(",
             "inline float coin_override_or(",
             "inline float allowed_wallet_exposure_limit(",
             "inline float clamped_market_price(",
@@ -258,6 +259,11 @@ mod tests {
             assert_eq!(source.matches(signature).count(), 1, "{signature}");
         }
         assert_eq!(source.matches("struct JointPortfolioAccount").count(), 1);
+        assert!(source.contains("#ifndef PASSIVBOT_DYNAMIC_WEL_BY_TRADABILITY"));
+        assert!(source.contains("#define PASSIVBOT_DYNAMIC_WEL_BY_TRADABILITY 1"));
+        assert!(source.contains("#if PASSIVBOT_DYNAMIC_WEL_BY_TRADABILITY"));
+        assert!(source.contains("return min(configured_n_positions, observed_tradable_count)"));
+        assert!(source.contains("return configured_n_positions"));
         assert!(source.contains("if (is_long) account.realized_pnl_long += net_pnl"));
         assert!(source.contains("else account.realized_pnl_short += net_pnl"));
         assert!(source.contains("long_hsl.signal_mode != short_hsl.signal_mode"));
@@ -738,6 +744,10 @@ mod tests {
         assert!(source.contains("close_is_protective_reducer[MAX_COINS]"));
         assert!(!source.contains("realized_loss_proxy_allows_close"));
         assert!(source.contains("current_effective_n_positions"));
+        assert!(source.contains("wallet_exposure_denominator_n_positions("));
+        assert!(source.contains(
+            "coin_hsl[c].slot_count = float(effective_n_positions)"
+        ));
         assert!(source.contains("distance == best_distance && c > best"));
         assert!(source.contains("= fma("));
         assert!(source.contains("one global auto-unstuck intent"));
@@ -1067,6 +1077,10 @@ mod tests {
         assert!(source.contains("update_tm_multicoin_side_selection("));
         assert!(source.contains("generate_tm_multicoin_side_orders("));
         assert!(source.contains("tm_multicoin_entry_initial_balance_pct("));
+        assert!(source.contains("wallet_exposure_denominator_n_positions("));
+        assert!(source.contains(
+            "coin_hsl[c].slot_count = float(effective_n_positions)"
+        ));
         assert!(source.contains(
             "passivbot_trailing_martingale_multicoin_fused_impl("
         ));

--- a/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
@@ -1378,11 +1378,12 @@ inline void generate_ema_multicoin_side_orders(
         && twel_repair_target > 0.0f && balance > 0.0f
         && current_twe > twel_repair_target + 1.0e-9f
         && open_position_count > 0) {
-        // Reduce-overweight uses the current eligible count. The
-        // grow-only maximum remains exclusive to dynamic WEL sizing.
-        int current_effective_n_positions = min(
-            n_positions, tradable_count
-        );
+        // Reduce-overweight follows the configured denominator mode using
+        // the current eligible count as dynamic mode's observation.
+        int current_effective_n_positions =
+            wallet_exposure_denominator_n_positions(
+                n_positions, tradable_count
+            );
         int repair_n_positions = current_effective_n_positions > 0
             ? current_effective_n_positions : open_position_count;
         float overweight_target = twel_repair_target
@@ -3031,11 +3032,12 @@ inline void passivbot_ema_anchor_multicoin_impl(
                 side.max_tradable_seen, tradable_count
             );
         }
-        const int effective_n_positions = min(
-            n_positions, side.max_tradable_seen
-        );
+        const int effective_n_positions =
+            wallet_exposure_denominator_n_positions(
+                n_positions, side.max_tradable_seen
+            );
         const bool can_generate = alive && effective_n_positions > 0
-            && past_activation_guard;
+            && side.max_tradable_seen > 0 && past_activation_guard;
         equity_started = equity_started || can_generate;
         bool has_hsl_position = ema_multicoin_side_has_position(side, C);
         int current_hsl_mode = coin_hsl_mode
@@ -3387,9 +3389,10 @@ inline void passivbot_ema_anchor_multicoin_impl(
     scalars[scalar_offset + 18] = profit_sum;
     scalars[scalar_offset + 19] = loss_sum;
     scalars[scalar_offset + 20] = position_unchanged_max_min * interval_ms;
-    int entry_effective_n_positions = min(
-        n_positions, side.max_tradable_seen
-    );
+    int entry_effective_n_positions =
+        wallet_exposure_denominator_n_positions(
+            n_positions, side.max_tradable_seen
+        );
     float entry_base_limit = entry_effective_n_positions > 0
         ? twel / float(entry_effective_n_positions) : 0.0f;
     float entry_initial_qty_pct = coin_override_or(
@@ -3872,16 +3875,20 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
                 short_side.max_tradable_seen, short_tradable_count
             );
         }
-        const int long_effective_n_positions = min(
-            long_config.n_positions, long_side.max_tradable_seen
-        );
-        const int short_effective_n_positions = min(
-            short_config.n_positions, short_side.max_tradable_seen
-        );
+        const int long_effective_n_positions =
+            wallet_exposure_denominator_n_positions(
+                long_config.n_positions, long_side.max_tradable_seen
+            );
+        const int short_effective_n_positions =
+            wallet_exposure_denominator_n_positions(
+                short_config.n_positions, short_side.max_tradable_seen
+            );
         const bool long_can_generate = alive
-            && long_effective_n_positions > 0 && past_activation_guard;
+            && long_effective_n_positions > 0
+            && long_side.max_tradable_seen > 0 && past_activation_guard;
         const bool short_can_generate = alive
-            && short_effective_n_positions > 0 && past_activation_guard;
+            && short_effective_n_positions > 0
+            && short_side.max_tradable_seen > 0 && past_activation_guard;
         equity_started = equity_started
             || long_can_generate || short_can_generate;
 
@@ -4331,7 +4338,9 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
         fills.position_unchanged_max_min * interval_ms;
     scalars[scalar_offset + 21] = ema_multicoin_entry_initial_balance_pct(
         long_config, long_coin_overrides,
-        min(long_config.n_positions, long_side.max_tradable_seen)
+        wallet_exposure_denominator_n_positions(
+            long_config.n_positions, long_side.max_tradable_seen
+        )
     );
     scalars[scalar_offset + 22] = total_wallet_exposure_max;
     scalars[scalar_offset + 23] = total_wallet_exposure_mean;
@@ -4365,7 +4374,9 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
     }
     scalars[scalar_offset + 59] = ema_multicoin_entry_initial_balance_pct(
         short_config, short_coin_overrides,
-        min(short_config.n_positions, short_side.max_tradable_seen)
+        wallet_exposure_denominator_n_positions(
+            short_config.n_positions, short_side.max_tradable_seen
+        )
     );
     scalars[scalar_offset + 60] = fills.profit_sum_long;
     scalars[scalar_offset + 61] = fills.loss_sum_long;

--- a/passivbot-rust/src/gpu/mps_multicoin_common.metal
+++ b/passivbot-rust/src/gpu/mps_multicoin_common.metal
@@ -202,6 +202,21 @@ inline void record_gross_pnl(
     else loss_sum += fabs(pnl);
 }
 
+// Backtest WEL denominator mode is fixed for a compiled proxy instance.
+#ifndef PASSIVBOT_DYNAMIC_WEL_BY_TRADABILITY
+#define PASSIVBOT_DYNAMIC_WEL_BY_TRADABILITY 1
+#endif
+
+inline int wallet_exposure_denominator_n_positions(
+    int configured_n_positions, int observed_tradable_count
+) {
+#if PASSIVBOT_DYNAMIC_WEL_BY_TRADABILITY
+    return min(configured_n_positions, observed_tradable_count);
+#else
+    return configured_n_positions;
+#endif
+}
+
 inline float coin_override_or(
     constant float* coin_overrides, int coin, int column, float fallback
 ) {

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
@@ -3576,11 +3576,12 @@ inline void generate_tm_multicoin_side_orders(
         && twel_repair_target > 0.0f && balance > 0.0f
         && current_twe > twel_repair_target + 1.0e-9f
         && open_position_count > 0) {
-        // TWEL reduce_overweight uses the current eligible count.
-        // Keep the grow-only maximum solely for dynamic WEL sizing.
-        int current_effective_n_positions = min(
-            n_positions, tradable_count
-        );
+        // TWEL reduce_overweight follows the configured denominator mode
+        // using the current eligible count as dynamic mode's observation.
+        int current_effective_n_positions =
+            wallet_exposure_denominator_n_positions(
+                n_positions, tradable_count
+            );
         int repair_n_positions = current_effective_n_positions > 0
             ? current_effective_n_positions : open_position_count;
         float overweight_target = twel_repair_target
@@ -5012,16 +5013,20 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
                 short_side.max_tradable_seen, short_tradable_count
             );
         }
-        const int long_effective_n_positions = min(
-            long_config.n_positions, long_side.max_tradable_seen
-        );
-        const int short_effective_n_positions = min(
-            short_config.n_positions, short_side.max_tradable_seen
-        );
+        const int long_effective_n_positions =
+            wallet_exposure_denominator_n_positions(
+                long_config.n_positions, long_side.max_tradable_seen
+            );
+        const int short_effective_n_positions =
+            wallet_exposure_denominator_n_positions(
+                short_config.n_positions, short_side.max_tradable_seen
+            );
         const bool long_can_generate = alive
-            && long_effective_n_positions > 0 && past_activation_guard;
+            && long_effective_n_positions > 0
+            && long_side.max_tradable_seen > 0 && past_activation_guard;
         const bool short_can_generate = alive
-            && short_effective_n_positions > 0 && past_activation_guard;
+            && short_effective_n_positions > 0
+            && short_side.max_tradable_seen > 0 && past_activation_guard;
         equity_started = equity_started
             || long_can_generate || short_can_generate;
 
@@ -5472,7 +5477,9 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
         fills.position_unchanged_max_min * interval_ms;
     scalars[scalar_offset + 21] = tm_multicoin_entry_initial_balance_pct(
         long_config, long_coin_overrides,
-        min(long_config.n_positions, long_side.max_tradable_seen)
+        wallet_exposure_denominator_n_positions(
+            long_config.n_positions, long_side.max_tradable_seen
+        )
     );
     scalars[scalar_offset + 22] = total_wallet_exposure_max;
     scalars[scalar_offset + 23] = total_wallet_exposure_mean;
@@ -5506,7 +5513,9 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
     }
     scalars[scalar_offset + 59] = tm_multicoin_entry_initial_balance_pct(
         short_config, short_coin_overrides,
-        min(short_config.n_positions, short_side.max_tradable_seen)
+        wallet_exposure_denominator_n_positions(
+            short_config.n_positions, short_side.max_tradable_seen
+        )
     );
     scalars[scalar_offset + 60] = fills.profit_sum_long;
     scalars[scalar_offset + 61] = fills.loss_sum_long;
@@ -5786,9 +5795,12 @@ inline void passivbot_trailing_martingale_multicoin_impl(
         if (alive && !post_fill_balance_depleted && past_activation_guard) {
             max_tradable_seen = max(max_tradable_seen, tradable_count);
         }
-        const int effective_n_positions = min(n_positions, max_tradable_seen);
+        const int effective_n_positions =
+            wallet_exposure_denominator_n_positions(
+                n_positions, max_tradable_seen
+            );
         const bool can_generate = alive && effective_n_positions > 0
-            && past_activation_guard;
+            && max_tradable_seen > 0 && past_activation_guard;
         equity_started = equity_started || can_generate;
         bool has_hsl_position = tm_multicoin_side_has_position(side, C);
         int current_hsl_mode = coin_hsl_mode
@@ -6142,7 +6154,10 @@ inline void passivbot_trailing_martingale_multicoin_impl(
     scalars[scalar_offset + 18] = profit_sum;
     scalars[scalar_offset + 19] = loss_sum;
     scalars[scalar_offset + 20] = position_unchanged_max_min * interval_ms;
-    int entry_effective_n_positions = min(n_positions, max_tradable_seen);
+    int entry_effective_n_positions =
+        wallet_exposure_denominator_n_positions(
+            n_positions, max_tradable_seen
+        );
     float entry_base_limit = entry_effective_n_positions > 0
         ? twel / float(entry_effective_n_positions) : 0.0f;
     float entry_initial_qty_pct = coin_override_or(

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -297,6 +297,7 @@ GPU_SUPPORTED_OPTIMIZER_OVERRIDES = {
 # selection and unsupported execution/risk behavior must continue to fail
 # closed instead of being accepted merely because the config path exists.
 GPU_SUPPORTED_SUITE_NON_BOT_OVERRIDE_PATHS = {
+    ("backtest", "dynamic_wel_by_tradability"),
     ("backtest", "filter_by_min_effective_cost"),
     ("backtest", "liquidation_threshold"),
     ("backtest", "maker_fee_override"),
@@ -1069,11 +1070,6 @@ def _validate_scope_config(
         if len(enabled_sides) not in (1, 2):
             raise ValueError(
                 "GPU multicoin foundation requires one or two enabled sides"
-            )
-        if not bool(config.get("backtest", {}).get("dynamic_wel_by_tradability")):
-            raise ValueError(
-                "GPU multicoin foundation requires "
-                "backtest.dynamic_wel_by_tradability=true"
             )
     _validate_gpu_coin_overrides(
         config,

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -51,6 +51,9 @@ _HSL_RAW_TAIL_DEFINE = "#define PASSIVBOT_HSL_RAW_TAIL_ENABLED 1\n"
 _RECOVERY_DISTRIBUTION_DEFINE = (
     "#define PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED 1\n"
 )
+_FIXED_WEL_DENOMINATOR_DEFINE = (
+    "#define PASSIVBOT_DYNAMIC_WEL_BY_TRADABILITY 0\n"
+)
 
 
 def _with_hsl_ema_tail(source: str, enabled: bool) -> str:
@@ -90,6 +93,16 @@ def _with_recovery_distribution(source: str, enabled: bool) -> str:
             "MPS source is missing the strategy-equity recovery-distribution feature guard"
         )
     return _RECOVERY_DISTRIBUTION_DEFINE + source
+
+
+def _with_dynamic_wel_by_tradability(source: str, enabled: bool) -> str:
+    if enabled:
+        return source
+    if "#ifndef PASSIVBOT_DYNAMIC_WEL_BY_TRADABILITY" not in source:
+        raise RuntimeError(
+            "MPS multicoin source is missing the dynamic-WEL feature guard"
+        )
+    return _FIXED_WEL_DENOMINATOR_DEFINE + source
 
 
 def _encode_max_realized_loss_pct(value: float) -> float:
@@ -401,50 +414,58 @@ def _trailing_martingale_short_no_hsl_shader_library(
     )
 
 
-@lru_cache(maxsize=8)
+@lru_cache(maxsize=16)
 def _ema_anchor_multicoin_shader_library(
     hsl_ema_tail_enabled: bool = False,
     hsl_raw_drawdown_enabled: bool = False,
     hsl_raw_tail_enabled: bool = False,
     recovery_distribution_enabled: bool = False,
+    dynamic_wel_by_tradability: bool = True,
 ):
     if not torch.backends.mps.is_available():
         raise RuntimeError("Apple MPS is not available in this process")
     import passivbot_rust
 
     return torch.mps.compile_shader(
-        _with_recovery_distribution(
-            _with_hsl_features(
-                passivbot_rust.mps_ema_anchor_multicoin_source_py(),
-                ema_tail_enabled=hsl_ema_tail_enabled,
-                raw_drawdown_enabled=hsl_raw_drawdown_enabled,
-                raw_tail_enabled=hsl_raw_tail_enabled,
+        _with_dynamic_wel_by_tradability(
+            _with_recovery_distribution(
+                _with_hsl_features(
+                    passivbot_rust.mps_ema_anchor_multicoin_source_py(),
+                    ema_tail_enabled=hsl_ema_tail_enabled,
+                    raw_drawdown_enabled=hsl_raw_drawdown_enabled,
+                    raw_tail_enabled=hsl_raw_tail_enabled,
+                ),
+                recovery_distribution_enabled,
             ),
-            recovery_distribution_enabled,
+            dynamic_wel_by_tradability,
         )
     )
 
 
-@lru_cache(maxsize=8)
+@lru_cache(maxsize=16)
 def _trailing_martingale_multicoin_shader_library(
     hsl_ema_tail_enabled: bool = False,
     hsl_raw_drawdown_enabled: bool = False,
     hsl_raw_tail_enabled: bool = False,
     recovery_distribution_enabled: bool = False,
+    dynamic_wel_by_tradability: bool = True,
 ):
     if not torch.backends.mps.is_available():
         raise RuntimeError("Apple MPS is not available in this process")
     import passivbot_rust
 
     return torch.mps.compile_shader(
-        _with_recovery_distribution(
-            _with_hsl_features(
-                passivbot_rust.mps_trailing_martingale_multicoin_source_py(),
-                ema_tail_enabled=hsl_ema_tail_enabled,
-                raw_drawdown_enabled=hsl_raw_drawdown_enabled,
-                raw_tail_enabled=hsl_raw_tail_enabled,
+        _with_dynamic_wel_by_tradability(
+            _with_recovery_distribution(
+                _with_hsl_features(
+                    passivbot_rust.mps_trailing_martingale_multicoin_source_py(),
+                    ema_tail_enabled=hsl_ema_tail_enabled,
+                    raw_drawdown_enabled=hsl_raw_drawdown_enabled,
+                    raw_tail_enabled=hsl_raw_tail_enabled,
+                ),
+                recovery_distribution_enabled,
             ),
-            recovery_distribution_enabled,
+            dynamic_wel_by_tradability,
         )
     )
 
@@ -1138,6 +1159,7 @@ class MpsEmaAnchorMulticoinRunner:
         hsl_raw_drawdown_enabled: bool = False,
         hsl_raw_tail_enabled: bool = False,
         recovery_distribution_enabled: bool = False,
+        dynamic_wel_by_tradability: bool = True,
     ):
         if side not in {"long", "short"}:
             raise ValueError(
@@ -1149,6 +1171,7 @@ class MpsEmaAnchorMulticoinRunner:
         self.hsl_raw_drawdown_enabled = bool(hsl_raw_drawdown_enabled)
         self.hsl_raw_tail_enabled = bool(hsl_raw_tail_enabled)
         self.recovery_distribution_enabled = bool(recovery_distribution_enabled)
+        self.dynamic_wel_by_tradability = bool(dynamic_wel_by_tradability)
         fused = self.scalar_cols == MPS_MULTICOIN_FUSED_SCALAR_COLS
         if self.hsl_raw_tail_enabled:
             self.scalar_cols = (
@@ -1407,6 +1430,7 @@ class MpsEmaAnchorMulticoinRunner:
             self.hsl_raw_drawdown_enabled,
             self.hsl_raw_tail_enabled,
             self.recovery_distribution_enabled,
+            self.dynamic_wel_by_tradability,
         )
 
     def _decode(self, daily, scalars, gaps) -> dict:
@@ -1531,6 +1555,7 @@ class MpsEmaAnchorMulticoinFusedRunner(MpsEmaAnchorMulticoinRunner):
         hsl_raw_tail_enabled: bool = False,
         recovery_distribution_enabled: bool = False,
         hedge_mode: bool = True,
+        dynamic_wel_by_tradability: bool = True,
     ):
         super().__init__(
             run,
@@ -1549,6 +1574,7 @@ class MpsEmaAnchorMulticoinFusedRunner(MpsEmaAnchorMulticoinRunner):
             hsl_raw_drawdown_enabled=hsl_raw_drawdown_enabled,
             hsl_raw_tail_enabled=hsl_raw_tail_enabled,
             recovery_distribution_enabled=recovery_distribution_enabled,
+            dynamic_wel_by_tradability=dynamic_wel_by_tradability,
         )
         if short_coin_overrides is None:
             short_coin_overrides = np.full(
@@ -1661,15 +1687,37 @@ class MpsEmaAnchorMulticoinFusedRunner(MpsEmaAnchorMulticoinRunner):
 class MpsEmaAnchorMulticoinLongRunner(MpsEmaAnchorMulticoinRunner):
     """Compatibility wrapper for the original long-only multicoin runner."""
 
-    def __init__(self, run: ProxyRun, data: dict):
-        super().__init__(run, data, side="long")
+    def __init__(
+        self,
+        run: ProxyRun,
+        data: dict,
+        *,
+        dynamic_wel_by_tradability: bool = True,
+    ):
+        super().__init__(
+            run,
+            data,
+            side="long",
+            dynamic_wel_by_tradability=dynamic_wel_by_tradability,
+        )
 
 
 class MpsEmaAnchorMulticoinShortRunner(MpsEmaAnchorMulticoinRunner):
     """Short-only multicoin EMA Anchor screening runner."""
 
-    def __init__(self, run: ProxyRun, data: dict):
-        super().__init__(run, data, side="short")
+    def __init__(
+        self,
+        run: ProxyRun,
+        data: dict,
+        *,
+        dynamic_wel_by_tradability: bool = True,
+    ):
+        super().__init__(
+            run,
+            data,
+            side="short",
+            dynamic_wel_by_tradability=dynamic_wel_by_tradability,
+        )
 
 
 class MpsTrailingMartingaleMulticoinRunner(MpsEmaAnchorMulticoinRunner):
@@ -1701,6 +1749,7 @@ class MpsTrailingMartingaleMulticoinRunner(MpsEmaAnchorMulticoinRunner):
         hsl_raw_drawdown_enabled: bool = False,
         hsl_raw_tail_enabled: bool = False,
         recovery_distribution_enabled: bool = False,
+        dynamic_wel_by_tradability: bool = True,
     ):
         super().__init__(
             run,
@@ -1719,6 +1768,7 @@ class MpsTrailingMartingaleMulticoinRunner(MpsEmaAnchorMulticoinRunner):
             hsl_raw_drawdown_enabled=hsl_raw_drawdown_enabled,
             hsl_raw_tail_enabled=hsl_raw_tail_enabled,
             recovery_distribution_enabled=recovery_distribution_enabled,
+            dynamic_wel_by_tradability=dynamic_wel_by_tradability,
         )
 
     def _pack_params(self, params: np.ndarray) -> np.ndarray:
@@ -1745,6 +1795,7 @@ class MpsTrailingMartingaleMulticoinRunner(MpsEmaAnchorMulticoinRunner):
             self.hsl_raw_drawdown_enabled,
             self.hsl_raw_tail_enabled,
             self.recovery_distribution_enabled,
+            self.dynamic_wel_by_tradability,
         )
 
     def _dispatch(
@@ -1819,6 +1870,7 @@ class MpsTrailingMartingaleMulticoinFusedRunner(
         hsl_raw_tail_enabled: bool = False,
         recovery_distribution_enabled: bool = False,
         hedge_mode: bool = True,
+        dynamic_wel_by_tradability: bool = True,
     ):
         super().__init__(
             run,
@@ -1837,6 +1889,7 @@ class MpsTrailingMartingaleMulticoinFusedRunner(
             hsl_raw_drawdown_enabled=hsl_raw_drawdown_enabled,
             hsl_raw_tail_enabled=hsl_raw_tail_enabled,
             recovery_distribution_enabled=recovery_distribution_enabled,
+            dynamic_wel_by_tradability=dynamic_wel_by_tradability,
         )
         if short_coin_overrides is None:
             short_coin_overrides = np.full(

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -2171,10 +2171,9 @@ class MpsMulticoinProxy:
         candle_interval_minutes = _single_coin_candle_interval_minutes(
             backtest_params
         )
-        if not bool(backtest_params.get("dynamic_wel_by_tradability")):
-            raise ValueError(
-                "MPS multicoin proxy requires backtest.dynamic_wel_by_tradability=true"
-            )
+        self.dynamic_wel_by_tradability = bool(
+            backtest_params.get("dynamic_wel_by_tradability", True)
+        )
         self.forager_score_hysteresis_pct = float(
             backtest_params.get("forager_score_hysteresis_pct", 0.0) or 0.0
         )
@@ -2504,6 +2503,7 @@ class MpsMulticoinProxy:
                 self.needed_metrics
                 & _STRATEGY_EQ_RECOVERY_DISTRIBUTION_METRICS
             ),
+            "dynamic_wel_by_tradability": self.dynamic_wel_by_tradability,
         }
         if self.shared_account_fused:
             fused_runner_cls = (

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -668,6 +668,11 @@ def test_gpu_suite_inputs_reject_unsupported_scenario_scope(
 @pytest.mark.parametrize(
     ("dotted_path", "value", "resolved_path"),
     [
+        (
+            "backtest.dynamic_wel_by_tradability",
+            False,
+            ("backtest", "dynamic_wel_by_tradability"),
+        ),
         ("backtest.starting_balance", 12_345.0, ("backtest", "starting_balance")),
         ("backtest.maker_fee_override", 0.0002, ("backtest", "maker_fee_override")),
         ("backtest.taker_fee_override", 0.0007, ("backtest", "taker_fee_override")),
@@ -2809,28 +2814,13 @@ def test_gpu_multicoin_tm_coin_overrides_accept_entry_ema_gate_mode(mode):
     )
 
 
-@pytest.mark.parametrize(
-    ("mutate", "message"),
-    [
-        (
-            lambda config: config["backtest"].__setitem__(
-                "dynamic_wel_by_tradability", False
-            ),
-            "dynamic_wel_by_tradability",
-        ),
-    ],
-)
-def test_gpu_multicoin_foundation_fails_closed_for_unsupported_scope(
-    mutate, message
-):
+def test_gpu_multicoin_foundation_accepts_fixed_wel_denominator():
     config = _long_only_ema_config()
     config["live"]["approved_coins"]["long"] = ["BTC", "ETH", "SOL"]
     config["live"]["forager_score_hysteresis_pct"] = 0.0
-    config["backtest"]["dynamic_wel_by_tradability"] = True
-    mutate(config)
+    config["backtest"]["dynamic_wel_by_tradability"] = False
 
-    with pytest.raises(ValueError, match=message):
-        _validate_scope(config, _MulticoinEvaluator())
+    _validate_scope(config, _MulticoinEvaluator())
 
 
 @pytest.mark.parametrize("side", ["long", "short"])

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -44,6 +44,7 @@ from optimization.gpu.mps_kernel import (
     _scale_tm_multicoin_coin_overrides,
     _scale_single_coin_minute_parameters,
     _upgrade_legacy_single_coin_wel_params,
+    _with_dynamic_wel_by_tradability,
     _with_hsl_ema_tail,
     _with_hsl_features,
     _with_recovery_distribution,
@@ -422,6 +423,17 @@ def test_recovery_distribution_source_variant_is_opt_in_and_guarded():
     )
     with pytest.raises(RuntimeError, match="recovery-distribution feature guard"):
         _with_recovery_distribution("body", True)
+
+
+def test_fixed_wel_denominator_source_variant_is_opt_in_and_guarded():
+    source = "#ifndef PASSIVBOT_DYNAMIC_WEL_BY_TRADABILITY\nbody"
+
+    assert _with_dynamic_wel_by_tradability(source, True) is source
+    assert _with_dynamic_wel_by_tradability(source, False) == (
+        "#define PASSIVBOT_DYNAMIC_WEL_BY_TRADABILITY 0\n" + source
+    )
+    with pytest.raises(RuntimeError, match="dynamic-WEL feature guard"):
+        _with_dynamic_wel_by_tradability("body", False)
 
 
 @pytest.mark.skipif(
@@ -4723,7 +4735,9 @@ def test_mps_multicoin_service_dispatches_forced_delist_tail(
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
 @pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
-@pytest.mark.parametrize("topology", ["long", "short", "fused"])
+@pytest.mark.parametrize(
+    "topology", ["long", "short", "fused-hedge", "fused-one-way"]
+)
 @pytest.mark.parametrize(
     ("count", "first_valid_indices", "last_valid_indices"),
     [
@@ -4746,9 +4760,9 @@ def test_mps_multicoin_service_matches_exact_declared_all_invalid_time(
 
     hlcvs = np.full((count, 2, 4), 100.0, dtype=np.float64)
     hlcvs[:, :, 3] = 1.0
-    if topology in {"long", "fused"}:
+    if topology in {"long", "fused-hedge", "fused-one-way"}:
         hlcvs[3, 0, 1] = 80.0
-    if topology in {"short", "fused"}:
+    if topology in {"short", "fused-hedge", "fused-one-way"}:
         hlcvs[3, 0, 0] = 120.0
     timestamps = (
         1_700_000_000_000
@@ -4781,20 +4795,21 @@ def test_mps_multicoin_service_matches_exact_declared_all_invalid_time(
     config["live"]["strategy_kind"] = strategy_kind
     config["live"]["max_warmup_minutes"] = 1
     enabled_sides = (
-        ("long", "short") if topology == "fused" else (topology,)
+        ("long", "short") if topology.startswith("fused-") else (topology,)
     )
     config["live"]["approved_coins"] = {
         side: ["BTC"] if side in enabled_sides else []
         for side in ("long", "short")
     }
-    config["live"]["hedge_mode"] = topology == "fused"
+    config["live"]["hedge_mode"] = topology == "fused-hedge"
     config["backtest"]["coins"] = {"bybit": ["BTC", "ETH"]}
     config["backtest"]["exchanges"] = ["bybit"]
+    config["backtest"]["dynamic_wel_by_tradability"] = False
     for side in ("long", "short"):
         enabled = side in enabled_sides
         risk = config["bot"][side]["risk"]
         risk["total_wallet_exposure_limit"] = 0.1 if enabled else 0.0
-        risk["n_positions"] = 1 if enabled else 0
+        risk["n_positions"] = 2 if enabled else 0
         risk["entry_cooldown_minutes"] = 100.0
         risk["we_excess_allowance_pct"] = 0.0
         risk["position_exposure_enforcer_enabled"] = False
@@ -4835,6 +4850,8 @@ def test_mps_multicoin_service_matches_exact_declared_all_invalid_time(
         batch_size=1,
         needed_metrics={
             "backtest_completion_ratio",
+            "entry_initial_balance_pct_long",
+            "entry_initial_balance_pct_short",
             "fills_count",
             "position_held_days_max",
         },
@@ -4851,6 +4868,9 @@ def test_mps_multicoin_service_matches_exact_declared_all_invalid_time(
 
     assert result["fills_count"] == exact_analysis["fills_count"]
     assert len(exact_fills) == exact_analysis["fills_count"]
+    for side in enabled_sides:
+        metric = f"entry_initial_balance_pct_{side}"
+        assert result[metric] == pytest.approx(exact_analysis[metric], rel=1.0e-5)
     # The synthetic exact helper retains the template's calendar date span,
     # whereas the proxy receives this prepared span directly. The
     # proxy must nevertheless cover the all-invalid tail through its endpoint.
@@ -5035,6 +5055,7 @@ def _multicoin_exposure_fixture(
     market_order_near_touch_threshold=0.001,
     hsl_panic_market=False,
     recovery_distribution_enabled=False,
+    dynamic_wel_by_tradability=True,
     requested_start_index=0,
     return_context=False,
     interval_minutes=1,
@@ -5134,6 +5155,7 @@ def _multicoin_exposure_fixture(
             market_order_near_touch_threshold=market_order_near_touch_threshold,
             hsl_panic_market=hsl_panic_market,
             recovery_distribution_enabled=recovery_distribution_enabled,
+            dynamic_wel_by_tradability=dynamic_wel_by_tradability,
         )
     else:
         values = {
@@ -5196,6 +5218,7 @@ def _multicoin_exposure_fixture(
             market_order_near_touch_threshold=market_order_near_touch_threshold,
             hsl_panic_market=hsl_panic_market,
             recovery_distribution_enabled=recovery_distribution_enabled,
+            dynamic_wel_by_tradability=dynamic_wel_by_tradability,
         )
     if return_context:
         return runner, row, runs[0], data
@@ -7184,6 +7207,89 @@ def test_mps_multicoin_tracks_position_unchanged_max(strategy_kind, side):
         assert torch.equal(output["fill_count_long"], output["fill_count"])
     else:
         assert (output["fill_count_long"] == 0.0).all()
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_multicoin_fixed_wel_uses_configured_position_denominator(
+    strategy_kind, side
+):
+    override_cols = (
+        EMA_ANCHOR_COIN_OVERRIDE_COLS
+        if strategy_kind == "ema_anchor"
+        else TRAILING_MARTINGALE_COIN_OVERRIDE_COLS
+    )
+    wallet_exposure_column = 11 if strategy_kind == "ema_anchor" else 24
+    overrides = np.full((2, override_cols), np.nan, dtype=np.float32)
+    overrides[1, wallet_exposure_column] = 0.0
+    fixed_runner, row = _multicoin_exposure_fixture(
+        strategy_kind,
+        side,
+        coin_overrides=overrides,
+        dynamic_wel_by_tradability=False,
+    )
+    dynamic_runner, _ = _multicoin_exposure_fixture(
+        strategy_kind,
+        side,
+        coin_overrides=overrides,
+        dynamic_wel_by_tradability=True,
+    )
+
+    parameters = np.asarray([row], dtype=np.float64)
+    fixed = fixed_runner.run(parameters)
+    dynamic = dynamic_runner.run(parameters)
+    torch.mps.synchronize()
+
+    # Fixed WEL allocates TWEL 1.0 across both configured slots even though
+    # the second prepared coin is explicitly ineligible for this side. Dynamic
+    # mode allocates the same TWEL to its one observed eligible slot.
+    assert fixed["entry_initial_balance_pct"].item() == pytest.approx(0.5)
+    assert dynamic["entry_initial_balance_pct"].item() == pytest.approx(1.0)
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
+@pytest.mark.parametrize("hedge_mode", [True, False], ids=["hedge", "one-way"])
+def test_mps_fused_multicoin_fixed_wel_uses_each_configured_denominator(
+    strategy_kind, hedge_mode
+):
+    _, row, run, data = _multicoin_exposure_fixture(
+        strategy_kind,
+        "long",
+        return_context=True,
+    )
+    runner_cls = (
+        MpsEmaAnchorMulticoinFusedRunner
+        if strategy_kind == "ema_anchor"
+        else MpsTrailingMartingaleMulticoinFusedRunner
+    )
+    override_cols = (
+        EMA_ANCHOR_COIN_OVERRIDE_COLS
+        if strategy_kind == "ema_anchor"
+        else TRAILING_MARTINGALE_COIN_OVERRIDE_COLS
+    )
+    wallet_exposure_column = 11 if strategy_kind == "ema_anchor" else 24
+    overrides = np.full((2, override_cols), np.nan, dtype=np.float32)
+    overrides[1, wallet_exposure_column] = 0.0
+    runner = runner_cls(
+        run,
+        data,
+        long_coin_overrides=overrides,
+        short_coin_overrides=overrides,
+        hedge_mode=hedge_mode,
+        dynamic_wel_by_tradability=False,
+    )
+
+    output = runner.run(np.asarray([row + row], dtype=np.float64))
+    torch.mps.synchronize()
+
+    assert output["entry_initial_balance_pct_long"].item() == pytest.approx(0.5)
+    assert output["entry_initial_balance_pct_short"].item() == pytest.approx(0.5)
 
 
 @pytest.mark.skipif(

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -995,6 +995,7 @@ def test_multicoin_proxy_routes_dual_side_batch_through_fused_runner(
         ({"strategy_eq_recovery_days_p99"}, False, False, False, True),
     ],
 )
+@pytest.mark.parametrize("dynamic_wel_by_tradability", [True, False])
 def test_multicoin_proxy_constructs_fused_shared_account_runner(
     monkeypatch,
     strategy_kind,
@@ -1007,6 +1008,7 @@ def test_multicoin_proxy_constructs_fused_shared_account_runner(
     raw_drawdown_enabled,
     raw_tail_enabled,
     recovery_distribution_enabled,
+    dynamic_wel_by_tradability,
 ):
     torch = pytest.importorskip("torch")
 
@@ -1030,7 +1032,9 @@ def test_multicoin_proxy_constructs_fused_shared_account_runner(
             "hsl_signal_mode": "coin",
         }
     )
-    config["backtest"]["dynamic_wel_by_tradability"] = True
+    config["backtest"]["dynamic_wel_by_tradability"] = (
+        dynamic_wel_by_tradability
+    )
     for side in ("long", "short"):
         config["bot"][side]["risk"].update(
             {
@@ -1117,7 +1121,7 @@ def test_multicoin_proxy_constructs_fused_shared_account_runner(
         ],
         backtest_params={
             "candle_interval_minutes": interval_minutes,
-            "dynamic_wel_by_tradability": True,
+            "dynamic_wel_by_tradability": dynamic_wel_by_tradability,
             "forager_score_hysteresis_pct": 0.0,
             "last_valid_indices": [2, 3],
             "first_valid_indices": [0, 0],
@@ -1206,6 +1210,10 @@ def test_multicoin_proxy_constructs_fused_shared_account_runner(
     )
     assert constructed["kwargs"]["hedge_mode"] is False
     assert constructed["kwargs"]["filter_by_min_effective_cost"] is True
+    assert (
+        constructed["kwargs"]["dynamic_wel_by_tradability"]
+        is dynamic_wel_by_tradability
+    )
 
 
 def test_gpu_multicoin_proxy_accepts_staggered_valid_gaps_and_ended_tails():


### PR DESCRIPTION
## Summary
- support backtest.dynamic_wel_by_tradability=false in Apple MPS multi-coin EMA Anchor and Trailing Martingale optimization
- compile distinct fixed/dynamic Metal variants and apply the exact Rust denominator contract to entries, exposure repair, HSL slot sizing, and reported initial allocation
- accept compatible suite scenario overrides while preserving current-tradability Forager selection and fail-closed GPU scope validation
- document the mode semantics and user-facing support

## Validation
- 268 Rust tests passed; cargo check --tests passed
- full tests/optimization suite passed
- complete physical Apple MPS test_gpu_mps.py suite passed
- physical exact-parity matrix passed for EMA Anchor and Trailing Martingale across long, short, fused hedge, and fused one-way modes with valid-tail variations
- direct physical-MPS assertions distinguish configured two-slot fixed allocation (0.5) from one-observed-slot dynamic allocation (1.0)
- local cached-data CLI smoke completed 8 generations / 512 proxy / 64 exact evaluations without drift or constraint halt
- git diff --check and compileall passed
- AI documentation check: 0 errors; 2 pre-existing size warnings