### PR TITLE
GPU: support BTC account metrics without collateral

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,13 @@ All notable user-facing changes will be documented in this file.
 - Apple MPS single- and multi-coin EMA Anchor and Trailing Martingale optimization now accepts
   BTC-denominated account-equity scoring and limits while `backtest.btc_collateral_cap` is zero.
   The proxy converts its compact USD daily equity surface with the canonical prepared BTC/USD
-  series and supports the existing gain, return/risk, drawdown, equity-shape, exposure-ratio,
-  recovery, per-exposure, and weighted BTC metric surface. UTC day-end conversion is exact for the
-  compact surface; intraday minima use a conservative daily BTC-price envelope and drawdown and
-  recovery remain compact daily approximations under mandatory exact Rust validation and rolling
-  drift gates. BTC inputs enter checkpoint identity only when a BTC metric is requested, so USD-only
+  series and supports gain, ADG, MDG, Omega, equity shape, unweighted exposure ratios, peak
+  recovery, per-exposure forms, and the corresponding safe weighted close-equity variants. UTC
+  day-end conversion is exact for the compact surface, including candidate-specific liquidation
+  endpoints; recovery remains a compact daily approximation under mandatory exact Rust validation
+  and rolling drift gates. Intraday-risk metrics and weighted exposure ratios remain fail-closed
+  until Metal retains their required synchronized surfaces. BTC inputs enter checkpoint identity
+  only when a BTC metric is requested, so USD-only
   runs retain their previous dispatch and reduction cost. Positive BTC collateral remains
   fail-closed pending its separate simulation slice.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Apple MPS single- and multi-coin EMA Anchor and Trailing Martingale optimization now accepts
+  BTC-denominated account-equity scoring and limits while `backtest.btc_collateral_cap` is zero.
+  The proxy converts its compact USD daily equity surface with the canonical prepared BTC/USD
+  series and supports the existing gain, return/risk, drawdown, equity-shape, exposure-ratio,
+  recovery, per-exposure, and weighted BTC metric surface. UTC day-end conversion is exact for the
+  compact surface; intraday minima use a conservative daily BTC-price envelope and drawdown and
+  recovery remain compact daily approximations under mandatory exact Rust validation and rolling
+  drift gates. BTC inputs enter checkpoint identity only when a BTC metric is requested, so USD-only
+  runs retain their previous dispatch and reduction cost. Positive BTC collateral remains
+  fail-closed pending its separate simulation slice.
+
 - Apple MPS multi-coin EMA Anchor and Trailing Martingale optimization now supports both wallet-
   exposure denominator modes. With `backtest.dynamic_wel_by_tradability: false`, Metal divides
   total wallet exposure by each side's configured `n_positions`, matching exact Rust across

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -491,13 +491,15 @@ position-unchanged duration, initial-entry balance percentage for each side, vol
 total-wallet-exposure maximum and mean, USD exposure ratios, backtest completion, and weighted
 variants of ADG, MDG, Sharpe, Sortino, Omega, Calmar, and Sterling. With BTC collateral disabled,
 the corresponding canonical USD account-equity names share this strategy-equity surface. The GPU
-proxy also supports the BTC-denominated equivalents of that existing account-equity surface:
-gain, ADG, MDG, Sharpe, Sortino, Omega, Calmar, Sterling, expected shortfall, worst and worst-1%
-drawdown, equity shape, exposure ratios, peak recovery, per-side exposure-normalized gain/ADG/MDG,
-and their existing weighted variants. It converts the compact USD daily closing-equity surface
-with the canonical prepared BTC/USD price at each UTC day end. Intraday daily minima use the day's
-maximum BTC price as a conservative screening envelope, and BTC drawdown and recovery are compact
-daily approximations. Mandatory exact Rust validation and rolling drift gates remain authoritative.
+proxy also supports BTC-denominated gain, ADG, MDG, Omega, equity shape, unweighted exposure
+ratios, peak recovery, per-side exposure-normalized gain/ADG/MDG, and the existing weighted
+ADG/MDG/Omega and equity-shape variants. It converts the compact USD daily closing-equity surface
+with the canonical prepared BTC/USD price at each UTC day end, including a candidate-specific
+final endpoint after early liquidation. BTC peak recovery remains a compact daily approximation;
+mandatory exact Rust validation and rolling drift gates remain authoritative. BTC Sharpe, Sortino,
+expected shortfall, drawdown, Calmar, and Sterling require synchronized intraday BTC-equity minima,
+while weighted BTC exposure ratios require suffix-local exposure series. Those metrics remain
+fail-closed until the proxy retains those surfaces.
 The prepared BTC series must contain at least one sample in every covered UTC day; unusually coarse
 intervals which skip a whole UTC day fail closed for BTC scoring.
 Positive `backtest.btc_collateral_cap` remains unsupported and fails before GPU optimization.

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -155,7 +155,8 @@ The supported slice is intentionally narrow:
 - one-sided single-coin and multi-coin EMA Anchor and Trailing Martingale runs support HSL with
   `coin`, `pside`, or `unified` signals and both resting-limit and market panic closes. Unified and
   pside multi-coin runs use one portfolio controller; coin mode uses an independent controller per
-  coin and scales its loss budget by the dynamic effective position-slot count. Market panic orders fill on
+  coin and scales its loss budget by the configured denominator mode's effective position-slot
+  count. Market panic orders fill on
   the next valid bar at its close shifted adversely by `backtest.market_order_slippage_pct`, rounded
   directionally to the exchange price step, and charged the resolved taker fee. The Metal proxy
   models tunable RED
@@ -489,7 +490,17 @@ drawdown, mean and median underwater percentage, maximum recovery and position-h
 position-unchanged duration, initial-entry balance percentage for each side, volume per active day,
 total-wallet-exposure maximum and mean, USD exposure ratios, backtest completion, and weighted
 variants of ADG, MDG, Sharpe, Sortino, Omega, Calmar, and Sterling. With BTC collateral disabled,
-the corresponding canonical USD account-equity names share this strategy-equity surface.
+the corresponding canonical USD account-equity names share this strategy-equity surface. The GPU
+proxy also supports the BTC-denominated equivalents of that existing account-equity surface:
+gain, ADG, MDG, Sharpe, Sortino, Omega, Calmar, Sterling, expected shortfall, worst and worst-1%
+drawdown, equity shape, exposure ratios, peak recovery, per-side exposure-normalized gain/ADG/MDG,
+and their existing weighted variants. It converts the compact USD daily closing-equity surface
+with the canonical prepared BTC/USD price at each UTC day end. Intraday daily minima use the day's
+maximum BTC price as a conservative screening envelope, and BTC drawdown and recovery are compact
+daily approximations. Mandatory exact Rust validation and rolling drift gates remain authoritative.
+The prepared BTC series must contain at least one sample in every covered UTC day; unusually coarse
+intervals which skip a whole UTC day fail closed for BTC scoring.
+Positive `backtest.btc_collateral_cap` remains unsupported and fails before GPU optimization.
 Daily USD equity choppiness, jerkiness, and exponential fit error are reduced from that same active
 daily closing-equity surface with Rust's no-fill defaults and short-series behavior.
 Collateral-agnostic `adg_pnl`, `mdg_pnl`, `sharpe_ratio_pnl`, and `sortino_ratio_pnl` are also

--- a/src/optimization/gpu/metrics.py
+++ b/src/optimization/gpu/metrics.py
@@ -45,6 +45,47 @@ _USD_PER_EXPOSURE_METRICS = {
     "mdg_w_per_exposure_short_usd": ("mdg_strategy_eq_w", "short"),
 }
 
+_BTC_ACCOUNT_METRICS = {
+    "adg_btc",
+    "adg_w_btc",
+    "calmar_ratio_btc",
+    "calmar_ratio_w_btc",
+    "drawdown_worst_btc",
+    "drawdown_worst_mean_1pct_btc",
+    "equity_choppiness_btc",
+    "equity_choppiness_w_btc",
+    "equity_jerkiness_btc",
+    "equity_jerkiness_w_btc",
+    "expected_shortfall_1pct_btc",
+    "exponential_fit_error_btc",
+    "exponential_fit_error_w_btc",
+    "exposure_mean_ratio_btc",
+    "exposure_ratio_btc",
+    "gain_btc",
+    "mdg_btc",
+    "mdg_w_btc",
+    "omega_ratio_btc",
+    "omega_ratio_w_btc",
+    "peak_recovery_days_equity_btc",
+    "peak_recovery_hours_equity_btc",
+    "sharpe_ratio_btc",
+    "sharpe_ratio_w_btc",
+    "sortino_ratio_btc",
+    "sortino_ratio_w_btc",
+    "sterling_ratio_btc",
+    "sterling_ratio_w_btc",
+}
+
+_BTC_PER_EXPOSURE_METRICS = {
+    f"{metric}_per_exposure_{side}_btc"
+    for metric in ("adg", "adg_w", "gain", "mdg", "mdg_w")
+    for side in ("long", "short")
+}
+
+BTC_ACCOUNT_METRICS = frozenset(
+    _BTC_ACCOUNT_METRICS | _BTC_PER_EXPOSURE_METRICS
+)
+
 # Keep the public proxy surface deliberately narrow. Exact Rust evaluations
 # still emit the normal complete metric set; this list governs only which
 # metrics may guide Metal screening or proxy-side limits.
@@ -181,6 +222,7 @@ SUPPORTED_METRICS = (
     "volume_pct_per_day_avg_w",
     *_USD_STRATEGY_EQ_ALIASES,
     *_USD_PER_EXPOSURE_METRICS,
+    *sorted(BTC_ACCOUNT_METRICS),
 )
 
 # Metrics backed by additional per-fill aggregates emitted by Metal.
@@ -1480,6 +1522,314 @@ def _strategy_eq_recovery_distribution_metrics(out: dict) -> dict:
     return {name: values[:, index] for index, name in enumerate(names)}
 
 
+def _daily_peak_recovery_ms(day_end_eq, active):
+    """Approximate intraday recovery from the compact UTC daily surface."""
+
+    batch_size, day_count = day_end_eq.shape
+    peak = torch.full(
+        (batch_size,),
+        float("-inf"),
+        dtype=day_end_eq.dtype,
+        device=day_end_eq.device,
+    )
+    peak_day = torch.zeros(
+        batch_size, dtype=torch.long, device=day_end_eq.device
+    )
+    recovery_days = torch.zeros_like(peak)
+    started = torch.zeros(
+        batch_size, dtype=torch.bool, device=day_end_eq.device
+    )
+    for day in range(day_count):
+        valid = active[:, day]
+        value = day_end_eq[:, day]
+        new_high = valid & (~started | (value >= peak))
+        recovered = (day - peak_day).to(day_end_eq.dtype)
+        recovery_days = torch.where(
+            new_high & started,
+            torch.maximum(recovery_days, recovered),
+            recovery_days,
+        )
+        peak = torch.where(new_high, value, peak)
+        peak_day = torch.where(
+            new_high, torch.full_like(peak_day, day), peak_day
+        )
+        started |= valid
+    return torch.where(
+        started,
+        recovery_days * 86_400_000.0,
+        torch.zeros_like(recovery_days),
+    )
+
+
+def _btc_account_metrics(out: dict, run, data: dict, requested) -> dict:
+    """Reduce the compact USD strategy-equity surface into BTC account metrics.
+
+    Day-end conversion is exact for the prepared BTC series. Intraday minima
+    conservatively pair each day's USD minimum with that day's maximum BTC
+    price; drawdown and recovery therefore remain screening approximations and
+    exact Rust validation stays authoritative.
+    """
+
+    requested = set(requested) & BTC_ACCOUNT_METRICS
+    if not requested:
+        return {}
+    missing = [
+        key
+        for key in ("btc_day_end_price", "btc_day_max_price", "btc_prices")
+        if key not in data
+    ]
+    if missing:
+        raise RuntimeError(
+            "MPS BTC account metric context is missing " + ", ".join(missing)
+        )
+
+    day_end_usd = out["day_end_eq"].to(torch.float64)
+    day_min_usd = out["day_min_eq"].to(torch.float64)
+    active = _daily_series_masks(out["day_min_eq"])
+    day_end_price = torch.as_tensor(
+        data["btc_day_end_price"],
+        dtype=torch.float64,
+        device=day_end_usd.device,
+    ).reshape(1, -1).expand(day_end_usd.shape[0], -1)
+    day_max_price = torch.as_tensor(
+        data["btc_day_max_price"],
+        dtype=torch.float64,
+        device=day_end_usd.device,
+    ).reshape(1, -1)
+    if day_end_price.shape[1] != day_end_usd.shape[1]:
+        raise RuntimeError(
+            "MPS BTC account metric day grid disagrees with Metal output"
+        )
+    # A liquidated candidate may stop before the prepared UTC day ends. Rust
+    # values its final equity with BTC at that exact sample, not the later
+    # dataset day close. Replace only that candidate's final active-day price;
+    # complete days keep the precomputed shared day-end series.
+    btc_prices = torch.as_tensor(
+        data["btc_prices"],
+        dtype=torch.float64,
+        device=day_end_usd.device,
+    ).reshape(-1)
+    origin_ms = int(data["ts0"])
+    interval_ms = int(run.interval_ms)
+    last_eq_ts = out["last_eq_ts"].to(torch.float64)
+    relative_last_ms = torch.where(
+        last_eq_ts < float(origin_ms),
+        last_eq_ts,
+        last_eq_ts - float(origin_ms),
+    )
+    last_step = torch.floor(
+        relative_last_ms / float(interval_ms) + 0.5
+    ).to(torch.long)
+    safe_last_step = last_step.clamp(min=0, max=max(len(btc_prices) - 1, 0))
+    last_day = (
+        torch.div(
+            safe_last_step * interval_ms + origin_ms,
+            86_400_000,
+            rounding_mode="floor",
+        )
+        - origin_ms // 86_400_000
+    )
+    safe_last_day = last_day.clamp(
+        min=0, max=max(day_end_usd.shape[1] - 1, 0)
+    )
+    valid_endpoint = (
+        active.any(dim=1)
+        & torch.isfinite(last_eq_ts)
+        & (last_step >= 0)
+        & (last_step < len(btc_prices))
+        & (last_day >= 0)
+        & (last_day < day_end_usd.shape[1])
+    )
+    final_day_mask = (
+        torch.arange(day_end_usd.shape[1], device=day_end_usd.device)
+        .unsqueeze(0)
+        .eq(safe_last_day.unsqueeze(1))
+        & valid_endpoint.unsqueeze(1)
+    )
+    endpoint_price = btc_prices.gather(0, safe_last_step).unsqueeze(1)
+    day_end_price = torch.where(final_day_mask, endpoint_price, day_end_price)
+    day_end_btc = torch.where(
+        active, day_end_usd / day_end_price, torch.zeros_like(day_end_usd)
+    )
+    day_min_btc = torch.where(
+        active,
+        day_min_usd / day_max_price,
+        torch.full_like(day_min_usd, float("inf")),
+    )
+
+    masked_end = torch.where(
+        active, day_end_btc, torch.full_like(day_end_btc, float("-inf"))
+    )
+    running_peak = torch.cummax(masked_end, dim=1).values
+    day_max_dd = torch.where(
+        active & torch.isfinite(running_peak),
+        ((running_peak - day_min_btc) / running_peak.abs().clamp(min=1e-12)).clamp(
+            min=0.0
+        ),
+        torch.zeros_like(day_end_btc),
+    )
+    max_dd = day_max_dd.max(dim=1).values
+    worst_one_pct = _mean_worst_one_pct_largest(day_max_dd, active)
+    gain, adg = _smoothed_gain_adg(day_end_btc, active)
+    daily_changes, change_mask = _pct_change(day_end_btc, active)
+    mdg = _masked_median(daily_changes, change_mask)
+    omega = _omega_ratio(daily_changes, change_mask)
+    daily_min_changes, min_change_mask = _pct_change(day_min_btc, active)
+    sharpe, sortino = _sharpe_sortino(daily_min_changes, min_change_mask, adg)
+    expected_shortfall = _mean_worst_one_pct_abs(
+        daily_min_changes, min_change_mask
+    )
+    calmar = adg / max_dd.clamp(min=1e-12)
+    sterling = adg / worst_one_pct.clamp(min=1e-12)
+    has_fill = out["fill_count"].to(torch.float64) > 0.0
+    zeros = torch.zeros_like(adg)
+
+    values = {
+        "adg_btc": adg,
+        "calmar_ratio_btc": calmar,
+        "drawdown_worst_btc": max_dd,
+        "drawdown_worst_mean_1pct_btc": worst_one_pct,
+        "expected_shortfall_1pct_btc": expected_shortfall,
+        "gain_btc": gain,
+        "mdg_btc": mdg,
+        "omega_ratio_btc": omega,
+        "sharpe_ratio_btc": sharpe,
+        "sortino_ratio_btc": sortino,
+        "sterling_ratio_btc": sterling,
+    }
+    for name in tuple(values):
+        values[name] = torch.where(has_fill, values[name], zeros)
+
+    shape_names = {
+        "equity_choppiness_btc",
+        "equity_jerkiness_btc",
+        "exponential_fit_error_btc",
+    }
+    if requested & shape_names:
+        shape = _equity_shape_metrics(day_end_btc, active)
+        shape_sources = {
+            "equity_choppiness_btc": "equity_choppiness_usd",
+            "equity_jerkiness_btc": "equity_jerkiness_usd",
+            "exponential_fit_error_btc": "exponential_fit_error_usd",
+        }
+        for name, source in shape_sources.items():
+            values[name] = torch.where(
+                has_fill, shape[source], torch.ones_like(adg)
+            )
+
+    weighted_sources = {
+        "adg_w_btc": "adg_strategy_eq_w",
+        "calmar_ratio_w_btc": "calmar_ratio_strategy_eq_w",
+        "mdg_w_btc": "mdg_strategy_eq_w",
+        "omega_ratio_w_btc": "omega_ratio_strategy_eq_w",
+        "sharpe_ratio_w_btc": "sharpe_ratio_strategy_eq_w",
+        "sortino_ratio_w_btc": "sortino_ratio_strategy_eq_w",
+        "sterling_ratio_w_btc": "sterling_ratio_strategy_eq_w",
+    }
+    wanted_weighted_sources = {
+        source for name, source in weighted_sources.items() if name in requested
+    }
+    if requested & {
+        "adg_w_per_exposure_long_btc",
+        "adg_w_per_exposure_short_btc",
+    }:
+        wanted_weighted_sources.add("adg_strategy_eq_w")
+    if requested & {
+        "mdg_w_per_exposure_long_btc",
+        "mdg_w_per_exposure_short_btc",
+    }:
+        wanted_weighted_sources.add("mdg_strategy_eq_w")
+    if wanted_weighted_sources:
+        weighted = _weighted_strategy_eq_metrics(
+            day_end_btc,
+            day_min_btc,
+            day_max_dd,
+            active,
+            out["first_eq_ts"],
+            out["last_eq_ts"],
+            data["ts0"],
+            run.interval_ms,
+            wanted_weighted_sources,
+        )
+        enough_fills = out["fill_count"].to(torch.float64) > 1.0
+        for name, source in weighted_sources.items():
+            if source in weighted:
+                values[name] = torch.where(enough_fills, weighted[source], zeros)
+
+    weighted_shape_sources = {
+        "equity_choppiness_w_btc": "equity_choppiness_w_usd",
+        "equity_jerkiness_w_btc": "equity_jerkiness_w_usd",
+        "exponential_fit_error_w_btc": "exponential_fit_error_w_usd",
+    }
+    wanted_weighted_shape_sources = {
+        source
+        for name, source in weighted_shape_sources.items()
+        if name in requested
+    }
+    if wanted_weighted_shape_sources:
+        weighted_shape = _weighted_daily_series_metrics(
+            day_end_btc,
+            out["day_volume"].to(torch.float64),
+            out["day_has_fill"],
+            active,
+            out["fill_count"],
+            out["last_fill_ts"],
+            out["first_eq_ts"],
+            out["last_eq_ts"],
+            data["ts0"],
+            run.interval_ms,
+            wanted_weighted_shape_sources,
+        )
+        for name, source in weighted_shape_sources.items():
+            if source in weighted_shape:
+                values[name] = weighted_shape[source]
+
+    recovery_names = {
+        "peak_recovery_hours_equity_btc",
+        "peak_recovery_days_equity_btc",
+    }
+    if requested & recovery_names:
+        recovery_ms = _daily_peak_recovery_ms(day_end_btc, active)
+        values["peak_recovery_hours_equity_btc"] = torch.where(
+            has_fill, recovery_ms / 3_600_000.0, zeros
+        )
+        values["peak_recovery_days_equity_btc"] = torch.where(
+            has_fill, recovery_ms / 86_400_000.0, zeros
+        )
+    exposure_denominators = {
+        "exposure_ratio_btc": "total_wallet_exposure_max",
+        "exposure_mean_ratio_btc": "total_wallet_exposure_mean",
+    }
+    for name, denominator in exposure_denominators.items():
+        if name in requested:
+            ratio = adg / out[denominator].to(torch.float64).abs().clamp(
+                min=1e-12
+            )
+            values[name] = torch.where(has_fill, ratio, zeros)
+
+    per_exposure_sources = {
+        "adg": adg,
+        "adg_w": values.get("adg_w_btc", zeros),
+        "gain": gain,
+        "mdg": mdg,
+        "mdg_w": values.get("mdg_w_btc", zeros),
+    }
+    for metric, source in per_exposure_sources.items():
+        for side in ("long", "short"):
+            name = f"{metric}_per_exposure_{side}_btc"
+            if name not in requested:
+                continue
+            denominator = out[
+                f"candidate_total_wallet_exposure_limit_{side}"
+            ].to(torch.float64)
+            values[name] = torch.where(
+                has_fill & (denominator > 0.0),
+                source / denominator.clamp(min=1e-12),
+                zeros,
+            )
+    return {name: values[name] for name in requested if name in values}
+
+
 def compute_objectives(out: dict, run, data: dict, needed=None) -> dict:
     """Reduce compact Metal output into validated proxy objective metrics."""
 
@@ -1827,6 +2177,7 @@ def compute_objectives(out: dict, run, data: dict, needed=None) -> dict:
     for alias, source in _USD_STRATEGY_EQ_ALIASES.items():
         if alias in requested:
             objectives[alias] = objectives[source]
+    objectives.update(_btc_account_metrics(out, run, data, requested))
     if needed is None:
         return objectives
     return {key: value for key, value in objectives.items() if key in requested}

--- a/src/optimization/gpu/metrics.py
+++ b/src/optimization/gpu/metrics.py
@@ -48,15 +48,10 @@ _USD_PER_EXPOSURE_METRICS = {
 _BTC_ACCOUNT_METRICS = {
     "adg_btc",
     "adg_w_btc",
-    "calmar_ratio_btc",
-    "calmar_ratio_w_btc",
-    "drawdown_worst_btc",
-    "drawdown_worst_mean_1pct_btc",
     "equity_choppiness_btc",
     "equity_choppiness_w_btc",
     "equity_jerkiness_btc",
     "equity_jerkiness_w_btc",
-    "expected_shortfall_1pct_btc",
     "exponential_fit_error_btc",
     "exponential_fit_error_w_btc",
     "exposure_mean_ratio_btc",
@@ -68,12 +63,6 @@ _BTC_ACCOUNT_METRICS = {
     "omega_ratio_w_btc",
     "peak_recovery_days_equity_btc",
     "peak_recovery_hours_equity_btc",
-    "sharpe_ratio_btc",
-    "sharpe_ratio_w_btc",
-    "sortino_ratio_btc",
-    "sortino_ratio_w_btc",
-    "sterling_ratio_btc",
-    "sterling_ratio_w_btc",
 }
 
 _BTC_PER_EXPOSURE_METRICS = {
@@ -1564,10 +1553,9 @@ def _daily_peak_recovery_ms(day_end_eq, active):
 def _btc_account_metrics(out: dict, run, data: dict, requested) -> dict:
     """Reduce the compact USD strategy-equity surface into BTC account metrics.
 
-    Day-end conversion is exact for the prepared BTC series. Intraday minima
-    conservatively pair each day's USD minimum with that day's maximum BTC
-    price; drawdown and recovery therefore remain screening approximations and
-    exact Rust validation stays authoritative.
+    Day-end conversion is exact for the prepared BTC series. Metrics requiring
+    synchronized intraday BTC equity remain outside this surface; exact Rust
+    validation stays authoritative for the daily screening approximations.
     """
 
     requested = set(requested) & BTC_ACCOUNT_METRICS
@@ -1575,7 +1563,7 @@ def _btc_account_metrics(out: dict, run, data: dict, requested) -> dict:
         return {}
     missing = [
         key
-        for key in ("btc_day_end_price", "btc_day_max_price", "btc_prices")
+        for key in ("btc_day_end_price", "btc_prices")
         if key not in data
     ]
     if missing:
@@ -1584,18 +1572,12 @@ def _btc_account_metrics(out: dict, run, data: dict, requested) -> dict:
         )
 
     day_end_usd = out["day_end_eq"].to(torch.float64)
-    day_min_usd = out["day_min_eq"].to(torch.float64)
     active = _daily_series_masks(out["day_min_eq"])
     day_end_price = torch.as_tensor(
         data["btc_day_end_price"],
         dtype=torch.float64,
         device=day_end_usd.device,
     ).reshape(1, -1).expand(day_end_usd.shape[0], -1)
-    day_max_price = torch.as_tensor(
-        data["btc_day_max_price"],
-        dtype=torch.float64,
-        device=day_end_usd.device,
-    ).reshape(1, -1)
     if day_end_price.shape[1] != day_end_usd.shape[1]:
         raise RuntimeError(
             "MPS BTC account metric day grid disagrees with Metal output"
@@ -1651,51 +1633,18 @@ def _btc_account_metrics(out: dict, run, data: dict, requested) -> dict:
     day_end_btc = torch.where(
         active, day_end_usd / day_end_price, torch.zeros_like(day_end_usd)
     )
-    day_min_btc = torch.where(
-        active,
-        day_min_usd / day_max_price,
-        torch.full_like(day_min_usd, float("inf")),
-    )
-
-    masked_end = torch.where(
-        active, day_end_btc, torch.full_like(day_end_btc, float("-inf"))
-    )
-    running_peak = torch.cummax(masked_end, dim=1).values
-    day_max_dd = torch.where(
-        active & torch.isfinite(running_peak),
-        ((running_peak - day_min_btc) / running_peak.abs().clamp(min=1e-12)).clamp(
-            min=0.0
-        ),
-        torch.zeros_like(day_end_btc),
-    )
-    max_dd = day_max_dd.max(dim=1).values
-    worst_one_pct = _mean_worst_one_pct_largest(day_max_dd, active)
     gain, adg = _smoothed_gain_adg(day_end_btc, active)
     daily_changes, change_mask = _pct_change(day_end_btc, active)
     mdg = _masked_median(daily_changes, change_mask)
     omega = _omega_ratio(daily_changes, change_mask)
-    daily_min_changes, min_change_mask = _pct_change(day_min_btc, active)
-    sharpe, sortino = _sharpe_sortino(daily_min_changes, min_change_mask, adg)
-    expected_shortfall = _mean_worst_one_pct_abs(
-        daily_min_changes, min_change_mask
-    )
-    calmar = adg / max_dd.clamp(min=1e-12)
-    sterling = adg / worst_one_pct.clamp(min=1e-12)
     has_fill = out["fill_count"].to(torch.float64) > 0.0
     zeros = torch.zeros_like(adg)
 
     values = {
         "adg_btc": adg,
-        "calmar_ratio_btc": calmar,
-        "drawdown_worst_btc": max_dd,
-        "drawdown_worst_mean_1pct_btc": worst_one_pct,
-        "expected_shortfall_1pct_btc": expected_shortfall,
         "gain_btc": gain,
         "mdg_btc": mdg,
         "omega_ratio_btc": omega,
-        "sharpe_ratio_btc": sharpe,
-        "sortino_ratio_btc": sortino,
-        "sterling_ratio_btc": sterling,
     }
     for name in tuple(values):
         values[name] = torch.where(has_fill, values[name], zeros)
@@ -1719,12 +1668,8 @@ def _btc_account_metrics(out: dict, run, data: dict, requested) -> dict:
 
     weighted_sources = {
         "adg_w_btc": "adg_strategy_eq_w",
-        "calmar_ratio_w_btc": "calmar_ratio_strategy_eq_w",
         "mdg_w_btc": "mdg_strategy_eq_w",
         "omega_ratio_w_btc": "omega_ratio_strategy_eq_w",
-        "sharpe_ratio_w_btc": "sharpe_ratio_strategy_eq_w",
-        "sortino_ratio_w_btc": "sortino_ratio_strategy_eq_w",
-        "sterling_ratio_w_btc": "sterling_ratio_strategy_eq_w",
     }
     wanted_weighted_sources = {
         source for name, source in weighted_sources.items() if name in requested
@@ -1742,8 +1687,8 @@ def _btc_account_metrics(out: dict, run, data: dict, requested) -> dict:
     if wanted_weighted_sources:
         weighted = _weighted_strategy_eq_metrics(
             day_end_btc,
-            day_min_btc,
-            day_max_dd,
+            day_end_btc,
+            torch.zeros_like(day_end_btc),
             active,
             out["first_eq_ts"],
             out["last_eq_ts"],

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -161,7 +161,6 @@ def _btc_daily_price_context(
             "MPS BTC analysis day grid disagrees with the prepared proxy timeline"
         )
     day_end = np.full(int(expected_days), np.nan, dtype=np.float64)
-    day_max = np.full(int(expected_days), np.nan, dtype=np.float64)
     for day in range(int(expected_days)):
         values = btc[day_idx == day]
         if len(values) == 0:
@@ -169,10 +168,8 @@ def _btc_daily_price_context(
                 f"MPS BTC analysis is missing prepared prices for UTC day {day}"
             )
         day_end[day] = values[-1]
-        day_max[day] = values.max()
     return {
         "btc_day_end_price": day_end,
-        "btc_day_max_price": day_max,
     }
 
 

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -133,6 +133,49 @@ DIRECTIONAL_HSL_OUTPUT_KEYS = {
 }
 
 
+def _metric_uses_btc_analysis(metric) -> bool:
+    name = str(metric or "").strip().lower()
+    return name.endswith("_btc") or "_btc_" in name
+
+
+def _btc_daily_price_context(
+    btc_prices, timestamps, *, expected_count: int, expected_days: int
+) -> dict[str, np.ndarray]:
+    """Reduce the canonical BTC/USD series onto the proxy's UTC-day grid."""
+
+    btc = np.asarray(btc_prices, dtype=np.float64).reshape(-1)
+    ts = np.asarray(timestamps, dtype=np.int64).reshape(-1)
+    if len(btc) != int(expected_count) or len(ts) != int(expected_count):
+        raise ValueError(
+            "MPS BTC analysis requires BTC prices and timestamps matching the "
+            f"prepared candles: btc={len(btc)}, timestamps={len(ts)}, "
+            f"candles={expected_count}"
+        )
+    if len(btc) == 0 or np.any(~np.isfinite(btc)) or np.any(btc <= 0.0):
+        raise ValueError(
+            "MPS BTC analysis requires finite positive BTC/USD prices for every candle"
+        )
+    day_idx = ((ts // 86_400_000) - (ts[0] // 86_400_000)).astype(np.int64)
+    if np.any(day_idx < 0) or int(day_idx[-1]) + 1 != int(expected_days):
+        raise ValueError(
+            "MPS BTC analysis day grid disagrees with the prepared proxy timeline"
+        )
+    day_end = np.full(int(expected_days), np.nan, dtype=np.float64)
+    day_max = np.full(int(expected_days), np.nan, dtype=np.float64)
+    for day in range(int(expected_days)):
+        values = btc[day_idx == day]
+        if len(values) == 0:
+            raise ValueError(
+                f"MPS BTC analysis is missing prepared prices for UTC day {day}"
+            )
+        day_end[day] = values[-1]
+        day_max[day] = values.max()
+    return {
+        "btc_day_end_price": day_end,
+        "btc_day_max_price": day_max,
+    }
+
+
 # One MPS thread simulates one candidate across every candle stream. Long-running
 # command buffers can starve WindowServer because Apple silicon shares the GPU
 # with the desktop. Keep one dispatch below the bounded work envelope measured
@@ -151,6 +194,7 @@ def _gpu_proxy_execution_checkpoint_contract(
     backtest_params: dict,
     exchange_params,
     base_params,
+    btc_prices=None,
 ) -> dict:
     """Return the prepared execution inputs which make proxy state reusable."""
 
@@ -192,7 +236,7 @@ def _gpu_proxy_execution_checkpoint_contract(
         "maker_fee",
         "taker_fee",
     )
-    return {
+    contract = {
         "version": 1,
         "strategy_kind": str(strategy_kind),
         "exchange": str(exchange),
@@ -226,6 +270,21 @@ def _gpu_proxy_execution_checkpoint_contract(
             for side, params in sorted((base_params or {}).items())
         },
     }
+    if btc_prices is not None:
+        btc_values = np.ascontiguousarray(
+            np.asarray(btc_prices, dtype=np.float64).reshape(-1)
+        )
+        if len(btc_values) != int(hlcv_values.shape[0]):
+            raise ValueError(
+                "GPU proxy checkpoint BTC identity disagrees with prepared "
+                f"candles: btc={len(btc_values)}, candles={hlcv_values.shape[0]}"
+            )
+        contract["btc_analysis"] = {
+            "count": int(len(btc_values)),
+            "dtype": str(btc_values.dtype.str),
+            "sha256": hashlib.sha256(btc_values.tobytes()).hexdigest(),
+        }
+    return contract
 
 
 def _mps_dispatch_batch_size(
@@ -1279,6 +1338,12 @@ class MpsSingleCoinProxy:
         self._torch = torch
         self._compute_objectives = compute_objectives
         self.needed_metrics = set(needed_metrics)
+        self.btc_analysis_enabled = any(
+            _metric_uses_btc_analysis(metric) for metric in self.needed_metrics
+        )
+        btc_values = np.ascontiguousarray(
+            np.asarray(btc, dtype=np.float64).reshape(-1)
+        )
         self.batch_size = max(1, int(batch_size))
         self.interrupt_check = interrupt_check or (lambda: None)
         self.profile_enabled = os.environ.get(
@@ -1304,10 +1369,10 @@ class MpsSingleCoinProxy:
             mss,
             copy.deepcopy(config),
             exchange,
-            np.ascontiguousarray(btc),
+            btc_values,
             timestamps,
             metrics_only=True,
-            skip_btc_analysis=True,
+            skip_btc_analysis=not self.btc_analysis_enabled,
         )
         if len(payload.bot_params_list) != 1:
             raise ValueError(
@@ -1454,6 +1519,7 @@ class MpsSingleCoinProxy:
             backtest_params=backtest_params,
             exchange_params=payload.exchange_params,
             base_params=self.base_params,
+            btc_prices=btc_values if self.btc_analysis_enabled else None,
         )
 
         self.base_total_wallet_exposure_limits = {
@@ -1520,6 +1586,16 @@ class MpsSingleCoinProxy:
             )
         self.data = build_mps_data(high, low, close, timestamps, self.run, self.market)
         self.metrics_data = {"ts0": self.data["ts0"], "n": self.data["n"]}
+        if self.btc_analysis_enabled:
+            self.metrics_data.update(
+                _btc_daily_price_context(
+                    btc_values,
+                    timestamps,
+                    expected_count=self.data["n"],
+                    expected_days=self.data["n_days"],
+                )
+            )
+            self.metrics_data["btc_prices"] = btc_values
         runner_cls = (
             MpsTrailingMartingaleRunner
             if self.strategy_kind == "trailing_martingale"
@@ -2082,6 +2158,12 @@ class MpsMulticoinProxy:
         self._torch = torch
         self._compute_objectives = compute_objectives
         self.needed_metrics = set(needed_metrics)
+        self.btc_analysis_enabled = any(
+            _metric_uses_btc_analysis(metric) for metric in self.needed_metrics
+        )
+        btc_values = np.ascontiguousarray(
+            np.asarray(btc, dtype=np.float64).reshape(-1)
+        )
         self.batch_size = max(1, int(batch_size))
         self.interrupt_check = interrupt_check or (lambda: None)
         self.profile_enabled = os.environ.get(
@@ -2150,10 +2232,10 @@ class MpsMulticoinProxy:
             mss,
             copy.deepcopy(config),
             exchange,
-            np.ascontiguousarray(btc),
+            btc_values,
             timestamps,
             metrics_only=True,
-            skip_btc_analysis=True,
+            skip_btc_analysis=not self.btc_analysis_enabled,
         )
         if not (
             len(payload.bot_params_list)
@@ -2331,6 +2413,7 @@ class MpsMulticoinProxy:
             backtest_params=backtest_params,
             exchange_params=payload.exchange_params,
             base_params=self.base_params,
+            btc_prices=btc_values if self.btc_analysis_enabled else None,
         )
 
         coins = list(backtest_params.get("coins") or [])
@@ -2466,6 +2549,16 @@ class MpsMulticoinProxy:
             include_hourly_ranges=True,
         )
         self.metrics_data = {"ts0": self.data["ts0"], "n": self.data["n"]}
+        if self.btc_analysis_enabled:
+            self.metrics_data.update(
+                _btc_daily_price_context(
+                    btc_values,
+                    timestamps,
+                    expected_count=self.data["n"],
+                    expected_days=self.data["n_days"],
+                )
+            )
+            self.metrics_data["btc_prices"] = btc_values
         self.runners = {}
         self.fused_runner = None
         common_runner_kwargs = {

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -85,7 +85,6 @@ from optimization.backends.gpu_backend import (
     TRAILING_MARTINGALE_BOUND_MAP,
 )
 from optimization.fine_tune_anchors import ANCHOR_GENE_KEY, ANCHOR_PLAN_KEY
-from optimization.gpu.metrics import SUPPORTED_METRICS
 from optimization.warmup import build_optimizer_vector_config
 
 
@@ -3237,6 +3236,9 @@ def test_gpu_foundation_accepts_btc_account_metrics_without_collateral(
     ],
 )
 def test_gpu_foundation_excludes_btc_metrics_without_safe_proxy_surface(metric):
+    pytest.importorskip("torch")
+    from optimization.gpu.metrics import SUPPORTED_METRICS
+
     assert canonicalize_metric_name(metric) not in SUPPORTED_METRICS
 
 

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -3203,6 +3203,26 @@ def test_gpu_foundation_accepts_weighted_daily_series_metrics(metric, goal):
 
 
 @pytest.mark.parametrize(
+    ("metric", "goal"),
+    [
+        ("adg_btc", "max"),
+        ("drawdown_worst_btc", "min"),
+        ("gain_per_exposure_long_btc", "max"),
+        ("peak_recovery_days_equity_btc", "min"),
+        ("sortino_ratio_w_btc", "max"),
+    ],
+)
+def test_gpu_foundation_accepts_btc_account_metrics_without_collateral(
+    metric, goal
+):
+    config = _long_only_ema_config()
+    config["backtest"]["btc_collateral_cap"] = 0.0
+    config["optimize"]["scoring"] = [{"goal": goal, "metric": metric}]
+
+    assert _validate_scope(config, _Evaluator()) == "bybit"
+
+
+@pytest.mark.parametrize(
     "metric",
     [
         "entry_initial_balance_pct_long",

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock
 import numpy as np
 import pytest
 
+from config.metrics import canonicalize_metric_name
 from config.schema import get_template_config
 from optimizer_overrides import optimizer_overrides
 from optimization.bounds import Bound
@@ -84,6 +85,7 @@ from optimization.backends.gpu_backend import (
     TRAILING_MARTINGALE_BOUND_MAP,
 )
 from optimization.fine_tune_anchors import ANCHOR_GENE_KEY, ANCHOR_PLAN_KEY
+from optimization.gpu.metrics import SUPPORTED_METRICS
 from optimization.warmup import build_optimizer_vector_config
 
 
@@ -3206,10 +3208,9 @@ def test_gpu_foundation_accepts_weighted_daily_series_metrics(metric, goal):
     ("metric", "goal"),
     [
         ("adg_btc", "max"),
-        ("drawdown_worst_btc", "min"),
         ("gain_per_exposure_long_btc", "max"),
         ("peak_recovery_days_equity_btc", "min"),
-        ("sortino_ratio_w_btc", "max"),
+        ("omega_ratio_w_btc", "max"),
     ],
 )
 def test_gpu_foundation_accepts_btc_account_metrics_without_collateral(
@@ -3220,6 +3221,23 @@ def test_gpu_foundation_accepts_btc_account_metrics_without_collateral(
     config["optimize"]["scoring"] = [{"goal": goal, "metric": metric}]
 
     assert _validate_scope(config, _Evaluator()) == "bybit"
+
+
+@pytest.mark.parametrize(
+    "metric",
+    [
+        "drawdown_worst_btc",
+        "expected_shortfall_1pct_btc",
+        "sharpe_ratio_btc",
+        "sortino_ratio_w_btc",
+        "calmar_ratio_btc",
+        "sterling_ratio_w_btc",
+        "exposure_ratio_w_btc",
+        "exposure_mean_ratio_w_btc",
+    ],
+)
+def test_gpu_foundation_excludes_btc_metrics_without_safe_proxy_surface(metric):
+    assert canonicalize_metric_name(metric) not in SUPPORTED_METRICS
 
 
 @pytest.mark.parametrize(

--- a/tests/optimization/test_gpu_metrics.py
+++ b/tests/optimization/test_gpu_metrics.py
@@ -10,6 +10,7 @@ torch = pytest.importorskip("torch")
 from optimization.gpu.metrics import (
     SUPPORTED_METRICS,
     _GAP_HIST_UPPER_STEPS,
+    _daily_peak_recovery_ms,
     _equity_shape_metrics,
     _directional_pnl_metrics,
     _fill_activity_metrics,
@@ -32,6 +33,21 @@ from optimization.gpu.metrics import (
     _weighted_strategy_eq_metrics,
     compute_objectives,
 )
+
+
+def test_btc_daily_peak_recovery_matches_non_strict_rust_contract():
+    day_end = torch.tensor(
+        [
+            [10.0, 9.0, 10.0, 8.0],
+            [10.0, 9.0, 8.0, 7.0],
+        ],
+        dtype=torch.float64,
+    )
+    active = torch.ones_like(day_end, dtype=torch.bool)
+
+    recovery = _daily_peak_recovery_ms(day_end, active) / 86_400_000.0
+
+    assert recovery.tolist() == [2.0, 0.0]
 
 
 def test_fill_activity_ratio_recovers_integer_steps_at_whole_day_boundary():
@@ -1576,6 +1592,157 @@ def test_new_strategy_equity_metrics_reduce_existing_compact_surface():
         needed={"gain_per_exposure_short_usd"},
     )
     assert zero_exposure["gain_per_exposure_short_usd"].item() == 0.0
+
+
+def test_btc_account_metrics_use_prepared_daily_price_context():
+    day_end = torch.tensor([[100.0, 110.0, 90.0]], dtype=torch.float64)
+    out = {
+        "day_end_eq": day_end,
+        "day_min_eq": day_end.clone(),
+        "day_max_dd": torch.zeros_like(day_end),
+        "day_volume": torch.zeros_like(day_end),
+        "day_has_fill": torch.ones_like(day_end, dtype=torch.bool),
+        "fill_count": torch.tensor([3.0]),
+        "max_dd": torch.zeros(1),
+        "held_max_ms": torch.zeros(1),
+        "gap_hist": torch.zeros((1, 128), dtype=torch.int32),
+        "gap_max_ms": torch.zeros(1),
+        "first_fill_ts": torch.tensor([0.0]),
+        "last_fill_ts": torch.tensor([2 * 86_400_000.0]),
+        "recovery_max_ms": torch.zeros(1),
+        "last_high_ts": torch.tensor([86_400_000.0]),
+        "first_eq_ts": torch.tensor([0.0]),
+        "last_eq_ts": torch.tensor([2 * 86_400_000.0]),
+        "liq_step": torch.tensor([-1]),
+        "total_wallet_exposure_max": torch.tensor([2.0]),
+        "total_wallet_exposure_mean": torch.tensor([1.0]),
+        "candidate_total_wallet_exposure_limit_long": torch.tensor([1.25]),
+        "candidate_total_wallet_exposure_limit_short": torch.tensor([0.5]),
+    }
+    requested = {
+        "adg_btc",
+        "drawdown_worst_btc",
+        "gain_btc",
+        "gain_per_exposure_long_btc",
+        "peak_recovery_days_equity_btc",
+    }
+    btc_day_end = np.array([10.0, 10.0, 20.0])
+    btc_day_max = np.array([10.0, 10.0, 20.0])
+
+    metrics = compute_objectives(
+        out,
+        SimpleNamespace(
+            requested_start_ts_ms=0,
+            guard_ts_ms=0,
+            interval_ms=86_400_000,
+        ),
+        {
+            "ts0": 0.0,
+            "n": 3,
+            "btc_day_end_price": btc_day_end,
+            "btc_day_max_price": btc_day_max,
+            "btc_prices": btc_day_end,
+        },
+        needed=requested,
+    )
+
+    btc_equity = torch.tensor([[10.0, 11.0, 4.5]], dtype=torch.float64)
+    expected_gain, expected_adg = _smoothed_gain_adg(
+        btc_equity, torch.ones_like(btc_equity, dtype=torch.bool)
+    )
+    assert set(metrics) == requested
+    assert requested <= set(SUPPORTED_METRICS)
+    assert metrics["gain_btc"].item() == pytest.approx(expected_gain.item())
+    assert metrics["adg_btc"].item() == pytest.approx(expected_adg.item())
+    assert metrics["drawdown_worst_btc"].item() == pytest.approx(
+        (11.0 - 4.5) / 11.0
+    )
+    assert metrics["gain_per_exposure_long_btc"].item() == pytest.approx(
+        expected_gain.item() / 1.25
+    )
+    assert metrics["peak_recovery_days_equity_btc"].item() == 1.0
+
+
+def test_btc_account_metrics_fail_closed_without_price_context():
+    day_end = torch.tensor([[100.0, 101.0]], dtype=torch.float64)
+    out = {
+        "day_end_eq": day_end,
+        "day_min_eq": day_end.clone(),
+        "day_max_dd": torch.zeros_like(day_end),
+        "day_volume": torch.zeros_like(day_end),
+        "day_has_fill": torch.ones_like(day_end, dtype=torch.bool),
+        "fill_count": torch.tensor([1.0]),
+        "max_dd": torch.zeros(1),
+        "held_max_ms": torch.zeros(1),
+        "gap_hist": torch.zeros((1, 128), dtype=torch.int32),
+        "gap_max_ms": torch.zeros(1),
+        "first_fill_ts": torch.tensor([0.0]),
+        "last_fill_ts": torch.tensor([86_400_000.0]),
+        "recovery_max_ms": torch.zeros(1),
+        "last_high_ts": torch.tensor([86_400_000.0]),
+        "first_eq_ts": torch.tensor([0.0]),
+        "last_eq_ts": torch.tensor([86_400_000.0]),
+        "liq_step": torch.tensor([-1]),
+    }
+
+    with pytest.raises(RuntimeError, match="BTC account metric context"):
+        compute_objectives(
+            out,
+            SimpleNamespace(
+                requested_start_ts_ms=0,
+                guard_ts_ms=0,
+                interval_ms=86_400_000,
+            ),
+            {"ts0": 0.0, "n": 2},
+            needed={"adg_btc"},
+        )
+
+
+def test_btc_account_metrics_use_candidate_liquidation_endpoint_price():
+    day_ms = 86_400_000
+    minute_ms = 60_000
+    btc_prices = np.full(1442, 10.0)
+    btc_prices[1440] = 20.0
+    btc_prices[1441] = 40.0
+    day_end = torch.tensor([[100.0, 100.0]], dtype=torch.float64)
+    out = {
+        "day_end_eq": day_end,
+        "day_min_eq": day_end.clone(),
+        "day_max_dd": torch.zeros_like(day_end),
+        "day_volume": torch.zeros_like(day_end),
+        "day_has_fill": torch.ones_like(day_end, dtype=torch.bool),
+        "fill_count": torch.tensor([2.0]),
+        "max_dd": torch.zeros(1),
+        "held_max_ms": torch.zeros(1),
+        "gap_hist": torch.zeros((1, 128), dtype=torch.int32),
+        "gap_max_ms": torch.zeros(1),
+        "first_fill_ts": torch.tensor([0.0]),
+        "last_fill_ts": torch.tensor([float(day_ms)]),
+        "recovery_max_ms": torch.zeros(1),
+        "last_high_ts": torch.tensor([0.0]),
+        "first_eq_ts": torch.tensor([0.0]),
+        "last_eq_ts": torch.tensor([float(day_ms)]),
+        "liq_step": torch.tensor([1440]),
+    }
+
+    metrics = compute_objectives(
+        out,
+        SimpleNamespace(
+            requested_start_ts_ms=0,
+            guard_ts_ms=0,
+            interval_ms=minute_ms,
+        ),
+        {
+            "ts0": 0,
+            "n": len(btc_prices),
+            "btc_day_end_price": np.array([10.0, 40.0]),
+            "btc_day_max_price": np.array([10.0, 40.0]),
+            "btc_prices": btc_prices,
+        },
+        needed={"gain_btc"},
+    )
+
+    assert metrics["gain_btc"].item() == pytest.approx(0.75)
 
 
 def test_objectives_include_final_active_calendar_day():

--- a/tests/optimization/test_gpu_metrics.py
+++ b/tests/optimization/test_gpu_metrics.py
@@ -1621,13 +1621,11 @@ def test_btc_account_metrics_use_prepared_daily_price_context():
     }
     requested = {
         "adg_btc",
-        "drawdown_worst_btc",
         "gain_btc",
         "gain_per_exposure_long_btc",
         "peak_recovery_days_equity_btc",
     }
     btc_day_end = np.array([10.0, 10.0, 20.0])
-    btc_day_max = np.array([10.0, 10.0, 20.0])
 
     metrics = compute_objectives(
         out,
@@ -1640,7 +1638,6 @@ def test_btc_account_metrics_use_prepared_daily_price_context():
             "ts0": 0.0,
             "n": 3,
             "btc_day_end_price": btc_day_end,
-            "btc_day_max_price": btc_day_max,
             "btc_prices": btc_day_end,
         },
         needed=requested,
@@ -1654,9 +1651,6 @@ def test_btc_account_metrics_use_prepared_daily_price_context():
     assert requested <= set(SUPPORTED_METRICS)
     assert metrics["gain_btc"].item() == pytest.approx(expected_gain.item())
     assert metrics["adg_btc"].item() == pytest.approx(expected_adg.item())
-    assert metrics["drawdown_worst_btc"].item() == pytest.approx(
-        (11.0 - 4.5) / 11.0
-    )
     assert metrics["gain_per_exposure_long_btc"].item() == pytest.approx(
         expected_gain.item() / 1.25
     )
@@ -1736,7 +1730,6 @@ def test_btc_account_metrics_use_candidate_liquidation_endpoint_price():
             "ts0": 0,
             "n": len(btc_prices),
             "btc_day_end_price": np.array([10.0, 40.0]),
-            "btc_day_max_price": np.array([10.0, 40.0]),
             "btc_prices": btc_prices,
         },
         needed={"gain_btc"},

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -4353,17 +4353,20 @@ def test_mps_single_coin_service_dispatches_forced_delist_tail(strategy_kind):
         strategy["entry"]["initial_qty_pct"] = 0.1
         strategy["entry"]["initial_ema_dist"] = 0.01
 
+    btc_prices = np.linspace(50_000.0, 55_000.0, count)
     proxy = MpsSingleCoinProxy(
         config=config,
         hlcvs=hlcvs,
         mss=market_settings,
-        btc=np.full(count, 50_000.0),
+        btc=btc_prices,
         timestamps=timestamps,
         exchange="bybit",
         batch_size=1,
         needed_metrics={
             "backtest_completion_ratio",
             "fills_count",
+            "adg_btc",
+            "gain_btc",
             "hard_stop_panic_close_loss_sum",
         },
     )
@@ -4373,7 +4376,7 @@ def test_mps_single_coin_service_dispatches_forced_delist_tail(strategy_kind):
         market_settings,
         config,
         "bybit",
-        np.full(count, 50_000.0),
+        btc_prices,
         timestamps,
     )
 
@@ -4383,6 +4386,12 @@ def test_mps_single_coin_service_dispatches_forced_delist_tail(strategy_kind):
     assert result["hard_stop_panic_close_loss_sum"] > 0.0
     assert result["hard_stop_panic_close_loss_sum"] == pytest.approx(
         exact_analysis["hard_stop_panic_close_loss_sum"], rel=1.0e-5
+    )
+    assert result["gain_btc"] == pytest.approx(
+        exact_analysis["gain_btc"], rel=2.0e-3
+    )
+    assert result["adg_btc"] == pytest.approx(
+        exact_analysis["adg_btc"], rel=2.0e-3
     )
     assert result["backtest_completion_ratio"] > 0.99
 
@@ -4691,17 +4700,20 @@ def test_mps_multicoin_service_dispatches_forced_delist_tail(
             strategy["entry"]["double_down_factor"] = 0.0
             strategy["close"]["threshold_base_pct"] = 0.5
 
+    btc_prices = np.linspace(50_000.0, 55_000.0, count)
     proxy = MpsMulticoinProxy(
         config=config,
         hlcvs=hlcvs,
         mss=market_settings,
-        btc=np.full(count, 50_000.0),
+        btc=btc_prices,
         timestamps=timestamps,
         exchange="bybit",
         batch_size=1,
         needed_metrics={
             "backtest_completion_ratio",
             "fills_count",
+            "adg_btc",
+            "gain_btc",
             "hard_stop_panic_close_loss_sum",
         },
     )
@@ -4711,7 +4723,7 @@ def test_mps_multicoin_service_dispatches_forced_delist_tail(
         market_settings,
         config,
         "bybit",
-        np.full(count, 50_000.0),
+        btc_prices,
         timestamps,
     )
     expected_fills = 4.0 if topology == "fused" else 2.0
@@ -4728,6 +4740,12 @@ def test_mps_multicoin_service_dispatches_forced_delist_tail(
         assert result["hard_stop_panic_close_loss_sum"] == pytest.approx(
             exact_analysis["hard_stop_panic_close_loss_sum"], rel=5.0e-4
         )
+    assert result["gain_btc"] == pytest.approx(
+        exact_analysis["gain_btc"], rel=2.0e-3
+    )
+    assert result["adg_btc"] == pytest.approx(
+        exact_analysis["adg_btc"], rel=2.0e-3
+    )
     assert result["backtest_completion_ratio"] > 0.99
 
 

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -33,6 +33,7 @@ from optimization.gpu.service import (
     MpsMulticoinEmaProxy,
     _build_multicoin_ema_coin_overrides,
     _build_multicoin_tm_coin_overrides,
+    _btc_daily_price_context,
     _candidate_wallet_exposure_limit_outputs,
     _candidate_position_slot_outputs,
     _combine_hedged_multicoin_hsl_outputs,
@@ -163,12 +164,75 @@ def test_gpu_proxy_execution_checkpoint_contract_tracks_effective_inputs():
         exchange_params=[market],
         base_params={"long": {"offset": 0.02}},
     )
+    btc_prices = np.array([50_000.0, 51_000.0, 49_000.0])
+    with_btc = _gpu_proxy_execution_checkpoint_contract(
+        strategy_kind="ema_anchor",
+        exchange="bybit",
+        enabled_sides=["long"],
+        hlcvs=np.arange(12, dtype=np.float64).reshape(3, 1, 4),
+        timestamps=np.array([1_000, 2_000, 3_000], dtype=np.int64),
+        backtest_params=backtest_params,
+        exchange_params=[market],
+        base_params={"long": {"offset": 0.01}},
+        btc_prices=btc_prices,
+    )
+    changed_btc = _gpu_proxy_execution_checkpoint_contract(
+        strategy_kind="ema_anchor",
+        exchange="bybit",
+        enabled_sides=["long"],
+        hlcvs=np.arange(12, dtype=np.float64).reshape(3, 1, 4),
+        timestamps=np.array([1_000, 2_000, 3_000], dtype=np.int64),
+        backtest_params=backtest_params,
+        exchange_params=[market],
+        base_params={"long": {"offset": 0.01}},
+        btc_prices=btc_prices + np.array([0.0, 1.0, 0.0]),
+    )
 
     assert changed != original
     assert changed_timestamps != original
     assert changed_hlcvs != original
     assert changed_base_params != original
+    assert "btc_analysis" not in original
+    assert changed_btc != with_btc
     assert original["timestamps"]["count"] == 3
+
+
+def test_btc_daily_price_context_matches_proxy_utc_day_grid():
+    day_ms = 86_400_000
+    context = _btc_daily_price_context(
+        [10.0, 12.0, 11.0, 20.0],
+        [0, day_ms - 1, day_ms, 2 * day_ms - 1],
+        expected_count=4,
+        expected_days=2,
+    )
+
+    assert context["btc_day_end_price"].tolist() == [12.0, 20.0]
+    assert context["btc_day_max_price"].tolist() == [12.0, 20.0]
+
+
+@pytest.mark.parametrize(
+    "btc_prices",
+    ([10.0, float("nan")], [10.0, 0.0], [10.0]),
+)
+def test_btc_daily_price_context_rejects_unsafe_series(btc_prices):
+    with pytest.raises(ValueError, match="MPS BTC analysis"):
+        _btc_daily_price_context(
+            btc_prices,
+            [0, 60_000],
+            expected_count=2,
+            expected_days=1,
+        )
+
+
+def test_btc_daily_price_context_rejects_skipped_utc_days():
+    day_ms = 86_400_000
+    with pytest.raises(ValueError, match="missing prepared prices"):
+        _btc_daily_price_context(
+            [10.0, 20.0],
+            [0, 2 * day_ms],
+            expected_count=2,
+            expected_days=3,
+        )
 
 
 def test_gpu_proxy_execution_checkpoint_contract_rejects_timestamp_shape_mismatch():

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -207,7 +207,6 @@ def test_btc_daily_price_context_matches_proxy_utc_day_grid():
     )
 
     assert context["btc_day_end_price"].tolist() == [12.0, 20.0]
-    assert context["btc_day_max_price"].tolist() == [12.0, 20.0]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- add BTC-denominated account-equity proxy metrics for Apple MPS when BTC collateral is disabled
- derive BTC daily equity from the existing compact USD surface and canonical BTC/USD data, including candidate-specific liquidation endpoints
- keep USD-only runs unchanged and bind BTC data to checkpoint identity only when BTC scoring or limits request it
- retain fail-closed rejection of positive `backtest.btc_collateral_cap` and document approximation boundaries

## Supported BTC proxy surface
Gain, ADG, MDG, Omega, equity shape, unweighted exposure ratios, peak recovery, per-side exposure-normalized gain/ADG/MDG, and the safe weighted ADG/MDG/Omega and equity-shape variants. Metrics requiring synchronized intraday BTC-equity minima (Sharpe, Sortino, expected shortfall, drawdown, Calmar, and Sterling) and weighted exposure ratios remain fail-closed until Metal retains the required surfaces. Exact Rust remains authoritative through mandatory validation and drift gates.

## Validation
- `python -m pytest -q tests/optimization`
- `python -m pytest -q tests/optimization/test_gpu_mps.py` on physical Apple M3/MPS (679 passed)
- `cargo test --manifest-path passivbot-rust/Cargo.toml --no-default-features` (268 passed)
- `cargo check --manifest-path passivbot-rust/Cargo.toml`
- `python -m compileall -q src tests/optimization`
- end-to-end BTC-scored EMA Anchor GPU smoke using ADG/MDG/Omega: 8 generations, 512 proxy evaluations, 16 exact validations, clean completion

`mkdocs build --strict` reaches the documentation build but aborts on the two pre-existing `release_notes_v8.0.0.md` / `release_notes_v8.1.0.md` links to `../CHANGELOG.md`; this PR introduces no new documentation warnings.
