### PR TITLE
GPU: add synchronized BTC risk metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,16 @@ All notable user-facing changes will be documented in this file.
   BTC-denominated account-equity scoring and limits while `backtest.btc_collateral_cap` is zero.
   The proxy converts its compact USD daily equity surface with the canonical prepared BTC/USD
   series and supports gain, ADG, MDG, Omega, equity shape, unweighted exposure ratios, peak
-  recovery, per-exposure forms, and the corresponding safe weighted close-equity variants. UTC
+  recovery, per-exposure forms, Sharpe, Sortino, expected shortfall, worst and worst-1% drawdown,
+  Calmar, Sterling, and the corresponding safe weighted variants. UTC
   day-end conversion is exact for the compact surface, including candidate-specific liquidation
   endpoints; recovery remains a compact daily approximation under mandatory exact Rust validation
-  and rolling drift gates. Intraday-risk metrics and weighted exposure ratios remain fail-closed
-  until Metal retains their required synchronized surfaces. BTC inputs enter checkpoint identity
-  only when a BTC metric is requested, so USD-only
-  runs retain their previous dispatch and reduction cost. Positive BTC collateral remains
-  fail-closed pending its separate simulation slice.
+  and rolling drift gates. Metal conditionally retains synchronized BTC day-end equity, daily
+  minima, and full-curve daily worst drawdowns only when one of the intraday-risk metrics is
+  requested; USD-only and close-equity-only BTC runs retain their previous kernel ABI, output
+  width, and dispatch cost. Weighted BTC exposure ratios remain fail-closed until the proxy owns
+  suffix-local exposure series. BTC inputs enter checkpoint identity only when a BTC metric is
+  requested. Positive BTC collateral remains fail-closed pending its separate simulation slice.
 
 - Apple MPS multi-coin EMA Anchor and Trailing Martingale optimization now supports both wallet-
   exposure denominator modes. With `backtest.dynamic_wel_by_tradability: false`, Metal divides

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,14 @@ All notable user-facing changes will be documented in this file.
   The proxy converts its compact USD daily equity surface with the canonical prepared BTC/USD
   series and supports gain, ADG, MDG, Omega, equity shape, unweighted exposure ratios, peak
   recovery, per-exposure forms, Sharpe, Sortino, expected shortfall, worst and worst-1% drawdown,
-  Calmar, Sterling, and weighted Sharpe and Sortino. UTC
+  Calmar, and Sterling. UTC
   day-end conversion is exact for the compact surface, including candidate-specific liquidation
   endpoints; recovery remains a compact daily approximation under mandatory exact Rust validation
   and rolling drift gates. Metal conditionally retains synchronized BTC day-end equity, daily
   minima, and full-curve daily worst drawdowns only when one of the intraday-risk metrics is
   requested; USD-only and close-equity-only BTC runs retain their previous kernel ABI, output
-  width, and dispatch cost. Weighted BTC Calmar/Sterling and exposure ratios remain fail-closed
-  until the proxy owns suffix-local drawdown and exposure series. BTC inputs enter checkpoint
+  width, and dispatch cost. Weighted BTC Sharpe/Sortino/Calmar/Sterling and exposure ratios remain
+  fail-closed until the proxy owns suffix-local intraday minima, drawdown, and exposure series. BTC inputs enter checkpoint
   identity only when a BTC metric is requested. Positive BTC collateral remains fail-closed
   pending its separate simulation slice.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,16 @@ All notable user-facing changes will be documented in this file.
   The proxy converts its compact USD daily equity surface with the canonical prepared BTC/USD
   series and supports gain, ADG, MDG, Omega, equity shape, unweighted exposure ratios, peak
   recovery, per-exposure forms, Sharpe, Sortino, expected shortfall, worst and worst-1% drawdown,
-  Calmar, Sterling, and the corresponding safe weighted variants. UTC
+  Calmar, Sterling, and weighted Sharpe and Sortino. UTC
   day-end conversion is exact for the compact surface, including candidate-specific liquidation
   endpoints; recovery remains a compact daily approximation under mandatory exact Rust validation
   and rolling drift gates. Metal conditionally retains synchronized BTC day-end equity, daily
   minima, and full-curve daily worst drawdowns only when one of the intraday-risk metrics is
   requested; USD-only and close-equity-only BTC runs retain their previous kernel ABI, output
-  width, and dispatch cost. Weighted BTC exposure ratios remain fail-closed until the proxy owns
-  suffix-local exposure series. BTC inputs enter checkpoint identity only when a BTC metric is
-  requested. Positive BTC collateral remains fail-closed pending its separate simulation slice.
+  width, and dispatch cost. Weighted BTC Calmar/Sterling and exposure ratios remain fail-closed
+  until the proxy owns suffix-local drawdown and exposure series. BTC inputs enter checkpoint
+  identity only when a BTC metric is requested. Positive BTC collateral remains fail-closed
+  pending its separate simulation slice.
 
 - Apple MPS multi-coin EMA Anchor and Trailing Martingale optimization now supports both wallet-
   exposure denominator modes. With `backtest.dynamic_wel_by_tradability: false`, Metal divides

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -496,10 +496,10 @@ ratios, peak recovery, per-side exposure-normalized gain/ADG/MDG, and the existi
 ADG/MDG/Omega and equity-shape variants. It converts the compact USD daily closing-equity surface
 with the canonical prepared BTC/USD price at each UTC day end, including a candidate-specific
 final endpoint after early liquidation. For BTC Sharpe, Sortino, expected shortfall, worst and
-worst-1% drawdown, Calmar, Sterling, plus weighted Sharpe and Sortino, Metal conditionally retains a
+worst-1% drawdown, Calmar, and Sterling, Metal conditionally retains a
 synchronized BTC-equity surface containing each UTC day's close, minimum, and worst full-curve
-drawdown. Weighted support in this intraday slice is limited to Sharpe and Sortino; weighted BTC
-Calmar and Sterling require suffix-local drawdown reconstruction and remain fail-closed. Runs that
+drawdown. Weighted BTC Sharpe, Sortino, Calmar, and Sterling require suffix-local intraday minima
+and drawdown reconstruction and remain fail-closed. Runs that
 do not request one of these intraday-risk metrics keep the smaller existing kernel ABI and output
 buffers. BTC peak recovery remains a compact daily approximation; mandatory exact Rust validation
 and rolling drift gates remain authoritative. Weighted BTC exposure ratios still require

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -495,11 +495,13 @@ proxy also supports BTC-denominated gain, ADG, MDG, Omega, equity shape, unweigh
 ratios, peak recovery, per-side exposure-normalized gain/ADG/MDG, and the existing weighted
 ADG/MDG/Omega and equity-shape variants. It converts the compact USD daily closing-equity surface
 with the canonical prepared BTC/USD price at each UTC day end, including a candidate-specific
-final endpoint after early liquidation. BTC peak recovery remains a compact daily approximation;
-mandatory exact Rust validation and rolling drift gates remain authoritative. BTC Sharpe, Sortino,
-expected shortfall, drawdown, Calmar, and Sterling require synchronized intraday BTC-equity minima,
-while weighted BTC exposure ratios require suffix-local exposure series. Those metrics remain
-fail-closed until the proxy retains those surfaces.
+final endpoint after early liquidation. For BTC Sharpe, Sortino, expected shortfall, worst and
+worst-1% drawdown, Calmar, Sterling, and their weighted variants, Metal conditionally retains a
+synchronized BTC-equity surface containing each UTC day's close, minimum, and worst full-curve
+drawdown. Runs that do not request one of these intraday-risk metrics keep the smaller existing
+kernel ABI and output buffers. BTC peak recovery remains a compact daily approximation; mandatory
+exact Rust validation and rolling drift gates remain authoritative. Weighted BTC exposure ratios
+still require suffix-local exposure series and remain fail-closed.
 The prepared BTC series must contain at least one sample in every covered UTC day; unusually coarse
 intervals which skip a whole UTC day fail closed for BTC scoring.
 Positive `backtest.btc_collateral_cap` remains unsupported and fails before GPU optimization.

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -496,12 +496,14 @@ ratios, peak recovery, per-side exposure-normalized gain/ADG/MDG, and the existi
 ADG/MDG/Omega and equity-shape variants. It converts the compact USD daily closing-equity surface
 with the canonical prepared BTC/USD price at each UTC day end, including a candidate-specific
 final endpoint after early liquidation. For BTC Sharpe, Sortino, expected shortfall, worst and
-worst-1% drawdown, Calmar, Sterling, and their weighted variants, Metal conditionally retains a
+worst-1% drawdown, Calmar, Sterling, plus weighted Sharpe and Sortino, Metal conditionally retains a
 synchronized BTC-equity surface containing each UTC day's close, minimum, and worst full-curve
-drawdown. Runs that do not request one of these intraday-risk metrics keep the smaller existing
-kernel ABI and output buffers. BTC peak recovery remains a compact daily approximation; mandatory
-exact Rust validation and rolling drift gates remain authoritative. Weighted BTC exposure ratios
-still require suffix-local exposure series and remain fail-closed.
+drawdown. Weighted support in this intraday slice is limited to Sharpe and Sortino; weighted BTC
+Calmar and Sterling require suffix-local drawdown reconstruction and remain fail-closed. Runs that
+do not request one of these intraday-risk metrics keep the smaller existing kernel ABI and output
+buffers. BTC peak recovery remains a compact daily approximation; mandatory exact Rust validation
+and rolling drift gates remain authoritative. Weighted BTC exposure ratios still require
+suffix-local exposure series and remain fail-closed.
 The prepared BTC series must contain at least one sample in every covered UTC day; unusually coarse
 intervals which skip a whole UTC day fail closed for BTC scoring.
 Positive `backtest.btc_collateral_cap` remains unsupported and fails before GPU optimization.

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -8,6 +8,8 @@ use std::sync::LazyLock;
 
 const MPS_HSL_MARKER: &str = "// PASSIVBOT_HSL_COMMON";
 const MPS_HSL_COMMON_SOURCE: &str = include_str!("gpu/mps_hsl_common.metal");
+const MPS_BTC_RISK_MARKER: &str = "// PASSIVBOT_BTC_RISK_COMMON";
+const MPS_BTC_RISK_COMMON_SOURCE: &str = include_str!("gpu/mps_btc_risk_common.metal");
 const MPS_MULTICOIN_MARKER: &str = "// PASSIVBOT_MULTICOIN_COMMON";
 const MPS_MULTICOIN_COMMON_SOURCE: &str = include_str!("gpu/mps_multicoin_common.metal");
 const MPS_EMA_ANCHOR_BODY: &str = include_str!("gpu/mps_ema_anchor_directional.metal");
@@ -29,7 +31,13 @@ fn compose_hsl_source(body: &str) -> String {
         1,
         "MPS source must contain exactly one shared-HSL marker"
     );
+    assert_eq!(
+        body.matches(MPS_BTC_RISK_MARKER).count(),
+        1,
+        "MPS source must contain exactly one shared BTC-risk marker"
+    );
     body.replacen(MPS_HSL_MARKER, MPS_HSL_COMMON_SOURCE, 1)
+        .replacen(MPS_BTC_RISK_MARKER, MPS_BTC_RISK_COMMON_SOURCE, 1)
 }
 
 fn compose_multicoin_source(body: &str) -> String {
@@ -187,6 +195,22 @@ mod tests {
         assert!(source.contains("const bool shared_has_blocking_orders = has_blocking_orders_long"));
     }
 
+    fn assert_shared_btc_risk_contract(source: &str) {
+        assert!(!source.contains(MPS_BTC_RISK_MARKER));
+        assert!(source.contains(MPS_BTC_RISK_COMMON_SOURCE));
+        for signature in [
+            "struct BtcRiskState",
+            "inline BtcRiskState init_btc_risk_state()",
+            "inline void reset_btc_risk_day(",
+            "inline void update_btc_risk_state(",
+            "inline void write_btc_risk_day(",
+        ] {
+            assert_eq!(source.matches(signature).count(), 1, "{signature}");
+        }
+        assert!(source.contains("#if PASSIVBOT_BTC_RISK_ENABLED"));
+        assert!(source.contains("float btc_equity = usd_equity / btc_price"));
+    }
+
     fn assert_directional_recovery_sampling_contract(source: &str) {
         assert_eq!(source.matches("device float* recovery_samples").count(), 2);
         assert!(source.contains("#ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED"));
@@ -334,6 +358,32 @@ mod tests {
         assert_shared_hsl_contract(mps_trailing_martingale_source());
         assert_directional_hsl_accounting_contract(mps_ema_anchor_source());
         assert_directional_hsl_accounting_contract(mps_trailing_martingale_source());
+    }
+
+    #[test]
+    fn all_strategy_sources_compose_one_shared_btc_risk_controller() {
+        for body in [
+            MPS_EMA_ANCHOR_BODY,
+            MPS_EMA_ANCHOR_MULTICOIN_BODY,
+            MPS_TRAILING_MARTINGALE_BODY,
+            MPS_TRAILING_MARTINGALE_MULTICOIN_BODY,
+        ] {
+            assert_eq!(body.matches(MPS_BTC_RISK_MARKER).count(), 1);
+            assert!(!body.contains("struct BtcRiskState"));
+        }
+        for source in [
+            mps_ema_anchor_source(),
+            mps_ema_anchor_multicoin_source(),
+            mps_trailing_martingale_source(),
+            mps_trailing_martingale_long_no_hsl_source(),
+            mps_trailing_martingale_short_no_hsl_source(),
+            mps_trailing_martingale_multicoin_source(),
+        ] {
+            assert_shared_btc_risk_contract(source);
+            assert!(source.contains("constant float* btc_prices"));
+            assert!(source.contains("update_btc_risk_state("));
+            assert!(source.contains("write_btc_risk_day("));
+        }
     }
 
     #[test]

--- a/passivbot-rust/src/gpu/mps_btc_risk_common.metal
+++ b/passivbot-rust/src/gpu/mps_btc_risk_common.metal
@@ -1,0 +1,52 @@
+#if PASSIVBOT_BTC_RISK_ENABLED
+
+struct BtcRiskState {
+    float peak;
+    float day_end;
+    float day_min;
+    float day_max_drawdown;
+};
+
+inline BtcRiskState init_btc_risk_state() {
+    BtcRiskState state;
+    state.peak = -INFINITY;
+    state.day_end = 0.0f;
+    state.day_min = INFINITY;
+    state.day_max_drawdown = 0.0f;
+    return state;
+}
+
+inline void reset_btc_risk_day(thread BtcRiskState& state) {
+    state.day_end = 0.0f;
+    state.day_min = INFINITY;
+    state.day_max_drawdown = 0.0f;
+}
+
+inline void update_btc_risk_state(
+    thread BtcRiskState& state,
+    float usd_equity,
+    float btc_price
+) {
+    float btc_equity = usd_equity / btc_price;
+    state.peak = fmax(state.peak, btc_equity);
+    float drawdown = fmax(
+        (state.peak - btc_equity) / fmax(fabs(state.peak), 1.0e-12f),
+        0.0f
+    );
+    state.day_end = btc_equity;
+    state.day_min = fmin(state.day_min, btc_equity);
+    state.day_max_drawdown = fmax(state.day_max_drawdown, drawdown);
+}
+
+inline void write_btc_risk_day(
+    thread const BtcRiskState& state,
+    device float* daily,
+    int output,
+    int first_column
+) {
+    daily[output + first_column + 0] = state.day_end;
+    daily[output + first_column + 1] = state.day_min;
+    daily[output + first_column + 2] = state.day_max_drawdown;
+}
+
+#endif

--- a/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
@@ -1,7 +1,11 @@
 #include <metal_stdlib>
 using namespace metal;
 
+#if PASSIVBOT_BTC_RISK_ENABLED
+constant int DAILY_COLS = 11;
+#else
 constant int DAILY_COLS = 8;
+#endif
 #if PASSIVBOT_HSL_RAW_TAIL_ENABLED
 constant int SCALAR_COLS = 72;
 #elif PASSIVBOT_HSL_RAW_DRAWDOWN_ENABLED
@@ -138,6 +142,8 @@ inline float float32_floor_nonnegative(float value) {
 }
 
 // PASSIVBOT_HSL_COMMON
+
+// PASSIVBOT_BTC_RISK_COMMON
 
 inline void record_realized_net(
     float net_pnl,
@@ -1121,6 +1127,9 @@ inline void passivbot_single_coin_impl(
     constant float* params,
     constant float* settings,
     constant int* sizes,
+#if PASSIVBOT_BTC_RISK_ENABLED
+    constant float* btc_prices,
+#endif
     device float* daily,
     device float* scalars,
     device int* gap_hist,
@@ -1235,6 +1244,9 @@ inline void passivbot_single_coin_impl(
     float first_eq_k = -1.0f;
     float last_eq_k = -1.0f;
     bool eq_started = false;
+#if PASSIVBOT_BTC_RISK_ENABLED
+    BtcRiskState btc_risk = init_btc_risk_state();
+#endif
 #ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
     int recovery_start_k = -1;
 #endif
@@ -1291,6 +1303,9 @@ inline void passivbot_single_coin_impl(
                 daily[o + 5] = balance - day_start_balance;
                 daily[o + 6] = balance;
                 daily[o + 7] = day_fill_count;
+#if PASSIVBOT_BTC_RISK_ENABLED
+                write_btc_risk_day(btc_risk, daily, o, 8);
+#endif
             }
             cur_day = di;
             day_touched = false;
@@ -1301,6 +1316,9 @@ inline void passivbot_single_coin_impl(
             day_has_fill = 0.0f;
             day_start_balance = balance;
             day_fill_count = 0.0f;
+#if PASSIVBOT_BTC_RISK_ENABLED
+            reset_btc_risk_day(btc_risk);
+#endif
         }
 
         bool long_close_fill = false;
@@ -2102,6 +2120,9 @@ inline void passivbot_single_coin_impl(
             day_end = eqf;
             day_min = fmin(day_min, eqf);
             day_dd = fmax(day_dd, dd);
+#if PASSIVBOT_BTC_RISK_ENABLED
+            update_btc_risk_state(btc_risk, eqf, btc_prices[k]);
+#endif
             day_touched = true;
             if (!liq) {
                 float twe_net = (
@@ -2134,6 +2155,9 @@ inline void passivbot_single_coin_impl(
         daily[o + 5] = balance - day_start_balance;
         daily[o + 6] = balance;
         daily[o + 7] = day_fill_count;
+#if PASSIVBOT_BTC_RISK_ENABLED
+        write_btc_risk_day(btc_risk, daily, o, 8);
+#endif
     }
 
     if (long_side.pos_open_k >= 0.0f && last_eq_k >= 0.0f) {
@@ -2300,6 +2324,9 @@ kernel void passivbot_ema_anchor(
     constant float* params,
     constant float* settings,
     constant int* sizes,
+#if PASSIVBOT_BTC_RISK_ENABLED
+    constant float* btc_prices,
+#endif
     device float* daily,
     device float* scalars,
     device int* gap_hist,
@@ -2311,7 +2338,11 @@ kernel void passivbot_ema_anchor(
     uint b [[thread_position_in_grid]]
 ) {
     passivbot_single_coin_impl(
-        bars, flags, params, settings, sizes, daily, scalars, gap_hist,
+        bars, flags, params, settings, sizes,
+#if PASSIVBOT_BTC_RISK_ENABLED
+        btc_prices,
+#endif
+        daily, scalars, gap_hist,
         rolling_pnl_values, rolling_pnl_indices,
 #ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
         recovery_samples,

--- a/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
@@ -7,7 +7,11 @@ constant int COIN_COLS = 13;
 constant int OVERRIDE_COLS = 30;
 constant int HSL_OVERRIDE_START = 19;
 constant int FORCED_ACTIVE_OVERRIDE_COL = 29;
+#if PASSIVBOT_BTC_RISK_ENABLED
+constant int DAILY_COLS = 12;
+#else
 constant int DAILY_COLS = 9;
+#endif
 #if PASSIVBOT_HSL_RAW_TAIL_ENABLED
 constant int SCALAR_COLS = 67;
 constant int FUSED_SCALAR_COLS = 72;
@@ -27,6 +31,8 @@ constant float RECOVERY_FAIL_CLOSED_SENTINEL = -3.402823466e+38f;
 #endif
 
 // PASSIVBOT_HSL_COMMON
+
+// PASSIVBOT_BTC_RISK_COMMON
 
 // PASSIVBOT_MULTICOIN_COMMON
 
@@ -2850,6 +2856,9 @@ inline void passivbot_ema_anchor_multicoin_impl(
     constant float* run_settings,
     constant int* sizes,
     constant int* end_steps,
+#if PASSIVBOT_BTC_RISK_ENABLED
+    constant float* btc_prices,
+#endif
     device float* daily,
     device float* scalars,
     device int* gap_hist,
@@ -2956,6 +2965,9 @@ inline void passivbot_ema_anchor_multicoin_impl(
     float account_recovery_max_min = 0.0f;
     float first_eq_k = -1.0f;
     float last_eq_k = -1.0f;
+#if PASSIVBOT_BTC_RISK_ENABLED
+    BtcRiskState btc_risk = init_btc_risk_state();
+#endif
 #ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
     int recovery_start_k = -1;
 #endif
@@ -2992,6 +3004,9 @@ inline void passivbot_ema_anchor_multicoin_impl(
                 daily[output + 6] = balance - day_start_balance;
                 daily[output + 7] = balance;
                 daily[output + 8] = day_fill_count;
+#if PASSIVBOT_BTC_RISK_ENABLED
+                write_btc_risk_day(btc_risk, daily, output, 9);
+#endif
             }
             current_day = day_index;
             day_touched = false;
@@ -3003,6 +3018,9 @@ inline void passivbot_ema_anchor_multicoin_impl(
             day_min_balance = INFINITY;
             day_start_balance = balance;
             day_fill_count = 0.0f;
+#if PASSIVBOT_BTC_RISK_ENABLED
+            reset_btc_risk_day(btc_risk);
+#endif
         }
 
         float hsl_equity_before_fills =
@@ -3306,6 +3324,11 @@ inline void passivbot_ema_anchor_multicoin_impl(
             day_min = fmin(day_min, effective_equity);
             day_min_balance = fmin(day_min_balance, balance);
             day_dd = fmax(day_dd, drawdown);
+#if PASSIVBOT_BTC_RISK_ENABLED
+            update_btc_risk_state(
+                btc_risk, effective_equity, btc_prices[k]
+            );
+#endif
             day_touched = true;
             if (!liquidated) {
                 float twe_abs = position_cost / balance;
@@ -3335,6 +3358,9 @@ inline void passivbot_ema_anchor_multicoin_impl(
         daily[output + 6] = balance - day_start_balance;
         daily[output + 7] = balance;
         daily[output + 8] = day_fill_count;
+#if PASSIVBOT_BTC_RISK_ENABLED
+        write_btc_risk_day(btc_risk, daily, output, 9);
+#endif
     }
 
     float total_size = 0.0f;
@@ -3647,6 +3673,9 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
     constant float* run_settings,
     constant int* sizes,
     constant int* end_steps,
+#if PASSIVBOT_BTC_RISK_ENABLED
+    constant float* btc_prices,
+#endif
     device float* daily,
     device float* scalars,
     device int* gap_hist,
@@ -3764,6 +3793,9 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
     float account_recovery_max_min = 0.0f;
     float first_eq_k = -1.0f;
     float last_eq_k = -1.0f;
+#if PASSIVBOT_BTC_RISK_ENABLED
+    BtcRiskState btc_risk = init_btc_risk_state();
+#endif
 #ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
     int recovery_start_k = -1;
 #endif
@@ -3798,6 +3830,9 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
                 daily[output + 6] = account.balance - day_start_balance;
                 daily[output + 7] = account.balance;
                 daily[output + 8] = fills.day_fill_count;
+#if PASSIVBOT_BTC_RISK_ENABLED
+                write_btc_risk_day(btc_risk, daily, output, 9);
+#endif
             }
             current_day = day_index;
             day_touched = false;
@@ -3809,6 +3844,9 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
             day_min_balance = INFINITY;
             day_start_balance = account.balance;
             fills.day_fill_count = 0.0f;
+#if PASSIVBOT_BTC_RISK_ENABLED
+            reset_btc_risk_day(btc_risk);
+#endif
         }
 
         float long_hsl_equity_before_fills = account.balance;
@@ -4217,6 +4255,11 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
             day_min = fmin(day_min, effective_equity);
             day_min_balance = fmin(day_min_balance, account.balance);
             day_dd = fmax(day_dd, drawdown);
+#if PASSIVBOT_BTC_RISK_ENABLED
+            update_btc_risk_state(
+                btc_risk, effective_equity, btc_prices[k]
+            );
+#endif
             day_touched = true;
             if (!liquidated) {
                 float twe_abs = fabs(net_position_cost / account.balance);
@@ -4246,6 +4289,9 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
         daily[output + 6] = account.balance - day_start_balance;
         daily[output + 7] = account.balance;
         daily[output + 8] = fills.day_fill_count;
+#if PASSIVBOT_BTC_RISK_ENABLED
+        write_btc_risk_day(btc_risk, daily, output, 9);
+#endif
     }
 
     float long_total_size = 0.0f;
@@ -4428,6 +4474,9 @@ kernel void passivbot_ema_anchor_multicoin_fused(
     constant float* run_settings,
     constant int* sizes,
     constant int* end_steps,
+#if PASSIVBOT_BTC_RISK_ENABLED
+    constant float* btc_prices,
+#endif
     device float* daily,
     device float* scalars,
     device int* gap_hist,
@@ -4441,6 +4490,9 @@ kernel void passivbot_ema_anchor_multicoin_fused(
         bars, fill_ticks, touch_ticks, hour_log_ranges, coin_settings,
         long_coin_overrides, short_coin_overrides,
         params, run_settings, sizes, end_steps,
+#if PASSIVBOT_BTC_RISK_ENABLED
+        btc_prices,
+#endif
         daily, scalars, gap_hist, coin_fill_counts,
 #ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
         recovery_samples,
@@ -4460,6 +4512,9 @@ kernel void passivbot_ema_anchor_multicoin(
     constant float* run_settings,
     constant int* sizes,
     constant int* end_steps,
+#if PASSIVBOT_BTC_RISK_ENABLED
+    constant float* btc_prices,
+#endif
     device float* daily,
     device float* scalars,
     device int* gap_hist,
@@ -4473,7 +4528,11 @@ kernel void passivbot_ema_anchor_multicoin(
     passivbot_ema_anchor_multicoin_impl(
         bars, fill_ticks, touch_ticks, hour_log_ranges,
         coin_settings, coin_overrides, params, run_settings,
-        sizes, end_steps, daily, scalars, gap_hist, coin_fill_counts,
+        sizes, end_steps,
+#if PASSIVBOT_BTC_RISK_ENABLED
+        btc_prices,
+#endif
+        daily, scalars, gap_hist, coin_fill_counts,
 #ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
         recovery_samples,
 #endif
@@ -4492,6 +4551,9 @@ kernel void passivbot_ema_anchor_multicoin_long(
     constant float* run_settings,
     constant int* sizes,
     constant int* end_steps,
+#if PASSIVBOT_BTC_RISK_ENABLED
+    constant float* btc_prices,
+#endif
     device float* daily,
     device float* scalars,
     device int* gap_hist,
@@ -4504,7 +4566,11 @@ kernel void passivbot_ema_anchor_multicoin_long(
     passivbot_ema_anchor_multicoin_impl(
         bars, fill_ticks, touch_ticks, hour_log_ranges,
         coin_settings, coin_overrides, params, run_settings,
-        sizes, end_steps, daily, scalars, gap_hist, coin_fill_counts,
+        sizes, end_steps,
+#if PASSIVBOT_BTC_RISK_ENABLED
+        btc_prices,
+#endif
+        daily, scalars, gap_hist, coin_fill_counts,
 #ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
         recovery_samples,
 #endif

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -1,7 +1,11 @@
 #include <metal_stdlib>
 using namespace metal;
 
+#if PASSIVBOT_BTC_RISK_ENABLED
+constant int DAILY_COLS = 11;
+#else
 constant int DAILY_COLS = 8;
+#endif
 #if PASSIVBOT_HSL_RAW_TAIL_ENABLED
 constant int SCALAR_COLS = 72;
 #elif PASSIVBOT_HSL_RAW_DRAWDOWN_ENABLED
@@ -194,6 +198,8 @@ inline bool realized_loss_proxy_allows_reducer(
 }
 
 // PASSIVBOT_HSL_COMMON
+
+// PASSIVBOT_BTC_RISK_COMMON
 
 inline void record_realized_net(
     float net_pnl,
@@ -1715,6 +1721,9 @@ inline void passivbot_single_coin_impl(
     constant float* params,
     constant float* settings,
     constant int* sizes,
+#if PASSIVBOT_BTC_RISK_ENABLED
+    constant float* btc_prices,
+#endif
     device float* daily,
     device float* scalars,
     device int* gap_hist,
@@ -1846,6 +1855,9 @@ inline void passivbot_single_coin_impl(
     float first_eq_k = -1.0f;
     float last_eq_k = -1.0f;
     bool eq_started = false;
+#if PASSIVBOT_BTC_RISK_ENABLED
+    BtcRiskState btc_risk = init_btc_risk_state();
+#endif
 #ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
     int recovery_start_k = -1;
 #endif
@@ -1905,6 +1917,9 @@ inline void passivbot_single_coin_impl(
                 daily[o + 5] = balance - day_start_balance;
                 daily[o + 6] = balance;
                 daily[o + 7] = day_fill_count;
+#if PASSIVBOT_BTC_RISK_ENABLED
+                write_btc_risk_day(btc_risk, daily, o, 8);
+#endif
             }
             cur_day = di;
             day_touched = false;
@@ -1915,6 +1930,9 @@ inline void passivbot_single_coin_impl(
             day_has_fill = 0.0f;
             day_start_balance = balance;
             day_fill_count = 0.0f;
+#if PASSIVBOT_BTC_RISK_ENABLED
+            reset_btc_risk_day(btc_risk);
+#endif
         }
 
         bool long_close_fill = false;
@@ -3933,6 +3951,9 @@ inline void passivbot_single_coin_impl(
             day_end = eqf;
             day_min = fmin(day_min, eqf);
             day_dd = fmax(day_dd, dd);
+#if PASSIVBOT_BTC_RISK_ENABLED
+            update_btc_risk_state(btc_risk, eqf, btc_prices[k]);
+#endif
             day_touched = true;
             if (!liq) {
                 float twe_net = (
@@ -3965,6 +3986,9 @@ inline void passivbot_single_coin_impl(
         daily[o + 5] = balance - day_start_balance;
         daily[o + 6] = balance;
         daily[o + 7] = day_fill_count;
+#if PASSIVBOT_BTC_RISK_ENABLED
+        write_btc_risk_day(btc_risk, daily, o, 8);
+#endif
     }
 
     if (long_side.pos_open_k >= 0.0f && last_eq_k >= 0.0f) {
@@ -4131,6 +4155,9 @@ kernel void passivbot_trailing_martingale(
     constant float* params,
     constant float* settings,
     constant int* sizes,
+#if PASSIVBOT_BTC_RISK_ENABLED
+    constant float* btc_prices,
+#endif
     device float* daily,
     device float* scalars,
     device int* gap_hist,
@@ -4142,7 +4169,11 @@ kernel void passivbot_trailing_martingale(
     uint b [[thread_position_in_grid]]
 ) {
     passivbot_single_coin_impl(
-        bars, flags, params, settings, sizes, daily, scalars, gap_hist,
+        bars, flags, params, settings, sizes,
+#if PASSIVBOT_BTC_RISK_ENABLED
+        btc_prices,
+#endif
+        daily, scalars, gap_hist,
         rolling_pnl_values, rolling_pnl_indices,
 #ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
         recovery_samples,

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
@@ -9,7 +9,11 @@ constant int GATE_INITIAL_OVERRIDE_COL = 44;
 constant int GATE_REENTRY_OVERRIDE_COL = 45;
 constant int FORCED_ACTIVE_OVERRIDE_COL = 46;
 constant int COIN_COLS = 13;
+#if PASSIVBOT_BTC_RISK_ENABLED
+constant int DAILY_COLS = 12;
+#else
 constant int DAILY_COLS = 9;
+#endif
 #if PASSIVBOT_HSL_RAW_TAIL_ENABLED
 constant int SCALAR_COLS = 67;
 constant int FUSED_SCALAR_COLS = 72;
@@ -29,6 +33,8 @@ constant float RECOVERY_FAIL_CLOSED_SENTINEL = -3.402823466e+38f;
 #endif
 
 // PASSIVBOT_HSL_COMMON
+
+// PASSIVBOT_BTC_RISK_COMMON
 
 // PASSIVBOT_MULTICOIN_COMMON
 
@@ -4774,6 +4780,9 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
     constant float* run_settings,
     constant int* sizes,
     constant int* end_steps,
+#if PASSIVBOT_BTC_RISK_ENABLED
+    constant float* btc_prices,
+#endif
     device float* daily,
     device float* scalars,
     device int* gap_hist,
@@ -4894,6 +4903,9 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
     float account_recovery_max_min = 0.0f;
     float first_eq_k = -1.0f;
     float last_eq_k = -1.0f;
+#if PASSIVBOT_BTC_RISK_ENABLED
+    BtcRiskState btc_risk = init_btc_risk_state();
+#endif
 #ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
     int recovery_start_k = -1;
 #endif
@@ -4928,6 +4940,9 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
                 daily[output + 6] = account.balance - day_start_balance;
                 daily[output + 7] = account.balance;
                 daily[output + 8] = fills.day_fill_count;
+#if PASSIVBOT_BTC_RISK_ENABLED
+                write_btc_risk_day(btc_risk, daily, output, 9);
+#endif
             }
             current_day = day_index;
             day_touched = false;
@@ -4939,6 +4954,9 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
             day_min_balance = INFINITY;
             day_start_balance = account.balance;
             fills.day_fill_count = 0.0f;
+#if PASSIVBOT_BTC_RISK_ENABLED
+            reset_btc_risk_day(btc_risk);
+#endif
         }
 
         float long_hsl_equity_before_fills = account.balance;
@@ -5356,6 +5374,11 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
             day_min = fmin(day_min, effective_equity);
             day_min_balance = fmin(day_min_balance, account.balance);
             day_dd = fmax(day_dd, drawdown);
+#if PASSIVBOT_BTC_RISK_ENABLED
+            update_btc_risk_state(
+                btc_risk, effective_equity, btc_prices[k]
+            );
+#endif
             day_touched = true;
             if (!liquidated) {
                 float twe_abs = fabs(net_position_cost / account.balance);
@@ -5385,6 +5408,9 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
         daily[output + 6] = account.balance - day_start_balance;
         daily[output + 7] = account.balance;
         daily[output + 8] = fills.day_fill_count;
+#if PASSIVBOT_BTC_RISK_ENABLED
+        write_btc_risk_day(btc_risk, daily, output, 9);
+#endif
     }
 
     float long_total_size = 0.0f;
@@ -5570,6 +5596,9 @@ kernel void passivbot_trailing_martingale_multicoin_fused(
     constant float* run_settings,
     constant int* sizes,
     constant int* end_steps,
+#if PASSIVBOT_BTC_RISK_ENABLED
+    constant float* btc_prices,
+#endif
     device float* daily,
     device float* scalars,
     device int* gap_hist,
@@ -5585,6 +5614,9 @@ kernel void passivbot_trailing_martingale_multicoin_fused(
         hour_log_ranges, coin_settings,
         long_coin_overrides, short_coin_overrides,
         params, run_settings, sizes, end_steps,
+#if PASSIVBOT_BTC_RISK_ENABLED
+        btc_prices,
+#endif
         daily, scalars, gap_hist, coin_fill_counts,
 #ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
         recovery_samples,
@@ -5607,6 +5639,9 @@ inline void passivbot_trailing_martingale_multicoin_impl(
     constant float* run_settings,
     constant int* sizes,
     constant int* end_steps,
+#if PASSIVBOT_BTC_RISK_ENABLED
+    constant float* btc_prices,
+#endif
     device float* daily,
     device float* scalars,
     device int* gap_hist,
@@ -5718,6 +5753,9 @@ inline void passivbot_trailing_martingale_multicoin_impl(
     float account_recovery_max_min = 0.0f;
     float first_eq_k = -1.0f;
     float last_eq_k = -1.0f;
+#if PASSIVBOT_BTC_RISK_ENABLED
+    BtcRiskState btc_risk = init_btc_risk_state();
+#endif
 #ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
     int recovery_start_k = -1;
 #endif
@@ -5754,6 +5792,9 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                 daily[output + 6] = balance - day_start_balance;
                 daily[output + 7] = balance;
                 daily[output + 8] = day_fill_count;
+#if PASSIVBOT_BTC_RISK_ENABLED
+                write_btc_risk_day(btc_risk, daily, output, 9);
+#endif
             }
             current_day = day_index;
             day_touched = false;
@@ -5765,6 +5806,9 @@ inline void passivbot_trailing_martingale_multicoin_impl(
             day_min_balance = INFINITY;
             day_start_balance = balance;
             day_fill_count = 0.0f;
+#if PASSIVBOT_BTC_RISK_ENABLED
+            reset_btc_risk_day(btc_risk);
+#endif
         }
 
         float hsl_equity_before_fills =
@@ -6071,6 +6115,11 @@ inline void passivbot_trailing_martingale_multicoin_impl(
             day_min = fmin(day_min, effective_equity);
             day_min_balance = fmin(day_min_balance, balance);
             day_dd = fmax(day_dd, drawdown);
+#if PASSIVBOT_BTC_RISK_ENABLED
+            update_btc_risk_state(
+                btc_risk, effective_equity, btc_prices[k]
+            );
+#endif
             day_touched = true;
             if (!liquidated) {
                 float twe_abs = position_cost / balance;
@@ -6100,6 +6149,9 @@ inline void passivbot_trailing_martingale_multicoin_impl(
         daily[output + 6] = balance - day_start_balance;
         daily[output + 7] = balance;
         daily[output + 8] = day_fill_count;
+#if PASSIVBOT_BTC_RISK_ENABLED
+        write_btc_risk_day(btc_risk, daily, output, 9);
+#endif
     }
 
     float total_size = 0.0f;
@@ -6242,6 +6294,9 @@ kernel void passivbot_trailing_martingale_multicoin(
     constant float* run_settings,
     constant int* sizes,
     constant int* end_steps,
+#if PASSIVBOT_BTC_RISK_ENABLED
+    constant float* btc_prices,
+#endif
     device float* daily,
     device float* scalars,
     device int* gap_hist,
@@ -6257,7 +6312,11 @@ kernel void passivbot_trailing_martingale_multicoin(
         touch_min_qty_bits, touch_min_qty_relation,
         hour_log_ranges, coin_settings,
         coin_overrides, params, run_settings,
-        sizes, end_steps, daily, scalars, gap_hist, coin_fill_counts,
+        sizes, end_steps,
+#if PASSIVBOT_BTC_RISK_ENABLED
+        btc_prices,
+#endif
+        daily, scalars, gap_hist, coin_fill_counts,
 #ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
         recovery_samples,
 #endif
@@ -6279,6 +6338,9 @@ kernel void passivbot_trailing_martingale_multicoin_long(
     constant float* run_settings,
     constant int* sizes,
     constant int* end_steps,
+#if PASSIVBOT_BTC_RISK_ENABLED
+    constant float* btc_prices,
+#endif
     device float* daily,
     device float* scalars,
     device int* gap_hist,
@@ -6293,7 +6355,11 @@ kernel void passivbot_trailing_martingale_multicoin_long(
         touch_min_qty_bits, touch_min_qty_relation,
         hour_log_ranges, coin_settings,
         coin_overrides, params, run_settings,
-        sizes, end_steps, daily, scalars, gap_hist, coin_fill_counts,
+        sizes, end_steps,
+#if PASSIVBOT_BTC_RISK_ENABLED
+        btc_prices,
+#endif
+        daily, scalars, gap_hist, coin_fill_counts,
 #ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
         recovery_samples,
 #endif

--- a/src/optimization/gpu/metrics.py
+++ b/src/optimization/gpu/metrics.py
@@ -68,7 +68,6 @@ _BTC_ACCOUNT_METRICS = {
 BTC_INTRADAY_RISK_METRICS = frozenset(
     {
         "calmar_ratio_btc",
-        "calmar_ratio_w_btc",
         "drawdown_worst_btc",
         "drawdown_worst_mean_1pct_btc",
         "expected_shortfall_1pct_btc",
@@ -77,7 +76,6 @@ BTC_INTRADAY_RISK_METRICS = frozenset(
         "sortino_ratio_btc",
         "sortino_ratio_w_btc",
         "sterling_ratio_btc",
-        "sterling_ratio_w_btc",
     }
 )
 
@@ -1730,10 +1728,8 @@ def _btc_account_metrics(out: dict, run, data: dict, requested) -> dict:
         "omega_ratio_w_btc": "omega_ratio_strategy_eq_w",
     }
     risk_weighted_sources = {
-        "calmar_ratio_w_btc": "calmar_ratio_strategy_eq_w",
         "sharpe_ratio_w_btc": "sharpe_ratio_strategy_eq_w",
         "sortino_ratio_w_btc": "sortino_ratio_strategy_eq_w",
-        "sterling_ratio_w_btc": "sterling_ratio_strategy_eq_w",
     }
     wanted_safe_weighted_sources = {
         source

--- a/src/optimization/gpu/metrics.py
+++ b/src/optimization/gpu/metrics.py
@@ -65,6 +65,24 @@ _BTC_ACCOUNT_METRICS = {
     "peak_recovery_hours_equity_btc",
 }
 
+BTC_INTRADAY_RISK_METRICS = frozenset(
+    {
+        "calmar_ratio_btc",
+        "calmar_ratio_w_btc",
+        "drawdown_worst_btc",
+        "drawdown_worst_mean_1pct_btc",
+        "expected_shortfall_1pct_btc",
+        "sharpe_ratio_btc",
+        "sharpe_ratio_w_btc",
+        "sortino_ratio_btc",
+        "sortino_ratio_w_btc",
+        "sterling_ratio_btc",
+        "sterling_ratio_w_btc",
+    }
+)
+
+_BTC_ACCOUNT_METRICS.update(BTC_INTRADAY_RISK_METRICS)
+
 _BTC_PER_EXPOSURE_METRICS = {
     f"{metric}_per_exposure_{side}_btc"
     for metric in ("adg", "adg_w", "gain", "mdg", "mdg_w")
@@ -1553,26 +1571,39 @@ def _daily_peak_recovery_ms(day_end_eq, active):
 def _btc_account_metrics(out: dict, run, data: dict, requested) -> dict:
     """Reduce the compact USD strategy-equity surface into BTC account metrics.
 
-    Day-end conversion is exact for the prepared BTC series. Metrics requiring
-    synchronized intraday BTC equity remain outside this surface; exact Rust
-    validation stays authoritative for the daily screening approximations.
+    Close-only metrics convert the compact USD surface at prepared BTC day-end
+    prices. Intraday-risk metrics consume the synchronized BTC surface emitted
+    by the opt-in Metal feature. Exact Rust validation remains authoritative.
     """
 
     requested = set(requested) & BTC_ACCOUNT_METRICS
     if not requested:
         return {}
+    day_end_usd = out["day_end_eq"].to(torch.float64)
+    active = _daily_series_masks(out["day_min_eq"])
+    risk_requested = bool(requested & BTC_INTRADAY_RISK_METRICS)
+    if risk_requested:
+        missing = [
+            key
+            for key in ("btc_day_end_eq", "btc_day_min_eq", "btc_day_max_dd")
+            if key not in out
+        ]
+        if missing:
+            raise RuntimeError(
+                "MPS synchronized BTC-risk output is missing "
+                + ", ".join(missing)
+            )
+        risk_day_end_btc = out["btc_day_end_eq"].to(torch.float64)
+        risk_day_min_btc = out["btc_day_min_eq"].to(torch.float64)
+        risk_day_max_dd_btc = out["btc_day_max_dd"].to(torch.float64)
+
     missing = [
-        key
-        for key in ("btc_day_end_price", "btc_prices")
-        if key not in data
+        key for key in ("btc_day_end_price", "btc_prices") if key not in data
     ]
     if missing:
         raise RuntimeError(
             "MPS BTC account metric context is missing " + ", ".join(missing)
         )
-
-    day_end_usd = out["day_end_eq"].to(torch.float64)
-    active = _daily_series_masks(out["day_min_eq"])
     day_end_price = torch.as_tensor(
         data["btc_day_end_price"],
         dtype=torch.float64,
@@ -1582,10 +1613,7 @@ def _btc_account_metrics(out: dict, run, data: dict, requested) -> dict:
         raise RuntimeError(
             "MPS BTC account metric day grid disagrees with Metal output"
         )
-    # A liquidated candidate may stop before the prepared UTC day ends. Rust
-    # values its final equity with BTC at that exact sample, not the later
-    # dataset day close. Replace only that candidate's final active-day price;
-    # complete days keep the precomputed shared day-end series.
+    # A liquidated candidate may stop before the prepared UTC day ends.
     btc_prices = torch.as_tensor(
         data["btc_prices"],
         dtype=torch.float64,
@@ -1646,8 +1674,38 @@ def _btc_account_metrics(out: dict, run, data: dict, requested) -> dict:
         "mdg_btc": mdg,
         "omega_ratio_btc": omega,
     }
+    if risk_requested:
+        _risk_gain, risk_adg = _smoothed_gain_adg(risk_day_end_btc, active)
+        min_changes, min_change_mask = _pct_change(risk_day_min_btc, active)
+        sharpe, sortino = _sharpe_sortino(
+            min_changes, min_change_mask, risk_adg
+        )
+        expected_shortfall = _mean_worst_one_pct_abs(
+            min_changes, min_change_mask
+        )
+        max_dd = risk_day_max_dd_btc.max(dim=1).values
+        worst_one_pct = _mean_worst_one_pct_largest(
+            risk_day_max_dd_btc, active
+        )
+        values.update(
+            {
+                "calmar_ratio_btc": risk_adg / max_dd.clamp(min=1e-12),
+                "drawdown_worst_btc": max_dd,
+                "drawdown_worst_mean_1pct_btc": worst_one_pct,
+                "expected_shortfall_1pct_btc": expected_shortfall,
+                "sharpe_ratio_btc": sharpe,
+                "sortino_ratio_btc": sortino,
+                "sterling_ratio_btc": risk_adg
+                / worst_one_pct.clamp(min=1e-12),
+            }
+        )
+    drawdown_defaults = {
+        "drawdown_worst_btc",
+        "drawdown_worst_mean_1pct_btc",
+    }
     for name in tuple(values):
-        values[name] = torch.where(has_fill, values[name], zeros)
+        default = torch.ones_like(adg) if name in drawdown_defaults else zeros
+        values[name] = torch.where(has_fill, values[name], default)
 
     shape_names = {
         "equity_choppiness_btc",
@@ -1666,26 +1724,35 @@ def _btc_account_metrics(out: dict, run, data: dict, requested) -> dict:
                 has_fill, shape[source], torch.ones_like(adg)
             )
 
-    weighted_sources = {
+    safe_weighted_sources = {
         "adg_w_btc": "adg_strategy_eq_w",
         "mdg_w_btc": "mdg_strategy_eq_w",
         "omega_ratio_w_btc": "omega_ratio_strategy_eq_w",
     }
-    wanted_weighted_sources = {
-        source for name, source in weighted_sources.items() if name in requested
+    risk_weighted_sources = {
+        "calmar_ratio_w_btc": "calmar_ratio_strategy_eq_w",
+        "sharpe_ratio_w_btc": "sharpe_ratio_strategy_eq_w",
+        "sortino_ratio_w_btc": "sortino_ratio_strategy_eq_w",
+        "sterling_ratio_w_btc": "sterling_ratio_strategy_eq_w",
+    }
+    wanted_safe_weighted_sources = {
+        source
+        for name, source in safe_weighted_sources.items()
+        if name in requested
     }
     if requested & {
         "adg_w_per_exposure_long_btc",
         "adg_w_per_exposure_short_btc",
     }:
-        wanted_weighted_sources.add("adg_strategy_eq_w")
+        wanted_safe_weighted_sources.add("adg_strategy_eq_w")
     if requested & {
         "mdg_w_per_exposure_long_btc",
         "mdg_w_per_exposure_short_btc",
     }:
-        wanted_weighted_sources.add("mdg_strategy_eq_w")
-    if wanted_weighted_sources:
-        weighted = _weighted_strategy_eq_metrics(
+        wanted_safe_weighted_sources.add("mdg_strategy_eq_w")
+    enough_fills = out["fill_count"].to(torch.float64) > 1.0
+    if wanted_safe_weighted_sources:
+        safe_weighted = _weighted_strategy_eq_metrics(
             day_end_btc,
             day_end_btc,
             torch.zeros_like(day_end_btc),
@@ -1694,12 +1761,35 @@ def _btc_account_metrics(out: dict, run, data: dict, requested) -> dict:
             out["last_eq_ts"],
             data["ts0"],
             run.interval_ms,
-            wanted_weighted_sources,
+            wanted_safe_weighted_sources,
         )
-        enough_fills = out["fill_count"].to(torch.float64) > 1.0
-        for name, source in weighted_sources.items():
-            if source in weighted:
-                values[name] = torch.where(enough_fills, weighted[source], zeros)
+        for name, source in safe_weighted_sources.items():
+            if source in safe_weighted:
+                values[name] = torch.where(
+                    enough_fills, safe_weighted[source], zeros
+                )
+    wanted_risk_weighted_sources = {
+        source
+        for name, source in risk_weighted_sources.items()
+        if name in requested
+    }
+    if wanted_risk_weighted_sources:
+        risk_weighted = _weighted_strategy_eq_metrics(
+            risk_day_end_btc,
+            risk_day_min_btc,
+            risk_day_max_dd_btc,
+            active,
+            out["first_eq_ts"],
+            out["last_eq_ts"],
+            data["ts0"],
+            run.interval_ms,
+            wanted_risk_weighted_sources,
+        )
+        for name, source in risk_weighted_sources.items():
+            if source in risk_weighted:
+                values[name] = torch.where(
+                    enough_fills, risk_weighted[source], zeros
+                )
 
     weighted_shape_sources = {
         "equity_choppiness_w_btc": "equity_choppiness_w_usd",

--- a/src/optimization/gpu/metrics.py
+++ b/src/optimization/gpu/metrics.py
@@ -72,9 +72,7 @@ BTC_INTRADAY_RISK_METRICS = frozenset(
         "drawdown_worst_mean_1pct_btc",
         "expected_shortfall_1pct_btc",
         "sharpe_ratio_btc",
-        "sharpe_ratio_w_btc",
         "sortino_ratio_btc",
-        "sortino_ratio_w_btc",
         "sterling_ratio_btc",
     }
 )
@@ -1727,10 +1725,6 @@ def _btc_account_metrics(out: dict, run, data: dict, requested) -> dict:
         "mdg_w_btc": "mdg_strategy_eq_w",
         "omega_ratio_w_btc": "omega_ratio_strategy_eq_w",
     }
-    risk_weighted_sources = {
-        "sharpe_ratio_w_btc": "sharpe_ratio_strategy_eq_w",
-        "sortino_ratio_w_btc": "sortino_ratio_strategy_eq_w",
-    }
     wanted_safe_weighted_sources = {
         source
         for name, source in safe_weighted_sources.items()
@@ -1764,29 +1758,6 @@ def _btc_account_metrics(out: dict, run, data: dict, requested) -> dict:
                 values[name] = torch.where(
                     enough_fills, safe_weighted[source], zeros
                 )
-    wanted_risk_weighted_sources = {
-        source
-        for name, source in risk_weighted_sources.items()
-        if name in requested
-    }
-    if wanted_risk_weighted_sources:
-        risk_weighted = _weighted_strategy_eq_metrics(
-            risk_day_end_btc,
-            risk_day_min_btc,
-            risk_day_max_dd_btc,
-            active,
-            out["first_eq_ts"],
-            out["last_eq_ts"],
-            data["ts0"],
-            run.interval_ms,
-            wanted_risk_weighted_sources,
-        )
-        for name, source in risk_weighted_sources.items():
-            if source in risk_weighted:
-                values[name] = torch.where(
-                    enough_fills, risk_weighted[source], zeros
-                )
-
     weighted_shape_sources = {
         "equity_choppiness_w_btc": "equity_choppiness_w_usd",
         "equity_jerkiness_w_btc": "equity_jerkiness_w_usd",

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -54,6 +54,7 @@ _RECOVERY_DISTRIBUTION_DEFINE = (
 _FIXED_WEL_DENOMINATOR_DEFINE = (
     "#define PASSIVBOT_DYNAMIC_WEL_BY_TRADABILITY 0\n"
 )
+_BTC_RISK_DEFINE = "#define PASSIVBOT_BTC_RISK_ENABLED 1\n"
 
 
 def _with_hsl_ema_tail(source: str, enabled: bool) -> str:
@@ -105,6 +106,14 @@ def _with_dynamic_wel_by_tradability(source: str, enabled: bool) -> str:
     return _FIXED_WEL_DENOMINATOR_DEFINE + source
 
 
+def _with_btc_risk(source: str, enabled: bool) -> str:
+    if not enabled:
+        return source
+    if "struct BtcRiskState" not in source:
+        raise RuntimeError("MPS source is missing the shared BTC-risk contract")
+    return _BTC_RISK_DEFINE + source
+
+
 def _encode_max_realized_loss_pct(value: float) -> float:
     """Encode a float64 loss fraction without loosening its Metal budget."""
 
@@ -114,6 +123,24 @@ def _encode_max_realized_loss_pct(value: float) -> float:
     if float(encoded) > value:
         encoded = np.nextafter(encoded, np.float32(-np.inf))
     return float(encoded)
+
+
+def _btc_risk_price_tensor(btc_prices, *, expected_count: int):
+    if btc_prices is None:
+        return None
+    values = np.ascontiguousarray(
+        np.asarray(btc_prices, dtype=np.float32).reshape(-1)
+    )
+    if len(values) != int(expected_count):
+        raise ValueError(
+            "MPS BTC-risk prices must match the prepared candle count: "
+            f"btc={len(values)}, candles={expected_count}"
+        )
+    if np.any(~np.isfinite(values)) or np.any(values <= 0.0):
+        raise ValueError(
+            "MPS BTC-risk prices must remain finite and positive after float32 packing"
+        )
+    return torch.as_tensor(values, dtype=torch.float32, device="mps")
 
 
 def _pack_tm_parameter_matrix(
@@ -334,138 +361,176 @@ def _scalar_column_or_zero(scalars, index: int):
     return torch.zeros_like(scalars[:, 0])
 
 
-@lru_cache(maxsize=8)
+def _decode_btc_risk_outputs(daily, active_days, first_column: int) -> dict:
+    if daily.shape[2] < first_column + 3:
+        return {}
+    return {
+        "btc_day_end_eq": daily[:, :, first_column],
+        "btc_day_min_eq": torch.where(
+            active_days,
+            daily[:, :, first_column + 1],
+            torch.full_like(daily[:, :, first_column + 1], float("inf")),
+        ),
+        "btc_day_max_dd": daily[:, :, first_column + 2],
+    }
+
+
+@lru_cache(maxsize=16)
 def _shader_library(
     hsl_ema_tail_enabled: bool = False,
     hsl_raw_drawdown_enabled: bool = False,
     hsl_raw_tail_enabled: bool = False,
     recovery_distribution_enabled: bool = False,
+    btc_risk_enabled: bool = False,
 ):
     if not torch.backends.mps.is_available():
         raise RuntimeError("Apple MPS is not available in this process")
     import passivbot_rust
 
     return torch.mps.compile_shader(
-        _with_recovery_distribution(
-            _with_hsl_features(
-                passivbot_rust.mps_ema_anchor_source_py(),
-                ema_tail_enabled=hsl_ema_tail_enabled,
-                raw_drawdown_enabled=hsl_raw_drawdown_enabled,
-                raw_tail_enabled=hsl_raw_tail_enabled,
+        _with_btc_risk(
+            _with_recovery_distribution(
+                _with_hsl_features(
+                    passivbot_rust.mps_ema_anchor_source_py(),
+                    ema_tail_enabled=hsl_ema_tail_enabled,
+                    raw_drawdown_enabled=hsl_raw_drawdown_enabled,
+                    raw_tail_enabled=hsl_raw_tail_enabled,
+                ),
+                recovery_distribution_enabled,
             ),
-            recovery_distribution_enabled,
-        )
-    )
-
-
-@lru_cache(maxsize=8)
-def _trailing_martingale_shader_library(
-    hsl_ema_tail_enabled: bool = False,
-    hsl_raw_drawdown_enabled: bool = False,
-    hsl_raw_tail_enabled: bool = False,
-    recovery_distribution_enabled: bool = False,
-):
-    if not torch.backends.mps.is_available():
-        raise RuntimeError("Apple MPS is not available in this process")
-    import passivbot_rust
-
-    return torch.mps.compile_shader(
-        _with_recovery_distribution(
-            _with_hsl_features(
-                passivbot_rust.mps_trailing_martingale_source_py(),
-                ema_tail_enabled=hsl_ema_tail_enabled,
-                raw_drawdown_enabled=hsl_raw_drawdown_enabled,
-                raw_tail_enabled=hsl_raw_tail_enabled,
-            ),
-            recovery_distribution_enabled,
-        )
-    )
-
-
-@lru_cache(maxsize=2)
-def _trailing_martingale_long_no_hsl_shader_library(
-    recovery_distribution_enabled: bool = False,
-):
-    if not torch.backends.mps.is_available():
-        raise RuntimeError("Apple MPS is not available in this process")
-    import passivbot_rust
-
-    return torch.mps.compile_shader(
-        _with_recovery_distribution(
-            passivbot_rust.mps_trailing_martingale_long_no_hsl_source_py(),
-            recovery_distribution_enabled,
-        )
-    )
-
-
-@lru_cache(maxsize=2)
-def _trailing_martingale_short_no_hsl_shader_library(
-    recovery_distribution_enabled: bool = False,
-):
-    if not torch.backends.mps.is_available():
-        raise RuntimeError("Apple MPS is not available in this process")
-    import passivbot_rust
-
-    return torch.mps.compile_shader(
-        _with_recovery_distribution(
-            passivbot_rust.mps_trailing_martingale_short_no_hsl_source_py(),
-            recovery_distribution_enabled,
+            btc_risk_enabled,
         )
     )
 
 
 @lru_cache(maxsize=16)
+def _trailing_martingale_shader_library(
+    hsl_ema_tail_enabled: bool = False,
+    hsl_raw_drawdown_enabled: bool = False,
+    hsl_raw_tail_enabled: bool = False,
+    recovery_distribution_enabled: bool = False,
+    btc_risk_enabled: bool = False,
+):
+    if not torch.backends.mps.is_available():
+        raise RuntimeError("Apple MPS is not available in this process")
+    import passivbot_rust
+
+    return torch.mps.compile_shader(
+        _with_btc_risk(
+            _with_recovery_distribution(
+                _with_hsl_features(
+                    passivbot_rust.mps_trailing_martingale_source_py(),
+                    ema_tail_enabled=hsl_ema_tail_enabled,
+                    raw_drawdown_enabled=hsl_raw_drawdown_enabled,
+                    raw_tail_enabled=hsl_raw_tail_enabled,
+                ),
+                recovery_distribution_enabled,
+            ),
+            btc_risk_enabled,
+        )
+    )
+
+
+@lru_cache(maxsize=4)
+def _trailing_martingale_long_no_hsl_shader_library(
+    recovery_distribution_enabled: bool = False,
+    btc_risk_enabled: bool = False,
+):
+    if not torch.backends.mps.is_available():
+        raise RuntimeError("Apple MPS is not available in this process")
+    import passivbot_rust
+
+    return torch.mps.compile_shader(
+        _with_btc_risk(
+            _with_recovery_distribution(
+                passivbot_rust.mps_trailing_martingale_long_no_hsl_source_py(),
+                recovery_distribution_enabled,
+            ),
+            btc_risk_enabled,
+        )
+    )
+
+
+@lru_cache(maxsize=4)
+def _trailing_martingale_short_no_hsl_shader_library(
+    recovery_distribution_enabled: bool = False,
+    btc_risk_enabled: bool = False,
+):
+    if not torch.backends.mps.is_available():
+        raise RuntimeError("Apple MPS is not available in this process")
+    import passivbot_rust
+
+    return torch.mps.compile_shader(
+        _with_btc_risk(
+            _with_recovery_distribution(
+                passivbot_rust.mps_trailing_martingale_short_no_hsl_source_py(),
+                recovery_distribution_enabled,
+            ),
+            btc_risk_enabled,
+        )
+    )
+
+
+@lru_cache(maxsize=32)
 def _ema_anchor_multicoin_shader_library(
     hsl_ema_tail_enabled: bool = False,
     hsl_raw_drawdown_enabled: bool = False,
     hsl_raw_tail_enabled: bool = False,
     recovery_distribution_enabled: bool = False,
     dynamic_wel_by_tradability: bool = True,
+    btc_risk_enabled: bool = False,
 ):
     if not torch.backends.mps.is_available():
         raise RuntimeError("Apple MPS is not available in this process")
     import passivbot_rust
 
     return torch.mps.compile_shader(
-        _with_dynamic_wel_by_tradability(
-            _with_recovery_distribution(
-                _with_hsl_features(
-                    passivbot_rust.mps_ema_anchor_multicoin_source_py(),
-                    ema_tail_enabled=hsl_ema_tail_enabled,
-                    raw_drawdown_enabled=hsl_raw_drawdown_enabled,
-                    raw_tail_enabled=hsl_raw_tail_enabled,
+        _with_btc_risk(
+            _with_dynamic_wel_by_tradability(
+                _with_recovery_distribution(
+                    _with_hsl_features(
+                        passivbot_rust.mps_ema_anchor_multicoin_source_py(),
+                        ema_tail_enabled=hsl_ema_tail_enabled,
+                        raw_drawdown_enabled=hsl_raw_drawdown_enabled,
+                        raw_tail_enabled=hsl_raw_tail_enabled,
+                    ),
+                    recovery_distribution_enabled,
                 ),
-                recovery_distribution_enabled,
+                dynamic_wel_by_tradability,
             ),
-            dynamic_wel_by_tradability,
+            btc_risk_enabled,
         )
     )
 
 
-@lru_cache(maxsize=16)
+@lru_cache(maxsize=32)
 def _trailing_martingale_multicoin_shader_library(
     hsl_ema_tail_enabled: bool = False,
     hsl_raw_drawdown_enabled: bool = False,
     hsl_raw_tail_enabled: bool = False,
     recovery_distribution_enabled: bool = False,
     dynamic_wel_by_tradability: bool = True,
+    btc_risk_enabled: bool = False,
 ):
     if not torch.backends.mps.is_available():
         raise RuntimeError("Apple MPS is not available in this process")
     import passivbot_rust
 
     return torch.mps.compile_shader(
-        _with_dynamic_wel_by_tradability(
-            _with_recovery_distribution(
-                _with_hsl_features(
-                    passivbot_rust.mps_trailing_martingale_multicoin_source_py(),
-                    ema_tail_enabled=hsl_ema_tail_enabled,
-                    raw_drawdown_enabled=hsl_raw_drawdown_enabled,
-                    raw_tail_enabled=hsl_raw_tail_enabled,
+        _with_btc_risk(
+            _with_dynamic_wel_by_tradability(
+                _with_recovery_distribution(
+                    _with_hsl_features(
+                        passivbot_rust.mps_trailing_martingale_multicoin_source_py(),
+                        ema_tail_enabled=hsl_ema_tail_enabled,
+                        raw_drawdown_enabled=hsl_raw_drawdown_enabled,
+                        raw_tail_enabled=hsl_raw_tail_enabled,
+                    ),
+                    recovery_distribution_enabled,
                 ),
-                recovery_distribution_enabled,
+                dynamic_wel_by_tradability,
             ),
-            dynamic_wel_by_tradability,
+            btc_risk_enabled,
         )
     )
 
@@ -553,7 +618,7 @@ def _decode_outputs(daily, scalars, gaps) -> dict:
             values >= 0.0, values, torch.full_like(values, float("nan"))
         )
 
-    return {
+    output = {
         "day_end_eq": daily[:, :, 0],
         "day_min_eq": torch.where(
             active_days,
@@ -647,6 +712,8 @@ def _decode_outputs(daily, scalars, gaps) -> dict:
             scalars, 66
         ),
     }
+    output.update(_decode_btc_risk_outputs(daily, active_days, 9))
+    return output
 
 
 def _decode_multicoin_fused_outputs(daily, scalars, gaps) -> dict:
@@ -690,7 +757,7 @@ def _decode_directional_outputs(daily, scalars, gaps) -> dict:
             values >= 0.0, values, torch.full_like(values, float("nan"))
         )
 
-    return {
+    output = {
         "day_end_eq": daily[:, :, 0],
         "day_min_eq": torch.where(
             active_days,
@@ -783,6 +850,8 @@ def _decode_directional_outputs(daily, scalars, gaps) -> dict:
             scalars, 71
         ),
     }
+    output.update(_decode_btc_risk_outputs(daily, active_days, 8))
+    return output
 
 
 class MpsEmaAnchorRunner:
@@ -810,6 +879,7 @@ class MpsEmaAnchorRunner:
         hsl_raw_drawdown_enabled: bool = False,
         hsl_raw_tail_enabled: bool = False,
         recovery_distribution_enabled: bool = False,
+        btc_prices: np.ndarray | None = None,
     ):
         self.market = market
         self.run_config = run
@@ -872,6 +942,11 @@ class MpsEmaAnchorRunner:
         )
         self.n = int(data["n"])
         self.n_days = int(data["n_days"])
+        self.btc_prices = _btc_risk_price_tensor(
+            btc_prices, expected_count=self.n
+        )
+        self.btc_risk_enabled = self.btc_prices is not None
+        self.daily_cols = MPS_DAILY_COLS + (3 if self.btc_risk_enabled else 0)
         self.recovery_stride = (
             max(1, int(np.ceil(3_600_000.0 / float(run.interval_ms))))
             if self.recovery_distribution_enabled
@@ -979,7 +1054,7 @@ class MpsEmaAnchorRunner:
             self._buffers = {
                 batch_size: (
                     torch.zeros(
-                        (batch_size, self.n_days, MPS_DAILY_COLS),
+                        (batch_size, self.n_days, self.daily_cols),
                         dtype=torch.float32,
                         device="mps",
                     ),
@@ -1089,6 +1164,7 @@ class MpsEmaAnchorRunner:
             self.hsl_raw_drawdown_enabled,
             self.hsl_raw_tail_enabled,
             self.recovery_distribution_enabled,
+            self.btc_risk_enabled,
         )
         compiled = time.perf_counter()
         if profile:
@@ -1102,6 +1178,10 @@ class MpsEmaAnchorRunner:
             params_mps,
             self.settings,
             self._sizes[sizes_key],
+        )
+        if self.btc_risk_enabled:
+            kernel_args += (self.btc_prices,)
+        kernel_args += (
             daily,
             scalars,
             gaps,
@@ -1160,6 +1240,7 @@ class MpsEmaAnchorMulticoinRunner:
         hsl_raw_tail_enabled: bool = False,
         recovery_distribution_enabled: bool = False,
         dynamic_wel_by_tradability: bool = True,
+        btc_prices: np.ndarray | None = None,
     ):
         if side not in {"long", "short"}:
             raise ValueError(
@@ -1211,6 +1292,13 @@ class MpsEmaAnchorMulticoinRunner:
         self.n = int(data["n"])
         self.n_coins = int(data["n_coins"])
         self.n_days = int(data["n_days"])
+        self.btc_prices = _btc_risk_price_tensor(
+            btc_prices, expected_count=self.n
+        )
+        self.btc_risk_enabled = self.btc_prices is not None
+        self.daily_cols = MPS_MULTICOIN_DAILY_COLS + (
+            3 if self.btc_risk_enabled else 0
+        )
         self.recovery_stride = (
             max(1, int(np.ceil(3_600_000.0 / float(run.interval_ms))))
             if self.recovery_distribution_enabled
@@ -1342,7 +1430,7 @@ class MpsEmaAnchorMulticoinRunner:
             self._buffers = {
                 batch_size: (
                     torch.zeros(
-                        (batch_size, self.n_days, MPS_MULTICOIN_DAILY_COLS),
+                        (batch_size, self.n_days, self.daily_cols),
                         dtype=torch.float32,
                         device="mps",
                     ),
@@ -1412,6 +1500,10 @@ class MpsEmaAnchorMulticoinRunner:
             self.settings,
             sizes,
             end_steps,
+        )
+        if self.btc_risk_enabled:
+            kernel_args += (self.btc_prices,)
+        kernel_args += (
             daily,
             scalars,
             gaps,
@@ -1431,6 +1523,7 @@ class MpsEmaAnchorMulticoinRunner:
             self.hsl_raw_tail_enabled,
             self.recovery_distribution_enabled,
             self.dynamic_wel_by_tradability,
+            self.btc_risk_enabled,
         )
 
     def _decode(self, daily, scalars, gaps) -> dict:
@@ -1556,6 +1649,7 @@ class MpsEmaAnchorMulticoinFusedRunner(MpsEmaAnchorMulticoinRunner):
         recovery_distribution_enabled: bool = False,
         hedge_mode: bool = True,
         dynamic_wel_by_tradability: bool = True,
+        btc_prices: np.ndarray | None = None,
     ):
         super().__init__(
             run,
@@ -1575,6 +1669,7 @@ class MpsEmaAnchorMulticoinFusedRunner(MpsEmaAnchorMulticoinRunner):
             hsl_raw_tail_enabled=hsl_raw_tail_enabled,
             recovery_distribution_enabled=recovery_distribution_enabled,
             dynamic_wel_by_tradability=dynamic_wel_by_tradability,
+            btc_prices=btc_prices,
         )
         if short_coin_overrides is None:
             short_coin_overrides = np.full(
@@ -1668,6 +1763,10 @@ class MpsEmaAnchorMulticoinFusedRunner(MpsEmaAnchorMulticoinRunner):
             self.settings,
             sizes,
             end_steps,
+        )
+        if self.btc_risk_enabled:
+            kernel_args += (self.btc_prices,)
+        kernel_args += (
             daily,
             scalars,
             gaps,
@@ -1693,12 +1792,14 @@ class MpsEmaAnchorMulticoinLongRunner(MpsEmaAnchorMulticoinRunner):
         data: dict,
         *,
         dynamic_wel_by_tradability: bool = True,
+        btc_prices: np.ndarray | None = None,
     ):
         super().__init__(
             run,
             data,
             side="long",
             dynamic_wel_by_tradability=dynamic_wel_by_tradability,
+            btc_prices=btc_prices,
         )
 
 
@@ -1711,12 +1812,14 @@ class MpsEmaAnchorMulticoinShortRunner(MpsEmaAnchorMulticoinRunner):
         data: dict,
         *,
         dynamic_wel_by_tradability: bool = True,
+        btc_prices: np.ndarray | None = None,
     ):
         super().__init__(
             run,
             data,
             side="short",
             dynamic_wel_by_tradability=dynamic_wel_by_tradability,
+            btc_prices=btc_prices,
         )
 
 
@@ -1750,6 +1853,7 @@ class MpsTrailingMartingaleMulticoinRunner(MpsEmaAnchorMulticoinRunner):
         hsl_raw_tail_enabled: bool = False,
         recovery_distribution_enabled: bool = False,
         dynamic_wel_by_tradability: bool = True,
+        btc_prices: np.ndarray | None = None,
     ):
         super().__init__(
             run,
@@ -1769,6 +1873,7 @@ class MpsTrailingMartingaleMulticoinRunner(MpsEmaAnchorMulticoinRunner):
             hsl_raw_tail_enabled=hsl_raw_tail_enabled,
             recovery_distribution_enabled=recovery_distribution_enabled,
             dynamic_wel_by_tradability=dynamic_wel_by_tradability,
+            btc_prices=btc_prices,
         )
 
     def _pack_params(self, params: np.ndarray) -> np.ndarray:
@@ -1796,6 +1901,7 @@ class MpsTrailingMartingaleMulticoinRunner(MpsEmaAnchorMulticoinRunner):
             self.hsl_raw_tail_enabled,
             self.recovery_distribution_enabled,
             self.dynamic_wel_by_tradability,
+            self.btc_risk_enabled,
         )
 
     def _dispatch(
@@ -1826,6 +1932,10 @@ class MpsTrailingMartingaleMulticoinRunner(MpsEmaAnchorMulticoinRunner):
             self.settings,
             sizes,
             end_steps,
+        )
+        if self.btc_risk_enabled:
+            kernel_args += (self.btc_prices,)
+        kernel_args += (
             daily,
             scalars,
             gaps,
@@ -1871,6 +1981,7 @@ class MpsTrailingMartingaleMulticoinFusedRunner(
         recovery_distribution_enabled: bool = False,
         hedge_mode: bool = True,
         dynamic_wel_by_tradability: bool = True,
+        btc_prices: np.ndarray | None = None,
     ):
         super().__init__(
             run,
@@ -1890,6 +2001,7 @@ class MpsTrailingMartingaleMulticoinFusedRunner(
             hsl_raw_tail_enabled=hsl_raw_tail_enabled,
             recovery_distribution_enabled=recovery_distribution_enabled,
             dynamic_wel_by_tradability=dynamic_wel_by_tradability,
+            btc_prices=btc_prices,
         )
         if short_coin_overrides is None:
             short_coin_overrides = np.full(
@@ -1981,6 +2093,10 @@ class MpsTrailingMartingaleMulticoinFusedRunner(
             self.settings,
             sizes,
             end_steps,
+        )
+        if self.btc_risk_enabled:
+            kernel_args += (self.btc_prices,)
+        kernel_args += (
             daily,
             scalars,
             gaps,
@@ -2018,17 +2134,20 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
     def _shader_library(self):
         if self.shader_topology == "long_no_hsl":
             return _trailing_martingale_long_no_hsl_shader_library(
-                self.recovery_distribution_enabled
+                self.recovery_distribution_enabled,
+                self.btc_risk_enabled,
             )
         if self.shader_topology == "short_no_hsl":
             return _trailing_martingale_short_no_hsl_shader_library(
-                self.recovery_distribution_enabled
+                self.recovery_distribution_enabled,
+                self.btc_risk_enabled,
             )
         return _trailing_martingale_shader_library(
             self.hsl_ema_tail_enabled,
             self.hsl_raw_drawdown_enabled,
             self.hsl_raw_tail_enabled,
             self.recovery_distribution_enabled,
+            self.btc_risk_enabled,
         )
 
     def _pack_params(self, params: np.ndarray) -> np.ndarray:
@@ -2092,6 +2211,10 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
             params_mps,
             self.settings,
             self._sizes[sizes_key],
+        )
+        if self.btc_risk_enabled:
+            kernel_args += (self.btc_prices,)
+        kernel_args += (
             daily,
             scalars,
             gaps,

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -51,6 +51,9 @@ from optimization.gpu.model import (
 
 
 CORE_OUTPUT_KEYS = {
+    "btc_day_end_eq",
+    "btc_day_min_eq",
+    "btc_day_max_dd",
     "day_end_eq",
     "day_min_eq",
     "day_max_dd",
@@ -1326,7 +1329,10 @@ class MpsSingleCoinProxy:
             )
 
         from backtest import build_backtest_payload
-        from optimization.gpu.metrics import compute_objectives
+        from optimization.gpu.metrics import (
+            BTC_INTRADAY_RISK_METRICS,
+            compute_objectives,
+        )
         from optimization.gpu.mps_kernel import (
             MpsEmaAnchorRunner,
             MpsTrailingMartingaleRunner,
@@ -1337,6 +1343,9 @@ class MpsSingleCoinProxy:
         self.needed_metrics = set(needed_metrics)
         self.btc_analysis_enabled = any(
             _metric_uses_btc_analysis(metric) for metric in self.needed_metrics
+        )
+        self.btc_risk_enabled = bool(
+            self.needed_metrics & BTC_INTRADAY_RISK_METRICS
         )
         btc_values = np.ascontiguousarray(
             np.asarray(btc, dtype=np.float64).reshape(-1)
@@ -1634,6 +1643,7 @@ class MpsSingleCoinProxy:
             recovery_distribution_enabled=bool(
                 self.needed_metrics & _STRATEGY_EQ_RECOVERY_DISTRIBUTION_METRICS
             ),
+            btc_prices=btc_values if self.btc_risk_enabled else None,
         )
         if self.strategy_kind == "trailing_martingale":
             runner_kwargs["hsl_enabled"] = any_configured_hsl
@@ -2144,7 +2154,10 @@ class MpsMulticoinProxy:
             )
 
         from backtest import build_backtest_payload
-        from optimization.gpu.metrics import compute_objectives
+        from optimization.gpu.metrics import (
+            BTC_INTRADAY_RISK_METRICS,
+            compute_objectives,
+        )
         from optimization.gpu.mps_kernel import (
             MpsEmaAnchorMulticoinFusedRunner,
             MpsEmaAnchorMulticoinRunner,
@@ -2157,6 +2170,9 @@ class MpsMulticoinProxy:
         self.needed_metrics = set(needed_metrics)
         self.btc_analysis_enabled = any(
             _metric_uses_btc_analysis(metric) for metric in self.needed_metrics
+        )
+        self.btc_risk_enabled = bool(
+            self.needed_metrics & BTC_INTRADAY_RISK_METRICS
         )
         btc_values = np.ascontiguousarray(
             np.asarray(btc, dtype=np.float64).reshape(-1)
@@ -2594,6 +2610,7 @@ class MpsMulticoinProxy:
                 & _STRATEGY_EQ_RECOVERY_DISTRIBUTION_METRICS
             ),
             "dynamic_wel_by_tradability": self.dynamic_wel_by_tradability,
+            "btc_prices": btc_values if self.btc_risk_enabled else None,
         }
         if self.shared_account_fused:
             fused_runner_cls = (

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -3227,6 +3227,8 @@ def test_gpu_foundation_accepts_btc_account_metrics_without_collateral(
     [
         "exposure_ratio_w_btc",
         "exposure_mean_ratio_w_btc",
+        "calmar_ratio_w_btc",
+        "sterling_ratio_w_btc",
     ],
 )
 def test_gpu_foundation_excludes_btc_metrics_without_safe_proxy_surface(metric):
@@ -3247,9 +3249,7 @@ def test_gpu_foundation_excludes_btc_metrics_without_safe_proxy_surface(metric):
         ("sortino_ratio_btc", "max"),
         ("sortino_ratio_w_btc", "max"),
         ("calmar_ratio_btc", "max"),
-        ("calmar_ratio_w_btc", "max"),
         ("sterling_ratio_btc", "max"),
-        ("sterling_ratio_w_btc", "max"),
     ],
 )
 def test_gpu_foundation_accepts_synchronized_btc_risk_metrics(metric, goal):

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -3228,6 +3228,8 @@ def test_gpu_foundation_accepts_btc_account_metrics_without_collateral(
         "exposure_ratio_w_btc",
         "exposure_mean_ratio_w_btc",
         "calmar_ratio_w_btc",
+        "sharpe_ratio_w_btc",
+        "sortino_ratio_w_btc",
         "sterling_ratio_w_btc",
     ],
 )
@@ -3245,9 +3247,7 @@ def test_gpu_foundation_excludes_btc_metrics_without_safe_proxy_surface(metric):
         ("drawdown_worst_mean_1pct_btc", "min"),
         ("expected_shortfall_1pct_btc", "min"),
         ("sharpe_ratio_btc", "max"),
-        ("sharpe_ratio_w_btc", "max"),
         ("sortino_ratio_btc", "max"),
-        ("sortino_ratio_w_btc", "max"),
         ("calmar_ratio_btc", "max"),
         ("sterling_ratio_btc", "max"),
     ],

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -3225,12 +3225,6 @@ def test_gpu_foundation_accepts_btc_account_metrics_without_collateral(
 @pytest.mark.parametrize(
     "metric",
     [
-        "drawdown_worst_btc",
-        "expected_shortfall_1pct_btc",
-        "sharpe_ratio_btc",
-        "sortino_ratio_w_btc",
-        "calmar_ratio_btc",
-        "sterling_ratio_w_btc",
         "exposure_ratio_w_btc",
         "exposure_mean_ratio_w_btc",
     ],
@@ -3240,6 +3234,30 @@ def test_gpu_foundation_excludes_btc_metrics_without_safe_proxy_surface(metric):
     from optimization.gpu.metrics import SUPPORTED_METRICS
 
     assert canonicalize_metric_name(metric) not in SUPPORTED_METRICS
+
+
+@pytest.mark.parametrize(
+    ("metric", "goal"),
+    [
+        ("drawdown_worst_btc", "min"),
+        ("drawdown_worst_mean_1pct_btc", "min"),
+        ("expected_shortfall_1pct_btc", "min"),
+        ("sharpe_ratio_btc", "max"),
+        ("sharpe_ratio_w_btc", "max"),
+        ("sortino_ratio_btc", "max"),
+        ("sortino_ratio_w_btc", "max"),
+        ("calmar_ratio_btc", "max"),
+        ("calmar_ratio_w_btc", "max"),
+        ("sterling_ratio_btc", "max"),
+        ("sterling_ratio_w_btc", "max"),
+    ],
+)
+def test_gpu_foundation_accepts_synchronized_btc_risk_metrics(metric, goal):
+    config = _long_only_ema_config()
+    config["backtest"]["btc_collateral_cap"] = 0.0
+    config["optimize"]["scoring"] = [{"goal": goal, "metric": metric}]
+
+    assert _validate_scope(config, _Evaluator()) == "bybit"
 
 
 @pytest.mark.parametrize(

--- a/tests/optimization/test_gpu_metrics.py
+++ b/tests/optimization/test_gpu_metrics.py
@@ -1735,9 +1735,7 @@ def test_btc_risk_metrics_use_synchronized_intraday_surface():
         "expected_shortfall_1pct_btc",
         "gain_btc",
         "sharpe_ratio_btc",
-        "sharpe_ratio_w_btc",
         "sortino_ratio_btc",
-        "sortino_ratio_w_btc",
         "sterling_ratio_btc",
     }
 
@@ -1783,29 +1781,6 @@ def test_btc_risk_metrics_use_synchronized_intraday_surface():
     assert metrics["sterling_ratio_btc"].item() == pytest.approx(
         adg.item() / 0.50
     )
-    expected_weighted = _weighted_strategy_eq_metrics(
-        day_end_btc,
-        day_min_btc,
-        day_max_dd_btc,
-        active,
-        out["first_eq_ts"],
-        out["last_eq_ts"],
-        0.0,
-        86_400_000,
-        {
-            "sharpe_ratio_strategy_eq_w",
-            "sortino_ratio_strategy_eq_w",
-        },
-    )
-    for btc_name, usd_source in {
-        "sharpe_ratio_w_btc": "sharpe_ratio_strategy_eq_w",
-        "sortino_ratio_w_btc": "sortino_ratio_strategy_eq_w",
-    }.items():
-        assert metrics[btc_name].item() == pytest.approx(
-            expected_weighted[usd_source].item()
-        )
-
-
 def test_btc_risk_metrics_fail_closed_without_synchronized_surface():
     day_end = torch.tensor([[100.0, 101.0]], dtype=torch.float64)
     out = {

--- a/tests/optimization/test_gpu_metrics.py
+++ b/tests/optimization/test_gpu_metrics.py
@@ -10,6 +10,7 @@ torch = pytest.importorskip("torch")
 from optimization.gpu.metrics import (
     SUPPORTED_METRICS,
     _GAP_HIST_UPPER_STEPS,
+    _btc_account_metrics,
     _daily_peak_recovery_ms,
     _equity_shape_metrics,
     _directional_pnl_metrics,
@@ -1690,6 +1691,195 @@ def test_btc_account_metrics_fail_closed_without_price_context():
             {"ts0": 0.0, "n": 2},
             needed={"adg_btc"},
         )
+
+
+def test_btc_risk_metrics_use_synchronized_intraday_surface():
+    day_end_usd = torch.tensor(
+        [[1_000.0, 1_100.0, 900.0, 1_200.0]], dtype=torch.float64
+    )
+    day_end_btc = torch.tensor([[10.0, 8.0, 12.0, 9.0]], dtype=torch.float64)
+    day_min_btc = torch.tensor([[9.0, 7.0, 10.0, 6.0]], dtype=torch.float64)
+    day_max_dd_btc = torch.tensor(
+        [[0.10, 0.30, 0.20, 0.50]], dtype=torch.float64
+    )
+    out = {
+        "day_end_eq": day_end_usd,
+        # Deliberately incompatible USD minima prove the reducer does not
+        # derive BTC risk from independently sampled USD and BTC surfaces.
+        "day_min_eq": torch.tensor(
+            [[999.0, 998.0, 997.0, 996.0]], dtype=torch.float64
+        ),
+        "day_max_dd": torch.zeros_like(day_end_usd),
+        "day_volume": torch.zeros_like(day_end_usd),
+        "day_has_fill": torch.ones_like(day_end_usd, dtype=torch.bool),
+        "btc_day_end_eq": day_end_btc,
+        "btc_day_min_eq": day_min_btc,
+        "btc_day_max_dd": day_max_dd_btc,
+        "fill_count": torch.tensor([4.0]),
+        "max_dd": torch.zeros(1),
+        "held_max_ms": torch.zeros(1),
+        "gap_hist": torch.zeros((1, 128), dtype=torch.int32),
+        "gap_max_ms": torch.zeros(1),
+        "first_fill_ts": torch.tensor([0.0]),
+        "last_fill_ts": torch.tensor([3 * 86_400_000.0]),
+        "recovery_max_ms": torch.zeros(1),
+        "last_high_ts": torch.tensor([0.0]),
+        "first_eq_ts": torch.tensor([0.0]),
+        "last_eq_ts": torch.tensor([3 * 86_400_000.0]),
+        "liq_step": torch.tensor([-1]),
+    }
+    requested = {
+        "calmar_ratio_btc",
+        "calmar_ratio_w_btc",
+        "drawdown_worst_btc",
+        "drawdown_worst_mean_1pct_btc",
+        "expected_shortfall_1pct_btc",
+        "gain_btc",
+        "sharpe_ratio_btc",
+        "sharpe_ratio_w_btc",
+        "sortino_ratio_btc",
+        "sortino_ratio_w_btc",
+        "sterling_ratio_btc",
+        "sterling_ratio_w_btc",
+    }
+
+    metrics = compute_objectives(
+        out,
+        SimpleNamespace(
+            requested_start_ts_ms=0,
+            guard_ts_ms=0,
+            interval_ms=86_400_000,
+        ),
+        {
+            "ts0": 0.0,
+            "n": 4,
+            "btc_day_end_price": np.full(4, 100.0),
+            "btc_prices": np.full(4, 100.0),
+        },
+        needed=requested,
+    )
+
+    active = torch.ones_like(day_end_btc, dtype=torch.bool)
+    _gain, adg = _smoothed_gain_adg(day_end_btc, active)
+    min_changes, min_change_mask = _pct_change(day_min_btc, active)
+    sharpe, sortino = _sharpe_sortino(min_changes, min_change_mask, adg)
+    expected_shortfall = _mean_worst_one_pct_abs(
+        min_changes, min_change_mask
+    )
+    assert set(metrics) == requested
+    safe_day_end_btc = day_end_usd / 100.0
+    safe_gain, _safe_adg = _smoothed_gain_adg(safe_day_end_btc, active)
+    assert metrics["gain_btc"].item() == pytest.approx(safe_gain.item())
+    assert metrics["drawdown_worst_btc"].item() == pytest.approx(0.50)
+    assert metrics["drawdown_worst_mean_1pct_btc"].item() == pytest.approx(
+        0.50
+    )
+    assert metrics["expected_shortfall_1pct_btc"].item() == pytest.approx(
+        expected_shortfall.item()
+    )
+    assert metrics["sharpe_ratio_btc"].item() == pytest.approx(sharpe.item())
+    assert metrics["sortino_ratio_btc"].item() == pytest.approx(sortino.item())
+    assert metrics["calmar_ratio_btc"].item() == pytest.approx(
+        adg.item() / 0.50
+    )
+    assert metrics["sterling_ratio_btc"].item() == pytest.approx(
+        adg.item() / 0.50
+    )
+    expected_weighted = _weighted_strategy_eq_metrics(
+        day_end_btc,
+        day_min_btc,
+        day_max_dd_btc,
+        active,
+        out["first_eq_ts"],
+        out["last_eq_ts"],
+        0.0,
+        86_400_000,
+        {
+            "calmar_ratio_strategy_eq_w",
+            "sharpe_ratio_strategy_eq_w",
+            "sortino_ratio_strategy_eq_w",
+            "sterling_ratio_strategy_eq_w",
+        },
+    )
+    for btc_name, usd_source in {
+        "calmar_ratio_w_btc": "calmar_ratio_strategy_eq_w",
+        "sharpe_ratio_w_btc": "sharpe_ratio_strategy_eq_w",
+        "sortino_ratio_w_btc": "sortino_ratio_strategy_eq_w",
+        "sterling_ratio_w_btc": "sterling_ratio_strategy_eq_w",
+    }.items():
+        assert metrics[btc_name].item() == pytest.approx(
+            expected_weighted[usd_source].item()
+        )
+
+
+def test_btc_risk_metrics_fail_closed_without_synchronized_surface():
+    day_end = torch.tensor([[100.0, 101.0]], dtype=torch.float64)
+    out = {
+        "day_end_eq": day_end,
+        "day_min_eq": day_end.clone(),
+        "day_max_dd": torch.zeros_like(day_end),
+        "day_volume": torch.zeros_like(day_end),
+        "day_has_fill": torch.ones_like(day_end, dtype=torch.bool),
+        "fill_count": torch.tensor([2.0]),
+        "max_dd": torch.zeros(1),
+        "first_eq_ts": torch.tensor([0.0]),
+        "last_eq_ts": torch.tensor([86_400_000.0]),
+    }
+
+    with pytest.raises(RuntimeError, match="synchronized BTC-risk output"):
+        _btc_account_metrics(
+            out,
+            SimpleNamespace(interval_ms=86_400_000),
+            {"ts0": 0.0, "n": 2},
+            {"sharpe_ratio_btc"},
+        )
+
+
+def test_btc_risk_metrics_match_no_fill_defaults():
+    day_end = torch.tensor([[10.0, 8.0]], dtype=torch.float64)
+    out = {
+        "day_end_eq": day_end,
+        "day_min_eq": day_end.clone(),
+        "day_max_dd": torch.zeros_like(day_end),
+        "day_volume": torch.zeros_like(day_end),
+        "day_has_fill": torch.zeros_like(day_end, dtype=torch.bool),
+        "btc_day_end_eq": day_end,
+        "btc_day_min_eq": torch.tensor([[9.0, 7.0]], dtype=torch.float64),
+        "btc_day_max_dd": torch.tensor([[0.1, 0.3]], dtype=torch.float64),
+        "fill_count": torch.tensor([0.0]),
+        "max_dd": torch.zeros(1),
+        "first_eq_ts": torch.tensor([0.0]),
+        "last_eq_ts": torch.tensor([86_400_000.0]),
+    }
+    requested = {
+        "calmar_ratio_btc",
+        "drawdown_worst_btc",
+        "drawdown_worst_mean_1pct_btc",
+        "expected_shortfall_1pct_btc",
+        "sharpe_ratio_btc",
+        "sortino_ratio_btc",
+        "sterling_ratio_btc",
+    }
+
+    metrics = _btc_account_metrics(
+        out,
+        SimpleNamespace(interval_ms=86_400_000),
+        {
+            "ts0": 0.0,
+            "n": 2,
+            "btc_day_end_price": np.ones(2),
+            "btc_prices": np.ones(2),
+        },
+        requested,
+    )
+
+    assert metrics["drawdown_worst_btc"].item() == 1.0
+    assert metrics["drawdown_worst_mean_1pct_btc"].item() == 1.0
+    for metric in requested - {
+        "drawdown_worst_btc",
+        "drawdown_worst_mean_1pct_btc",
+    }:
+        assert metrics[metric].item() == 0.0
 
 
 def test_btc_account_metrics_use_candidate_liquidation_endpoint_price():

--- a/tests/optimization/test_gpu_metrics.py
+++ b/tests/optimization/test_gpu_metrics.py
@@ -1730,7 +1730,6 @@ def test_btc_risk_metrics_use_synchronized_intraday_surface():
     }
     requested = {
         "calmar_ratio_btc",
-        "calmar_ratio_w_btc",
         "drawdown_worst_btc",
         "drawdown_worst_mean_1pct_btc",
         "expected_shortfall_1pct_btc",
@@ -1740,7 +1739,6 @@ def test_btc_risk_metrics_use_synchronized_intraday_surface():
         "sortino_ratio_btc",
         "sortino_ratio_w_btc",
         "sterling_ratio_btc",
-        "sterling_ratio_w_btc",
     }
 
     metrics = compute_objectives(
@@ -1795,17 +1793,13 @@ def test_btc_risk_metrics_use_synchronized_intraday_surface():
         0.0,
         86_400_000,
         {
-            "calmar_ratio_strategy_eq_w",
             "sharpe_ratio_strategy_eq_w",
             "sortino_ratio_strategy_eq_w",
-            "sterling_ratio_strategy_eq_w",
         },
     )
     for btc_name, usd_source in {
-        "calmar_ratio_w_btc": "calmar_ratio_strategy_eq_w",
         "sharpe_ratio_w_btc": "sharpe_ratio_strategy_eq_w",
         "sortino_ratio_w_btc": "sortino_ratio_strategy_eq_w",
-        "sterling_ratio_w_btc": "sterling_ratio_strategy_eq_w",
     }.items():
         assert metrics[btc_name].item() == pytest.approx(
             expected_weighted[usd_source].item()

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -44,6 +44,7 @@ from optimization.gpu.mps_kernel import (
     _scale_tm_multicoin_coin_overrides,
     _scale_single_coin_minute_parameters,
     _upgrade_legacy_single_coin_wel_params,
+    _with_btc_risk,
     _with_dynamic_wel_by_tradability,
     _with_hsl_ema_tail,
     _with_hsl_features,
@@ -434,6 +435,17 @@ def test_fixed_wel_denominator_source_variant_is_opt_in_and_guarded():
     )
     with pytest.raises(RuntimeError, match="dynamic-WEL feature guard"):
         _with_dynamic_wel_by_tradability("body", False)
+
+
+def test_btc_risk_source_variant_is_opt_in_and_guarded():
+    source = "struct BtcRiskState { float peak; };\nbody"
+
+    assert _with_btc_risk(source, False) is source
+    assert _with_btc_risk(source, True) == (
+        "#define PASSIVBOT_BTC_RISK_ENABLED 1\n" + source
+    )
+    with pytest.raises(RuntimeError, match="shared BTC-risk contract"):
+        _with_btc_risk("body", True)
 
 
 @pytest.mark.skipif(
@@ -4366,6 +4378,8 @@ def test_mps_single_coin_service_dispatches_forced_delist_tail(strategy_kind):
             "backtest_completion_ratio",
             "fills_count",
             "adg_btc",
+            "drawdown_worst_btc",
+            "expected_shortfall_1pct_btc",
             "gain_btc",
             "hard_stop_panic_close_loss_sum",
         },
@@ -4393,6 +4407,13 @@ def test_mps_single_coin_service_dispatches_forced_delist_tail(strategy_kind):
     assert result["adg_btc"] == pytest.approx(
         exact_analysis["adg_btc"], rel=2.0e-3
     )
+    assert result["drawdown_worst_btc"] == pytest.approx(
+        exact_analysis["drawdown_worst_btc"], rel=2.0e-3
+    )
+    assert result["expected_shortfall_1pct_btc"] == pytest.approx(
+        exact_analysis["expected_shortfall_1pct_btc"], rel=2.0e-3
+    )
+    assert proxy.btc_risk_enabled is True
     assert result["backtest_completion_ratio"] > 0.99
 
 
@@ -4713,6 +4734,8 @@ def test_mps_multicoin_service_dispatches_forced_delist_tail(
             "backtest_completion_ratio",
             "fills_count",
             "adg_btc",
+            "drawdown_worst_btc",
+            "expected_shortfall_1pct_btc",
             "gain_btc",
             "hard_stop_panic_close_loss_sum",
         },
@@ -4746,6 +4769,13 @@ def test_mps_multicoin_service_dispatches_forced_delist_tail(
     assert result["adg_btc"] == pytest.approx(
         exact_analysis["adg_btc"], rel=2.0e-3
     )
+    assert result["drawdown_worst_btc"] == pytest.approx(
+        exact_analysis["drawdown_worst_btc"], rel=2.0e-3
+    )
+    assert result["expected_shortfall_1pct_btc"] == pytest.approx(
+        exact_analysis["expected_shortfall_1pct_btc"], rel=2.0e-3
+    )
+    assert proxy.btc_risk_enabled is True
     assert result["backtest_completion_ratio"] > 0.99
 
 
@@ -5241,6 +5271,51 @@ def _multicoin_exposure_fixture(
     if return_context:
         return runner, row, runs[0], data
     return runner, row
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
+@pytest.mark.parametrize("topology", ["single_side", "fused"])
+def test_mps_multicoin_retains_synchronized_btc_risk_surface(
+    strategy_kind, topology
+):
+    _, row, run, data = _multicoin_exposure_fixture(
+        strategy_kind, "long", count=5, return_context=True
+    )
+    btc_prices = np.array([100.0, 100.0, 50.0, 200.0, 100.0])
+    if strategy_kind == "ema_anchor":
+        row[EMA_ANCHOR_MULTICOIN_PARAM_KEYS.index("base_qty_pct")] = 0.0
+        runner_cls = (
+            MpsEmaAnchorMulticoinFusedRunner
+            if topology == "fused"
+            else MpsEmaAnchorMulticoinRunner
+        )
+    else:
+        row[
+            TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS.index(
+                "entry_initial_qty_pct"
+            )
+        ] = 0.0
+        runner_cls = (
+            MpsTrailingMartingaleMulticoinFusedRunner
+            if topology == "fused"
+            else MpsTrailingMartingaleMulticoinRunner
+        )
+    if topology == "fused":
+        runner = runner_cls(run, data, btc_prices=btc_prices)
+        candidates = np.asarray([row + row], dtype=np.float64)
+    else:
+        runner = runner_cls(run, data, side="long", btc_prices=btc_prices)
+        candidates = np.asarray([row], dtype=np.float64)
+
+    output = runner.run(candidates)
+    torch.mps.synchronize()
+
+    assert output["btc_day_end_eq"][0, 0].item() == pytest.approx(5.0)
+    assert output["btc_day_min_eq"][0, 0].item() == pytest.approx(5.0)
+    assert output["btc_day_max_dd"][0, 0].item() == pytest.approx(0.75)
 
 
 @pytest.mark.skipif(
@@ -11933,6 +12008,121 @@ def _tm_single_row(
         unstuck_loss_allowance_pct=unstuck_loss_allowance_pct,
         unstuck_threshold=unstuck_threshold,
     ) + [-1.0]
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
+def test_mps_single_coin_retains_synchronized_btc_risk_surface(strategy_kind):
+    from optimization.gpu.mps_kernel import (
+        MpsEmaAnchorRunner,
+        MpsTrailingMartingaleRunner,
+    )
+
+    count = 5
+    prices = np.full(count, 100.0)
+    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    market = ProxyMarket(0.001, 0.01, 0.001, 0.0, 1.0, 0.0)
+    run = ProxyRun(
+        1_000.0,
+        1,
+        1,
+        int(timestamps[0]),
+        int(timestamps[0]),
+        int(timestamps[0]),
+        60_000,
+        0.05,
+        0,
+        count - 1,
+    )
+    data = build_mps_data(prices, prices, prices, timestamps, run, market)
+    btc_prices = np.array([100.0, 100.0, 50.0, 200.0, 100.0])
+    if strategy_kind == "trailing_martingale":
+        row = _tm_single_row()
+        row[6] = 0.0
+        runner_cls = MpsTrailingMartingaleRunner
+    else:
+        row = [0.0, 2.0, 3.0, 0.0, 0.01, 0.0, 0.0, 0.0, 2.0, 2.0, 0.0, 1.0]
+        row += _single_coin_exposure_fields() + _tm_twel_enforcer_fields()
+        runner_cls = MpsEmaAnchorRunner
+
+    output = runner_cls(
+        market,
+        run,
+        data,
+        btc_prices=btc_prices,
+    ).run(np.asarray([row + row], dtype=np.float64))
+    torch.mps.synchronize()
+
+    assert output["btc_day_end_eq"][0, 0].item() == pytest.approx(5.0)
+    assert output["btc_day_min_eq"][0, 0].item() == pytest.approx(5.0)
+    assert output["btc_day_max_dd"][0, 0].item() == pytest.approx(0.75)
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_tm_no_hsl_specializations_retain_synchronized_btc_risk_surface(
+    side,
+):
+    count = 5
+    prices = np.full(count, 100.0)
+    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    market = ProxyMarket(0.001, 0.01, 0.001, 0.0, 1.0, 0.0)
+    run = ProxyRun(
+        1_000.0,
+        1,
+        1,
+        int(timestamps[0]),
+        int(timestamps[0]),
+        int(timestamps[0]),
+        60_000,
+        0.05,
+        0,
+        count - 1,
+    )
+    data = build_mps_data(prices, prices, prices, timestamps, run, market)
+    row = _tm_single_row()
+    row[6] = 0.0
+    runner = MpsTrailingMartingaleRunner(
+        market,
+        run,
+        data,
+        long_enabled=side == "long",
+        short_enabled=side == "short",
+        hsl_enabled=False,
+        btc_prices=np.array([100.0, 100.0, 50.0, 200.0, 100.0]),
+    )
+
+    output = runner.run(np.asarray([row + row], dtype=np.float64))
+    torch.mps.synchronize()
+
+    assert runner.shader_topology == f"{side}_no_hsl"
+    assert output["btc_day_end_eq"][0, 0].item() == pytest.approx(5.0)
+    assert output["btc_day_min_eq"][0, 0].item() == pytest.approx(5.0)
+    assert output["btc_day_max_dd"][0, 0].item() == pytest.approx(0.75)
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize(
+    "btc_prices",
+    [
+        np.array([100.0, 101.0]),
+        np.array([100.0, 0.0, 102.0]),
+        np.array([100.0, np.nan, 102.0]),
+        np.array([100.0, np.inf, 102.0]),
+        np.array([100.0, 1.0e-50, 102.0]),
+    ],
+)
+def test_mps_btc_risk_prices_fail_closed_after_float32_packing(btc_prices):
+    from optimization.gpu.mps_kernel import _btc_risk_price_tensor
+
+    with pytest.raises(ValueError, match="MPS BTC-risk prices"):
+        _btc_risk_price_tensor(btc_prices, expected_count=3)
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## Summary

- add an opt-in Metal BTC-equity accumulator for synchronized UTC day-end equity, daily minima, and full-curve daily worst drawdowns
- support unweighted BTC Sharpe, Sortino, expected shortfall, worst/worst-1% drawdown, Calmar, and Sterling for EMA Anchor and Trailing Martingale across single-coin and multi-coin MPS topologies
- keep USD-only and close-only BTC runs on their existing kernel ABI, buffer width, dispatch path, and higher-precision day-end reducer
- validate BTC inputs after float32 packing and fail closed when synchronized outputs are unavailable

Exact Rust validation and rolling drift gates remain authoritative. Weighted BTC intraday ratios, weighted BTC exposure ratios, and positive BTC collateral remain out of scope and fail closed.

## Validation

- `PYTHONPATH=src .../python -m pytest -q tests/optimization`
- physical Apple M3/MPS: `PYTHONPATH=src .../python -m pytest -q tests/optimization/test_gpu_mps.py` (700 passed)
- `cargo test --no-default-features` (269 passed)
- `cargo check --tests`
- Python compileall and `git diff --check`
- end-to-end Apple MPS optimization, ETH/Bybit 2025-present, scoring `sharpe_ratio_btc,drawdown_worst_btc,sortino_ratio_btc`: 8 generations, 2,048 proxy evaluations, 64 exact validations, completed without drift or constraint halt