### PR TITLE
Fix equity-balance analysis alignment after warmup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Backtest analysis now aligns realized balance changes with tracked equity samples by timestamp
+  when timestamp data is available. This fixes equity-vs-balance and paper-loss metrics after a
+  warmup period, where absolute fill candle indices were previously compared with equity-series
+  offsets and could leave a stale balance in the analysis.
+
 - Apple MPS single- and multi-coin EMA Anchor and Trailing Martingale optimization now accepts
   BTC-denominated account-equity scoring and limits while `backtest.btc_collateral_cap` is zero.
   The proxy converts its compact USD daily equity surface with the canonical prepared BTC/USD

--- a/passivbot-rust/src/analysis.rs
+++ b/passivbot-rust/src/analysis.rs
@@ -674,7 +674,12 @@ fn analyze_backtest_basic(
 
     for (i, &equity) in equities.iter().enumerate() {
         while let Some(fill) = fill_iter.peek() {
-            if fill.index <= i {
+            let fill_precedes_sample = if use_timestamps {
+                fill_timestamp_ms(fill) <= timestamps_ms[i]
+            } else {
+                fill.index <= i
+            };
+            if fill_precedes_sample {
                 last_balance = fill.usd_total_balance;
                 fill_iter.next();
             } else {
@@ -2175,6 +2180,34 @@ mod tests {
         assert!((analysis.exposure_mean_ratio - expected_adg / 0.45).abs() < 1e-12);
         assert!((analysis.total_wallet_exposure_mean - 0.45).abs() < 1e-12);
         assert!((analysis.total_wallet_exposure_median - 0.4).abs() < 1e-12);
+    }
+
+    #[test]
+    fn equity_balance_differences_align_fills_by_timestamp_after_warmup() {
+        let start = 1_740_000_000_000_u64;
+        let fills = vec![
+            make_trade_fill(100, start, "BTC", 0.0, 0.1, 0.1, 100.0, true),
+            make_trade_fill(
+                102,
+                start + 2 * 60_000,
+                "BTC",
+                -10.0,
+                -0.1,
+                0.0,
+                90.0,
+                true,
+            ),
+        ];
+        let equities = vec![100.0, 90.0, 95.0];
+        let timestamps = vec![start, start + 60_000, start + 2 * 60_000];
+
+        let analysis = analyze_backtest_basic(&fills, &equities, &timestamps, &[]);
+
+        assert!((analysis.equity_balance_diff_neg_max - 0.1).abs() < 1e-12);
+        assert!((analysis.equity_balance_diff_neg_mean - 0.1).abs() < 1e-12);
+        let expected_positive = (95.0 - 90.0) / 90.0;
+        assert!((analysis.equity_balance_diff_pos_max - expected_positive).abs() < 1e-12);
+        assert!((analysis.equity_balance_diff_pos_mean - expected_positive).abs() < 1e-12);
     }
 
     #[test]

--- a/passivbot-rust/src/analysis.rs
+++ b/passivbot-rust/src/analysis.rs
@@ -674,8 +674,8 @@ fn analyze_backtest_basic(
 
     for (i, &equity) in equities.iter().enumerate() {
         while let Some(fill) = fill_iter.peek() {
-            let fill_precedes_sample = if use_timestamps {
-                fill_timestamp_ms(fill) <= timestamps_ms[i]
+            let fill_precedes_sample = if use_timestamps && fill.timestamp_ms > 0 {
+                fill.timestamp_ms <= timestamps_ms[i]
             } else {
                 fill.index <= i
             };
@@ -2207,6 +2207,23 @@ mod tests {
         assert!((analysis.equity_balance_diff_neg_mean - 0.1).abs() < 1e-12);
         let expected_positive = (95.0 - 90.0) / 90.0;
         assert!((analysis.equity_balance_diff_pos_max - expected_positive).abs() < 1e-12);
+        assert!((analysis.equity_balance_diff_pos_mean - expected_positive).abs() < 1e-12);
+    }
+
+    #[test]
+    fn equity_balance_differences_keep_index_fallback_for_timestamp_less_fills() {
+        let start = 1_740_000_000_000_u64;
+        let fills = vec![
+            make_trade_fill(0, 0, "BTC", 0.0, 0.1, 0.1, 100.0, true),
+            make_trade_fill(2, 0, "BTC", -10.0, -0.1, 0.0, 90.0, true),
+        ];
+        let equities = vec![100.0, 90.0, 95.0];
+        let timestamps = vec![start, start + 60_000, start + 2 * 60_000];
+
+        let analysis = analyze_backtest_basic(&fills, &equities, &timestamps, &[]);
+
+        assert!((analysis.equity_balance_diff_neg_mean - 0.1).abs() < 1e-12);
+        let expected_positive = (95.0 - 90.0) / 90.0;
         assert!((analysis.equity_balance_diff_pos_mean - expected_positive).abs() < 1e-12);
     }
 


### PR DESCRIPTION
## Summary
- align realized balance changes to equity samples by timestamp when canonical timestamps are available
- preserve the fill-index fallback for timestamp-less analysis inputs
- add a regression covering absolute fill indices after an equity-tracking warmup

## Why
Backtests store absolute candle indices on fills, while the tracked equity vector starts at zero after warmup. Comparing those two indices left stale balances in equity-vs-balance and paper-loss metrics. This was exposed while adding the corresponding opt-in Apple MPS proxy metrics.

## Validation
- cargo test --no-default-features (270 passed)
- cargo check --tests --no-default-features
- git diff --check

Note: cargo fmt --check reports existing formatting drift in passivbot-rust/src/gpu.rs; this PR does not touch that file.