### PR TITLE
GPU: add equity balance difference metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,9 @@ All notable user-facing changes will be documented in this file.
   unweighted positive and negative equity-vs-balance maximum and mean metrics, plus paper-loss
   maximum and mean ratios, in USD and BTC. Metal enables a separate compact accumulator only when
   one of these metrics is requested, so ordinary GPU runs retain their existing kernel ABI and
-  dispatch cost. BTC balance is rebased at each proxy fill; positive sign-filtered means remain an
-  online approximation under mandatory exact Rust validation and rolling drift gates.
+  dispatch cost. BTC balance is rebased at each proxy fill, with tracked pre-fill samples replayed
+  against the first-fill baseline; positive sign-filtered means remain an online approximation
+  under mandatory exact Rust validation and rolling drift gates.
 
 - Apple MPS single- and multi-coin EMA Anchor and Trailing Martingale optimization now accepts
   BTC-denominated account-equity scoring and limits while `backtest.btc_collateral_cap` is zero.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ All notable user-facing changes will be documented in this file.
   warmup period, where absolute fill candle indices were previously compared with equity-series
   offsets and could leave a stale balance in the analysis.
 
+- Apple MPS single- and multi-coin EMA Anchor and Trailing Martingale optimization now supports
+  unweighted positive and negative equity-vs-balance maximum and mean metrics, plus paper-loss
+  maximum and mean ratios, in USD and BTC. Metal enables a separate compact accumulator only when
+  one of these metrics is requested, so ordinary GPU runs retain their existing kernel ABI and
+  dispatch cost. BTC balance is rebased at each proxy fill; positive sign-filtered means remain an
+  online approximation under mandatory exact Rust validation and rolling drift gates.
+
 - Apple MPS single- and multi-coin EMA Anchor and Trailing Martingale optimization now accepts
   BTC-denominated account-equity scoring and limits while `backtest.btc_collateral_cap` is zero.
   The proxy converts its compact USD daily equity surface with the canonical prepared BTC/USD

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -506,8 +506,9 @@ and rolling drift gates remain authoritative. Weighted BTC exposure ratios still
 suffix-local exposure series and remain fail-closed.
 Unweighted `equity_balance_diff_{neg,pos}_{max,mean}_{usd,btc}` and
 `paper_loss{,_mean}_ratio_{usd,btc}` are supported through an opt-in full-resolution accumulator.
-The BTC balance baseline is rebased at each proxy fill. Positive sign-filtered means may differ at
-the pre-fill/tracking boundary and remain proxy approximations under exact validation; negative
+The BTC balance baseline is rebased at each proxy fill; when the first fill establishes that
+baseline, the kernel replays earlier tracked BTC prices without repeating the strategy simulation.
+Positive sign-filtered means may remain proxy approximations under exact validation; negative
 maxima and means, which supply the paper-loss denominators, retain tight parity coverage.
 The prepared BTC series must contain at least one sample in every covered UTC day; unusually coarse
 intervals which skip a whole UTC day fail closed for BTC scoring.

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -504,6 +504,11 @@ do not request one of these intraday-risk metrics keep the smaller existing kern
 buffers. BTC peak recovery remains a compact daily approximation; mandatory exact Rust validation
 and rolling drift gates remain authoritative. Weighted BTC exposure ratios still require
 suffix-local exposure series and remain fail-closed.
+Unweighted `equity_balance_diff_{neg,pos}_{max,mean}_{usd,btc}` and
+`paper_loss{,_mean}_ratio_{usd,btc}` are supported through an opt-in full-resolution accumulator.
+The BTC balance baseline is rebased at each proxy fill. Positive sign-filtered means may differ at
+the pre-fill/tracking boundary and remain proxy approximations under exact validation; negative
+maxima and means, which supply the paper-loss denominators, retain tight parity coverage.
 The prepared BTC series must contain at least one sample in every covered UTC day; unusually coarse
 intervals which skip a whole UTC day fail closed for BTC scoring.
 Positive `backtest.btc_collateral_cap` remains unsupported and fails before GPU optimization.

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -10,6 +10,10 @@ const MPS_HSL_MARKER: &str = "// PASSIVBOT_HSL_COMMON";
 const MPS_HSL_COMMON_SOURCE: &str = include_str!("gpu/mps_hsl_common.metal");
 const MPS_BTC_RISK_MARKER: &str = "// PASSIVBOT_BTC_RISK_COMMON";
 const MPS_BTC_RISK_COMMON_SOURCE: &str = include_str!("gpu/mps_btc_risk_common.metal");
+const MPS_EQUITY_BALANCE_DIFF_MARKER: &str =
+    "// PASSIVBOT_EQUITY_BALANCE_DIFF_COMMON";
+const MPS_EQUITY_BALANCE_DIFF_COMMON_SOURCE: &str =
+    include_str!("gpu/mps_equity_balance_diff_common.metal");
 const MPS_MULTICOIN_MARKER: &str = "// PASSIVBOT_MULTICOIN_COMMON";
 const MPS_MULTICOIN_COMMON_SOURCE: &str = include_str!("gpu/mps_multicoin_common.metal");
 const MPS_EMA_ANCHOR_BODY: &str = include_str!("gpu/mps_ema_anchor_directional.metal");
@@ -36,8 +40,18 @@ fn compose_hsl_source(body: &str) -> String {
         1,
         "MPS source must contain exactly one shared BTC-risk marker"
     );
+    assert_eq!(
+        body.matches(MPS_EQUITY_BALANCE_DIFF_MARKER).count(),
+        1,
+        "MPS source must contain exactly one shared equity-balance-diff marker"
+    );
     body.replacen(MPS_HSL_MARKER, MPS_HSL_COMMON_SOURCE, 1)
         .replacen(MPS_BTC_RISK_MARKER, MPS_BTC_RISK_COMMON_SOURCE, 1)
+        .replacen(
+            MPS_EQUITY_BALANCE_DIFF_MARKER,
+            MPS_EQUITY_BALANCE_DIFF_COMMON_SOURCE,
+            1,
+        )
 }
 
 fn compose_multicoin_source(body: &str) -> String {
@@ -209,6 +223,21 @@ mod tests {
         }
         assert!(source.contains("#if PASSIVBOT_BTC_RISK_ENABLED"));
         assert!(source.contains("float btc_equity = usd_equity / btc_price"));
+    }
+
+    fn assert_shared_equity_balance_diff_contract(source: &str) {
+        assert!(!source.contains(MPS_EQUITY_BALANCE_DIFF_MARKER));
+        assert!(source.contains(MPS_EQUITY_BALANCE_DIFF_COMMON_SOURCE));
+        for signature in [
+            "struct EquityBalanceDiffState",
+            "inline EquityBalanceDiffState init_equity_balance_diff_state()",
+            "inline void update_equity_balance_diff_state(",
+            "inline void write_equity_balance_diff_state(",
+        ] {
+            assert_eq!(source.matches(signature).count(), 1, "{signature}");
+        }
+        assert!(source.contains("#if PASSIVBOT_EQUITY_BALANCE_DIFF_ENABLED"));
+        assert!(source.contains("const float diff = (equity - balance) / balance"));
     }
 
     fn assert_directional_recovery_sampling_contract(source: &str) {
@@ -383,6 +412,31 @@ mod tests {
             assert!(source.contains("constant float* btc_prices"));
             assert!(source.contains("update_btc_risk_state("));
             assert!(source.contains("write_btc_risk_day("));
+        }
+    }
+
+    #[test]
+    fn all_strategy_sources_compose_one_shared_equity_balance_diff_controller() {
+        for body in [
+            MPS_EMA_ANCHOR_BODY,
+            MPS_EMA_ANCHOR_MULTICOIN_BODY,
+            MPS_TRAILING_MARTINGALE_BODY,
+            MPS_TRAILING_MARTINGALE_MULTICOIN_BODY,
+        ] {
+            assert_eq!(body.matches(MPS_EQUITY_BALANCE_DIFF_MARKER).count(), 1);
+            assert!(!body.contains("struct EquityBalanceDiffState"));
+        }
+        for source in [
+            mps_ema_anchor_source(),
+            mps_ema_anchor_multicoin_source(),
+            mps_trailing_martingale_source(),
+            mps_trailing_martingale_long_no_hsl_source(),
+            mps_trailing_martingale_short_no_hsl_source(),
+            mps_trailing_martingale_multicoin_source(),
+        ] {
+            assert_shared_equity_balance_diff_contract(source);
+            assert!(source.contains("update_equity_balance_diff_state("));
+            assert!(source.contains("write_equity_balance_diff_state("));
         }
     }
 

--- a/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
@@ -145,6 +145,8 @@ inline float float32_floor_nonnegative(float value) {
 
 // PASSIVBOT_BTC_RISK_COMMON
 
+// PASSIVBOT_EQUITY_BALANCE_DIFF_COMMON
+
 inline void record_realized_net(
     float net_pnl,
     thread float& realized_pnl_cumsum_last,
@@ -1127,8 +1129,11 @@ inline void passivbot_single_coin_impl(
     constant float* params,
     constant float* settings,
     constant int* sizes,
-#if PASSIVBOT_BTC_RISK_ENABLED
+#if PASSIVBOT_BTC_PRICES_ENABLED
     constant float* btc_prices,
+#endif
+#if PASSIVBOT_EQUITY_BALANCE_DIFF_ENABLED
+    device float* equity_balance_diff,
 #endif
     device float* daily,
     device float* scalars,
@@ -1246,6 +1251,10 @@ inline void passivbot_single_coin_impl(
     bool eq_started = false;
 #if PASSIVBOT_BTC_RISK_ENABLED
     BtcRiskState btc_risk = init_btc_risk_state();
+#endif
+#if PASSIVBOT_EQUITY_BALANCE_DIFF_ENABLED
+    EquityBalanceDiffState equity_balance_diff_state =
+        init_equity_balance_diff_state();
 #endif
 #ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
     int recovery_start_k = -1;
@@ -2123,6 +2132,11 @@ inline void passivbot_single_coin_impl(
 #if PASSIVBOT_BTC_RISK_ENABLED
             update_btc_risk_state(btc_risk, eqf, btc_prices[k]);
 #endif
+#if PASSIVBOT_EQUITY_BALANCE_DIFF_ENABLED
+            update_equity_balance_diff_state(
+                equity_balance_diff_state, balance, eqf, btc_prices[k], any_fill
+            );
+#endif
             day_touched = true;
             if (!liq) {
                 float twe_net = (
@@ -2316,6 +2330,11 @@ inline void passivbot_single_coin_impl(
         short_hsl_strategy_eq
     );
 #endif
+#if PASSIVBOT_EQUITY_BALANCE_DIFF_ENABLED
+    write_equity_balance_diff_state(
+        equity_balance_diff_state, equity_balance_diff, b
+    );
+#endif
 }
 
 kernel void passivbot_ema_anchor(
@@ -2324,8 +2343,11 @@ kernel void passivbot_ema_anchor(
     constant float* params,
     constant float* settings,
     constant int* sizes,
-#if PASSIVBOT_BTC_RISK_ENABLED
+#if PASSIVBOT_BTC_PRICES_ENABLED
     constant float* btc_prices,
+#endif
+#if PASSIVBOT_EQUITY_BALANCE_DIFF_ENABLED
+    device float* equity_balance_diff,
 #endif
     device float* daily,
     device float* scalars,
@@ -2339,8 +2361,11 @@ kernel void passivbot_ema_anchor(
 ) {
     passivbot_single_coin_impl(
         bars, flags, params, settings, sizes,
-#if PASSIVBOT_BTC_RISK_ENABLED
+#if PASSIVBOT_BTC_PRICES_ENABLED
         btc_prices,
+#endif
+#if PASSIVBOT_EQUITY_BALANCE_DIFF_ENABLED
+        equity_balance_diff,
 #endif
         daily, scalars, gap_hist,
         rolling_pnl_values, rolling_pnl_indices,

--- a/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
@@ -2134,7 +2134,8 @@ inline void passivbot_single_coin_impl(
 #endif
 #if PASSIVBOT_EQUITY_BALANCE_DIFF_ENABLED
             update_equity_balance_diff_state(
-                equity_balance_diff_state, balance, eqf, btc_prices[k], any_fill
+                equity_balance_diff_state, balance, eqf, btc_prices, k,
+                starting_balance, any_fill
             );
 #endif
             day_touched = true;

--- a/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
@@ -3343,7 +3343,9 @@ inline void passivbot_ema_anchor_multicoin_impl(
                 equity_balance_diff_state,
                 balance,
                 effective_equity,
-                btc_prices[k],
+                btc_prices,
+                k,
+                starting_balance,
                 any_fill
             );
 #endif
@@ -4295,7 +4297,9 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
                 equity_balance_diff_state,
                 account.balance,
                 effective_equity,
-                btc_prices[k],
+                btc_prices,
+                k,
+                starting_balance,
                 any_fill
             );
 #endif

--- a/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
@@ -34,6 +34,8 @@ constant float RECOVERY_FAIL_CLOSED_SENTINEL = -3.402823466e+38f;
 
 // PASSIVBOT_BTC_RISK_COMMON
 
+// PASSIVBOT_EQUITY_BALANCE_DIFF_COMMON
+
 // PASSIVBOT_MULTICOIN_COMMON
 
 inline float finalized_reducer_qty_with_ordinary(
@@ -2856,8 +2858,11 @@ inline void passivbot_ema_anchor_multicoin_impl(
     constant float* run_settings,
     constant int* sizes,
     constant int* end_steps,
-#if PASSIVBOT_BTC_RISK_ENABLED
+#if PASSIVBOT_BTC_PRICES_ENABLED
     constant float* btc_prices,
+#endif
+#if PASSIVBOT_EQUITY_BALANCE_DIFF_ENABLED
+    device float* equity_balance_diff,
 #endif
     device float* daily,
     device float* scalars,
@@ -2967,6 +2972,10 @@ inline void passivbot_ema_anchor_multicoin_impl(
     float last_eq_k = -1.0f;
 #if PASSIVBOT_BTC_RISK_ENABLED
     BtcRiskState btc_risk = init_btc_risk_state();
+#endif
+#if PASSIVBOT_EQUITY_BALANCE_DIFF_ENABLED
+    EquityBalanceDiffState equity_balance_diff_state =
+        init_equity_balance_diff_state();
 #endif
 #ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
     int recovery_start_k = -1;
@@ -3329,6 +3338,15 @@ inline void passivbot_ema_anchor_multicoin_impl(
                 btc_risk, effective_equity, btc_prices[k]
             );
 #endif
+#if PASSIVBOT_EQUITY_BALANCE_DIFF_ENABLED
+            update_equity_balance_diff_state(
+                equity_balance_diff_state,
+                balance,
+                effective_equity,
+                btc_prices[k],
+                any_fill
+            );
+#endif
             day_touched = true;
             if (!liquidated) {
                 float twe_abs = position_cost / balance;
@@ -3486,6 +3504,11 @@ inline void passivbot_ema_anchor_multicoin_impl(
     scalars[scalar_offset + 66] = short_side
         ? hsl_strategy_equity_drawdown_mean_worst_1pct(side.hsl_strategy_eq)
         : 0.0f;
+#endif
+#if PASSIVBOT_EQUITY_BALANCE_DIFF_ENABLED
+    write_equity_balance_diff_state(
+        equity_balance_diff_state, equity_balance_diff, b
+    );
 #endif
 }
 
@@ -3673,8 +3696,11 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
     constant float* run_settings,
     constant int* sizes,
     constant int* end_steps,
-#if PASSIVBOT_BTC_RISK_ENABLED
+#if PASSIVBOT_BTC_PRICES_ENABLED
     constant float* btc_prices,
+#endif
+#if PASSIVBOT_EQUITY_BALANCE_DIFF_ENABLED
+    device float* equity_balance_diff,
 #endif
     device float* daily,
     device float* scalars,
@@ -3795,6 +3821,10 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
     float last_eq_k = -1.0f;
 #if PASSIVBOT_BTC_RISK_ENABLED
     BtcRiskState btc_risk = init_btc_risk_state();
+#endif
+#if PASSIVBOT_EQUITY_BALANCE_DIFF_ENABLED
+    EquityBalanceDiffState equity_balance_diff_state =
+        init_equity_balance_diff_state();
 #endif
 #ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
     int recovery_start_k = -1;
@@ -4260,6 +4290,15 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
                 btc_risk, effective_equity, btc_prices[k]
             );
 #endif
+#if PASSIVBOT_EQUITY_BALANCE_DIFF_ENABLED
+            update_equity_balance_diff_state(
+                equity_balance_diff_state,
+                account.balance,
+                effective_equity,
+                btc_prices[k],
+                any_fill
+            );
+#endif
             day_touched = true;
             if (!liquidated) {
                 float twe_abs = fabs(net_position_cost / account.balance);
@@ -4460,6 +4499,11 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
             short_side.hsl_strategy_eq
         );
 #endif
+#if PASSIVBOT_EQUITY_BALANCE_DIFF_ENABLED
+    write_equity_balance_diff_state(
+        equity_balance_diff_state, equity_balance_diff, b
+    );
+#endif
 }
 
 kernel void passivbot_ema_anchor_multicoin_fused(
@@ -4474,8 +4518,11 @@ kernel void passivbot_ema_anchor_multicoin_fused(
     constant float* run_settings,
     constant int* sizes,
     constant int* end_steps,
-#if PASSIVBOT_BTC_RISK_ENABLED
+#if PASSIVBOT_BTC_PRICES_ENABLED
     constant float* btc_prices,
+#endif
+#if PASSIVBOT_EQUITY_BALANCE_DIFF_ENABLED
+    device float* equity_balance_diff,
 #endif
     device float* daily,
     device float* scalars,
@@ -4490,8 +4537,11 @@ kernel void passivbot_ema_anchor_multicoin_fused(
         bars, fill_ticks, touch_ticks, hour_log_ranges, coin_settings,
         long_coin_overrides, short_coin_overrides,
         params, run_settings, sizes, end_steps,
-#if PASSIVBOT_BTC_RISK_ENABLED
+#if PASSIVBOT_BTC_PRICES_ENABLED
         btc_prices,
+#endif
+#if PASSIVBOT_EQUITY_BALANCE_DIFF_ENABLED
+        equity_balance_diff,
 #endif
         daily, scalars, gap_hist, coin_fill_counts,
 #ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
@@ -4512,8 +4562,11 @@ kernel void passivbot_ema_anchor_multicoin(
     constant float* run_settings,
     constant int* sizes,
     constant int* end_steps,
-#if PASSIVBOT_BTC_RISK_ENABLED
+#if PASSIVBOT_BTC_PRICES_ENABLED
     constant float* btc_prices,
+#endif
+#if PASSIVBOT_EQUITY_BALANCE_DIFF_ENABLED
+    device float* equity_balance_diff,
 #endif
     device float* daily,
     device float* scalars,
@@ -4529,8 +4582,11 @@ kernel void passivbot_ema_anchor_multicoin(
         bars, fill_ticks, touch_ticks, hour_log_ranges,
         coin_settings, coin_overrides, params, run_settings,
         sizes, end_steps,
-#if PASSIVBOT_BTC_RISK_ENABLED
+#if PASSIVBOT_BTC_PRICES_ENABLED
         btc_prices,
+#endif
+#if PASSIVBOT_EQUITY_BALANCE_DIFF_ENABLED
+        equity_balance_diff,
 #endif
         daily, scalars, gap_hist, coin_fill_counts,
 #ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
@@ -4551,8 +4607,11 @@ kernel void passivbot_ema_anchor_multicoin_long(
     constant float* run_settings,
     constant int* sizes,
     constant int* end_steps,
-#if PASSIVBOT_BTC_RISK_ENABLED
+#if PASSIVBOT_BTC_PRICES_ENABLED
     constant float* btc_prices,
+#endif
+#if PASSIVBOT_EQUITY_BALANCE_DIFF_ENABLED
+    device float* equity_balance_diff,
 #endif
     device float* daily,
     device float* scalars,
@@ -4567,8 +4626,11 @@ kernel void passivbot_ema_anchor_multicoin_long(
         bars, fill_ticks, touch_ticks, hour_log_ranges,
         coin_settings, coin_overrides, params, run_settings,
         sizes, end_steps,
-#if PASSIVBOT_BTC_RISK_ENABLED
+#if PASSIVBOT_BTC_PRICES_ENABLED
         btc_prices,
+#endif
+#if PASSIVBOT_EQUITY_BALANCE_DIFF_ENABLED
+        equity_balance_diff,
 #endif
         daily, scalars, gap_hist, coin_fill_counts,
 #ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED

--- a/passivbot-rust/src/gpu/mps_equity_balance_diff_common.metal
+++ b/passivbot-rust/src/gpu/mps_equity_balance_diff_common.metal
@@ -29,6 +29,7 @@ struct EquityBalanceDiffState {
     float btc_negative_sum;
     float btc_negative_count;
     float btc_balance;
+    int first_sample_k;
     bool btc_balance_initialized;
     bool valid;
 };
@@ -48,12 +49,13 @@ inline EquityBalanceDiffState init_equity_balance_diff_state() {
     state.btc_negative_sum = 0.0f;
     state.btc_negative_count = 0.0f;
     state.btc_balance = 0.0f;
+    state.first_sample_k = -1;
     state.btc_balance_initialized = false;
     state.valid = true;
     return state;
 }
 
-inline void update_equity_balance_diff_accumulator(
+inline bool update_equity_balance_diff_accumulator(
     thread float& positive_max,
     thread float& positive_sum,
     thread float& positive_count,
@@ -64,6 +66,9 @@ inline void update_equity_balance_diff_accumulator(
     float equity
 ) {
     const float diff = (equity - balance) / balance;
+    if (!isfinite(diff)) {
+        return false;
+    }
     if (diff > 0.0f) {
         positive_max = fmax(positive_max, diff);
         positive_sum += diff;
@@ -74,21 +79,73 @@ inline void update_equity_balance_diff_accumulator(
         negative_sum += loss;
         negative_count += 1.0f;
     }
+    return true;
 }
 
 inline void update_equity_balance_diff_state(
     thread EquityBalanceDiffState& state,
     float balance,
     float equity,
-    float btc_price,
+    constant float* btc_prices,
+    int sample_k,
+    float starting_balance,
     bool any_fill
 ) {
-    if (!(balance > 0.0f) || !isfinite(balance) || !isfinite(equity)
-        || !(btc_price > 0.0f) || !isfinite(btc_price)) {
+    const float btc_price = btc_prices[sample_k];
+    if (balance == 0.0f || !isfinite(balance) || !isfinite(equity)
+        || !(btc_price > 0.0f) || !isfinite(btc_price)
+        || !(starting_balance > 0.0f) || !isfinite(starting_balance)) {
         state.valid = false;
         return;
     }
-    update_equity_balance_diff_accumulator(
+    if (state.first_sample_k < 0) {
+        state.first_sample_k = sample_k;
+    }
+    if (!state.btc_balance_initialized) {
+        if (!any_fill) {
+            return;
+        }
+        state.btc_balance = balance / btc_price;
+        state.btc_balance_initialized = true;
+        // Canonical Rust seeds analysis balance from the first fill and
+        // applies that baseline to every earlier tracked equity sample. No
+        // position exists before the first fill, so replaying BTC prices with
+        // starting USD equity reproduces those samples without a second
+        // strategy simulation or a per-candidate history buffer.
+        for (int k = state.first_sample_k; k < sample_k; ++k) {
+            const float prefill_btc_price = btc_prices[k];
+            if (!(prefill_btc_price > 0.0f)
+                || !isfinite(prefill_btc_price)) {
+                state.valid = false;
+                return;
+            }
+            state.valid = state.valid
+                && update_equity_balance_diff_accumulator(
+                    state.usd_positive_max,
+                    state.usd_positive_sum,
+                    state.usd_positive_count,
+                    state.usd_negative_max,
+                    state.usd_negative_sum,
+                    state.usd_negative_count,
+                    balance,
+                    starting_balance
+                );
+            state.valid = state.valid
+                && update_equity_balance_diff_accumulator(
+                    state.btc_positive_max,
+                    state.btc_positive_sum,
+                    state.btc_positive_count,
+                    state.btc_negative_max,
+                    state.btc_negative_sum,
+                    state.btc_negative_count,
+                    state.btc_balance,
+                    starting_balance / prefill_btc_price
+                );
+        }
+    } else if (any_fill) {
+        state.btc_balance = balance / btc_price;
+    }
+    state.valid = state.valid && update_equity_balance_diff_accumulator(
         state.usd_positive_max,
         state.usd_positive_sum,
         state.usd_positive_count,
@@ -98,20 +155,13 @@ inline void update_equity_balance_diff_state(
         balance,
         equity
     );
-    if (!state.btc_balance_initialized && !any_fill) {
-        return;
-    }
-    if (!state.btc_balance_initialized || any_fill) {
-        state.btc_balance = balance / btc_price;
-        state.btc_balance_initialized = true;
-    }
     const float btc_equity = equity / btc_price;
-    if (!(state.btc_balance > 0.0f) || !isfinite(state.btc_balance)
+    if (state.btc_balance == 0.0f || !isfinite(state.btc_balance)
         || !isfinite(btc_equity)) {
         state.valid = false;
         return;
     }
-    update_equity_balance_diff_accumulator(
+    state.valid = state.valid && update_equity_balance_diff_accumulator(
         state.btc_positive_max,
         state.btc_positive_sum,
         state.btc_positive_count,

--- a/passivbot-rust/src/gpu/mps_equity_balance_diff_common.metal
+++ b/passivbot-rust/src/gpu/mps_equity_balance_diff_common.metal
@@ -1,0 +1,151 @@
+// Shared opt-in account equity-vs-balance accumulator.
+//
+// USD and BTC analysis use separate balance histories. USD balance changes on
+// fills, while BTC balance is the post-fill USD balance converted at that
+// fill's BTC/USD price. Keep both compact accumulators in one opt-in surface.
+
+#ifndef PASSIVBOT_EQUITY_BALANCE_DIFF_ENABLED
+#define PASSIVBOT_EQUITY_BALANCE_DIFF_ENABLED 0
+#endif
+
+#if PASSIVBOT_BTC_RISK_ENABLED || PASSIVBOT_EQUITY_BALANCE_DIFF_ENABLED
+#define PASSIVBOT_BTC_PRICES_ENABLED 1
+#else
+#define PASSIVBOT_BTC_PRICES_ENABLED 0
+#endif
+
+#if PASSIVBOT_EQUITY_BALANCE_DIFF_ENABLED
+struct EquityBalanceDiffState {
+    float usd_positive_max;
+    float usd_positive_sum;
+    float usd_positive_count;
+    float usd_negative_max;
+    float usd_negative_sum;
+    float usd_negative_count;
+    float btc_positive_max;
+    float btc_positive_sum;
+    float btc_positive_count;
+    float btc_negative_max;
+    float btc_negative_sum;
+    float btc_negative_count;
+    float btc_balance;
+    bool btc_balance_initialized;
+    bool valid;
+};
+
+inline EquityBalanceDiffState init_equity_balance_diff_state() {
+    EquityBalanceDiffState state;
+    state.usd_positive_max = 0.0f;
+    state.usd_positive_sum = 0.0f;
+    state.usd_positive_count = 0.0f;
+    state.usd_negative_max = 0.0f;
+    state.usd_negative_sum = 0.0f;
+    state.usd_negative_count = 0.0f;
+    state.btc_positive_max = 0.0f;
+    state.btc_positive_sum = 0.0f;
+    state.btc_positive_count = 0.0f;
+    state.btc_negative_max = 0.0f;
+    state.btc_negative_sum = 0.0f;
+    state.btc_negative_count = 0.0f;
+    state.btc_balance = 0.0f;
+    state.btc_balance_initialized = false;
+    state.valid = true;
+    return state;
+}
+
+inline void update_equity_balance_diff_accumulator(
+    thread float& positive_max,
+    thread float& positive_sum,
+    thread float& positive_count,
+    thread float& negative_max,
+    thread float& negative_sum,
+    thread float& negative_count,
+    float balance,
+    float equity
+) {
+    const float diff = (equity - balance) / balance;
+    if (diff > 0.0f) {
+        positive_max = fmax(positive_max, diff);
+        positive_sum += diff;
+        positive_count += 1.0f;
+    } else if (diff < 0.0f) {
+        const float loss = fabs(diff);
+        negative_max = fmax(negative_max, loss);
+        negative_sum += loss;
+        negative_count += 1.0f;
+    }
+}
+
+inline void update_equity_balance_diff_state(
+    thread EquityBalanceDiffState& state,
+    float balance,
+    float equity,
+    float btc_price,
+    bool any_fill
+) {
+    if (!(balance > 0.0f) || !isfinite(balance) || !isfinite(equity)
+        || !(btc_price > 0.0f) || !isfinite(btc_price)) {
+        state.valid = false;
+        return;
+    }
+    update_equity_balance_diff_accumulator(
+        state.usd_positive_max,
+        state.usd_positive_sum,
+        state.usd_positive_count,
+        state.usd_negative_max,
+        state.usd_negative_sum,
+        state.usd_negative_count,
+        balance,
+        equity
+    );
+    if (!state.btc_balance_initialized && !any_fill) {
+        return;
+    }
+    if (!state.btc_balance_initialized || any_fill) {
+        state.btc_balance = balance / btc_price;
+        state.btc_balance_initialized = true;
+    }
+    const float btc_equity = equity / btc_price;
+    if (!(state.btc_balance > 0.0f) || !isfinite(state.btc_balance)
+        || !isfinite(btc_equity)) {
+        state.valid = false;
+        return;
+    }
+    update_equity_balance_diff_accumulator(
+        state.btc_positive_max,
+        state.btc_positive_sum,
+        state.btc_positive_count,
+        state.btc_negative_max,
+        state.btc_negative_sum,
+        state.btc_negative_count,
+        state.btc_balance,
+        btc_equity
+    );
+}
+
+inline void write_equity_balance_diff_state(
+    thread const EquityBalanceDiffState& state,
+    device float* output,
+    uint candidate
+) {
+    const int offset = int(candidate) * 12;
+    if (!state.valid) {
+        for (int column = 0; column < 12; ++column) {
+            output[offset + column] = NAN;
+        }
+        return;
+    }
+    output[offset + 0] = state.usd_positive_max;
+    output[offset + 1] = state.usd_positive_sum;
+    output[offset + 2] = state.usd_positive_count;
+    output[offset + 3] = state.usd_negative_max;
+    output[offset + 4] = state.usd_negative_sum;
+    output[offset + 5] = state.usd_negative_count;
+    output[offset + 6] = state.btc_positive_max;
+    output[offset + 7] = state.btc_positive_sum;
+    output[offset + 8] = state.btc_positive_count;
+    output[offset + 9] = state.btc_negative_max;
+    output[offset + 10] = state.btc_negative_sum;
+    output[offset + 11] = state.btc_negative_count;
+}
+#endif

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -201,6 +201,8 @@ inline bool realized_loss_proxy_allows_reducer(
 
 // PASSIVBOT_BTC_RISK_COMMON
 
+// PASSIVBOT_EQUITY_BALANCE_DIFF_COMMON
+
 inline void record_realized_net(
     float net_pnl,
     thread float& realized_pnl_cumsum_last,
@@ -1721,8 +1723,11 @@ inline void passivbot_single_coin_impl(
     constant float* params,
     constant float* settings,
     constant int* sizes,
-#if PASSIVBOT_BTC_RISK_ENABLED
+#if PASSIVBOT_BTC_PRICES_ENABLED
     constant float* btc_prices,
+#endif
+#if PASSIVBOT_EQUITY_BALANCE_DIFF_ENABLED
+    device float* equity_balance_diff,
 #endif
     device float* daily,
     device float* scalars,
@@ -1857,6 +1862,10 @@ inline void passivbot_single_coin_impl(
     bool eq_started = false;
 #if PASSIVBOT_BTC_RISK_ENABLED
     BtcRiskState btc_risk = init_btc_risk_state();
+#endif
+#if PASSIVBOT_EQUITY_BALANCE_DIFF_ENABLED
+    EquityBalanceDiffState equity_balance_diff_state =
+        init_equity_balance_diff_state();
 #endif
 #ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
     int recovery_start_k = -1;
@@ -3954,6 +3963,11 @@ inline void passivbot_single_coin_impl(
 #if PASSIVBOT_BTC_RISK_ENABLED
             update_btc_risk_state(btc_risk, eqf, btc_prices[k]);
 #endif
+#if PASSIVBOT_EQUITY_BALANCE_DIFF_ENABLED
+            update_equity_balance_diff_state(
+                equity_balance_diff_state, balance, eqf, btc_prices[k], any_fill
+            );
+#endif
             day_touched = true;
             if (!liq) {
                 float twe_net = (
@@ -4147,6 +4161,11 @@ inline void passivbot_single_coin_impl(
         short_hsl_strategy_eq
     );
 #endif
+#if PASSIVBOT_EQUITY_BALANCE_DIFF_ENABLED
+    write_equity_balance_diff_state(
+        equity_balance_diff_state, equity_balance_diff, b
+    );
+#endif
 }
 
 kernel void passivbot_trailing_martingale(
@@ -4155,8 +4174,11 @@ kernel void passivbot_trailing_martingale(
     constant float* params,
     constant float* settings,
     constant int* sizes,
-#if PASSIVBOT_BTC_RISK_ENABLED
+#if PASSIVBOT_BTC_PRICES_ENABLED
     constant float* btc_prices,
+#endif
+#if PASSIVBOT_EQUITY_BALANCE_DIFF_ENABLED
+    device float* equity_balance_diff,
 #endif
     device float* daily,
     device float* scalars,
@@ -4170,8 +4192,11 @@ kernel void passivbot_trailing_martingale(
 ) {
     passivbot_single_coin_impl(
         bars, flags, params, settings, sizes,
-#if PASSIVBOT_BTC_RISK_ENABLED
+#if PASSIVBOT_BTC_PRICES_ENABLED
         btc_prices,
+#endif
+#if PASSIVBOT_EQUITY_BALANCE_DIFF_ENABLED
+        equity_balance_diff,
 #endif
         daily, scalars, gap_hist,
         rolling_pnl_values, rolling_pnl_indices,

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -3965,7 +3965,8 @@ inline void passivbot_single_coin_impl(
 #endif
 #if PASSIVBOT_EQUITY_BALANCE_DIFF_ENABLED
             update_equity_balance_diff_state(
-                equity_balance_diff_state, balance, eqf, btc_prices[k], any_fill
+                equity_balance_diff_state, balance, eqf, btc_prices, k,
+                starting_balance, any_fill
             );
 #endif
             day_touched = true;

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
@@ -5393,7 +5393,9 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
                 equity_balance_diff_state,
                 account.balance,
                 effective_equity,
-                btc_prices[k],
+                btc_prices,
+                k,
+                starting_balance,
                 any_fill
             );
 #endif
@@ -6161,7 +6163,9 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                 equity_balance_diff_state,
                 balance,
                 effective_equity,
-                btc_prices[k],
+                btc_prices,
+                k,
+                starting_balance,
                 any_fill
             );
 #endif

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
@@ -36,6 +36,8 @@ constant float RECOVERY_FAIL_CLOSED_SENTINEL = -3.402823466e+38f;
 
 // PASSIVBOT_BTC_RISK_COMMON
 
+// PASSIVBOT_EQUITY_BALANCE_DIFF_COMMON
+
 // PASSIVBOT_MULTICOIN_COMMON
 
 inline bool realized_loss_proxy_allows_close(
@@ -4780,8 +4782,11 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
     constant float* run_settings,
     constant int* sizes,
     constant int* end_steps,
-#if PASSIVBOT_BTC_RISK_ENABLED
+#if PASSIVBOT_BTC_PRICES_ENABLED
     constant float* btc_prices,
+#endif
+#if PASSIVBOT_EQUITY_BALANCE_DIFF_ENABLED
+    device float* equity_balance_diff,
 #endif
     device float* daily,
     device float* scalars,
@@ -4905,6 +4910,10 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
     float last_eq_k = -1.0f;
 #if PASSIVBOT_BTC_RISK_ENABLED
     BtcRiskState btc_risk = init_btc_risk_state();
+#endif
+#if PASSIVBOT_EQUITY_BALANCE_DIFF_ENABLED
+    EquityBalanceDiffState equity_balance_diff_state =
+        init_equity_balance_diff_state();
 #endif
 #ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
     int recovery_start_k = -1;
@@ -5379,6 +5388,15 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
                 btc_risk, effective_equity, btc_prices[k]
             );
 #endif
+#if PASSIVBOT_EQUITY_BALANCE_DIFF_ENABLED
+            update_equity_balance_diff_state(
+                equity_balance_diff_state,
+                account.balance,
+                effective_equity,
+                btc_prices[k],
+                any_fill
+            );
+#endif
             day_touched = true;
             if (!liquidated) {
                 float twe_abs = fabs(net_position_cost / account.balance);
@@ -5579,6 +5597,11 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
             short_side.hsl_strategy_eq
         );
 #endif
+#if PASSIVBOT_EQUITY_BALANCE_DIFF_ENABLED
+    write_equity_balance_diff_state(
+        equity_balance_diff_state, equity_balance_diff, b
+    );
+#endif
 }
 
 kernel void passivbot_trailing_martingale_multicoin_fused(
@@ -5596,8 +5619,11 @@ kernel void passivbot_trailing_martingale_multicoin_fused(
     constant float* run_settings,
     constant int* sizes,
     constant int* end_steps,
-#if PASSIVBOT_BTC_RISK_ENABLED
+#if PASSIVBOT_BTC_PRICES_ENABLED
     constant float* btc_prices,
+#endif
+#if PASSIVBOT_EQUITY_BALANCE_DIFF_ENABLED
+    device float* equity_balance_diff,
 #endif
     device float* daily,
     device float* scalars,
@@ -5614,8 +5640,11 @@ kernel void passivbot_trailing_martingale_multicoin_fused(
         hour_log_ranges, coin_settings,
         long_coin_overrides, short_coin_overrides,
         params, run_settings, sizes, end_steps,
-#if PASSIVBOT_BTC_RISK_ENABLED
+#if PASSIVBOT_BTC_PRICES_ENABLED
         btc_prices,
+#endif
+#if PASSIVBOT_EQUITY_BALANCE_DIFF_ENABLED
+        equity_balance_diff,
 #endif
         daily, scalars, gap_hist, coin_fill_counts,
 #ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
@@ -5639,8 +5668,11 @@ inline void passivbot_trailing_martingale_multicoin_impl(
     constant float* run_settings,
     constant int* sizes,
     constant int* end_steps,
-#if PASSIVBOT_BTC_RISK_ENABLED
+#if PASSIVBOT_BTC_PRICES_ENABLED
     constant float* btc_prices,
+#endif
+#if PASSIVBOT_EQUITY_BALANCE_DIFF_ENABLED
+    device float* equity_balance_diff,
 #endif
     device float* daily,
     device float* scalars,
@@ -5755,6 +5787,10 @@ inline void passivbot_trailing_martingale_multicoin_impl(
     float last_eq_k = -1.0f;
 #if PASSIVBOT_BTC_RISK_ENABLED
     BtcRiskState btc_risk = init_btc_risk_state();
+#endif
+#if PASSIVBOT_EQUITY_BALANCE_DIFF_ENABLED
+    EquityBalanceDiffState equity_balance_diff_state =
+        init_equity_balance_diff_state();
 #endif
 #ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
     int recovery_start_k = -1;
@@ -6120,6 +6156,15 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                 btc_risk, effective_equity, btc_prices[k]
             );
 #endif
+#if PASSIVBOT_EQUITY_BALANCE_DIFF_ENABLED
+            update_equity_balance_diff_state(
+                equity_balance_diff_state,
+                balance,
+                effective_equity,
+                btc_prices[k],
+                any_fill
+            );
+#endif
             day_touched = true;
             if (!liquidated) {
                 float twe_abs = position_cost / balance;
@@ -6278,6 +6323,11 @@ inline void passivbot_trailing_martingale_multicoin_impl(
         ? hsl_strategy_equity_drawdown_mean_worst_1pct(side.hsl_strategy_eq)
         : 0.0f;
 #endif
+#if PASSIVBOT_EQUITY_BALANCE_DIFF_ENABLED
+    write_equity_balance_diff_state(
+        equity_balance_diff_state, equity_balance_diff, b
+    );
+#endif
 }
 
 kernel void passivbot_trailing_martingale_multicoin(
@@ -6294,8 +6344,11 @@ kernel void passivbot_trailing_martingale_multicoin(
     constant float* run_settings,
     constant int* sizes,
     constant int* end_steps,
-#if PASSIVBOT_BTC_RISK_ENABLED
+#if PASSIVBOT_BTC_PRICES_ENABLED
     constant float* btc_prices,
+#endif
+#if PASSIVBOT_EQUITY_BALANCE_DIFF_ENABLED
+    device float* equity_balance_diff,
 #endif
     device float* daily,
     device float* scalars,
@@ -6313,8 +6366,11 @@ kernel void passivbot_trailing_martingale_multicoin(
         hour_log_ranges, coin_settings,
         coin_overrides, params, run_settings,
         sizes, end_steps,
-#if PASSIVBOT_BTC_RISK_ENABLED
+#if PASSIVBOT_BTC_PRICES_ENABLED
         btc_prices,
+#endif
+#if PASSIVBOT_EQUITY_BALANCE_DIFF_ENABLED
+        equity_balance_diff,
 #endif
         daily, scalars, gap_hist, coin_fill_counts,
 #ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
@@ -6338,8 +6394,11 @@ kernel void passivbot_trailing_martingale_multicoin_long(
     constant float* run_settings,
     constant int* sizes,
     constant int* end_steps,
-#if PASSIVBOT_BTC_RISK_ENABLED
+#if PASSIVBOT_BTC_PRICES_ENABLED
     constant float* btc_prices,
+#endif
+#if PASSIVBOT_EQUITY_BALANCE_DIFF_ENABLED
+    device float* equity_balance_diff,
 #endif
     device float* daily,
     device float* scalars,
@@ -6356,8 +6415,11 @@ kernel void passivbot_trailing_martingale_multicoin_long(
         hour_log_ranges, coin_settings,
         coin_overrides, params, run_settings,
         sizes, end_steps,
-#if PASSIVBOT_BTC_RISK_ENABLED
+#if PASSIVBOT_BTC_PRICES_ENABLED
         btc_prices,
+#endif
+#if PASSIVBOT_EQUITY_BALANCE_DIFF_ENABLED
+        equity_balance_diff,
 #endif
         daily, scalars, gap_hist, coin_fill_counts,
 #ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED

--- a/src/optimization/gpu/metrics.py
+++ b/src/optimization/gpu/metrics.py
@@ -77,7 +77,24 @@ BTC_INTRADAY_RISK_METRICS = frozenset(
     }
 )
 
+EQUITY_BALANCE_DIFF_METRICS = frozenset(
+    {
+        f"equity_balance_diff_{sign}_{stat}_{currency}"
+        for sign in ("neg", "pos")
+        for stat in ("max", "mean")
+        for currency in ("btc", "usd")
+    }
+    | {
+        f"paper_loss{middle}_ratio_{currency}"
+        for middle in ("", "_mean")
+        for currency in ("btc", "usd")
+    }
+)
+
 _BTC_ACCOUNT_METRICS.update(BTC_INTRADAY_RISK_METRICS)
+_BTC_ACCOUNT_METRICS.update(
+    metric for metric in EQUITY_BALANCE_DIFF_METRICS if metric.endswith("_btc")
+)
 
 _BTC_PER_EXPOSURE_METRICS = {
     f"{metric}_per_exposure_{side}_btc"
@@ -226,6 +243,11 @@ SUPPORTED_METRICS = (
     *_USD_STRATEGY_EQ_ALIASES,
     *_USD_PER_EXPOSURE_METRICS,
     *sorted(BTC_ACCOUNT_METRICS),
+    *sorted(
+        metric
+        for metric in EQUITY_BALANCE_DIFF_METRICS
+        if metric.endswith("_usd")
+    ),
 )
 
 # Metrics backed by additional per-fill aggregates emitted by Metal.
@@ -1564,6 +1586,28 @@ def _daily_peak_recovery_ms(day_end_eq, active):
     )
 
 
+def _equity_balance_diff_values(out: dict, *, suffix: str = "") -> dict:
+    base_names = (
+        "equity_balance_diff_pos_max",
+        "equity_balance_diff_pos_mean",
+        "equity_balance_diff_neg_max",
+        "equity_balance_diff_neg_mean",
+    )
+    names = tuple(f"{name}{suffix}" for name in base_names)
+    missing = [name for name in names if name not in out]
+    if missing:
+        raise RuntimeError(
+            "MPS equity-balance-diff output is missing " + ", ".join(missing)
+        )
+    values = {
+        base_name: out[name].to(torch.float64)
+        for base_name, name in zip(base_names, names)
+    }
+    if any(not bool(torch.isfinite(value).all()) for value in values.values()):
+        raise RuntimeError("MPS equity-balance-diff output is non-finite")
+    return values
+
+
 def _btc_account_metrics(out: dict, run, data: dict, requested) -> dict:
     """Reduce the compact USD strategy-equity surface into BTC account metrics.
 
@@ -1670,6 +1714,21 @@ def _btc_account_metrics(out: dict, run, data: dict, requested) -> dict:
         "mdg_btc": mdg,
         "omega_ratio_btc": omega,
     }
+    btc_equity_balance_metrics = {
+        metric
+        for metric in EQUITY_BALANCE_DIFF_METRICS
+        if metric.endswith("_btc")
+    }
+    if requested & btc_equity_balance_metrics:
+        differences = _equity_balance_diff_values(out, suffix="_btc")
+        for name, value in differences.items():
+            values[f"{name}_btc"] = value
+        values["paper_loss_ratio_btc"] = adg / differences[
+            "equity_balance_diff_neg_max"
+        ].clamp(min=1e-12)
+        values["paper_loss_mean_ratio_btc"] = adg / differences[
+            "equity_balance_diff_neg_mean"
+        ].clamp(min=1e-12)
     if risk_requested:
         _risk_gain, risk_adg = _smoothed_gain_adg(risk_day_end_btc, active)
         min_changes, min_change_mask = _pct_change(risk_day_min_btc, active)
@@ -1699,8 +1758,17 @@ def _btc_account_metrics(out: dict, run, data: dict, requested) -> dict:
         "drawdown_worst_btc",
         "drawdown_worst_mean_1pct_btc",
     }
+    equity_balance_diff_defaults = {
+        f"equity_balance_diff_{sign}_{stat}_btc"
+        for sign in ("neg", "pos")
+        for stat in ("max", "mean")
+    }
     for name in tuple(values):
-        default = torch.ones_like(adg) if name in drawdown_defaults else zeros
+        default = (
+            torch.ones_like(adg)
+            if name in drawdown_defaults | equity_balance_diff_defaults
+            else zeros
+        )
         values[name] = torch.where(has_fill, values[name], default)
 
     shape_names = {
@@ -2112,6 +2180,30 @@ def compute_objectives(out: dict, run, data: dict, needed=None) -> dict:
         "strategy_eq_underwater_pct_median": underwater_median,
         "volume_pct_per_day_avg": volume_pct,
     }
+    usd_equity_balance_metrics = {
+        metric
+        for metric in EQUITY_BALANCE_DIFF_METRICS
+        if metric.endswith("_usd")
+    }
+    if requested & usd_equity_balance_metrics:
+        differences = _equity_balance_diff_values(out)
+        has_fills = out["fill_count"].to(torch.float64) > 0.0
+        for name, value in differences.items():
+            objectives[f"{name}_usd"] = torch.where(
+                has_fills, value, torch.ones_like(value)
+            )
+        objectives["paper_loss_ratio_usd"] = torch.where(
+            has_fills,
+            adg
+            / differences["equity_balance_diff_neg_max"].clamp(min=1e-12),
+            torch.zeros_like(adg),
+        )
+        objectives["paper_loss_mean_ratio_usd"] = torch.where(
+            has_fills,
+            adg
+            / differences["equity_balance_diff_neg_mean"].clamp(min=1e-12),
+            torch.zeros_like(adg),
+        )
     objectives.update(hard_stop_ema_drawdown_metrics)
     objectives.update(hard_stop_raw_drawdown_metrics)
     objectives.update(hard_stop_ema_tail_metrics)

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -44,6 +44,7 @@ MPS_MULTICOIN_FUSED_RAW_DRAWDOWN_SCALAR_COLS = 70
 MPS_MULTICOIN_FUSED_SCALAR_COLS = 72
 MPS_DIRECTIONAL_HSL_ROLLING_CAPACITY = 2048
 MPS_STRATEGY_EQ_RECOVERY_METRIC_COLS = 7
+MPS_EQUITY_BALANCE_DIFF_COLS = 12
 
 _HSL_EMA_TAIL_DEFINE = "#define PASSIVBOT_HSL_EMA_TAIL_ENABLED 1\n"
 _HSL_RAW_DRAWDOWN_DEFINE = "#define PASSIVBOT_HSL_RAW_DRAWDOWN_ENABLED 1\n"
@@ -55,6 +56,9 @@ _FIXED_WEL_DENOMINATOR_DEFINE = (
     "#define PASSIVBOT_DYNAMIC_WEL_BY_TRADABILITY 0\n"
 )
 _BTC_RISK_DEFINE = "#define PASSIVBOT_BTC_RISK_ENABLED 1\n"
+_EQUITY_BALANCE_DIFF_DEFINE = (
+    "#define PASSIVBOT_EQUITY_BALANCE_DIFF_ENABLED 1\n"
+)
 
 
 def _with_hsl_ema_tail(source: str, enabled: bool) -> str:
@@ -112,6 +116,16 @@ def _with_btc_risk(source: str, enabled: bool) -> str:
     if "struct BtcRiskState" not in source:
         raise RuntimeError("MPS source is missing the shared BTC-risk contract")
     return _BTC_RISK_DEFINE + source
+
+
+def _with_equity_balance_diff(source: str, enabled: bool) -> str:
+    if not enabled:
+        return source
+    if "struct EquityBalanceDiffState" not in source:
+        raise RuntimeError(
+            "MPS source is missing the shared equity-balance-diff contract"
+        )
+    return _EQUITY_BALANCE_DIFF_DEFINE + source
 
 
 def _encode_max_realized_loss_pct(value: float) -> float:
@@ -375,6 +389,34 @@ def _decode_btc_risk_outputs(daily, active_days, first_column: int) -> dict:
     }
 
 
+def _decode_equity_balance_diff_outputs(values) -> dict:
+    if values is None:
+        return {}
+    if values.ndim != 2 or values.shape[1] != MPS_EQUITY_BALANCE_DIFF_COLS:
+        raise RuntimeError(
+            "MPS equity-balance-diff output has an invalid shape: "
+            f"{tuple(values.shape)}"
+        )
+    output = {}
+    for suffix, offset in (("", 0), ("_btc", 6)):
+        positive_count = values[:, offset + 2]
+        negative_count = values[:, offset + 5]
+        zeros = torch.zeros_like(positive_count)
+        output[f"equity_balance_diff_pos_max{suffix}"] = values[:, offset]
+        output[f"equity_balance_diff_pos_mean{suffix}"] = torch.where(
+            positive_count > 0.0,
+            values[:, offset + 1] / positive_count.clamp(min=1.0),
+            zeros,
+        )
+        output[f"equity_balance_diff_neg_max{suffix}"] = values[:, offset + 3]
+        output[f"equity_balance_diff_neg_mean{suffix}"] = torch.where(
+            negative_count > 0.0,
+            values[:, offset + 4] / negative_count.clamp(min=1.0),
+            zeros,
+        )
+    return output
+
+
 @lru_cache(maxsize=16)
 def _shader_library(
     hsl_ema_tail_enabled: bool = False,
@@ -382,25 +424,22 @@ def _shader_library(
     hsl_raw_tail_enabled: bool = False,
     recovery_distribution_enabled: bool = False,
     btc_risk_enabled: bool = False,
+    equity_balance_diff_enabled: bool = False,
 ):
     if not torch.backends.mps.is_available():
         raise RuntimeError("Apple MPS is not available in this process")
     import passivbot_rust
 
-    return torch.mps.compile_shader(
-        _with_btc_risk(
-            _with_recovery_distribution(
-                _with_hsl_features(
-                    passivbot_rust.mps_ema_anchor_source_py(),
-                    ema_tail_enabled=hsl_ema_tail_enabled,
-                    raw_drawdown_enabled=hsl_raw_drawdown_enabled,
-                    raw_tail_enabled=hsl_raw_tail_enabled,
-                ),
-                recovery_distribution_enabled,
-            ),
-            btc_risk_enabled,
-        )
+    source = _with_hsl_features(
+        passivbot_rust.mps_ema_anchor_source_py(),
+        ema_tail_enabled=hsl_ema_tail_enabled,
+        raw_drawdown_enabled=hsl_raw_drawdown_enabled,
+        raw_tail_enabled=hsl_raw_tail_enabled,
     )
+    source = _with_recovery_distribution(source, recovery_distribution_enabled)
+    source = _with_btc_risk(source, btc_risk_enabled)
+    source = _with_equity_balance_diff(source, equity_balance_diff_enabled)
+    return torch.mps.compile_shader(source)
 
 
 @lru_cache(maxsize=16)
@@ -410,65 +449,60 @@ def _trailing_martingale_shader_library(
     hsl_raw_tail_enabled: bool = False,
     recovery_distribution_enabled: bool = False,
     btc_risk_enabled: bool = False,
+    equity_balance_diff_enabled: bool = False,
 ):
     if not torch.backends.mps.is_available():
         raise RuntimeError("Apple MPS is not available in this process")
     import passivbot_rust
 
-    return torch.mps.compile_shader(
-        _with_btc_risk(
-            _with_recovery_distribution(
-                _with_hsl_features(
-                    passivbot_rust.mps_trailing_martingale_source_py(),
-                    ema_tail_enabled=hsl_ema_tail_enabled,
-                    raw_drawdown_enabled=hsl_raw_drawdown_enabled,
-                    raw_tail_enabled=hsl_raw_tail_enabled,
-                ),
-                recovery_distribution_enabled,
-            ),
-            btc_risk_enabled,
-        )
+    source = _with_hsl_features(
+        passivbot_rust.mps_trailing_martingale_source_py(),
+        ema_tail_enabled=hsl_ema_tail_enabled,
+        raw_drawdown_enabled=hsl_raw_drawdown_enabled,
+        raw_tail_enabled=hsl_raw_tail_enabled,
     )
+    source = _with_recovery_distribution(source, recovery_distribution_enabled)
+    source = _with_btc_risk(source, btc_risk_enabled)
+    source = _with_equity_balance_diff(source, equity_balance_diff_enabled)
+    return torch.mps.compile_shader(source)
 
 
 @lru_cache(maxsize=4)
 def _trailing_martingale_long_no_hsl_shader_library(
     recovery_distribution_enabled: bool = False,
     btc_risk_enabled: bool = False,
+    equity_balance_diff_enabled: bool = False,
 ):
     if not torch.backends.mps.is_available():
         raise RuntimeError("Apple MPS is not available in this process")
     import passivbot_rust
 
-    return torch.mps.compile_shader(
-        _with_btc_risk(
-            _with_recovery_distribution(
-                passivbot_rust.mps_trailing_martingale_long_no_hsl_source_py(),
-                recovery_distribution_enabled,
-            ),
-            btc_risk_enabled,
-        )
+    source = _with_recovery_distribution(
+        passivbot_rust.mps_trailing_martingale_long_no_hsl_source_py(),
+        recovery_distribution_enabled,
     )
+    source = _with_btc_risk(source, btc_risk_enabled)
+    source = _with_equity_balance_diff(source, equity_balance_diff_enabled)
+    return torch.mps.compile_shader(source)
 
 
 @lru_cache(maxsize=4)
 def _trailing_martingale_short_no_hsl_shader_library(
     recovery_distribution_enabled: bool = False,
     btc_risk_enabled: bool = False,
+    equity_balance_diff_enabled: bool = False,
 ):
     if not torch.backends.mps.is_available():
         raise RuntimeError("Apple MPS is not available in this process")
     import passivbot_rust
 
-    return torch.mps.compile_shader(
-        _with_btc_risk(
-            _with_recovery_distribution(
-                passivbot_rust.mps_trailing_martingale_short_no_hsl_source_py(),
-                recovery_distribution_enabled,
-            ),
-            btc_risk_enabled,
-        )
+    source = _with_recovery_distribution(
+        passivbot_rust.mps_trailing_martingale_short_no_hsl_source_py(),
+        recovery_distribution_enabled,
     )
+    source = _with_btc_risk(source, btc_risk_enabled)
+    source = _with_equity_balance_diff(source, equity_balance_diff_enabled)
+    return torch.mps.compile_shader(source)
 
 
 @lru_cache(maxsize=32)
@@ -479,28 +513,25 @@ def _ema_anchor_multicoin_shader_library(
     recovery_distribution_enabled: bool = False,
     dynamic_wel_by_tradability: bool = True,
     btc_risk_enabled: bool = False,
+    equity_balance_diff_enabled: bool = False,
 ):
     if not torch.backends.mps.is_available():
         raise RuntimeError("Apple MPS is not available in this process")
     import passivbot_rust
 
-    return torch.mps.compile_shader(
-        _with_btc_risk(
-            _with_dynamic_wel_by_tradability(
-                _with_recovery_distribution(
-                    _with_hsl_features(
-                        passivbot_rust.mps_ema_anchor_multicoin_source_py(),
-                        ema_tail_enabled=hsl_ema_tail_enabled,
-                        raw_drawdown_enabled=hsl_raw_drawdown_enabled,
-                        raw_tail_enabled=hsl_raw_tail_enabled,
-                    ),
-                    recovery_distribution_enabled,
-                ),
-                dynamic_wel_by_tradability,
-            ),
-            btc_risk_enabled,
-        )
+    source = _with_hsl_features(
+        passivbot_rust.mps_ema_anchor_multicoin_source_py(),
+        ema_tail_enabled=hsl_ema_tail_enabled,
+        raw_drawdown_enabled=hsl_raw_drawdown_enabled,
+        raw_tail_enabled=hsl_raw_tail_enabled,
     )
+    source = _with_recovery_distribution(source, recovery_distribution_enabled)
+    source = _with_dynamic_wel_by_tradability(
+        source, dynamic_wel_by_tradability
+    )
+    source = _with_btc_risk(source, btc_risk_enabled)
+    source = _with_equity_balance_diff(source, equity_balance_diff_enabled)
+    return torch.mps.compile_shader(source)
 
 
 @lru_cache(maxsize=32)
@@ -511,28 +542,25 @@ def _trailing_martingale_multicoin_shader_library(
     recovery_distribution_enabled: bool = False,
     dynamic_wel_by_tradability: bool = True,
     btc_risk_enabled: bool = False,
+    equity_balance_diff_enabled: bool = False,
 ):
     if not torch.backends.mps.is_available():
         raise RuntimeError("Apple MPS is not available in this process")
     import passivbot_rust
 
-    return torch.mps.compile_shader(
-        _with_btc_risk(
-            _with_dynamic_wel_by_tradability(
-                _with_recovery_distribution(
-                    _with_hsl_features(
-                        passivbot_rust.mps_trailing_martingale_multicoin_source_py(),
-                        ema_tail_enabled=hsl_ema_tail_enabled,
-                        raw_drawdown_enabled=hsl_raw_drawdown_enabled,
-                        raw_tail_enabled=hsl_raw_tail_enabled,
-                    ),
-                    recovery_distribution_enabled,
-                ),
-                dynamic_wel_by_tradability,
-            ),
-            btc_risk_enabled,
-        )
+    source = _with_hsl_features(
+        passivbot_rust.mps_trailing_martingale_multicoin_source_py(),
+        ema_tail_enabled=hsl_ema_tail_enabled,
+        raw_drawdown_enabled=hsl_raw_drawdown_enabled,
+        raw_tail_enabled=hsl_raw_tail_enabled,
     )
+    source = _with_recovery_distribution(source, recovery_distribution_enabled)
+    source = _with_dynamic_wel_by_tradability(
+        source, dynamic_wel_by_tradability
+    )
+    source = _with_btc_risk(source, btc_risk_enabled)
+    source = _with_equity_balance_diff(source, equity_balance_diff_enabled)
+    return torch.mps.compile_shader(source)
 
 
 @lru_cache(maxsize=1)
@@ -880,6 +908,8 @@ class MpsEmaAnchorRunner:
         hsl_raw_tail_enabled: bool = False,
         recovery_distribution_enabled: bool = False,
         btc_prices: np.ndarray | None = None,
+        btc_risk_enabled: bool | None = None,
+        equity_balance_diff_enabled: bool = False,
     ):
         self.market = market
         self.run_config = run
@@ -945,7 +975,19 @@ class MpsEmaAnchorRunner:
         self.btc_prices = _btc_risk_price_tensor(
             btc_prices, expected_count=self.n
         )
-        self.btc_risk_enabled = self.btc_prices is not None
+        self.equity_balance_diff_enabled = bool(equity_balance_diff_enabled)
+        self.btc_risk_enabled = (
+            self.btc_prices is not None
+            if btc_risk_enabled is None
+            else bool(btc_risk_enabled)
+        )
+        if (
+            self.btc_risk_enabled or self.equity_balance_diff_enabled
+        ) and self.btc_prices is None:
+            raise ValueError("MPS opt-in BTC-priced metrics require BTC prices")
+        self.btc_prices_enabled = (
+            self.btc_risk_enabled or self.equity_balance_diff_enabled
+        )
         self.daily_cols = MPS_DAILY_COLS + (3 if self.btc_risk_enabled else 0)
         self.recovery_stride = (
             max(1, int(np.ceil(3_600_000.0 / float(run.interval_ms))))
@@ -1025,6 +1067,7 @@ class MpsEmaAnchorRunner:
         self._buffers: dict[int, tuple[torch.Tensor, torch.Tensor, torch.Tensor]] = {}
         self._rolling_buffers: dict[int, tuple[torch.Tensor, torch.Tensor]] = {}
         self._recovery_buffers: dict[int, torch.Tensor] = {}
+        self._equity_balance_diff_buffers: dict[int, torch.Tensor] = {}
         self._sizes: dict[tuple[int, int], torch.Tensor] = {}
         self.last_profile: dict[str, float] = {}
 
@@ -1116,6 +1159,21 @@ class MpsEmaAnchorRunner:
             self._recovery_buffers[batch_size].fill_(float("nan"))
         return self._recovery_buffers[batch_size]
 
+    def _equity_balance_diff_buffer(self, batch_size: int):
+        if not self.equity_balance_diff_enabled:
+            return None
+        if batch_size not in self._equity_balance_diff_buffers:
+            self._equity_balance_diff_buffers = {
+                batch_size: torch.zeros(
+                    (batch_size, MPS_EQUITY_BALANCE_DIFF_COLS),
+                    dtype=torch.float32,
+                    device="mps",
+                )
+            }
+        else:
+            self._equity_balance_diff_buffers[batch_size].zero_()
+        return self._equity_balance_diff_buffers[batch_size]
+
     def _single_coin_size_values(
         self, batch_size: int, parameter_count: int
     ) -> list[int]:
@@ -1148,6 +1206,7 @@ class MpsEmaAnchorRunner:
             if self.recovery_distribution_enabled
             else None
         )
+        equity_balance_diff = self._equity_balance_diff_buffer(batch_size)
         sizes_key = (batch_size, int(matrix.shape[1]))
         if sizes_key not in self._sizes:
             size_values = self._single_coin_size_values(
@@ -1165,6 +1224,7 @@ class MpsEmaAnchorRunner:
             self.hsl_raw_tail_enabled,
             self.recovery_distribution_enabled,
             self.btc_risk_enabled,
+            self.equity_balance_diff_enabled,
         )
         compiled = time.perf_counter()
         if profile:
@@ -1179,8 +1239,10 @@ class MpsEmaAnchorRunner:
             self.settings,
             self._sizes[sizes_key],
         )
-        if self.btc_risk_enabled:
+        if self.btc_prices_enabled:
             kernel_args += (self.btc_prices,)
+        if self.equity_balance_diff_enabled:
+            kernel_args += (equity_balance_diff,)
         kernel_args += (
             daily,
             scalars,
@@ -1205,6 +1267,7 @@ class MpsEmaAnchorRunner:
             "kernel_seconds": finished - dispatched,
         }
         output = _decode_directional_outputs(daily, scalars, gaps)
+        output.update(_decode_equity_balance_diff_outputs(equity_balance_diff))
         if self.recovery_distribution_enabled:
             output["strategy_eq_recovery_samples"] = recovery_samples
             output["strategy_eq_recovery_sample_interval_days"] = (
@@ -1241,6 +1304,8 @@ class MpsEmaAnchorMulticoinRunner:
         recovery_distribution_enabled: bool = False,
         dynamic_wel_by_tradability: bool = True,
         btc_prices: np.ndarray | None = None,
+        btc_risk_enabled: bool | None = None,
+        equity_balance_diff_enabled: bool = False,
     ):
         if side not in {"long", "short"}:
             raise ValueError(
@@ -1295,7 +1360,19 @@ class MpsEmaAnchorMulticoinRunner:
         self.btc_prices = _btc_risk_price_tensor(
             btc_prices, expected_count=self.n
         )
-        self.btc_risk_enabled = self.btc_prices is not None
+        self.equity_balance_diff_enabled = bool(equity_balance_diff_enabled)
+        self.btc_risk_enabled = (
+            self.btc_prices is not None
+            if btc_risk_enabled is None
+            else bool(btc_risk_enabled)
+        )
+        if (
+            self.btc_risk_enabled or self.equity_balance_diff_enabled
+        ) and self.btc_prices is None:
+            raise ValueError("MPS opt-in BTC-priced metrics require BTC prices")
+        self.btc_prices_enabled = (
+            self.btc_risk_enabled or self.equity_balance_diff_enabled
+        )
         self.daily_cols = MPS_MULTICOIN_DAILY_COLS + (
             3 if self.btc_risk_enabled else 0
         )
@@ -1390,6 +1467,7 @@ class MpsEmaAnchorMulticoinRunner:
         )
         self._buffers: dict[int, tuple[torch.Tensor, ...]] = {}
         self._recovery_buffers: dict[int, torch.Tensor] = {}
+        self._equity_balance_diff_buffers: dict[int, torch.Tensor] = {}
         self._sizes: dict[tuple[int, int], torch.Tensor] = {}
         self._full_end_steps: dict[int, torch.Tensor] = {}
         self.last_profile: dict[str, float] = {}
@@ -1485,6 +1563,7 @@ class MpsEmaAnchorMulticoinRunner:
         scalars,
         gaps,
         coin_fill_counts,
+        equity_balance_diff,
         recovery_samples,
         *,
         batch_size: int,
@@ -1501,8 +1580,10 @@ class MpsEmaAnchorMulticoinRunner:
             sizes,
             end_steps,
         )
-        if self.btc_risk_enabled:
+        if self.btc_prices_enabled:
             kernel_args += (self.btc_prices,)
+        if self.equity_balance_diff_enabled:
+            kernel_args += (equity_balance_diff,)
         kernel_args += (
             daily,
             scalars,
@@ -1524,6 +1605,7 @@ class MpsEmaAnchorMulticoinRunner:
             self.recovery_distribution_enabled,
             self.dynamic_wel_by_tradability,
             self.btc_risk_enabled,
+            self.equity_balance_diff_enabled,
         )
 
     def _decode(self, daily, scalars, gaps) -> dict:
@@ -1540,6 +1622,21 @@ class MpsEmaAnchorMulticoinRunner:
         else:
             self._recovery_buffers[batch_size].fill_(float("nan"))
         return self._recovery_buffers[batch_size]
+
+    def _equity_balance_diff_buffer(self, batch_size: int):
+        if not self.equity_balance_diff_enabled:
+            return None
+        if batch_size not in self._equity_balance_diff_buffers:
+            self._equity_balance_diff_buffers = {
+                batch_size: torch.zeros(
+                    (batch_size, MPS_EQUITY_BALANCE_DIFF_COLS),
+                    dtype=torch.float32,
+                    device="mps",
+                )
+            }
+        else:
+            self._equity_balance_diff_buffers[batch_size].zero_()
+        return self._equity_balance_diff_buffers[batch_size]
 
     def run(
         self,
@@ -1560,6 +1657,7 @@ class MpsEmaAnchorMulticoinRunner:
             if self.recovery_distribution_enabled
             else None
         )
+        equity_balance_diff = self._equity_balance_diff_buffer(batch_size)
         sizes_key = (batch_size, int(matrix.shape[1]))
         if sizes_key not in self._sizes:
             size_values = [
@@ -1598,6 +1696,7 @@ class MpsEmaAnchorMulticoinRunner:
             scalars,
             gaps,
             coin_fill_counts,
+            equity_balance_diff,
             recovery_samples,
             batch_size=batch_size,
         )
@@ -1612,6 +1711,7 @@ class MpsEmaAnchorMulticoinRunner:
             "kernel_seconds": finished - dispatched,
         }
         output = self._decode(daily, scalars, gaps)
+        output.update(_decode_equity_balance_diff_outputs(equity_balance_diff))
         if self.recovery_distribution_enabled:
             output["strategy_eq_recovery_samples"] = recovery_samples
             output["strategy_eq_recovery_sample_interval_days"] = (
@@ -1650,6 +1750,8 @@ class MpsEmaAnchorMulticoinFusedRunner(MpsEmaAnchorMulticoinRunner):
         hedge_mode: bool = True,
         dynamic_wel_by_tradability: bool = True,
         btc_prices: np.ndarray | None = None,
+        btc_risk_enabled: bool | None = None,
+        equity_balance_diff_enabled: bool = False,
     ):
         super().__init__(
             run,
@@ -1670,6 +1772,8 @@ class MpsEmaAnchorMulticoinFusedRunner(MpsEmaAnchorMulticoinRunner):
             recovery_distribution_enabled=recovery_distribution_enabled,
             dynamic_wel_by_tradability=dynamic_wel_by_tradability,
             btc_prices=btc_prices,
+            btc_risk_enabled=btc_risk_enabled,
+            equity_balance_diff_enabled=equity_balance_diff_enabled,
         )
         if short_coin_overrides is None:
             short_coin_overrides = np.full(
@@ -1747,6 +1851,7 @@ class MpsEmaAnchorMulticoinFusedRunner(MpsEmaAnchorMulticoinRunner):
         scalars,
         gaps,
         coin_fill_counts,
+        equity_balance_diff,
         recovery_samples,
         *,
         batch_size: int,
@@ -1764,8 +1869,10 @@ class MpsEmaAnchorMulticoinFusedRunner(MpsEmaAnchorMulticoinRunner):
             sizes,
             end_steps,
         )
-        if self.btc_risk_enabled:
+        if self.btc_prices_enabled:
             kernel_args += (self.btc_prices,)
+        if self.equity_balance_diff_enabled:
+            kernel_args += (equity_balance_diff,)
         kernel_args += (
             daily,
             scalars,
@@ -1793,6 +1900,8 @@ class MpsEmaAnchorMulticoinLongRunner(MpsEmaAnchorMulticoinRunner):
         *,
         dynamic_wel_by_tradability: bool = True,
         btc_prices: np.ndarray | None = None,
+        btc_risk_enabled: bool | None = None,
+        equity_balance_diff_enabled: bool = False,
     ):
         super().__init__(
             run,
@@ -1800,6 +1909,8 @@ class MpsEmaAnchorMulticoinLongRunner(MpsEmaAnchorMulticoinRunner):
             side="long",
             dynamic_wel_by_tradability=dynamic_wel_by_tradability,
             btc_prices=btc_prices,
+            btc_risk_enabled=btc_risk_enabled,
+            equity_balance_diff_enabled=equity_balance_diff_enabled,
         )
 
 
@@ -1813,6 +1924,8 @@ class MpsEmaAnchorMulticoinShortRunner(MpsEmaAnchorMulticoinRunner):
         *,
         dynamic_wel_by_tradability: bool = True,
         btc_prices: np.ndarray | None = None,
+        btc_risk_enabled: bool | None = None,
+        equity_balance_diff_enabled: bool = False,
     ):
         super().__init__(
             run,
@@ -1820,6 +1933,8 @@ class MpsEmaAnchorMulticoinShortRunner(MpsEmaAnchorMulticoinRunner):
             side="short",
             dynamic_wel_by_tradability=dynamic_wel_by_tradability,
             btc_prices=btc_prices,
+            btc_risk_enabled=btc_risk_enabled,
+            equity_balance_diff_enabled=equity_balance_diff_enabled,
         )
 
 
@@ -1854,6 +1969,8 @@ class MpsTrailingMartingaleMulticoinRunner(MpsEmaAnchorMulticoinRunner):
         recovery_distribution_enabled: bool = False,
         dynamic_wel_by_tradability: bool = True,
         btc_prices: np.ndarray | None = None,
+        btc_risk_enabled: bool | None = None,
+        equity_balance_diff_enabled: bool = False,
     ):
         super().__init__(
             run,
@@ -1874,6 +1991,8 @@ class MpsTrailingMartingaleMulticoinRunner(MpsEmaAnchorMulticoinRunner):
             recovery_distribution_enabled=recovery_distribution_enabled,
             dynamic_wel_by_tradability=dynamic_wel_by_tradability,
             btc_prices=btc_prices,
+            btc_risk_enabled=btc_risk_enabled,
+            equity_balance_diff_enabled=equity_balance_diff_enabled,
         )
 
     def _pack_params(self, params: np.ndarray) -> np.ndarray:
@@ -1902,6 +2021,7 @@ class MpsTrailingMartingaleMulticoinRunner(MpsEmaAnchorMulticoinRunner):
             self.recovery_distribution_enabled,
             self.dynamic_wel_by_tradability,
             self.btc_risk_enabled,
+            self.equity_balance_diff_enabled,
         )
 
     def _dispatch(
@@ -1914,6 +2034,7 @@ class MpsTrailingMartingaleMulticoinRunner(MpsEmaAnchorMulticoinRunner):
         scalars,
         gaps,
         coin_fill_counts,
+        equity_balance_diff,
         recovery_samples,
         *,
         batch_size: int,
@@ -1933,8 +2054,10 @@ class MpsTrailingMartingaleMulticoinRunner(MpsEmaAnchorMulticoinRunner):
             sizes,
             end_steps,
         )
-        if self.btc_risk_enabled:
+        if self.btc_prices_enabled:
             kernel_args += (self.btc_prices,)
+        if self.equity_balance_diff_enabled:
+            kernel_args += (equity_balance_diff,)
         kernel_args += (
             daily,
             scalars,
@@ -1982,6 +2105,8 @@ class MpsTrailingMartingaleMulticoinFusedRunner(
         hedge_mode: bool = True,
         dynamic_wel_by_tradability: bool = True,
         btc_prices: np.ndarray | None = None,
+        btc_risk_enabled: bool | None = None,
+        equity_balance_diff_enabled: bool = False,
     ):
         super().__init__(
             run,
@@ -2002,6 +2127,8 @@ class MpsTrailingMartingaleMulticoinFusedRunner(
             recovery_distribution_enabled=recovery_distribution_enabled,
             dynamic_wel_by_tradability=dynamic_wel_by_tradability,
             btc_prices=btc_prices,
+            btc_risk_enabled=btc_risk_enabled,
+            equity_balance_diff_enabled=equity_balance_diff_enabled,
         )
         if short_coin_overrides is None:
             short_coin_overrides = np.full(
@@ -2074,6 +2201,7 @@ class MpsTrailingMartingaleMulticoinFusedRunner(
         scalars,
         gaps,
         coin_fill_counts,
+        equity_balance_diff,
         recovery_samples,
         *,
         batch_size: int,
@@ -2094,8 +2222,10 @@ class MpsTrailingMartingaleMulticoinFusedRunner(
             sizes,
             end_steps,
         )
-        if self.btc_risk_enabled:
+        if self.btc_prices_enabled:
             kernel_args += (self.btc_prices,)
+        if self.equity_balance_diff_enabled:
+            kernel_args += (equity_balance_diff,)
         kernel_args += (
             daily,
             scalars,
@@ -2136,11 +2266,13 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
             return _trailing_martingale_long_no_hsl_shader_library(
                 self.recovery_distribution_enabled,
                 self.btc_risk_enabled,
+                self.equity_balance_diff_enabled,
             )
         if self.shader_topology == "short_no_hsl":
             return _trailing_martingale_short_no_hsl_shader_library(
                 self.recovery_distribution_enabled,
                 self.btc_risk_enabled,
+                self.equity_balance_diff_enabled,
             )
         return _trailing_martingale_shader_library(
             self.hsl_ema_tail_enabled,
@@ -2148,6 +2280,7 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
             self.hsl_raw_tail_enabled,
             self.recovery_distribution_enabled,
             self.btc_risk_enabled,
+            self.equity_balance_diff_enabled,
         )
 
     def _pack_params(self, params: np.ndarray) -> np.ndarray:
@@ -2187,6 +2320,7 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
             if self.recovery_distribution_enabled
             else None
         )
+        equity_balance_diff = self._equity_balance_diff_buffer(batch_size)
         sizes_key = (batch_size, int(matrix.shape[1]))
         if sizes_key not in self._sizes:
             size_values = self._single_coin_size_values(
@@ -2212,8 +2346,10 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
             self.settings,
             self._sizes[sizes_key],
         )
-        if self.btc_risk_enabled:
+        if self.btc_prices_enabled:
             kernel_args += (self.btc_prices,)
+        if self.equity_balance_diff_enabled:
+            kernel_args += (equity_balance_diff,)
         kernel_args += (
             daily,
             scalars,
@@ -2238,6 +2374,7 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
             "kernel_seconds": finished - dispatched,
         }
         output = _decode_directional_outputs(daily, scalars, gaps)
+        output.update(_decode_equity_balance_diff_outputs(equity_balance_diff))
         if self.recovery_distribution_enabled:
             output["strategy_eq_recovery_samples"] = recovery_samples
             output["strategy_eq_recovery_sample_interval_days"] = (

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -54,6 +54,14 @@ CORE_OUTPUT_KEYS = {
     "btc_day_end_eq",
     "btc_day_min_eq",
     "btc_day_max_dd",
+    "equity_balance_diff_neg_max",
+    "equity_balance_diff_neg_mean",
+    "equity_balance_diff_pos_max",
+    "equity_balance_diff_pos_mean",
+    "equity_balance_diff_neg_max_btc",
+    "equity_balance_diff_neg_mean_btc",
+    "equity_balance_diff_pos_max_btc",
+    "equity_balance_diff_pos_mean_btc",
     "day_end_eq",
     "day_min_eq",
     "day_max_dd",
@@ -1331,6 +1339,7 @@ class MpsSingleCoinProxy:
         from backtest import build_backtest_payload
         from optimization.gpu.metrics import (
             BTC_INTRADAY_RISK_METRICS,
+            EQUITY_BALANCE_DIFF_METRICS,
             compute_objectives,
         )
         from optimization.gpu.mps_kernel import (
@@ -1346,6 +1355,9 @@ class MpsSingleCoinProxy:
         )
         self.btc_risk_enabled = bool(
             self.needed_metrics & BTC_INTRADAY_RISK_METRICS
+        )
+        self.equity_balance_diff_enabled = bool(
+            self.needed_metrics & EQUITY_BALANCE_DIFF_METRICS
         )
         btc_values = np.ascontiguousarray(
             np.asarray(btc, dtype=np.float64).reshape(-1)
@@ -1643,7 +1655,13 @@ class MpsSingleCoinProxy:
             recovery_distribution_enabled=bool(
                 self.needed_metrics & _STRATEGY_EQ_RECOVERY_DISTRIBUTION_METRICS
             ),
-            btc_prices=btc_values if self.btc_risk_enabled else None,
+            btc_prices=(
+                btc_values
+                if self.btc_risk_enabled or self.equity_balance_diff_enabled
+                else None
+            ),
+            btc_risk_enabled=self.btc_risk_enabled,
+            equity_balance_diff_enabled=self.equity_balance_diff_enabled,
         )
         if self.strategy_kind == "trailing_martingale":
             runner_kwargs["hsl_enabled"] = any_configured_hsl
@@ -2156,6 +2174,7 @@ class MpsMulticoinProxy:
         from backtest import build_backtest_payload
         from optimization.gpu.metrics import (
             BTC_INTRADAY_RISK_METRICS,
+            EQUITY_BALANCE_DIFF_METRICS,
             compute_objectives,
         )
         from optimization.gpu.mps_kernel import (
@@ -2173,6 +2192,9 @@ class MpsMulticoinProxy:
         )
         self.btc_risk_enabled = bool(
             self.needed_metrics & BTC_INTRADAY_RISK_METRICS
+        )
+        self.equity_balance_diff_enabled = bool(
+            self.needed_metrics & EQUITY_BALANCE_DIFF_METRICS
         )
         btc_values = np.ascontiguousarray(
             np.asarray(btc, dtype=np.float64).reshape(-1)
@@ -2610,7 +2632,13 @@ class MpsMulticoinProxy:
                 & _STRATEGY_EQ_RECOVERY_DISTRIBUTION_METRICS
             ),
             "dynamic_wel_by_tradability": self.dynamic_wel_by_tradability,
-            "btc_prices": btc_values if self.btc_risk_enabled else None,
+            "btc_prices": (
+                btc_values
+                if self.btc_risk_enabled or self.equity_balance_diff_enabled
+                else None
+            ),
+            "btc_risk_enabled": self.btc_risk_enabled,
+            "equity_balance_diff_enabled": self.equity_balance_diff_enabled,
         }
         if self.shared_account_fused:
             fused_runner_cls = (

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -3261,6 +3261,31 @@ def test_gpu_foundation_accepts_synchronized_btc_risk_metrics(metric, goal):
 
 
 @pytest.mark.parametrize(
+    ("metric", "goal"),
+    [
+        ("equity_balance_diff_neg_max_usd", "min"),
+        ("equity_balance_diff_neg_mean_usd", "min"),
+        ("equity_balance_diff_pos_max_usd", "max"),
+        ("equity_balance_diff_pos_mean_usd", "max"),
+        ("paper_loss_ratio_usd", "max"),
+        ("paper_loss_mean_ratio_usd", "max"),
+        ("equity_balance_diff_neg_max_btc", "min"),
+        ("equity_balance_diff_neg_mean_btc", "min"),
+        ("equity_balance_diff_pos_max_btc", "max"),
+        ("equity_balance_diff_pos_mean_btc", "max"),
+        ("paper_loss_ratio_btc", "max"),
+        ("paper_loss_mean_ratio_btc", "max"),
+    ],
+)
+def test_gpu_foundation_accepts_equity_balance_diff_metrics(metric, goal):
+    config = _long_only_ema_config()
+    config["backtest"]["btc_collateral_cap"] = 0.0
+    config["optimize"]["scoring"] = [{"goal": goal, "metric": metric}]
+
+    assert _validate_scope(config, _Evaluator()) == "bybit"
+
+
+@pytest.mark.parametrize(
     "metric",
     [
         "entry_initial_balance_pct_long",

--- a/tests/optimization/test_gpu_metrics.py
+++ b/tests/optimization/test_gpu_metrics.py
@@ -111,6 +111,180 @@ def test_directional_pnl_metrics_match_rust_neutral_and_alias_contracts():
     assert set(metrics) <= set(SUPPORTED_METRICS)
 
 
+def test_equity_balance_diff_and_paper_loss_metrics_match_rust_contract():
+    day_end = torch.tensor([[100.0, 110.0, 121.0]], dtype=torch.float64)
+    out = {
+        "day_end_eq": day_end,
+        "day_min_eq": day_end.clone(),
+        "day_max_dd": torch.zeros_like(day_end),
+        "day_volume": torch.zeros_like(day_end),
+        "day_has_fill": torch.ones_like(day_end, dtype=torch.bool),
+        "fill_count": torch.tensor([2.0]),
+        "max_dd": torch.zeros(1),
+        "held_max_ms": torch.zeros(1),
+        "gap_hist": torch.zeros((1, 128), dtype=torch.int32),
+        "gap_max_ms": torch.zeros(1),
+        "first_fill_ts": torch.tensor([0.0]),
+        "last_fill_ts": torch.tensor([2 * 86_400_000.0]),
+        "recovery_max_ms": torch.zeros(1),
+        "last_high_ts": torch.tensor([2 * 86_400_000.0]),
+        "first_eq_ts": torch.tensor([0.0]),
+        "last_eq_ts": torch.tensor([2 * 86_400_000.0]),
+        "liq_step": torch.tensor([-1]),
+        "equity_balance_diff_pos_max": torch.tensor([0.20]),
+        "equity_balance_diff_pos_mean": torch.tensor([0.10]),
+        "equity_balance_diff_neg_max": torch.tensor([0.30]),
+        "equity_balance_diff_neg_mean": torch.tensor([0.15]),
+        "equity_balance_diff_pos_max_btc": torch.tensor([0.25]),
+        "equity_balance_diff_pos_mean_btc": torch.tensor([0.125]),
+        "equity_balance_diff_neg_max_btc": torch.tensor([0.35]),
+        "equity_balance_diff_neg_mean_btc": torch.tensor([0.175]),
+    }
+    requested = {
+        f"equity_balance_diff_{sign}_{stat}_{currency}"
+        for sign in ("neg", "pos")
+        for stat in ("max", "mean")
+        for currency in ("btc", "usd")
+    } | {
+        f"paper_loss{middle}_ratio_{currency}"
+        for middle in ("", "_mean")
+        for currency in ("btc", "usd")
+    }
+
+    metrics = compute_objectives(
+        out,
+        SimpleNamespace(
+            requested_start_ts_ms=0,
+            guard_ts_ms=0,
+            interval_ms=86_400_000,
+        ),
+        {
+            "ts0": 0.0,
+            "n": 3,
+            "btc_day_end_price": np.ones(3),
+            "btc_prices": np.ones(3),
+        },
+        needed=requested,
+    )
+
+    _gain, adg = _smoothed_gain_adg(
+        day_end, torch.ones_like(day_end, dtype=torch.bool)
+    )
+    assert set(metrics) == requested
+    assert requested <= set(SUPPORTED_METRICS)
+    expected_differences = {
+        "usd": (0.20, 0.10, 0.30, 0.15),
+        "btc": (0.25, 0.125, 0.35, 0.175),
+    }
+    for currency, (pos_max, pos_mean, neg_max, neg_mean) in expected_differences.items():
+        assert metrics[f"equity_balance_diff_pos_max_{currency}"].item() == pytest.approx(pos_max)
+        assert metrics[f"equity_balance_diff_pos_mean_{currency}"].item() == pytest.approx(pos_mean)
+        assert metrics[f"equity_balance_diff_neg_max_{currency}"].item() == pytest.approx(neg_max)
+        assert metrics[f"equity_balance_diff_neg_mean_{currency}"].item() == pytest.approx(neg_mean)
+        assert metrics[f"paper_loss_ratio_{currency}"].item() == pytest.approx(
+            adg.item() / neg_max
+        )
+        assert metrics[f"paper_loss_mean_ratio_{currency}"].item() == pytest.approx(
+            adg.item() / neg_mean
+        )
+
+
+def test_equity_balance_diff_metrics_fail_closed_without_metal_output():
+    day_end = torch.tensor([[100.0]], dtype=torch.float64)
+    out = {
+        "day_end_eq": day_end,
+        "day_min_eq": day_end.clone(),
+        "day_max_dd": torch.zeros_like(day_end),
+        "day_volume": torch.zeros_like(day_end),
+        "day_has_fill": torch.zeros_like(day_end, dtype=torch.bool),
+        "fill_count": torch.zeros(1),
+        "max_dd": torch.zeros(1),
+        "held_max_ms": torch.zeros(1),
+        "gap_hist": torch.zeros((1, 128), dtype=torch.int32),
+        "gap_max_ms": torch.zeros(1),
+        "first_fill_ts": torch.full((1,), float("nan")),
+        "last_fill_ts": torch.full((1,), float("nan")),
+        "recovery_max_ms": torch.zeros(1),
+        "last_high_ts": torch.tensor([0.0]),
+        "first_eq_ts": torch.tensor([0.0]),
+        "last_eq_ts": torch.tensor([0.0]),
+        "liq_step": torch.tensor([-1]),
+    }
+
+    with pytest.raises(RuntimeError, match="equity-balance-diff output is missing"):
+        compute_objectives(
+            out,
+            SimpleNamespace(
+                requested_start_ts_ms=0,
+                guard_ts_ms=0,
+                interval_ms=60_000,
+            ),
+            {"ts0": 0.0, "n": 1},
+            needed={"paper_loss_ratio_usd"},
+        )
+
+
+def test_equity_balance_diff_metrics_use_rust_defaults_without_fills():
+    day_end = torch.tensor([[100.0]], dtype=torch.float64)
+    out = {
+        "day_end_eq": day_end,
+        "day_min_eq": day_end.clone(),
+        "day_max_dd": torch.zeros_like(day_end),
+        "day_volume": torch.zeros_like(day_end),
+        "day_has_fill": torch.zeros_like(day_end, dtype=torch.bool),
+        "fill_count": torch.zeros(1),
+        "max_dd": torch.zeros(1),
+        "held_max_ms": torch.zeros(1),
+        "gap_hist": torch.zeros((1, 128), dtype=torch.int32),
+        "gap_max_ms": torch.zeros(1),
+        "first_fill_ts": torch.full((1,), float("nan")),
+        "last_fill_ts": torch.full((1,), float("nan")),
+        "recovery_max_ms": torch.zeros(1),
+        "last_high_ts": torch.tensor([0.0]),
+        "first_eq_ts": torch.tensor([0.0]),
+        "last_eq_ts": torch.tensor([0.0]),
+        "liq_step": torch.tensor([-1]),
+        "equity_balance_diff_pos_max": torch.zeros(1),
+        "equity_balance_diff_pos_mean": torch.zeros(1),
+        "equity_balance_diff_neg_max": torch.zeros(1),
+        "equity_balance_diff_neg_mean": torch.zeros(1),
+        "equity_balance_diff_pos_max_btc": torch.zeros(1),
+        "equity_balance_diff_pos_mean_btc": torch.zeros(1),
+        "equity_balance_diff_neg_max_btc": torch.zeros(1),
+        "equity_balance_diff_neg_mean_btc": torch.zeros(1),
+    }
+    requested = {
+        f"equity_balance_diff_{sign}_{stat}_{currency}"
+        for sign in ("neg", "pos")
+        for stat in ("max", "mean")
+        for currency in ("btc", "usd")
+    } | {
+        f"paper_loss{middle}_ratio_{currency}"
+        for middle in ("", "_mean")
+        for currency in ("btc", "usd")
+    }
+
+    metrics = compute_objectives(
+        out,
+        SimpleNamespace(
+            requested_start_ts_ms=0,
+            guard_ts_ms=0,
+            interval_ms=60_000,
+        ),
+        {
+            "ts0": 0.0,
+            "n": 1,
+            "btc_day_end_price": np.ones(1),
+            "btc_prices": np.ones(1),
+        },
+        needed=requested,
+    )
+
+    for name in requested:
+        expected = 0.0 if name.startswith("paper_loss") else 1.0
+        assert metrics[name].item() == expected
+
+
 def test_equity_shape_metrics_match_rust_daily_series_contract():
     day_eq = torch.tensor(
         [

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -4303,11 +4303,12 @@ def test_mps_single_coin_service_dispatches_forced_delist_tail(strategy_kind):
     from config.schema import get_template_config
     from optimization.gpu.service import MpsSingleCoinProxy
 
-    last_valid = 6
+    entry_k = 7
+    last_valid = 10
     count = last_valid + 1401
     hlcvs = np.full((count, 1, 4), np.nan, dtype=np.float64)
     hlcvs[: last_valid + 1, 0] = [100.0, 100.0, 100.0, 1.0]
-    hlcvs[3, 0, 1] = 98.0
+    hlcvs[entry_k, 0, 1] = 98.0
     hlcvs[last_valid, 0] = [80.0, 80.0, 80.0, 1.0]
     timestamps = (
         1_700_000_000_000
@@ -4365,7 +4366,11 @@ def test_mps_single_coin_service_dispatches_forced_delist_tail(strategy_kind):
         strategy["entry"]["initial_qty_pct"] = 0.1
         strategy["entry"]["initial_ema_dist"] = 0.01
 
-    btc_prices = np.linspace(50_000.0, 55_000.0, count)
+    # The first tracked no-position sample sees the higher BTC price, then the
+    # first entry fills after the drop. Exact Rust seeds its BTC balance from
+    # that first fill and applies it to the earlier sample too.
+    btc_prices = np.full(count, 40_000.0)
+    btc_prices[:entry_k] = 60_000.0
     proxy = MpsSingleCoinProxy(
         config=config,
         hlcvs=hlcvs,
@@ -4683,15 +4688,16 @@ def test_mps_multicoin_service_dispatches_forced_delist_tail(
     from config.schema import get_template_config
     from optimization.gpu.service import MpsMulticoinProxy
 
-    last_valid = 6
+    entry_k = 7
+    last_valid = 10
     count = last_valid + 1401
     hlcvs = np.full((count, 2, 4), np.nan, dtype=np.float64)
     hlcvs[: last_valid + 1, 0] = [100.0, 100.0, 100.0, 1.0]
     hlcvs[:, 1] = [200.0, 200.0, 200.0, 1.0]
     if topology in {"long", "fused"}:
-        hlcvs[3, 0, 1] = 80.0
+        hlcvs[entry_k, 0, 1] = 80.0
     if topology in {"short", "fused"}:
-        hlcvs[3, 0, 0] = 120.0
+        hlcvs[entry_k, 0, 0] = 120.0
     delist_close = {
         "long": 50.0,
         "short": 150.0,
@@ -4774,7 +4780,9 @@ def test_mps_multicoin_service_dispatches_forced_delist_tail(
             strategy["entry"]["double_down_factor"] = 0.0
             strategy["close"]["threshold_base_pct"] = 0.5
 
-    btc_prices = np.linspace(50_000.0, 55_000.0, count)
+    # Exercise the canonical pre-fill BTC replay before the delayed entry.
+    btc_prices = np.full(count, 40_000.0)
+    btc_prices[:entry_k] = 60_000.0
     proxy = MpsMulticoinProxy(
         config=config,
         hlcvs=hlcvs,
@@ -11825,20 +11833,45 @@ def test_mps_recovery_captures_early_post_fill_liquidation_endpoint():
     data = build_mps_data(high, low, close, timestamps, run, market)
     row = [1.0, 2.0, 3.0, 0.0, 0.0001, 0.0, 0.0, 0.0, 2.0, 2.0, 0.0, 1.0]
     row += _single_coin_exposure_fields() + _tm_twel_enforcer_fields()
+    safe_row = list(row)
+    safe_row[0] = 0.0
     parameters = np.array(
-        [row + row],
+        [row + row, safe_row + safe_row],
         dtype=np.float64,
     )
+    btc_prices = np.full(count, 50_000.0)
 
     runner = MpsEmaAnchorRunner(
-        market, run, data, recovery_distribution_enabled=True
+        market,
+        run,
+        data,
+        recovery_distribution_enabled=True,
+        btc_prices=btc_prices,
+        btc_risk_enabled=False,
+        equity_balance_diff_enabled=True,
     )
     output = runner.run(parameters)
     torch.mps.synchronize()
 
     assert output["day_has_fill"].sum().item() > 0
-    assert output["day_volume"].sum().item() < 0.0
-    assert not output["alive"].item()
+    assert output["day_volume"][0].sum().item() < 0.0
+    assert not output["alive"][0].item()
+    assert output["alive"][1].item()
+    for name in (
+        "equity_balance_diff_neg_max",
+        "equity_balance_diff_neg_mean",
+        "equity_balance_diff_pos_max",
+        "equity_balance_diff_pos_mean",
+        "equity_balance_diff_neg_max_btc",
+        "equity_balance_diff_neg_mean_btc",
+        "equity_balance_diff_pos_max_btc",
+        "equity_balance_diff_pos_mean_btc",
+    ):
+        assert torch.isfinite(output[name]).all().item(), name
+    assert output["equity_balance_diff_neg_max"][0].item() > 1.9
+    assert output["equity_balance_diff_neg_max_btc"][0].item() == pytest.approx(
+        output["equity_balance_diff_neg_max"][0].item(), rel=1.0e-6
+    )
     samples = output["strategy_eq_recovery_samples"][0]
     finite_samples = samples[torch.isfinite(samples)]
     assert finite_samples.numel() >= 2

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -4379,9 +4379,21 @@ def test_mps_single_coin_service_dispatches_forced_delist_tail(strategy_kind):
             "fills_count",
             "adg_btc",
             "drawdown_worst_btc",
+            "equity_balance_diff_neg_max_btc",
+            "equity_balance_diff_neg_max_usd",
+            "equity_balance_diff_neg_mean_btc",
+            "equity_balance_diff_neg_mean_usd",
+            "equity_balance_diff_pos_max_btc",
+            "equity_balance_diff_pos_max_usd",
+            "equity_balance_diff_pos_mean_btc",
+            "equity_balance_diff_pos_mean_usd",
             "expected_shortfall_1pct_btc",
             "gain_btc",
             "hard_stop_panic_close_loss_sum",
+            "paper_loss_mean_ratio_btc",
+            "paper_loss_mean_ratio_usd",
+            "paper_loss_ratio_btc",
+            "paper_loss_ratio_usd",
         },
     )
     result = proxy.evaluate([{}])[0]
@@ -4413,8 +4425,49 @@ def test_mps_single_coin_service_dispatches_forced_delist_tail(strategy_kind):
     assert result["expected_shortfall_1pct_btc"] == pytest.approx(
         exact_analysis["expected_shortfall_1pct_btc"], rel=2.0e-3
     )
+    for metric in (
+        "equity_balance_diff_neg_max_btc",
+        "equity_balance_diff_neg_max_usd",
+        "equity_balance_diff_neg_mean_btc",
+        "equity_balance_diff_neg_mean_usd",
+        "equity_balance_diff_pos_max_btc",
+        "equity_balance_diff_pos_max_usd",
+        "equity_balance_diff_pos_mean_btc",
+        "equity_balance_diff_pos_mean_usd",
+        "paper_loss_mean_ratio_btc",
+        "paper_loss_mean_ratio_usd",
+        "paper_loss_ratio_btc",
+        "paper_loss_ratio_usd",
+    ):
+        # Exact Rust includes a slightly different pre-fill/tracking boundary
+        # in its sign-filtered mean; extrema and paper-loss denominators remain
+        # tightly matched, while positive means are proxy approximations.
+        relative_tolerance = (
+            0.4 if "equity_balance_diff_pos_mean" in metric else 3.0e-3
+        )
+        assert result[metric] == pytest.approx(
+            exact_analysis[metric], rel=relative_tolerance, abs=1.0e-8
+        ), metric
     assert proxy.btc_risk_enabled is True
+    assert proxy.equity_balance_diff_enabled is True
     assert result["backtest_completion_ratio"] > 0.99
+
+    ebd_only_proxy = MpsSingleCoinProxy(
+        config=config,
+        hlcvs=hlcvs,
+        mss=market_settings,
+        btc=btc_prices,
+        timestamps=timestamps,
+        exchange="bybit",
+        batch_size=1,
+        needed_metrics={"paper_loss_ratio_btc"},
+    )
+    ebd_only_result = ebd_only_proxy.evaluate([{}])[0]
+    assert ebd_only_proxy.btc_risk_enabled is False
+    assert ebd_only_proxy.equity_balance_diff_enabled is True
+    assert ebd_only_result["paper_loss_ratio_btc"] == pytest.approx(
+        exact_analysis["paper_loss_ratio_btc"], rel=3.0e-3, abs=1.0e-8
+    )
 
 
 @pytest.mark.skipif(
@@ -4735,9 +4788,21 @@ def test_mps_multicoin_service_dispatches_forced_delist_tail(
             "fills_count",
             "adg_btc",
             "drawdown_worst_btc",
+            "equity_balance_diff_neg_max_btc",
+            "equity_balance_diff_neg_max_usd",
+            "equity_balance_diff_neg_mean_btc",
+            "equity_balance_diff_neg_mean_usd",
+            "equity_balance_diff_pos_max_btc",
+            "equity_balance_diff_pos_max_usd",
+            "equity_balance_diff_pos_mean_btc",
+            "equity_balance_diff_pos_mean_usd",
             "expected_shortfall_1pct_btc",
             "gain_btc",
             "hard_stop_panic_close_loss_sum",
+            "paper_loss_mean_ratio_btc",
+            "paper_loss_mean_ratio_usd",
+            "paper_loss_ratio_btc",
+            "paper_loss_ratio_usd",
         },
     )
     result = proxy.evaluate([{}])[0]
@@ -4775,8 +4840,52 @@ def test_mps_multicoin_service_dispatches_forced_delist_tail(
     assert result["expected_shortfall_1pct_btc"] == pytest.approx(
         exact_analysis["expected_shortfall_1pct_btc"], rel=2.0e-3
     )
+    for metric in (
+        "equity_balance_diff_neg_max_btc",
+        "equity_balance_diff_neg_max_usd",
+        "equity_balance_diff_neg_mean_btc",
+        "equity_balance_diff_neg_mean_usd",
+        "equity_balance_diff_pos_max_btc",
+        "equity_balance_diff_pos_max_usd",
+        "equity_balance_diff_pos_mean_btc",
+        "equity_balance_diff_pos_mean_usd",
+        "paper_loss_mean_ratio_btc",
+        "paper_loss_mean_ratio_usd",
+        "paper_loss_ratio_btc",
+        "paper_loss_ratio_usd",
+    ):
+        # Exact Rust includes a slightly different pre-fill/tracking boundary
+        # in its sign-filtered mean; extrema and paper-loss denominators remain
+        # tightly matched, while positive means are proxy approximations.
+        relative_tolerance = (
+            0.4 if "equity_balance_diff_pos_mean" in metric else 3.0e-3
+        )
+        assert result[metric] == pytest.approx(
+            exact_analysis[metric], rel=relative_tolerance, abs=1.0e-8
+        ), metric
     assert proxy.btc_risk_enabled is True
+    assert proxy.equity_balance_diff_enabled is True
     assert result["backtest_completion_ratio"] > 0.99
+
+    if topology == "long":
+        ebd_only_proxy = MpsMulticoinProxy(
+            config=config,
+            hlcvs=hlcvs,
+            mss=market_settings,
+            btc=btc_prices,
+            timestamps=timestamps,
+            exchange="bybit",
+            batch_size=1,
+            needed_metrics={"paper_loss_ratio_btc"},
+        )
+        ebd_only_result = ebd_only_proxy.evaluate([{}])[0]
+        assert ebd_only_proxy.btc_risk_enabled is False
+        assert ebd_only_proxy.equity_balance_diff_enabled is True
+        assert ebd_only_result["paper_loss_ratio_btc"] == pytest.approx(
+            exact_analysis["paper_loss_ratio_btc"],
+            rel=3.0e-3,
+            abs=1.0e-8,
+        )
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## Summary
- add Apple MPS proxy support for the 12 unweighted USD/BTC equity-vs-balance and paper-loss metrics across EMA Anchor and Trailing Martingale
- cover single-coin long/short and multi-coin long/short/fused shared-account kernels with one opt-in compact accumulator
- keep ordinary GPU kernel signatures and buffers unchanged when none of these metrics is requested
- keep exact Rust validation authoritative; BTC balance rebases on proxy fills and positive sign-filtered means remain documented proxy approximations
- preserve canonical Rust no-fill and depleted-balance behavior and fail closed on missing or non-finite Metal output

## Review fixes
- replay tracked pre-fill BTC prices once the first fill establishes the canonical balance baseline, without repeating strategy simulation
- accept finite negative post-liquidation balances so one depleted candidate cannot poison an otherwise valid EBD batch
- add falling-BTC delayed-entry parity coverage and a mixed depleted/valid-candidate regression

## Validation
- `cargo test --no-default-features` (272 passed)
- `cargo check --tests --no-default-features`
- `cargo check --tests`
- `pytest -q tests/optimization/test_gpu_metrics.py tests/optimization/test_gpu_backend.py`
- `pytest -q tests/optimization` (green; platform tests skipped in sandbox)
- full physical Apple M3/MPS `tests/optimization/test_gpu_mps.py` (green)
- focused physical MPS delayed-entry/forced-delist and depleted-candidate regressions (9 passed)
- real 32-iteration BTC EMA Anchor GPU CLI smoke: 128 proxy evaluations, 32 exact validations, no drift halt, clean shutdown
- final seeded timing: ordinary 6.4s vs opt-in EBD 7.2s total optimizer wall time (~12.5% opt-in overhead); ordinary ABI path remained unchanged
- `mkdocs build` (green); strict mode reaches two pre-existing release-note link warnings
- `git diff --check`

This is one slice in the Apple M3/MPS optimizer parity series; `trailing_grid_v7` remains intentionally out of scope.