### PR TITLE
GPU: support multi-exchange suite scenarios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Apple MPS suite optimization now supports scenarios spanning a strict subset of multiple
+  exchanges. Metal evaluates each prepared exchange dataset independently, combines their proxy
+  metrics with the canonical CPU per-scenario mean/minimum/maximum/standard-deviation/median
+  contract, and only then applies suite reducers, named-scenario objectives, and limits. Exact Rust
+  suite validation remains authoritative, and every prepared exchange dataset remains part of
+  checkpoint identity.
+
 - Apple MPS Trailing Martingale optimization now supports normal-initial-entry interval mean,
   median, p95, p99, and maximum metrics across single-coin, multi-coin, long-only, short-only,
   and fused long+short runs. Metal tracks intervals independently per coin and position side;

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -426,9 +426,11 @@ path then calls the same canonical suite reducer and scenario-selection logic as
 for aggregate reducers, named-scenario objectives, and named-scenario or suite-reduced limits.
 Every exact validation still runs the unchanged Rust backtest for every scenario; only those exact
 suite metrics enter `all_results.bin` and the Pareto front. A scenario may select a different coin
-subset, date window, individual exchange, or canonical combined multi-exchange dataset, but each
-scenario must resolve to exactly one prepared dataset. Scenario
-`overrides` require
+subset, date window, individual exchange, canonical combined multi-exchange dataset, or a strict
+multi-exchange subset represented by one prepared dataset per exchange. In the last case, Metal
+evaluates each prepared exchange independently and the GPU path combines those proxy analyses with
+the same canonical per-scenario metric statistics as the CPU suite before applying suite reducers.
+Scenario `overrides` require
 explicit candidate-shadowing behavior in the proxy. This slice models `bot.long` and `bot.short`
 overrides: the canonical exact
 suite evaluator still applies them last, after candidate materialization, while each scenario's

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -654,50 +654,56 @@ _GPU_SUITE_VIOLATION_KEY = "__gpu_suite_constraint_violation__"
 _GPU_SUITE_METRICS_KEY = "__gpu_suite_metrics__"
 
 
-def _scalar_metric_stats(metrics: dict) -> dict:
-    return {
-        key: {
-            "mean": float(value),
-            "min": float(value),
-            "max": float(value),
-            "std": 0.0,
-            "median": float(value),
-        }
-        for key, value in metrics.items()
-    }
-
-
 def _evaluate_gpu_suite_proxies(suite_evaluator, scenario_proxies, candidates) -> list[dict]:
     """Screen one candidate batch across suite scenarios with canonical reducers."""
 
+    from metrics_schema import build_scenario_metrics
     from suite_runner import ScenarioResult, SuiteScenario
 
     scenario_rows = []
-    for ctx, proxy, parameter_overrides in scenario_proxies:
+    for ctx, exchange_proxies, parameter_overrides in scenario_proxies:
         scenario_candidates = (
             [dict(candidate, **parameter_overrides) for candidate in candidates]
             if parameter_overrides
             else candidates
         )
-        scenario_rows.append((ctx, proxy.evaluate(scenario_candidates)))
+        exchange_rows = []
+        for exchange, proxy in exchange_proxies:
+            rows = proxy.evaluate(scenario_candidates)
+            if len(rows) != len(candidates):
+                raise RuntimeError(
+                    f"GPU suite scenario {ctx.label!r} exchange {exchange!r} "
+                    "returned an unexpected proxy row count: "
+                    f"expected {len(candidates)}, got {len(rows)}"
+                )
+            exchange_rows.append((exchange, rows))
+        if not exchange_rows:
+            raise ValueError(
+                f"GPU suite scenario {ctx.label!r} has no prepared proxy datasets"
+            )
+        scenario_rows.append((ctx, exchange_rows))
     results = []
     for index in range(len(candidates)):
-        scenario_results = [
-            ScenarioResult(
-                scenario=SuiteScenario(
-                    label=ctx.label,
-                    start_date=None,
-                    end_date=None,
-                    coins=None,
-                    ignored_coins=None,
-                ),
-                per_exchange={},
-                metrics={"stats": _scalar_metric_stats(rows[index])},
-                elapsed_seconds=0.0,
-                output_path=None,
+        scenario_results = []
+        for ctx, exchange_rows in scenario_rows:
+            per_exchange = {
+                exchange: rows[index] for exchange, rows in exchange_rows
+            }
+            scenario_results.append(
+                ScenarioResult(
+                    scenario=SuiteScenario(
+                        label=ctx.label,
+                        start_date=None,
+                        end_date=None,
+                        coins=None,
+                        ignored_coins=None,
+                    ),
+                    per_exchange=per_exchange,
+                    metrics=build_scenario_metrics(per_exchange),
+                    elapsed_seconds=0.0,
+                    output_path=None,
+                )
             )
-            for ctx, rows in scenario_rows
-        ]
         scored = suite_evaluator.score_scenario_results(scenario_results)
         results.append(
             {
@@ -1442,68 +1448,67 @@ def _gpu_suite_scenario_inputs(proxy_config: dict, suite_evaluator) -> list[dict
                     "outside the supported modeled scenario scope"
                 )
         exchanges = list(ctx.exchanges)
-        if len(exchanges) != 1:
+        if not exchanges:
             raise ValueError(
-                f"GPU suite scenario {ctx.label!r} requires exactly one prepared "
-                "dataset, "
-                f"got {exchanges}"
+                f"GPU suite scenario {ctx.label!r} has no prepared datasets"
             )
-        exchange = exchanges[0]
-        scenario_mss = ctx.msss[exchange]
-        effective_coins = [
-            str(coin) for coin in scenario_mss if coin != "__meta__"
-        ]
-        effective_coin_set = set(effective_coins)
+        scenario_config = build_config(proxy_config, ctx)
         effective_coin_sources = (
             getattr(ctx, "config", {}).get("backtest", {}).get("coin_sources")
             or {}
         )
-        if exchange != "combined":
-            prepared_exchange = to_standard_exchange_name(exchange)
-            conflicting_sources = {
-                str(coin): str(source)
-                for coin, source in effective_coin_sources.items()
-                if str(coin) in effective_coin_set
-                and to_standard_exchange_name(str(source)) != prepared_exchange
-            }
-            if conflicting_sources:
-                raise ValueError(
-                    f"GPU suite scenario {ctx.label!r} assigns coin_sources "
-                    f"outside prepared dataset {prepared_exchange!r}: "
-                    f"{conflicting_sources}"
-                )
-        hlcvs, btc, coin_indices = get_data(ctx, exchange)
-        values = np.asarray(hlcvs)
-        if coin_indices is not None:
-            values = np.take(values, list(coin_indices), axis=1)
-        values = np.ascontiguousarray(values)
-        coin_count = int(values.shape[1])
-        scenario_config = build_config(proxy_config, ctx)
-        _validate_scope_config(
-            scenario_config,
-            exchanges=exchanges,
-            coin_count=coin_count,
-            allow_suite=True,
-        )
-        if len(effective_coins) != coin_count:
-            raise ValueError(
-                f"GPU suite scenario {ctx.label!r} prepared coin identity "
-                f"mismatch: hlcvs={coin_count}, market_settings={effective_coins}"
+        for exchange in exchanges:
+            scenario_mss = ctx.msss[exchange]
+            effective_coins = [
+                str(coin) for coin in scenario_mss if coin != "__meta__"
+            ]
+            effective_coin_set = set(effective_coins)
+            if exchange != "combined":
+                prepared_exchange = to_standard_exchange_name(exchange)
+                conflicting_sources = {
+                    str(coin): str(source)
+                    for coin, source in effective_coin_sources.items()
+                    if str(coin) in effective_coin_set
+                    and to_standard_exchange_name(str(source)) != prepared_exchange
+                }
+                if conflicting_sources:
+                    raise ValueError(
+                        f"GPU suite scenario {ctx.label!r} assigns coin_sources "
+                        f"outside prepared dataset {prepared_exchange!r}: "
+                        f"{conflicting_sources}"
+                    )
+            hlcvs, btc, coin_indices = get_data(ctx, exchange)
+            values = np.asarray(hlcvs)
+            if coin_indices is not None:
+                values = np.take(values, list(coin_indices), axis=1)
+            values = np.ascontiguousarray(values)
+            coin_count = int(values.shape[1])
+            _validate_scope_config(
+                scenario_config,
+                exchanges=[exchange],
+                coin_count=coin_count,
+                allow_suite=True,
             )
-        prepared.append(
-            {
-                "ctx": ctx,
-                "config": scenario_config,
-                "overrides": deepcopy(overrides),
-                "exchange": exchange,
-                "coin_count": coin_count,
-                "coins": effective_coins,
-                "hlcvs": values,
-                "mss": scenario_mss,
-                "btc": btc,
-                "timestamps": ctx.timestamps.get(exchange),
-            }
-        )
+            if len(effective_coins) != coin_count:
+                raise ValueError(
+                    f"GPU suite scenario {ctx.label!r} prepared coin identity "
+                    f"mismatch on {exchange!r}: hlcvs={coin_count}, "
+                    f"market_settings={effective_coins}"
+                )
+            prepared.append(
+                {
+                    "ctx": ctx,
+                    "config": deepcopy(scenario_config),
+                    "overrides": deepcopy(overrides),
+                    "exchange": exchange,
+                    "coin_count": coin_count,
+                    "coins": effective_coins,
+                    "hlcvs": values,
+                    "mss": scenario_mss,
+                    "btc": btc,
+                    "timestamps": ctx.timestamps.get(exchange),
+                }
+            )
     return prepared
 
 
@@ -3142,8 +3147,11 @@ def run_backend(
         min_coin_count, max_coin_count, suite_multicoin_sides = (
             _gpu_suite_search_context(suite_inputs)
         )
+        scenario_count = len({id(item["ctx"]) for item in suite_inputs})
         logging.info(
-            "GPU suite prepared %d scenarios | coins=%d..%d | multicoin_sides=%s",
+            "GPU suite prepared %d scenarios across %d datasets | "
+            "coins=%d..%d | multicoin_sides=%s",
+            scenario_count,
             len(suite_inputs),
             min_coin_count,
             max_coin_count,
@@ -3469,7 +3477,7 @@ def run_backend(
     )
 
     if suite_enabled:
-        scenario_proxies = []
+        scenario_proxy_groups = {}
         for item in suite_inputs:
             scenario_proxy = (
                 MpsMulticoinProxy
@@ -3492,9 +3500,20 @@ def run_backend(
             item["proxy_checkpoint_contract"] = getattr(
                 scenario_proxy, "checkpoint_contract", {}
             )
-            scenario_proxies.append(
-                (item["ctx"], scenario_proxy, item["parameter_overrides"])
+            group = scenario_proxy_groups.setdefault(
+                id(item["ctx"]),
+                [item["ctx"], [], item["parameter_overrides"]],
             )
+            if group[2] != item["parameter_overrides"]:
+                raise RuntimeError(
+                    f"GPU suite scenario {item['ctx'].label!r} prepared datasets "
+                    "disagree on candidate parameter overrides"
+                )
+            group[1].append((item["exchange"], scenario_proxy))
+        scenario_proxies = [
+            (ctx, tuple(exchange_proxies), parameter_overrides)
+            for ctx, exchange_proxies, parameter_overrides in scenario_proxy_groups.values()
+        ]
 
         def evaluate_proxy(candidates):
             return _evaluate_gpu_suite_proxies(

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -635,7 +635,6 @@ def test_gpu_suite_inputs_accept_dual_side_multicoin_hedge_scenario():
     ("overrides", "exchanges", "coin_indices", "message"),
     [
         ({"live.strategy_kind": "trailing_martingale"}, ["bybit"], [0], "outside the supported"),
-        ({}, ["bybit", "binance"], [0], "exactly one prepared dataset"),
     ],
 )
 def test_gpu_suite_inputs_reject_unsupported_scenario_scope(
@@ -664,6 +663,52 @@ def test_gpu_suite_inputs_reject_unsupported_scenario_scope(
 
     with pytest.raises(ValueError, match=message):
         _gpu_suite_scenario_inputs(config, Suite())
+
+
+def test_gpu_suite_inputs_materialize_each_exchange_in_one_scenario():
+    config = _long_only_ema_config()
+    config["backtest"]["suite_enabled"] = True
+    exchanges = ["bybit", "binance"]
+    ctx = SimpleNamespace(
+        label="two_venues",
+        config={"backtest": {"coin_sources": {}}},
+        overrides={},
+        exchanges=exchanges,
+        msss={
+            exchange: {
+                f"{exchange}_coin": {},
+                "__meta__": {},
+            }
+            for exchange in exchanges
+        },
+        timestamps={
+            exchange: np.arange(10, dtype=np.int64) for exchange in exchanges
+        },
+    )
+
+    class Suite:
+        contexts = [ctx]
+
+        @staticmethod
+        def get_prepared_context_data(_ctx, exchange):
+            width = 1 if exchange == "bybit" else 2
+            return np.zeros((10, width, 4)), np.ones(10), [width - 1]
+
+        @staticmethod
+        def build_scenario_candidate_config(proxy_config, _ctx):
+            return copy.deepcopy(proxy_config)
+
+    prepared = _gpu_suite_scenario_inputs(config, Suite())
+
+    assert [item["ctx"] for item in prepared] == [ctx, ctx]
+    assert [item["exchange"] for item in prepared] == exchanges
+    assert [item["coins"] for item in prepared] == [
+        ["bybit_coin"],
+        ["binance_coin"],
+    ]
+    assert all(item["coin_count"] == 1 for item in prepared)
+    assert prepared[0]["config"] == prepared[1]["config"]
+    assert prepared[0]["config"] is not prepared[1]["config"]
 
 
 @pytest.mark.parametrize(
@@ -1490,8 +1535,8 @@ def test_gpu_suite_proxy_rows_use_canonical_suite_scorer():
     rows = _evaluate_gpu_suite_proxies(
         Suite(),
         [
-            (contexts[0], Proxy([0.10, 0.20]), {}),
-            (contexts[1], Proxy([0.01, 0.02]), {}),
+            (contexts[0], (("bybit", Proxy([0.10, 0.20])),), {}),
+            (contexts[1], (("bybit", Proxy([0.01, 0.02])),), {}),
         ],
         [{"x": 1}, {"x": 2}],
     )
@@ -1508,6 +1553,60 @@ def test_gpu_suite_proxy_rows_use_canonical_suite_scorer():
             _GPU_SUITE_METRICS_KEY: {"values": [0.20, 0.02]},
         },
     ]
+
+
+def test_gpu_suite_proxy_combines_exchange_metrics_before_suite_reduction():
+    context = SimpleNamespace(label="regional_subset")
+
+    class Proxy:
+        def __init__(self, values):
+            self.values = values
+
+        def evaluate(self, candidates):
+            assert len(candidates) == 2
+            return [{"adg_strategy_eq": value} for value in self.values]
+
+    class Suite:
+        @staticmethod
+        def score_scenario_results(results):
+            assert len(results) == 1
+            result = results[0]
+            stats = result.metrics["stats"]["adg_strategy_eq"]
+            assert sorted(result.per_exchange) == ["binance", "bybit"]
+            return {
+                "objectives": (-stats["mean"],),
+                "constraint_violation": stats["max"],
+                "suite_metrics": {"stats": stats},
+            }
+
+    rows = _evaluate_gpu_suite_proxies(
+        Suite(),
+        [
+            (
+                context,
+                (
+                    ("bybit", Proxy([0.10, 0.40])),
+                    ("binance", Proxy([0.30, 0.20])),
+                ),
+                {},
+            )
+        ],
+        [{"x": 1}, {"x": 2}],
+    )
+
+    assert rows[0][_GPU_SUITE_OBJECTIVES_KEY] == pytest.approx((-0.20,))
+    assert rows[0][_GPU_SUITE_VIOLATION_KEY] == pytest.approx(0.30)
+    assert rows[0][_GPU_SUITE_METRICS_KEY]["stats"] == pytest.approx(
+        {
+            "mean": 0.20,
+            "min": 0.10,
+            "max": 0.30,
+            "std": 0.10,
+            "median": 0.20,
+        }
+    )
+    assert rows[1][_GPU_SUITE_OBJECTIVES_KEY] == pytest.approx((-0.30,))
+    assert rows[1][_GPU_SUITE_VIOLATION_KEY] == pytest.approx(0.40)
 
 
 def test_gpu_suite_proxy_applies_scenario_parameter_overrides_without_mutating_candidates():
@@ -1536,10 +1635,10 @@ def test_gpu_suite_proxy_applies_scenario_parameter_overrides_without_mutating_c
         [
             (
                 SimpleNamespace(label="fixed"),
-                Proxy(),
+                (("bybit", Proxy()),),
                 {"long_base_qty_pct": 0.025},
             ),
-            (SimpleNamespace(label="candidate"), Proxy(), {}),
+            (SimpleNamespace(label="candidate"), (("bybit", Proxy()),), {}),
         ],
         candidates,
     )
@@ -5486,6 +5585,28 @@ def test_gpu_suite_checkpoint_contract_tracks_prepared_scenario_identity():
             "coin_overrides": {},
         }
     ]
+
+    second_exchange = copy.deepcopy(item)
+    second_exchange["exchange"] = "binance"
+    second_exchange["mss"]["BTC"] = {"exchange": "binance"}
+    second_exchange["mss"]["ETH"] = {"exchange": "binance"}
+    multi_exchange = _gpu_suite_checkpoint_contract(
+        config, [item, second_exchange]
+    )
+    assert [
+        (entry["label"], entry["exchange"])
+        for entry in multi_exchange["prepared_scenarios"]
+    ] == [("stress", "bybit"), ("stress", "binance")]
+    assert multi_exchange != original
+
+    changed_second_exchange = copy.deepcopy(second_exchange)
+    changed_second_exchange["timestamps"] = np.array([1000, 2500, 3500])
+    assert (
+        _gpu_suite_checkpoint_contract(
+            config, [item, changed_second_exchange]
+        )
+        != multi_exchange
+    )
 
     changed_loss_gate = copy.deepcopy(item)
     changed_loss_gate["config"]["live"]["max_realized_loss_pct"] = 0.05


### PR DESCRIPTION
## Summary

- allow one GPU suite scenario to own multiple prepared exchange datasets
- run one Apple MPS proxy per prepared exchange, then combine proxy metrics with the canonical CPU scenario statistics before suite reducers, named-scenario objectives, and limits
- retain every prepared exchange dataset in checkpoint identity and preserve exact Rust suite validation as authoritative
- document the expanded suite scope and add user-facing release notes

## Validation

- `python -m pytest tests/optimization/test_gpu_backend.py tests/optimization/test_optimize_suite_contexts.py tests/test_config_optimize_suite.py tests/test_metrics_schema.py tests/test_suite_config_sources.py tests/test_suite_runner.py tests/optimization/test_gpu_service.py -q`
- `PYTHONPATH=src python -m pytest tests/optimization/test_gpu_mps.py -q` on Apple M3/MPS
- physical MPS smoke for EMA Anchor and Trailing Martingale with two independent exchange proxies and canonical scenario aggregation
- end-to-end Apple M3 GPU optimize smoke: one suite scenario selecting the strict Binance+Bybit subset from a three-exchange base, 8-candidate Metal batches, 32 exact Rust validations, drift gate enabled; completed cleanly
- `PYTHONPATH=src python src/tools/check_ai_docs.py` (warnings only for existing documentation-size thresholds)
- `git diff --check`
