### PR TITLE
GPU: complete coin override compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Apple MPS optimization now accepts the same per-coin live-only `leverage` and non-`normal`
+  `forced_mode_<side>` values as CPU optimization. These values do not affect CPU backtests, so
+  the MPS proxy also leaves them inert, emits an explicit warning instead of silently ignoring
+  them, and retains their exact values in checkpoint identity. This lets composed live configs
+  move between CPU and GPU optimization without deleting valid live-only coin settings.
+
 - Apple MPS suite optimization now supports scenarios spanning a strict subset of multiple
   exchanges. Metal evaluates each prepared exchange dataset independently, combines their proxy
   metrics with the canonical CPU per-scenario mean/minimum/maximum/standard-deviation/median

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@ All notable user-facing changes will be documented in this file.
 ## Unreleased
 
 - Apple MPS optimization now accepts the same per-coin live-only `leverage` and non-`normal`
-  `forced_mode_<side>` values as CPU optimization. These values do not affect CPU backtests, so
-  the MPS proxy also leaves them inert, emits an explicit warning instead of silently ignoring
-  them, and retains their exact values in checkpoint identity. This lets composed live configs
-  move between CPU and GPU optimization without deleting valid live-only coin settings.
+  `forced_mode_<side>` values on either enabled or disabled sides as CPU optimization. These values
+  do not affect CPU backtests, so the MPS proxy also leaves them inert, emits an explicit warning
+  instead of silently ignoring them, and retains their exact values in checkpoint identity. This
+  lets composed live configs move between CPU and GPU optimization without deleting valid live-only
+  coin settings.
 
 - Apple MPS suite optimization now supports scenarios spanning a strict subset of multiple
   exchanges. Metal evaluates each prepared exchange dataset independently, combines their proxy

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -147,14 +147,16 @@ The supported slice is intentionally narrow:
   per-coin
   `risk.position_exposure_enforcer_enabled` and
   `risk.position_exposure_enforcer_threshold`; per-coin
-  `risk.we_excess_allowance_mode`, disabled sides, and other override leaves fail closed. Trailing
+  `risk.we_excess_allowance_mode`, modeled leaves for disabled sides, and other override leaves
+  fail closed. Non-`normal` forced modes remain accepted for either side because they are
+  backtest-inert. Trailing
   Martingale also resolves all four `entry.ema_gate_mode` values per coin and side. In one-sided
   `live.hsl_signal_mode: coin` runs, all ten HSL
   leaves documented in `coin_overrides.md` are also supported. Fused dual-side EMA Anchor and
   Trailing Martingale coin mode resolve the same HSL leaves independently for long and short.
-  CPU-compatible per-coin `live.leverage` and non-`normal` forced modes are accepted for composed
-  live-config portability, but neither affects an exact CPU backtest; GPU optimization therefore
-  warns that they are backtest-inert and records them in checkpoint identity.
+  CPU-compatible per-coin `live.leverage` and non-`normal` forced modes on either side are accepted
+  for composed live-config portability, but neither affects an exact CPU backtest; GPU optimization
+  therefore warns that they are backtest-inert and records them in checkpoint identity.
 - one-sided single-coin and multi-coin EMA Anchor and Trailing Martingale runs support HSL with
   `coin`, `pside`, or `unified` signals and both resting-limit and market panic closes. Unified and
   pside multi-coin runs use one portfolio controller; coin mode uses an independent controller per

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -151,7 +151,10 @@ The supported slice is intentionally narrow:
   Martingale also resolves all four `entry.ema_gate_mode` values per coin and side. In one-sided
   `live.hsl_signal_mode: coin` runs, all ten HSL
   leaves documented in `coin_overrides.md` are also supported. Fused dual-side EMA Anchor and
-  Trailing Martingale coin mode resolve the same HSL leaves independently for long and short
+  Trailing Martingale coin mode resolve the same HSL leaves independently for long and short.
+  CPU-compatible per-coin `live.leverage` and non-`normal` forced modes are accepted for composed
+  live-config portability, but neither affects an exact CPU backtest; GPU optimization therefore
+  warns that they are backtest-inert and records them in checkpoint identity.
 - one-sided single-coin and multi-coin EMA Anchor and Trailing Martingale runs support HSL with
   `coin`, `pside`, or `unified` signals and both resting-limit and market panic closes. Unified and
   pside multi-coin runs use one portfolio controller; coin mode uses an independent controller per

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -1238,7 +1238,13 @@ def _validate_gpu_coin_overrides(
     enabled_sides,
     coin_count: int,
 ) -> None:
-    """Accept only the static per-coin leaves modeled by the MPS proxy."""
+    """Accept modeled leaves plus explicit CPU-compatible backtest no-ops.
+
+    ``live.leverage`` and forced modes other than ``normal`` affect live
+    exchange operation, but the exact Rust backtester does not consume them.
+    Keep composed live configs usable while making that no-op status visible.
+    Exact override documents remain part of checkpoint identity downstream.
+    """
 
     overrides = config.get("coin_overrides") or {}
     if not overrides:
@@ -1277,11 +1283,17 @@ def _validate_gpu_coin_overrides(
         else:
             yield prefix
 
+    def value_at(value, path):
+        for key in path:
+            value = value[key]
+        return value
+
     allowed = set()
     for enabled_side in enabled_sides:
         allowed.update(
             {
                 ("live", f"forced_mode_{enabled_side}"),
+                ("live", "leverage"),
                 ("bot", enabled_side, "risk", "entry_cooldown_minutes"),
                 ("bot", enabled_side, "risk", "we_excess_allowance_pct"),
                 ("bot", enabled_side, "wallet_exposure_limit"),
@@ -1330,6 +1342,7 @@ def _validate_gpu_coin_overrides(
             for _key, path in HSL_COIN_OVERRIDE_PATHS
         )
     unsupported = []
+    backtest_inert = []
     hsl_override_paths = []
     for coin, patch in overrides.items():
         if not isinstance(patch, dict):
@@ -1337,6 +1350,15 @@ def _validate_gpu_coin_overrides(
             continue
         for path in leaves(patch):
             rendered = ".".join(("coin_overrides", str(coin), *path))
+            if path == ("live", "leverage") or (
+                len(path) == 2
+                and path[0] == "live"
+                and path[1] in {
+                    f"forced_mode_{side}" for side in enabled_sides
+                }
+                and value_at(patch, path) != "normal"
+            ):
+                backtest_inert.append(rendered)
             if len(path) >= 3 and path[0] == "bot" and path[2] == "hsl":
                 hsl_override_paths.append(rendered)
             if path not in allowed:
@@ -1389,6 +1411,13 @@ def _validate_gpu_coin_overrides(
             f"forced_mode_<side>, {strategy_kind} parameters, {supported_risk}, "
             "unstuck parameters, HSL parameters in coin signal mode, and "
             "wallet_exposure_limit"
+        )
+    if backtest_inert:
+        logging.warning(
+            "GPU coin_overrides contain CPU-compatible live-only values with "
+            "no backtest effect; exact Rust and the MPS proxy both leave these "
+            "values inert, and checkpoint identity still records them: %s",
+            sorted(backtest_inert),
         )
 
 

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -1288,12 +1288,15 @@ def _validate_gpu_coin_overrides(
             value = value[key]
         return value
 
-    allowed = set()
+    forced_mode_paths = {
+        ("live", "forced_mode_long"),
+        ("live", "forced_mode_short"),
+    }
+    allowed = {("live", "leverage")}
     for enabled_side in enabled_sides:
         allowed.update(
             {
                 ("live", f"forced_mode_{enabled_side}"),
-                ("live", "leverage"),
                 ("bot", enabled_side, "risk", "entry_cooldown_minutes"),
                 ("bot", enabled_side, "risk", "we_excess_allowance_pct"),
                 ("bot", enabled_side, "wallet_exposure_limit"),
@@ -1350,18 +1353,14 @@ def _validate_gpu_coin_overrides(
             continue
         for path in leaves(patch):
             rendered = ".".join(("coin_overrides", str(coin), *path))
-            if path == ("live", "leverage") or (
-                len(path) == 2
-                and path[0] == "live"
-                and path[1] in {
-                    f"forced_mode_{side}" for side in enabled_sides
-                }
-                and value_at(patch, path) != "normal"
-            ):
+            inert_forced_mode = (
+                path in forced_mode_paths and value_at(patch, path) != "normal"
+            )
+            if path == ("live", "leverage") or inert_forced_mode:
                 backtest_inert.append(rendered)
             if len(path) >= 3 and path[0] == "bot" and path[2] == "hsl":
                 hsl_override_paths.append(rendered)
-            if path not in allowed:
+            if path not in allowed and not inert_forced_mode:
                 unsupported.append(rendered)
     if hsl_override_paths:
         signal_mode = str(

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -11,7 +11,9 @@ import numpy as np
 import pytest
 
 from config.metrics import canonicalize_metric_name
+from config.overrides import OVERRIDABLE_SHARED_BOT_PATHS
 from config.schema import get_template_config
+from config.strategy import get_strategy_param_keys
 from optimizer_overrides import optimizer_overrides
 from optimization.bounds import Bound
 from optimization.backends.gpu_backend import (
@@ -2598,10 +2600,156 @@ def test_gpu_multicoin_accepts_static_ema_coin_overrides(side):
     assert _validate_scope(config, _MulticoinEvaluator()) == "bybit"
 
 
+def _nested_patch(path, value):
+    result = value
+    for key in reversed(tuple(path)):
+        result = {key: result}
+    return result
+
+
+def _nested_value(value, path):
+    for key in path:
+        value = value[key]
+    return value
+
+
+@pytest.mark.parametrize(
+    ("strategy_kind", "config_factory"),
+    [
+        ("ema_anchor", _directional_ema_config),
+        ("trailing_martingale", _directional_tm_config),
+    ],
+)
+def test_gpu_coin_override_policy_covers_cpu_backtest_effective_allowlist(
+    strategy_kind, config_factory
+):
+    config = config_factory(long_enabled=True, short_enabled=False)
+    config["live"]["hsl_signal_mode"] = "coin"
+    side_config = config["bot"]["long"]
+    exact_inapplicable = {
+        "risk.position_exposure_enforcer_enabled",
+        "risk.position_exposure_enforcer_threshold",
+    }
+
+    for dotted_path in sorted(OVERRIDABLE_SHARED_BOT_PATHS):
+        if strategy_kind == "ema_anchor" and dotted_path in exact_inapplicable:
+            continue
+        path = tuple(dotted_path.split("."))
+        config["coin_overrides"] = {
+            "ETH": {
+                "bot": {
+                    "long": _nested_patch(path, _nested_value(side_config, path))
+                }
+            }
+        }
+        _validate_gpu_coin_overrides(
+            config,
+            strategy_kind=strategy_kind,
+            enabled_sides=["long"],
+            coin_count=3,
+        )
+
+    strategy = side_config["strategy"][strategy_kind]
+    for dotted_path in get_strategy_param_keys(strategy_kind):
+        path = tuple(dotted_path.split("."))
+        config["coin_overrides"] = {
+            "ETH": {
+                "bot": {
+                    "long": {
+                        "strategy": {
+                            strategy_kind: _nested_patch(
+                                path, _nested_value(strategy, path)
+                            )
+                        }
+                    }
+                }
+            }
+        }
+        _validate_gpu_coin_overrides(
+            config,
+            strategy_kind=strategy_kind,
+            enabled_sides=["long"],
+            coin_count=3,
+        )
+
+    for patch in (
+        {"bot": {"long": {"wallet_exposure_limit": 0.4}}},
+        {"live": {"forced_mode_long": "normal"}},
+    ):
+        config["coin_overrides"] = {"ETH": patch}
+        _validate_gpu_coin_overrides(
+            config,
+            strategy_kind=strategy_kind,
+            enabled_sides=["long"],
+            coin_count=3,
+        )
+
+
+@pytest.mark.parametrize(
+    ("strategy_kind", "config_factory"),
+    [
+        ("ema_anchor", _directional_ema_config),
+        ("trailing_martingale", _directional_tm_config),
+    ],
+)
+def test_gpu_coin_overrides_accept_cpu_compatible_live_only_values_with_warning(
+    strategy_kind, config_factory, caplog
+):
+    config = config_factory(long_enabled=True, short_enabled=False)
+    config["coin_overrides"] = {
+        "ETH": {
+            "live": {
+                "forced_mode_long": "graceful_stop",
+                "leverage": 3,
+            }
+        }
+    }
+
+    _validate_gpu_coin_overrides(
+        config,
+        strategy_kind=strategy_kind,
+        enabled_sides=["long"],
+        coin_count=3,
+    )
+
+    assert "CPU-compatible live-only values with no backtest effect" in caplog.text
+    assert "coin_overrides.ETH.live.forced_mode_long" in caplog.text
+    assert "coin_overrides.ETH.live.leverage" in caplog.text
+
+
+@pytest.mark.parametrize(
+    "risk_key",
+    [
+        "position_exposure_enforcer_enabled",
+        "position_exposure_enforcer_threshold",
+    ],
+)
+def test_gpu_ema_coin_overrides_reject_exact_inapplicable_position_enforcer(
+    risk_key,
+):
+    config = _directional_ema_config(long_enabled=True, short_enabled=False)
+    config["coin_overrides"] = {
+        "ETH": {
+            "bot": {
+                "long": {
+                    "risk": {risk_key: config["bot"]["long"]["risk"][risk_key]}
+                }
+            }
+        }
+    }
+
+    with pytest.raises(ValueError, match="do not model these paths yet"):
+        _validate_gpu_coin_overrides(
+            config,
+            strategy_kind="ema_anchor",
+            enabled_sides=["long"],
+            coin_count=3,
+        )
+
+
 @pytest.mark.parametrize(
     "patch",
     [
-        {"live": {"leverage": 3}},
         {"bot": {"long": {"risk": {"n_positions": 2}}}},
         {
             "bot": {
@@ -2872,7 +3020,6 @@ def test_gpu_multicoin_accepts_static_tm_coin_overrides(side):
 @pytest.mark.parametrize(
     "patch",
     [
-        {"live": {"leverage": 3}},
         {"bot": {"long": {"risk": {"n_positions": 2}}}},
     ],
 )

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -2700,6 +2700,7 @@ def test_gpu_coin_overrides_accept_cpu_compatible_live_only_values_with_warning(
         "ETH": {
             "live": {
                 "forced_mode_long": "graceful_stop",
+                "forced_mode_short": "panic",
                 "leverage": 3,
             }
         }
@@ -2714,7 +2715,66 @@ def test_gpu_coin_overrides_accept_cpu_compatible_live_only_values_with_warning(
 
     assert "CPU-compatible live-only values with no backtest effect" in caplog.text
     assert "coin_overrides.ETH.live.forced_mode_long" in caplog.text
+    assert "coin_overrides.ETH.live.forced_mode_short" in caplog.text
     assert "coin_overrides.ETH.live.leverage" in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("strategy_kind", "config_factory"),
+    [
+        ("ema_anchor", _directional_ema_config),
+        ("trailing_martingale", _directional_tm_config),
+    ],
+)
+@pytest.mark.parametrize(
+    ("enabled_side", "disabled_side"),
+    [("long", "short"), ("short", "long")],
+)
+def test_gpu_coin_overrides_accept_disabled_side_inert_forced_mode(
+    strategy_kind, config_factory, enabled_side, disabled_side, caplog
+):
+    config = config_factory(
+        long_enabled=enabled_side == "long",
+        short_enabled=enabled_side == "short",
+    )
+    config["coin_overrides"] = {
+        "ETH": {"live": {f"forced_mode_{disabled_side}": "graceful_stop"}}
+    }
+
+    _validate_gpu_coin_overrides(
+        config,
+        strategy_kind=strategy_kind,
+        enabled_sides=[enabled_side],
+        coin_count=3,
+    )
+
+    assert (
+        f"coin_overrides.ETH.live.forced_mode_{disabled_side}" in caplog.text
+    )
+
+
+@pytest.mark.parametrize(
+    ("enabled_side", "disabled_side"),
+    [("long", "short"), ("short", "long")],
+)
+def test_gpu_coin_overrides_reject_disabled_side_forced_normal(
+    enabled_side, disabled_side
+):
+    config = _directional_ema_config(
+        long_enabled=enabled_side == "long",
+        short_enabled=enabled_side == "short",
+    )
+    config["coin_overrides"] = {
+        "ETH": {"live": {f"forced_mode_{disabled_side}": "normal"}}
+    }
+
+    with pytest.raises(ValueError, match="do not model these paths yet"):
+        _validate_gpu_coin_overrides(
+            config,
+            strategy_kind="ema_anchor",
+            enabled_sides=[enabled_side],
+            coin_count=3,
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -2289,6 +2289,44 @@ def test_coin_override_contract_keeps_exact_values_beyond_float32_precision():
     assert second_exact["strategy"]["ema_anchor"]["offset"] == second
 
 
+def test_coin_override_contract_keeps_backtest_inert_live_values():
+    exact_patch = {
+        "live": {
+            "forced_mode_long": "graceful_stop",
+            "leverage": 3,
+        }
+    }
+    config = {"coin_overrides": {"ETH": exact_patch}}
+    payload = SimpleNamespace(
+        strategy_params_list=[{"long": {}}],
+        bot_params_list=[
+            {
+                "long": {
+                    "entry_eligible": True,
+                    "is_forced_active": False,
+                    "wallet_exposure_limit": -1.0,
+                }
+            }
+        ],
+    )
+
+    matrix, contract = _build_multicoin_ema_coin_overrides(
+        config=config,
+        mss={"ETH": {}},
+        exchange="bybit",
+        coins=["ETH"],
+        payload=payload,
+        side="long",
+        resolve_override=lambda config, _mss, _exchange, coin: config[
+            "coin_overrides"
+        ].get(coin, {}),
+    )
+
+    assert np.isnan(matrix).all()
+    assert contract["values"] == [[None] * EMA_ANCHOR_COIN_OVERRIDE_COLS]
+    assert contract["exact_overrides"] == [exact_patch]
+
+
 @pytest.mark.parametrize(
     ("builder", "strategy", "forced_column"),
     [

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -2293,6 +2293,7 @@ def test_coin_override_contract_keeps_backtest_inert_live_values():
     exact_patch = {
         "live": {
             "forced_mode_long": "graceful_stop",
+            "forced_mode_short": "panic",
             "leverage": 3,
         }
     }


### PR DESCRIPTION
## Summary
- accept CPU-compatible per-coin live leverage and non-normal forced modes in Apple MPS optimization
- warn explicitly that these live-only values are inert in both exact CPU backtests and the MPS proxy while retaining them in checkpoint identity
- add exhaustive policy coverage against the canonical CPU coin-override allowlist and direct checkpoint-contract coverage

## Validation
- full GPU backend and service test suites
- coin-override foundation, composer, suite-context, metrics-schema, and suite-runner suites
- full physical Apple MPS test suite
- physical EMA Anchor run with live-only override values: 16 generations, 128 proxy evaluations, 32 exact validations, clean completion
- physical nine-coin Trailing Martingale composed-config fine-tune run: 16 generations, 128 proxy evaluations, 32 exact validations, clean completion
- AI documentation check: 0 errors (existing size warnings only)
- Rust extension source stamp matched the current source fingerprint
- git diff --check and Python compileall