### PR TITLE
GPU: support high-exposure duration metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Apple MPS optimization now supports the eight unweighted high-exposure duration metrics for
+  EMA Anchor and Trailing Martingale across single-coin, multi-coin, long-only, short-only, and
+  fused long+short runs. When one of these metrics is scored or limited, Metal performs an opt-in
+  threshold pass followed by a duration pass; ordinary GPU runs keep their existing single
+  dispatch. Exact Rust validation and rolling drift gates remain authoritative when multiple
+  proxy fills share a candle.
+
 - Apple MPS optimization now accepts the same per-coin live-only `leverage` and non-`normal`
   `forced_mode_<side>` values on either enabled or disabled sides as CPU optimization. These values
   do not affect CPU backtests, so the MPS proxy also leaves them inert, emits an explicit warning

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -567,6 +567,16 @@ conservative upper edges from a bounded logarithmic histogram. EMA Anchor emits 
 so these metrics retain exact Rust's canonical zero values without allocating the optional output
 surface. Runs that do not request an entry-interval metric keep their existing kernel ABI and
 dispatch cost.
+The eight `high_exposure_{hours,days}_{mean,max}_{long,short}` metrics are supported for both
+strategies and every single-coin and multi-coin side topology. Exact Rust defines the threshold as
+the mean of per-fill TWE averages resampled by UTC day, including zero-valued gaps between the
+first and last fill day. Because that threshold is only known after the fill sequence completes,
+Metal enables an opt-in two-pass replay: the first pass derives the candidate's per-side threshold
+and the second measures continuous above-threshold fill-to-fill durations. Runs that do not request
+this family retain the normal one-pass dispatch. Metal cannot retain the exact ordering of several
+fills produced within one candle, so it weights that candle's final TWE by its fill count; exact
+Rust validation and rolling rank/constraint drift gates remain authoritative for this bounded
+screening approximation.
 Exact Rust metrics remain authoritative. Other metrics that require unmodeled per-fill, trade, or
 position aggregates are rejected before a run starts.
 

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -15,6 +15,8 @@ const MPS_EQUITY_BALANCE_DIFF_COMMON_SOURCE: &str =
     include_str!("gpu/mps_equity_balance_diff_common.metal");
 const MPS_ENTRY_INTERVAL_MARKER: &str = "// PASSIVBOT_ENTRY_INTERVAL_COMMON";
 const MPS_ENTRY_INTERVAL_COMMON_SOURCE: &str = include_str!("gpu/mps_entry_interval_common.metal");
+const MPS_HIGH_EXPOSURE_MARKER: &str = "// PASSIVBOT_HIGH_EXPOSURE_COMMON";
+const MPS_HIGH_EXPOSURE_COMMON_SOURCE: &str = include_str!("gpu/mps_high_exposure_common.metal");
 const MPS_MULTICOIN_MARKER: &str = "// PASSIVBOT_MULTICOIN_COMMON";
 const MPS_MULTICOIN_COMMON_SOURCE: &str = include_str!("gpu/mps_multicoin_common.metal");
 const MPS_EMA_ANCHOR_BODY: &str = include_str!("gpu/mps_ema_anchor_directional.metal");
@@ -51,6 +53,11 @@ fn compose_hsl_source(body: &str) -> String {
         1,
         "MPS source must contain exactly one shared entry-interval marker"
     );
+    assert_eq!(
+        body.matches(MPS_HIGH_EXPOSURE_MARKER).count(),
+        1,
+        "MPS source must contain exactly one shared high-exposure marker"
+    );
     body.replacen(MPS_HSL_MARKER, MPS_HSL_COMMON_SOURCE, 1)
         .replacen(MPS_BTC_RISK_MARKER, MPS_BTC_RISK_COMMON_SOURCE, 1)
         .replacen(
@@ -63,6 +70,7 @@ fn compose_hsl_source(body: &str) -> String {
             MPS_ENTRY_INTERVAL_COMMON_SOURCE,
             1,
         )
+        .replacen(MPS_HIGH_EXPOSURE_MARKER, MPS_HIGH_EXPOSURE_COMMON_SOURCE, 1)
 }
 
 fn compose_multicoin_source(body: &str) -> String {
@@ -265,6 +273,21 @@ mod tests {
         assert!(source.contains("constant int ENTRY_INTERVAL_STAT_COLS = 2"));
         assert!(source.contains("constant int ENTRY_INTERVAL_COUNT_COLS = 129"));
         assert!(source.contains("device int* counts"));
+    }
+
+    fn assert_shared_high_exposure_contract(source: &str) {
+        assert!(!source.contains(MPS_HIGH_EXPOSURE_MARKER));
+        assert!(source.contains(MPS_HIGH_EXPOSURE_COMMON_SOURCE));
+        for signature in [
+            "struct HighExposureState",
+            "inline HighExposureState init_high_exposure_state(",
+            "inline void record_high_exposure_fill(",
+            "inline void write_high_exposure_output(",
+        ] {
+            assert_eq!(source.matches(signature).count(), 1, "{signature}");
+        }
+        assert!(source.contains("#if PASSIVBOT_HIGH_EXPOSURE_ENABLED"));
+        assert!(source.contains("constant int HIGH_EXPOSURE_COLS = 8"));
     }
 
     fn assert_directional_recovery_sampling_contract(source: &str) {
@@ -487,6 +510,29 @@ mod tests {
             mps_trailing_martingale_multicoin_source(),
         ] {
             assert_shared_entry_interval_contract(source);
+        }
+    }
+
+    #[test]
+    fn all_strategy_sources_compose_one_shared_high_exposure_accumulator() {
+        for body in [
+            MPS_EMA_ANCHOR_BODY,
+            MPS_EMA_ANCHOR_MULTICOIN_BODY,
+            MPS_TRAILING_MARTINGALE_BODY,
+            MPS_TRAILING_MARTINGALE_MULTICOIN_BODY,
+        ] {
+            assert_eq!(body.matches(MPS_HIGH_EXPOSURE_MARKER).count(), 1);
+            assert!(!body.contains("struct HighExposureState"));
+        }
+        for source in [
+            mps_ema_anchor_source(),
+            mps_ema_anchor_multicoin_source(),
+            mps_trailing_martingale_source(),
+            mps_trailing_martingale_long_no_hsl_source(),
+            mps_trailing_martingale_short_no_hsl_source(),
+            mps_trailing_martingale_multicoin_source(),
+        ] {
+            assert_shared_high_exposure_contract(source);
         }
     }
 

--- a/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
@@ -1663,11 +1663,15 @@ inline void passivbot_single_coin_impl(
             day_has_fill = 1.0f;
             day_touched = true;
 #if PASSIVBOT_HIGH_EXPOSURE_ENABLED
-            const float exposure_balance = fmax(fabs(balance), 1.0e-12f);
+            const bool positive_exposure_balance = balance > 0.0f;
             record_high_exposure_fill(
                 high_exposure, kf, di, fill_count,
-                long_side.psize * long_side.pprice * c_mult / exposure_balance,
-                short_side.psize * short_side.pprice * c_mult / exposure_balance
+                positive_exposure_balance
+                    ? long_side.psize * long_side.pprice * c_mult / balance
+                    : 0.0f,
+                positive_exposure_balance
+                    ? short_side.psize * short_side.pprice * c_mult / balance
+                    : 0.0f
             );
 #endif
             if (last_fill_k >= 0.0f) {

--- a/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
@@ -149,6 +149,8 @@ inline float float32_floor_nonnegative(float value) {
 
 // PASSIVBOT_ENTRY_INTERVAL_COMMON
 
+// PASSIVBOT_HIGH_EXPOSURE_COMMON
+
 inline void record_realized_net(
     float net_pnl,
     thread float& realized_pnl_cumsum_last,
@@ -1137,6 +1139,9 @@ inline void passivbot_single_coin_impl(
 #if PASSIVBOT_EQUITY_BALANCE_DIFF_ENABLED
     device float* equity_balance_diff,
 #endif
+#if PASSIVBOT_HIGH_EXPOSURE_ENABLED
+    device float* high_exposure_output,
+#endif
     device float* daily,
     device float* scalars,
     device int* gap_hist,
@@ -1158,6 +1163,11 @@ inline void passivbot_single_coin_impl(
     const int recovery_sample_count = sizes[9];
 #endif
     if (b >= uint(B)) return;
+#if PASSIVBOT_HIGH_EXPOSURE_ENABLED
+    HighExposureState high_exposure = init_high_exposure_state(
+        high_exposure_output, b
+    );
+#endif
 
     const float qty_step = settings[0];
     const float price_step = settings[1];
@@ -1652,6 +1662,14 @@ inline void passivbot_single_coin_impl(
         if (any_fill) {
             day_has_fill = 1.0f;
             day_touched = true;
+#if PASSIVBOT_HIGH_EXPOSURE_ENABLED
+            const float exposure_balance = fmax(fabs(balance), 1.0e-12f);
+            record_high_exposure_fill(
+                high_exposure, kf, di, fill_count,
+                long_side.psize * long_side.pprice * c_mult / exposure_balance,
+                short_side.psize * short_side.pprice * c_mult / exposure_balance
+            );
+#endif
             if (last_fill_k >= 0.0f) {
                 float gap = kf - last_fill_k;
                 int bin = clamp(
@@ -2204,6 +2222,11 @@ inline void passivbot_single_coin_impl(
             pnl_recovery_max_min, last_eq_k - pnl_recovery_peak_k
         );
     }
+#if PASSIVBOT_HIGH_EXPOSURE_ENABLED
+    write_high_exposure_output(
+        high_exposure, last_fill_k, high_exposure_output, b
+    );
+#endif
     int so = int(b) * SCALAR_COLS;
     scalars[so + 0] = max_dd;
     scalars[so + 1] = held_max_min * interval_ms;
@@ -2352,6 +2375,9 @@ kernel void passivbot_ema_anchor(
 #if PASSIVBOT_EQUITY_BALANCE_DIFF_ENABLED
     device float* equity_balance_diff,
 #endif
+#if PASSIVBOT_HIGH_EXPOSURE_ENABLED
+    device float* high_exposure_output,
+#endif
     device float* daily,
     device float* scalars,
     device int* gap_hist,
@@ -2369,6 +2395,9 @@ kernel void passivbot_ema_anchor(
 #endif
 #if PASSIVBOT_EQUITY_BALANCE_DIFF_ENABLED
         equity_balance_diff,
+#endif
+#if PASSIVBOT_HIGH_EXPOSURE_ENABLED
+        high_exposure_output,
 #endif
         daily, scalars, gap_hist,
         rolling_pnl_values, rolling_pnl_indices,

--- a/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
@@ -3152,8 +3152,8 @@ inline void passivbot_ema_anchor_multicoin_impl(
                         * coin_settings[c * COIN_COLS + 4];
                 }
             }
-            const float side_twe = side_position_cost
-                / fmax(fabs(balance), 1.0e-12f);
+            const float side_twe = balance > 0.0f
+                ? side_position_cost / balance : 0.0f;
             record_high_exposure_fill(
                 high_exposure, float(k), day_index, fill_count,
                 short_side ? 0.0f : side_twe,
@@ -4200,13 +4200,13 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
                         * short_side.pprice[c] * c_mult;
                 }
             }
-            const float exposure_balance = fmax(
-                fabs(account.balance), 1.0e-12f
-            );
+            const bool positive_exposure_balance = account.balance > 0.0f;
             record_high_exposure_fill(
                 high_exposure, float(k), day_index, fills.fill_count,
-                long_position_cost / exposure_balance,
-                short_position_cost / exposure_balance
+                positive_exposure_balance
+                    ? long_position_cost / account.balance : 0.0f,
+                positive_exposure_balance
+                    ? short_position_cost / account.balance : 0.0f
             );
 #endif
             if (last_fill_k >= 0.0f) {

--- a/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
@@ -38,6 +38,8 @@ constant float RECOVERY_FAIL_CLOSED_SENTINEL = -3.402823466e+38f;
 
 // PASSIVBOT_ENTRY_INTERVAL_COMMON
 
+// PASSIVBOT_HIGH_EXPOSURE_COMMON
+
 // PASSIVBOT_MULTICOIN_COMMON
 
 inline float finalized_reducer_qty_with_ordinary(
@@ -2866,6 +2868,9 @@ inline void passivbot_ema_anchor_multicoin_impl(
 #if PASSIVBOT_EQUITY_BALANCE_DIFF_ENABLED
     device float* equity_balance_diff,
 #endif
+#if PASSIVBOT_HIGH_EXPOSURE_ENABLED
+    device float* high_exposure_output,
+#endif
     device float* daily,
     device float* scalars,
     device int* gap_hist,
@@ -2888,6 +2893,11 @@ inline void passivbot_ema_anchor_multicoin_impl(
     const int recovery_sample_count = sizes[9];
 #endif
     if (b >= uint(B)) return;
+#if PASSIVBOT_HIGH_EXPOSURE_ENABLED
+    HighExposureState high_exposure = init_high_exposure_state(
+        high_exposure_output, b
+    );
+#endif
     const int stop_k = clamp(end_steps[b], 1, T - 1);
     const bool collect_coin_fill_counts = run_settings[6] > 0.5f;
     if (collect_coin_fill_counts) {
@@ -3134,6 +3144,22 @@ inline void passivbot_ema_anchor_multicoin_impl(
         any_fill = any_fill || forced_delist_fill;
         if (any_fill) {
             day_has_fill = 1.0f;
+#if PASSIVBOT_HIGH_EXPOSURE_ENABLED
+            float side_position_cost = 0.0f;
+            for (int c = 0; c < C; ++c) {
+                if (psize[c] > 0.0f) {
+                    side_position_cost += psize[c] * pprice[c]
+                        * coin_settings[c * COIN_COLS + 4];
+                }
+            }
+            const float side_twe = side_position_cost
+                / fmax(fabs(balance), 1.0e-12f);
+            record_high_exposure_fill(
+                high_exposure, float(k), day_index, fill_count,
+                short_side ? 0.0f : side_twe,
+                short_side ? side_twe : 0.0f
+            );
+#endif
             if (last_fill_k >= 0.0f) {
                 float gap = float(k) - last_fill_k;
                 int bin = clamp(
@@ -3411,6 +3437,11 @@ inline void passivbot_ema_anchor_multicoin_impl(
             pnl_recovery_max_min, last_eq_k - pnl_recovery_peak_k
         );
     }
+#if PASSIVBOT_HIGH_EXPOSURE_ENABLED
+    write_high_exposure_output(
+        high_exposure, last_fill_k, high_exposure_output, b
+    );
+#endif
     int scalar_offset = int(b) * SCALAR_COLS;
     scalars[scalar_offset + 0] = max_dd;
     scalars[scalar_offset + 1] = held_max_min * interval_ms;
@@ -3706,6 +3737,9 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
 #if PASSIVBOT_EQUITY_BALANCE_DIFF_ENABLED
     device float* equity_balance_diff,
 #endif
+#if PASSIVBOT_HIGH_EXPOSURE_ENABLED
+    device float* high_exposure_output,
+#endif
     device float* daily,
     device float* scalars,
     device int* gap_hist,
@@ -3727,6 +3761,11 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
     const int recovery_sample_count = sizes[9];
 #endif
     if (b >= uint(B)) return;
+#if PASSIVBOT_HIGH_EXPOSURE_ENABLED
+    HighExposureState high_exposure = init_high_exposure_state(
+        high_exposure_output, b
+    );
+#endif
     const int stop_k = clamp(end_steps[b], 1, T - 1);
     const int scalar_offset = int(b) * FUSED_SCALAR_COLS;
     for (int j = 0; j < FUSED_SCALAR_COLS; ++j) {
@@ -3741,6 +3780,11 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
 #ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
         recovery_samples[int(b) * recovery_sample_count]
             = RECOVERY_FAIL_CLOSED_SENTINEL;
+#endif
+#if PASSIVBOT_HIGH_EXPOSURE_ENABLED
+        write_high_exposure_output(
+            high_exposure, -1.0f, high_exposure_output, b
+        );
 #endif
         return;
     }
@@ -3768,6 +3812,11 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
 #ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
         recovery_samples[int(b) * recovery_sample_count]
             = RECOVERY_FAIL_CLOSED_SENTINEL;
+#endif
+#if PASSIVBOT_HIGH_EXPOSURE_ENABLED
+        write_high_exposure_output(
+            high_exposure, -1.0f, high_exposure_output, b
+        );
 #endif
         return;
     }
@@ -4137,6 +4186,29 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
         any_fill = any_fill || forced_delist_fill;
         if (any_fill) {
             day_has_fill = 1.0f;
+#if PASSIVBOT_HIGH_EXPOSURE_ENABLED
+            float long_position_cost = 0.0f;
+            float short_position_cost = 0.0f;
+            for (int c = 0; c < C; ++c) {
+                const float c_mult = coin_settings[c * COIN_COLS + 4];
+                if (long_side.psize[c] > 0.0f) {
+                    long_position_cost += long_side.psize[c]
+                        * long_side.pprice[c] * c_mult;
+                }
+                if (short_side.psize[c] > 0.0f) {
+                    short_position_cost += short_side.psize[c]
+                        * short_side.pprice[c] * c_mult;
+                }
+            }
+            const float exposure_balance = fmax(
+                fabs(account.balance), 1.0e-12f
+            );
+            record_high_exposure_fill(
+                high_exposure, float(k), day_index, fills.fill_count,
+                long_position_cost / exposure_balance,
+                short_position_cost / exposure_balance
+            );
+#endif
             if (last_fill_k >= 0.0f) {
                 float gap = float(k) - last_fill_k;
                 int bin = clamp(
@@ -4396,6 +4468,12 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
         );
     }
 
+#if PASSIVBOT_HIGH_EXPOSURE_ENABLED
+    write_high_exposure_output(
+        high_exposure, last_fill_k, high_exposure_output, b
+    );
+#endif
+
     scalars[scalar_offset + 0] = max_dd;
     scalars[scalar_offset + 1] = fills.held_max_min * interval_ms;
     scalars[scalar_offset + 2] = gap_max_min * interval_ms;
@@ -4530,6 +4608,9 @@ kernel void passivbot_ema_anchor_multicoin_fused(
 #if PASSIVBOT_EQUITY_BALANCE_DIFF_ENABLED
     device float* equity_balance_diff,
 #endif
+#if PASSIVBOT_HIGH_EXPOSURE_ENABLED
+    device float* high_exposure_output,
+#endif
     device float* daily,
     device float* scalars,
     device int* gap_hist,
@@ -4548,6 +4629,9 @@ kernel void passivbot_ema_anchor_multicoin_fused(
 #endif
 #if PASSIVBOT_EQUITY_BALANCE_DIFF_ENABLED
         equity_balance_diff,
+#endif
+#if PASSIVBOT_HIGH_EXPOSURE_ENABLED
+        high_exposure_output,
 #endif
         daily, scalars, gap_hist, coin_fill_counts,
 #ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
@@ -4574,6 +4658,9 @@ kernel void passivbot_ema_anchor_multicoin(
 #if PASSIVBOT_EQUITY_BALANCE_DIFF_ENABLED
     device float* equity_balance_diff,
 #endif
+#if PASSIVBOT_HIGH_EXPOSURE_ENABLED
+    device float* high_exposure_output,
+#endif
     device float* daily,
     device float* scalars,
     device int* gap_hist,
@@ -4593,6 +4680,9 @@ kernel void passivbot_ema_anchor_multicoin(
 #endif
 #if PASSIVBOT_EQUITY_BALANCE_DIFF_ENABLED
         equity_balance_diff,
+#endif
+#if PASSIVBOT_HIGH_EXPOSURE_ENABLED
+        high_exposure_output,
 #endif
         daily, scalars, gap_hist, coin_fill_counts,
 #ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
@@ -4619,6 +4709,9 @@ kernel void passivbot_ema_anchor_multicoin_long(
 #if PASSIVBOT_EQUITY_BALANCE_DIFF_ENABLED
     device float* equity_balance_diff,
 #endif
+#if PASSIVBOT_HIGH_EXPOSURE_ENABLED
+    device float* high_exposure_output,
+#endif
     device float* daily,
     device float* scalars,
     device int* gap_hist,
@@ -4637,6 +4730,9 @@ kernel void passivbot_ema_anchor_multicoin_long(
 #endif
 #if PASSIVBOT_EQUITY_BALANCE_DIFF_ENABLED
         equity_balance_diff,
+#endif
+#if PASSIVBOT_HIGH_EXPOSURE_ENABLED
+        high_exposure_output,
 #endif
         daily, scalars, gap_hist, coin_fill_counts,
 #ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED

--- a/passivbot-rust/src/gpu/mps_high_exposure_common.metal
+++ b/passivbot-rust/src/gpu/mps_high_exposure_common.metal
@@ -1,0 +1,193 @@
+#ifndef PASSIVBOT_HIGH_EXPOSURE_ENABLED
+#define PASSIVBOT_HIGH_EXPOSURE_ENABLED 0
+#endif
+
+constant int HIGH_EXPOSURE_COLS = 8;
+
+#if PASSIVBOT_HIGH_EXPOSURE_ENABLED
+
+struct HighExposureState {
+    bool metric_pass;
+    int first_fill_day;
+    int last_fill_day;
+    int current_fill_day;
+    float current_day_twe_sum_long;
+    float current_day_twe_sum_short;
+    float current_day_fill_count;
+    float daily_twe_mean_sum_long;
+    float daily_twe_mean_sum_short;
+    float observed_fill_count;
+    float threshold_long;
+    float threshold_short;
+    float run_start_k_long;
+    float run_start_k_short;
+    float duration_sum_steps_long;
+    float duration_sum_steps_short;
+    float duration_max_steps_long;
+    float duration_max_steps_short;
+    float duration_count_long;
+    float duration_count_short;
+};
+
+inline HighExposureState init_high_exposure_state(
+    device float* output,
+    int candidate
+) {
+    const int offset = candidate * HIGH_EXPOSURE_COLS;
+    HighExposureState state;
+    state.threshold_long = output[offset + 0];
+    state.threshold_short = output[offset + 1];
+    state.metric_pass = isfinite(state.threshold_long)
+        && isfinite(state.threshold_short);
+    state.first_fill_day = -1;
+    state.last_fill_day = -1;
+    state.current_fill_day = -1;
+    state.current_day_twe_sum_long = 0.0f;
+    state.current_day_twe_sum_short = 0.0f;
+    state.current_day_fill_count = 0.0f;
+    state.daily_twe_mean_sum_long = 0.0f;
+    state.daily_twe_mean_sum_short = 0.0f;
+    state.observed_fill_count = 0.0f;
+    state.run_start_k_long = -1.0f;
+    state.run_start_k_short = -1.0f;
+    state.duration_sum_steps_long = 0.0f;
+    state.duration_sum_steps_short = 0.0f;
+    state.duration_max_steps_long = 0.0f;
+    state.duration_max_steps_short = 0.0f;
+    state.duration_count_long = 0.0f;
+    state.duration_count_short = 0.0f;
+    return state;
+}
+
+inline void flush_high_exposure_threshold_day(
+    thread HighExposureState& state
+) {
+    if (state.current_fill_day < 0 || !(state.current_day_fill_count > 0.0f)) {
+        return;
+    }
+    state.daily_twe_mean_sum_long += state.current_day_twe_sum_long
+        / state.current_day_fill_count;
+    state.daily_twe_mean_sum_short += state.current_day_twe_sum_short
+        / state.current_day_fill_count;
+    state.current_day_twe_sum_long = 0.0f;
+    state.current_day_twe_sum_short = 0.0f;
+    state.current_day_fill_count = 0.0f;
+}
+
+inline void update_high_exposure_duration(
+    float twe,
+    float threshold,
+    float fill_k,
+    thread float& run_start_k,
+    thread float& duration_sum_steps,
+    thread float& duration_max_steps,
+    thread float& duration_count
+) {
+    if (twe > threshold) {
+        if (run_start_k < 0.0f) run_start_k = fill_k;
+        return;
+    }
+    if (run_start_k >= 0.0f) {
+        const float duration = fmax(fill_k - run_start_k, 0.0f);
+        duration_sum_steps += duration;
+        duration_max_steps = fmax(duration_max_steps, duration);
+        duration_count += 1.0f;
+        run_start_k = -1.0f;
+    }
+}
+
+inline void record_high_exposure_fill(
+    thread HighExposureState& state,
+    float fill_k,
+    int fill_day,
+    float cumulative_fill_count,
+    float twe_long,
+    float twe_short
+) {
+    if (state.metric_pass) {
+        update_high_exposure_duration(
+            twe_long, state.threshold_long, fill_k,
+            state.run_start_k_long, state.duration_sum_steps_long,
+            state.duration_max_steps_long, state.duration_count_long
+        );
+        update_high_exposure_duration(
+            twe_short, state.threshold_short, fill_k,
+            state.run_start_k_short, state.duration_sum_steps_short,
+            state.duration_max_steps_short, state.duration_count_short
+        );
+        return;
+    }
+
+    if (state.current_fill_day != fill_day) {
+        flush_high_exposure_threshold_day(state);
+        state.current_fill_day = fill_day;
+        if (state.first_fill_day < 0) state.first_fill_day = fill_day;
+        state.last_fill_day = fill_day;
+    }
+    const float sample_count = fmax(
+        cumulative_fill_count - state.observed_fill_count, 1.0f
+    );
+    state.observed_fill_count = cumulative_fill_count;
+    state.current_day_twe_sum_long += fmax(twe_long, 0.0f) * sample_count;
+    state.current_day_twe_sum_short += fmax(twe_short, 0.0f) * sample_count;
+    state.current_day_fill_count += sample_count;
+}
+
+inline void close_high_exposure_tail(
+    float last_fill_k,
+    thread float& run_start_k,
+    thread float& duration_sum_steps,
+    thread float& duration_max_steps,
+    thread float& duration_count
+) {
+    if (run_start_k < 0.0f || last_fill_k < 0.0f) return;
+    const float duration = fmax(last_fill_k - run_start_k, 0.0f);
+    duration_sum_steps += duration;
+    duration_max_steps = fmax(duration_max_steps, duration);
+    duration_count += 1.0f;
+    run_start_k = -1.0f;
+}
+
+inline void write_high_exposure_output(
+    thread HighExposureState& state,
+    float last_fill_k,
+    device float* output,
+    int candidate
+) {
+    const int offset = candidate * HIGH_EXPOSURE_COLS;
+    if (!state.metric_pass) {
+        flush_high_exposure_threshold_day(state);
+        const int total_days = state.first_fill_day >= 0
+            ? state.last_fill_day - state.first_fill_day + 1
+            : 0;
+        output[offset + 0] = total_days > 0
+            ? state.daily_twe_mean_sum_long / float(total_days)
+            : 0.0f;
+        output[offset + 1] = total_days > 0
+            ? state.daily_twe_mean_sum_short / float(total_days)
+            : 0.0f;
+        for (int column = 2; column < HIGH_EXPOSURE_COLS; column++) {
+            output[offset + column] = 0.0f;
+        }
+        return;
+    }
+
+    close_high_exposure_tail(
+        last_fill_k, state.run_start_k_long,
+        state.duration_sum_steps_long, state.duration_max_steps_long,
+        state.duration_count_long
+    );
+    close_high_exposure_tail(
+        last_fill_k, state.run_start_k_short,
+        state.duration_sum_steps_short, state.duration_max_steps_short,
+        state.duration_count_short
+    );
+    output[offset + 2] = state.duration_sum_steps_long;
+    output[offset + 3] = state.duration_max_steps_long;
+    output[offset + 4] = state.duration_count_long;
+    output[offset + 5] = state.duration_sum_steps_short;
+    output[offset + 6] = state.duration_max_steps_short;
+    output[offset + 7] = state.duration_count_short;
+}
+
+#endif

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -3555,11 +3555,15 @@ inline void passivbot_single_coin_impl(
             day_has_fill = 1.0f;
             day_touched = true;
 #if PASSIVBOT_HIGH_EXPOSURE_ENABLED
-            const float exposure_balance = fmax(fabs(balance), 1.0e-12f);
+            const bool positive_exposure_balance = balance > 0.0f;
             record_high_exposure_fill(
                 high_exposure, kf, di, fill_count,
-                long_side.psize * long_side.pprice * c_mult / exposure_balance,
-                short_side.psize * short_side.pprice * c_mult / exposure_balance
+                positive_exposure_balance
+                    ? long_side.psize * long_side.pprice * c_mult / balance
+                    : 0.0f,
+                positive_exposure_balance
+                    ? short_side.psize * short_side.pprice * c_mult / balance
+                    : 0.0f
             );
 #endif
             if (last_fill_k >= 0.0f) {

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -205,6 +205,8 @@ inline bool realized_loss_proxy_allows_reducer(
 
 // PASSIVBOT_ENTRY_INTERVAL_COMMON
 
+// PASSIVBOT_HIGH_EXPOSURE_COMMON
+
 inline void record_realized_net(
     float net_pnl,
     thread float& realized_pnl_cumsum_last,
@@ -1735,6 +1737,9 @@ inline void passivbot_single_coin_impl(
     device float* entry_interval_stats,
     device int* entry_interval_counts,
 #endif
+#if PASSIVBOT_HIGH_EXPOSURE_ENABLED
+    device float* high_exposure_output,
+#endif
     device float* daily,
     device float* scalars,
     device int* gap_hist,
@@ -1756,6 +1761,11 @@ inline void passivbot_single_coin_impl(
     const int recovery_sample_count = sizes[9];
 #endif
     if (b >= uint(B)) return;
+#if PASSIVBOT_HIGH_EXPOSURE_ENABLED
+    HighExposureState high_exposure = init_high_exposure_state(
+        high_exposure_output, b
+    );
+#endif
 
     const float qty_step = settings[0];
     const float price_step = settings[1];
@@ -3544,6 +3554,14 @@ inline void passivbot_single_coin_impl(
         if (any_fill) {
             day_has_fill = 1.0f;
             day_touched = true;
+#if PASSIVBOT_HIGH_EXPOSURE_ENABLED
+            const float exposure_balance = fmax(fabs(balance), 1.0e-12f);
+            record_high_exposure_fill(
+                high_exposure, kf, di, fill_count,
+                long_side.psize * long_side.pprice * c_mult / exposure_balance,
+                short_side.psize * short_side.pprice * c_mult / exposure_balance
+            );
+#endif
             if (last_fill_k >= 0.0f) {
                 float gap = kf - last_fill_k;
                 int bin = clamp(
@@ -4064,6 +4082,11 @@ inline void passivbot_single_coin_impl(
             pnl_recovery_max_min, last_eq_k - pnl_recovery_peak_k
         );
     }
+#if PASSIVBOT_HIGH_EXPOSURE_ENABLED
+    write_high_exposure_output(
+        high_exposure, last_fill_k, high_exposure_output, b
+    );
+#endif
     int so = int(b) * SCALAR_COLS;
     scalars[so + 0] = max_dd;
     scalars[so + 1] = held_max_min * interval_ms;
@@ -4216,6 +4239,9 @@ kernel void passivbot_trailing_martingale(
     device float* entry_interval_stats,
     device int* entry_interval_counts,
 #endif
+#if PASSIVBOT_HIGH_EXPOSURE_ENABLED
+    device float* high_exposure_output,
+#endif
     device float* daily,
     device float* scalars,
     device int* gap_hist,
@@ -4236,6 +4262,9 @@ kernel void passivbot_trailing_martingale(
 #endif
 #if PASSIVBOT_ENTRY_INTERVAL_ENABLED
         entry_interval_stats, entry_interval_counts,
+#endif
+#if PASSIVBOT_HIGH_EXPOSURE_ENABLED
+        high_exposure_output,
 #endif
         daily, scalars, gap_hist,
         rolling_pnl_values, rolling_pnl_indices,

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
@@ -5321,13 +5321,13 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
                         * short_side.pprice[c] * c_mult;
                 }
             }
-            const float exposure_balance = fmax(
-                fabs(account.balance), 1.0e-12f
-            );
+            const bool positive_exposure_balance = account.balance > 0.0f;
             record_high_exposure_fill(
                 high_exposure, float(k), day_index, fills.fill_count,
-                long_position_cost / exposure_balance,
-                short_position_cost / exposure_balance
+                positive_exposure_balance
+                    ? long_position_cost / account.balance : 0.0f,
+                positive_exposure_balance
+                    ? short_position_cost / account.balance : 0.0f
             );
 #endif
             if (last_fill_k >= 0.0f) {
@@ -6098,8 +6098,8 @@ inline void passivbot_trailing_martingale_multicoin_impl(
                         * coin_settings[c * COIN_COLS + 4];
                 }
             }
-            const float side_twe = side_position_cost
-                / fmax(fabs(balance), 1.0e-12f);
+            const float side_twe = balance > 0.0f
+                ? side_position_cost / balance : 0.0f;
             record_high_exposure_fill(
                 high_exposure, float(k), day_index, fill_count,
                 short_side ? 0.0f : side_twe,

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
@@ -40,6 +40,8 @@ constant float RECOVERY_FAIL_CLOSED_SENTINEL = -3.402823466e+38f;
 
 // PASSIVBOT_ENTRY_INTERVAL_COMMON
 
+// PASSIVBOT_HIGH_EXPOSURE_COMMON
+
 // PASSIVBOT_MULTICOIN_COMMON
 
 inline bool realized_loss_proxy_allows_close(
@@ -4831,6 +4833,9 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
     device float* entry_interval_stats,
     device int* entry_interval_counts,
 #endif
+#if PASSIVBOT_HIGH_EXPOSURE_ENABLED
+    device float* high_exposure_output,
+#endif
     device float* daily,
     device float* scalars,
     device int* gap_hist,
@@ -4852,6 +4857,11 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
     const int recovery_sample_count = sizes[9];
 #endif
     if (b >= uint(B)) return;
+#if PASSIVBOT_HIGH_EXPOSURE_ENABLED
+    HighExposureState high_exposure = init_high_exposure_state(
+        high_exposure_output, b
+    );
+#endif
 #if PASSIVBOT_ENTRY_INTERVAL_ENABLED
     init_entry_interval_output(
         entry_interval_stats, entry_interval_counts, b
@@ -4871,6 +4881,11 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
 #ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
         recovery_samples[int(b) * recovery_sample_count]
             = RECOVERY_FAIL_CLOSED_SENTINEL;
+#endif
+#if PASSIVBOT_HIGH_EXPOSURE_ENABLED
+        write_high_exposure_output(
+            high_exposure, -1.0f, high_exposure_output, b
+        );
 #endif
         return;
     }
@@ -4900,6 +4915,11 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
 #ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
         recovery_samples[int(b) * recovery_sample_count]
             = RECOVERY_FAIL_CLOSED_SENTINEL;
+#endif
+#if PASSIVBOT_HIGH_EXPOSURE_ENABLED
+        write_high_exposure_output(
+            high_exposure, -1.0f, high_exposure_output, b
+        );
 #endif
         return;
     }
@@ -5287,6 +5307,29 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
         any_fill = any_fill || forced_delist_fill;
         if (any_fill) {
             day_has_fill = 1.0f;
+#if PASSIVBOT_HIGH_EXPOSURE_ENABLED
+            float long_position_cost = 0.0f;
+            float short_position_cost = 0.0f;
+            for (int c = 0; c < C; ++c) {
+                const float c_mult = coin_settings[c * COIN_COLS + 4];
+                if (long_side.psize[c] > 0.0f) {
+                    long_position_cost += long_side.psize[c]
+                        * long_side.pprice[c] * c_mult;
+                }
+                if (short_side.psize[c] > 0.0f) {
+                    short_position_cost += short_side.psize[c]
+                        * short_side.pprice[c] * c_mult;
+                }
+            }
+            const float exposure_balance = fmax(
+                fabs(account.balance), 1.0e-12f
+            );
+            record_high_exposure_fill(
+                high_exposure, float(k), day_index, fills.fill_count,
+                long_position_cost / exposure_balance,
+                short_position_cost / exposure_balance
+            );
+#endif
             if (last_fill_k >= 0.0f) {
                 float gap = float(k) - last_fill_k;
                 int bin = clamp(
@@ -5546,6 +5589,12 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
         );
     }
 
+#if PASSIVBOT_HIGH_EXPOSURE_ENABLED
+    write_high_exposure_output(
+        high_exposure, last_fill_k, high_exposure_output, b
+    );
+#endif
+
     scalars[scalar_offset + 0] = max_dd;
     scalars[scalar_offset + 1] = fills.held_max_min * interval_ms;
     scalars[scalar_offset + 2] = gap_max_min * interval_ms;
@@ -5687,6 +5736,9 @@ kernel void passivbot_trailing_martingale_multicoin_fused(
     device float* entry_interval_stats,
     device int* entry_interval_counts,
 #endif
+#if PASSIVBOT_HIGH_EXPOSURE_ENABLED
+    device float* high_exposure_output,
+#endif
     device float* daily,
     device float* scalars,
     device int* gap_hist,
@@ -5710,6 +5762,9 @@ kernel void passivbot_trailing_martingale_multicoin_fused(
 #endif
 #if PASSIVBOT_ENTRY_INTERVAL_ENABLED
         entry_interval_stats, entry_interval_counts,
+#endif
+#if PASSIVBOT_HIGH_EXPOSURE_ENABLED
+        high_exposure_output,
 #endif
         daily, scalars, gap_hist, coin_fill_counts,
 #ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
@@ -5743,6 +5798,9 @@ inline void passivbot_trailing_martingale_multicoin_impl(
     device float* entry_interval_stats,
     device int* entry_interval_counts,
 #endif
+#if PASSIVBOT_HIGH_EXPOSURE_ENABLED
+    device float* high_exposure_output,
+#endif
     device float* daily,
     device float* scalars,
     device int* gap_hist,
@@ -5765,6 +5823,11 @@ inline void passivbot_trailing_martingale_multicoin_impl(
     const int recovery_sample_count = sizes[9];
 #endif
     if (b >= uint(B)) return;
+#if PASSIVBOT_HIGH_EXPOSURE_ENABLED
+    HighExposureState high_exposure = init_high_exposure_state(
+        high_exposure_output, b
+    );
+#endif
 #if PASSIVBOT_ENTRY_INTERVAL_ENABLED
     init_entry_interval_output(
         entry_interval_stats, entry_interval_counts, b
@@ -6027,6 +6090,22 @@ inline void passivbot_trailing_martingale_multicoin_impl(
         any_fill = any_fill || forced_delist_fill;
         if (any_fill) {
             day_has_fill = 1.0f;
+#if PASSIVBOT_HIGH_EXPOSURE_ENABLED
+            float side_position_cost = 0.0f;
+            for (int c = 0; c < C; ++c) {
+                if (psize[c] > 0.0f) {
+                    side_position_cost += psize[c] * pprice[c]
+                        * coin_settings[c * COIN_COLS + 4];
+                }
+            }
+            const float side_twe = side_position_cost
+                / fmax(fabs(balance), 1.0e-12f);
+            record_high_exposure_fill(
+                high_exposure, float(k), day_index, fill_count,
+                short_side ? 0.0f : side_twe,
+                short_side ? side_twe : 0.0f
+            );
+#endif
             if (last_fill_k >= 0.0f) {
                 float gap = float(k) - last_fill_k;
                 int bin = clamp(
@@ -6304,6 +6383,11 @@ inline void passivbot_trailing_martingale_multicoin_impl(
             pnl_recovery_max_min, last_eq_k - pnl_recovery_peak_k
         );
     }
+#if PASSIVBOT_HIGH_EXPOSURE_ENABLED
+    write_high_exposure_output(
+        high_exposure, last_fill_k, high_exposure_output, b
+    );
+#endif
     int scalar_offset = int(b) * SCALAR_COLS;
     scalars[scalar_offset + 0] = max_dd;
     scalars[scalar_offset + 1] = held_max_min * interval_ms;
@@ -6433,6 +6517,9 @@ kernel void passivbot_trailing_martingale_multicoin(
     device float* entry_interval_stats,
     device int* entry_interval_counts,
 #endif
+#if PASSIVBOT_HIGH_EXPOSURE_ENABLED
+    device float* high_exposure_output,
+#endif
     device float* daily,
     device float* scalars,
     device int* gap_hist,
@@ -6457,6 +6544,9 @@ kernel void passivbot_trailing_martingale_multicoin(
 #endif
 #if PASSIVBOT_ENTRY_INTERVAL_ENABLED
         entry_interval_stats, entry_interval_counts,
+#endif
+#if PASSIVBOT_HIGH_EXPOSURE_ENABLED
+        high_exposure_output,
 #endif
         daily, scalars, gap_hist, coin_fill_counts,
 #ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
@@ -6490,6 +6580,9 @@ kernel void passivbot_trailing_martingale_multicoin_long(
     device float* entry_interval_stats,
     device int* entry_interval_counts,
 #endif
+#if PASSIVBOT_HIGH_EXPOSURE_ENABLED
+    device float* high_exposure_output,
+#endif
     device float* daily,
     device float* scalars,
     device int* gap_hist,
@@ -6513,6 +6606,9 @@ kernel void passivbot_trailing_martingale_multicoin_long(
 #endif
 #if PASSIVBOT_ENTRY_INTERVAL_ENABLED
         entry_interval_stats, entry_interval_counts,
+#endif
+#if PASSIVBOT_HIGH_EXPOSURE_ENABLED
+        high_exposure_output,
 #endif
         daily, scalars, gap_hist, coin_fill_counts,
 #ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED

--- a/src/optimization/gpu/metrics.py
+++ b/src/optimization/gpu/metrics.py
@@ -101,6 +101,15 @@ ENTRY_INTERVAL_METRICS = frozenset(
     }
 )
 
+HIGH_EXPOSURE_METRICS = frozenset(
+    {
+        f"high_exposure_{unit}_{stat}_{side}"
+        for unit in ("hours", "days")
+        for stat in ("mean", "max")
+        for side in ("long", "short")
+    }
+)
+
 _BTC_ACCOUNT_METRICS.update(BTC_INTRADAY_RISK_METRICS)
 _BTC_ACCOUNT_METRICS.update(
     metric for metric in EQUITY_BALANCE_DIFF_METRICS if metric.endswith("_btc")
@@ -200,6 +209,7 @@ SUPPORTED_METRICS = (
     "hard_stop_triggers_long",
     "hard_stop_triggers_per_year",
     "hard_stop_triggers_short",
+    *sorted(HIGH_EXPOSURE_METRICS),
     "loss_profit_ratio",
     "loss_profit_ratio_long",
     "loss_profit_ratio_short",
@@ -2369,6 +2379,15 @@ def compute_objectives(out: dict, run, data: dict, needed=None) -> dict:
     objectives.update(fill_gap_metrics)
     objectives.update(fill_activity_metrics)
     objectives.update(entry_interval_metrics)
+    requested_high_exposure = requested & HIGH_EXPOSURE_METRICS
+    missing_high_exposure = requested_high_exposure - out.keys()
+    if missing_high_exposure:
+        raise RuntimeError(
+            "MPS high-exposure output is missing from proxy results: "
+            + ", ".join(sorted(missing_high_exposure))
+        )
+    for name in requested_high_exposure:
+        objectives[name] = out[name].to(torch.float64)
     objectives.update(hard_stop_metrics)
     objectives.update(hard_stop_panic_loss_metrics)
     objectives.update(weighted_metrics)

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -47,6 +47,7 @@ MPS_STRATEGY_EQ_RECOVERY_METRIC_COLS = 7
 MPS_EQUITY_BALANCE_DIFF_COLS = 12
 MPS_ENTRY_INTERVAL_STAT_COLS = 2
 MPS_ENTRY_INTERVAL_COUNT_COLS = 129
+MPS_HIGH_EXPOSURE_COLS = 8
 
 _HSL_EMA_TAIL_DEFINE = "#define PASSIVBOT_HSL_EMA_TAIL_ENABLED 1\n"
 _HSL_RAW_DRAWDOWN_DEFINE = "#define PASSIVBOT_HSL_RAW_DRAWDOWN_ENABLED 1\n"
@@ -62,6 +63,7 @@ _EQUITY_BALANCE_DIFF_DEFINE = (
     "#define PASSIVBOT_EQUITY_BALANCE_DIFF_ENABLED 1\n"
 )
 _ENTRY_INTERVAL_DEFINE = "#define PASSIVBOT_ENTRY_INTERVAL_ENABLED 1\n"
+_HIGH_EXPOSURE_DEFINE = "#define PASSIVBOT_HIGH_EXPOSURE_ENABLED 1\n"
 
 
 def _with_hsl_ema_tail(source: str, enabled: bool) -> str:
@@ -139,6 +141,16 @@ def _with_entry_interval(source: str, enabled: bool) -> str:
             "MPS source is missing the shared entry-interval contract"
         )
     return _ENTRY_INTERVAL_DEFINE + source
+
+
+def _with_high_exposure(source: str, enabled: bool) -> str:
+    if not enabled:
+        return source
+    if "inline void record_high_exposure_fill(" not in source:
+        raise RuntimeError(
+            "MPS source is missing the shared high-exposure contract"
+        )
+    return _HIGH_EXPOSURE_DEFINE + source
 
 
 def _encode_max_realized_loss_pct(value: float) -> float:
@@ -453,6 +465,33 @@ def _decode_entry_interval_outputs(stats, counts) -> dict:
     }
 
 
+def _decode_high_exposure_outputs(output, interval_ms: float) -> dict:
+    if output is None:
+        return {}
+    if output.ndim != 2 or output.shape[1] != MPS_HIGH_EXPOSURE_COLS:
+        raise RuntimeError(
+            "MPS high-exposure output has an invalid shape: "
+            f"{tuple(output.shape)}"
+        )
+    hours_per_step = float(interval_ms) / 3_600_000.0
+    decoded = {}
+    for side, start in (("long", 2), ("short", 5)):
+        duration_count = output[:, start + 2]
+        duration_sum = output[:, start]
+        duration_max = output[:, start + 1]
+        mean_hours = torch.where(
+            duration_count > 0.0,
+            duration_sum / duration_count.clamp(min=1.0) * hours_per_step,
+            torch.zeros_like(duration_count),
+        )
+        max_hours = duration_max * hours_per_step
+        decoded[f"high_exposure_hours_mean_{side}"] = mean_hours
+        decoded[f"high_exposure_hours_max_{side}"] = max_hours
+        decoded[f"high_exposure_days_mean_{side}"] = mean_hours / 24.0
+        decoded[f"high_exposure_days_max_{side}"] = max_hours / 24.0
+    return decoded
+
+
 @lru_cache(maxsize=16)
 def _shader_library(
     hsl_ema_tail_enabled: bool = False,
@@ -461,6 +500,7 @@ def _shader_library(
     recovery_distribution_enabled: bool = False,
     btc_risk_enabled: bool = False,
     equity_balance_diff_enabled: bool = False,
+    high_exposure_enabled: bool = False,
 ):
     if not torch.backends.mps.is_available():
         raise RuntimeError("Apple MPS is not available in this process")
@@ -475,6 +515,7 @@ def _shader_library(
     source = _with_recovery_distribution(source, recovery_distribution_enabled)
     source = _with_btc_risk(source, btc_risk_enabled)
     source = _with_equity_balance_diff(source, equity_balance_diff_enabled)
+    source = _with_high_exposure(source, high_exposure_enabled)
     return torch.mps.compile_shader(source)
 
 
@@ -487,6 +528,7 @@ def _trailing_martingale_shader_library(
     btc_risk_enabled: bool = False,
     equity_balance_diff_enabled: bool = False,
     entry_interval_enabled: bool = False,
+    high_exposure_enabled: bool = False,
 ):
     if not torch.backends.mps.is_available():
         raise RuntimeError("Apple MPS is not available in this process")
@@ -502,6 +544,7 @@ def _trailing_martingale_shader_library(
     source = _with_btc_risk(source, btc_risk_enabled)
     source = _with_equity_balance_diff(source, equity_balance_diff_enabled)
     source = _with_entry_interval(source, entry_interval_enabled)
+    source = _with_high_exposure(source, high_exposure_enabled)
     return torch.mps.compile_shader(source)
 
 
@@ -511,6 +554,7 @@ def _trailing_martingale_long_no_hsl_shader_library(
     btc_risk_enabled: bool = False,
     equity_balance_diff_enabled: bool = False,
     entry_interval_enabled: bool = False,
+    high_exposure_enabled: bool = False,
 ):
     if not torch.backends.mps.is_available():
         raise RuntimeError("Apple MPS is not available in this process")
@@ -523,6 +567,7 @@ def _trailing_martingale_long_no_hsl_shader_library(
     source = _with_btc_risk(source, btc_risk_enabled)
     source = _with_equity_balance_diff(source, equity_balance_diff_enabled)
     source = _with_entry_interval(source, entry_interval_enabled)
+    source = _with_high_exposure(source, high_exposure_enabled)
     return torch.mps.compile_shader(source)
 
 
@@ -532,6 +577,7 @@ def _trailing_martingale_short_no_hsl_shader_library(
     btc_risk_enabled: bool = False,
     equity_balance_diff_enabled: bool = False,
     entry_interval_enabled: bool = False,
+    high_exposure_enabled: bool = False,
 ):
     if not torch.backends.mps.is_available():
         raise RuntimeError("Apple MPS is not available in this process")
@@ -544,6 +590,7 @@ def _trailing_martingale_short_no_hsl_shader_library(
     source = _with_btc_risk(source, btc_risk_enabled)
     source = _with_equity_balance_diff(source, equity_balance_diff_enabled)
     source = _with_entry_interval(source, entry_interval_enabled)
+    source = _with_high_exposure(source, high_exposure_enabled)
     return torch.mps.compile_shader(source)
 
 
@@ -556,6 +603,7 @@ def _ema_anchor_multicoin_shader_library(
     dynamic_wel_by_tradability: bool = True,
     btc_risk_enabled: bool = False,
     equity_balance_diff_enabled: bool = False,
+    high_exposure_enabled: bool = False,
 ):
     if not torch.backends.mps.is_available():
         raise RuntimeError("Apple MPS is not available in this process")
@@ -573,6 +621,7 @@ def _ema_anchor_multicoin_shader_library(
     )
     source = _with_btc_risk(source, btc_risk_enabled)
     source = _with_equity_balance_diff(source, equity_balance_diff_enabled)
+    source = _with_high_exposure(source, high_exposure_enabled)
     return torch.mps.compile_shader(source)
 
 
@@ -586,6 +635,7 @@ def _trailing_martingale_multicoin_shader_library(
     btc_risk_enabled: bool = False,
     equity_balance_diff_enabled: bool = False,
     entry_interval_enabled: bool = False,
+    high_exposure_enabled: bool = False,
 ):
     if not torch.backends.mps.is_available():
         raise RuntimeError("Apple MPS is not available in this process")
@@ -604,6 +654,7 @@ def _trailing_martingale_multicoin_shader_library(
     source = _with_btc_risk(source, btc_risk_enabled)
     source = _with_equity_balance_diff(source, equity_balance_diff_enabled)
     source = _with_entry_interval(source, entry_interval_enabled)
+    source = _with_high_exposure(source, high_exposure_enabled)
     return torch.mps.compile_shader(source)
 
 
@@ -955,6 +1006,7 @@ class MpsEmaAnchorRunner:
         btc_risk_enabled: bool | None = None,
         equity_balance_diff_enabled: bool = False,
         entry_interval_enabled: bool = False,
+        high_exposure_enabled: bool = False,
     ):
         self.market = market
         if entry_interval_enabled:
@@ -1025,6 +1077,7 @@ class MpsEmaAnchorRunner:
             btc_prices, expected_count=self.n
         )
         self.equity_balance_diff_enabled = bool(equity_balance_diff_enabled)
+        self.high_exposure_enabled = bool(high_exposure_enabled)
         self.btc_risk_enabled = (
             self.btc_prices is not None
             if btc_risk_enabled is None
@@ -1117,6 +1170,7 @@ class MpsEmaAnchorRunner:
         self._rolling_buffers: dict[int, tuple[torch.Tensor, torch.Tensor]] = {}
         self._recovery_buffers: dict[int, torch.Tensor] = {}
         self._equity_balance_diff_buffers: dict[int, torch.Tensor] = {}
+        self._high_exposure_buffers: dict[int, torch.Tensor] = {}
         self._sizes: dict[tuple[int, int], torch.Tensor] = {}
         self.last_profile: dict[str, float] = {}
 
@@ -1223,6 +1277,20 @@ class MpsEmaAnchorRunner:
             self._equity_balance_diff_buffers[batch_size].zero_()
         return self._equity_balance_diff_buffers[batch_size]
 
+    def _high_exposure_buffer(self, batch_size: int):
+        if not self.high_exposure_enabled:
+            return None
+        if batch_size not in self._high_exposure_buffers:
+            self._high_exposure_buffers[batch_size] = torch.full(
+                (batch_size, MPS_HIGH_EXPOSURE_COLS),
+                float("nan"),
+                dtype=torch.float32,
+                device="mps",
+            )
+        else:
+            self._high_exposure_buffers[batch_size].fill_(float("nan"))
+        return self._high_exposure_buffers[batch_size]
+
     def _single_coin_size_values(
         self, batch_size: int, parameter_count: int
     ) -> list[int]:
@@ -1256,6 +1324,7 @@ class MpsEmaAnchorRunner:
             else None
         )
         equity_balance_diff = self._equity_balance_diff_buffer(batch_size)
+        high_exposure_output = self._high_exposure_buffer(batch_size)
         sizes_key = (batch_size, int(matrix.shape[1]))
         if sizes_key not in self._sizes:
             size_values = self._single_coin_size_values(
@@ -1274,6 +1343,7 @@ class MpsEmaAnchorRunner:
             self.recovery_distribution_enabled,
             self.btc_risk_enabled,
             self.equity_balance_diff_enabled,
+            self.high_exposure_enabled,
         )
         compiled = time.perf_counter()
         if profile:
@@ -1281,30 +1351,47 @@ class MpsEmaAnchorRunner:
             dispatched = time.perf_counter()
         else:
             dispatched = compiled
-        kernel_args = (
-            self.bars,
-            self.flags,
-            params_mps,
-            self.settings,
-            self._sizes[sizes_key],
-        )
-        if self.btc_prices_enabled:
-            kernel_args += (self.btc_prices,)
-        if self.equity_balance_diff_enabled:
-            kernel_args += (equity_balance_diff,)
-        kernel_args += (
-            daily,
-            scalars,
-            gaps,
-            rolling_pnl_values,
-            rolling_pnl_indices,
-        )
-        if self.recovery_distribution_enabled:
-            kernel_args += (recovery_samples,)
-        library.passivbot_ema_anchor(
-            *kernel_args,
-            threads=(batch_size, 1, 1),
-        )
+        def dispatch_once():
+            kernel_args = (
+                self.bars,
+                self.flags,
+                params_mps,
+                self.settings,
+                self._sizes[sizes_key],
+            )
+            if self.btc_prices_enabled:
+                kernel_args += (self.btc_prices,)
+            if self.equity_balance_diff_enabled:
+                kernel_args += (equity_balance_diff,)
+            if self.high_exposure_enabled:
+                kernel_args += (high_exposure_output,)
+            kernel_args += (
+                daily,
+                scalars,
+                gaps,
+                rolling_pnl_values,
+                rolling_pnl_indices,
+            )
+            if self.recovery_distribution_enabled:
+                kernel_args += (recovery_samples,)
+            library.passivbot_ema_anchor(
+                *kernel_args,
+                threads=(batch_size, 1, 1),
+            )
+
+        dispatch_once()
+        if self.high_exposure_enabled:
+            daily, scalars, gaps = self._output_buffers(batch_size)
+            rolling_pnl_values, rolling_pnl_indices = self._hsl_rolling_buffers(
+                batch_size
+            )
+            recovery_samples = (
+                self._recovery_sample_buffer(batch_size)
+                if self.recovery_distribution_enabled
+                else None
+            )
+            equity_balance_diff = self._equity_balance_diff_buffer(batch_size)
+            dispatch_once()
         if profile:
             torch.mps.synchronize()
         finished = time.perf_counter()
@@ -1317,6 +1404,11 @@ class MpsEmaAnchorRunner:
         }
         output = _decode_directional_outputs(daily, scalars, gaps)
         output.update(_decode_equity_balance_diff_outputs(equity_balance_diff))
+        output.update(
+            _decode_high_exposure_outputs(
+                high_exposure_output, self.run_config.interval_ms
+            )
+        )
         if self.recovery_distribution_enabled:
             output["strategy_eq_recovery_samples"] = recovery_samples
             output["strategy_eq_recovery_sample_interval_days"] = (
@@ -1356,6 +1448,7 @@ class MpsEmaAnchorMulticoinRunner:
         btc_risk_enabled: bool | None = None,
         equity_balance_diff_enabled: bool = False,
         entry_interval_enabled: bool = False,
+        high_exposure_enabled: bool = False,
     ):
         if side not in {"long", "short"}:
             raise ValueError(
@@ -1411,6 +1504,7 @@ class MpsEmaAnchorMulticoinRunner:
             btc_prices, expected_count=self.n
         )
         self.equity_balance_diff_enabled = bool(equity_balance_diff_enabled)
+        self.high_exposure_enabled = bool(high_exposure_enabled)
         self.entry_interval_enabled = bool(entry_interval_enabled)
         if self.entry_interval_enabled and self.coin_override_label != "Trailing Martingale":
             raise ValueError(
@@ -1523,6 +1617,7 @@ class MpsEmaAnchorMulticoinRunner:
         self._buffers: dict[int, tuple[torch.Tensor, ...]] = {}
         self._recovery_buffers: dict[int, torch.Tensor] = {}
         self._equity_balance_diff_buffers: dict[int, torch.Tensor] = {}
+        self._high_exposure_buffers: dict[int, torch.Tensor] = {}
         self._entry_interval_stat_buffers: dict[int, torch.Tensor] = {}
         self._entry_interval_count_buffers: dict[int, torch.Tensor] = {}
         self._sizes: dict[tuple[int, int], torch.Tensor] = {}
@@ -1623,6 +1718,7 @@ class MpsEmaAnchorMulticoinRunner:
         equity_balance_diff,
         entry_interval_stats,
         entry_interval_counts,
+        high_exposure_output,
         recovery_samples,
         *,
         batch_size: int,
@@ -1645,6 +1741,8 @@ class MpsEmaAnchorMulticoinRunner:
             kernel_args += (equity_balance_diff,)
         if self.entry_interval_enabled:
             kernel_args += (entry_interval_stats, entry_interval_counts)
+        if self.high_exposure_enabled:
+            kernel_args += (high_exposure_output,)
         kernel_args += (
             daily,
             scalars,
@@ -1667,6 +1765,7 @@ class MpsEmaAnchorMulticoinRunner:
             self.dynamic_wel_by_tradability,
             self.btc_risk_enabled,
             self.equity_balance_diff_enabled,
+            self.high_exposure_enabled,
         )
 
     def _decode(self, daily, scalars, gaps) -> dict:
@@ -1725,6 +1824,20 @@ class MpsEmaAnchorMulticoinRunner:
             self._entry_interval_count_buffers[batch_size],
         )
 
+    def _high_exposure_buffer(self, batch_size: int):
+        if not self.high_exposure_enabled:
+            return None
+        if batch_size not in self._high_exposure_buffers:
+            self._high_exposure_buffers[batch_size] = torch.full(
+                (batch_size, MPS_HIGH_EXPOSURE_COLS),
+                float("nan"),
+                dtype=torch.float32,
+                device="mps",
+            )
+        else:
+            self._high_exposure_buffers[batch_size].fill_(float("nan"))
+        return self._high_exposure_buffers[batch_size]
+
     def run(
         self,
         params: np.ndarray,
@@ -1748,6 +1861,7 @@ class MpsEmaAnchorMulticoinRunner:
         entry_interval_stats, entry_interval_counts = self._entry_interval_buffers(
             batch_size
         )
+        high_exposure_output = self._high_exposure_buffer(batch_size)
         sizes_key = (batch_size, int(matrix.shape[1]))
         if sizes_key not in self._sizes:
             size_values = [
@@ -1789,9 +1903,37 @@ class MpsEmaAnchorMulticoinRunner:
             equity_balance_diff,
             entry_interval_stats,
             entry_interval_counts,
+            high_exposure_output,
             recovery_samples,
             batch_size=batch_size,
         )
+        if self.high_exposure_enabled:
+            daily, scalars, gaps, coin_fill_counts = self._output_buffers(batch_size)
+            recovery_samples = (
+                self._recovery_sample_buffer(batch_size)
+                if self.recovery_distribution_enabled
+                else None
+            )
+            equity_balance_diff = self._equity_balance_diff_buffer(batch_size)
+            entry_interval_stats, entry_interval_counts = (
+                self._entry_interval_buffers(batch_size)
+            )
+            self._dispatch(
+                library,
+                params_mps,
+                self._sizes[sizes_key],
+                end_steps_mps,
+                daily,
+                scalars,
+                gaps,
+                coin_fill_counts,
+                equity_balance_diff,
+                entry_interval_stats,
+                entry_interval_counts,
+                high_exposure_output,
+                recovery_samples,
+                batch_size=batch_size,
+            )
         if profile:
             torch.mps.synchronize()
         finished = time.perf_counter()
@@ -1807,6 +1949,11 @@ class MpsEmaAnchorMulticoinRunner:
         output.update(
             _decode_entry_interval_outputs(
                 entry_interval_stats, entry_interval_counts
+            )
+        )
+        output.update(
+            _decode_high_exposure_outputs(
+                high_exposure_output, self.run_config.interval_ms
             )
         )
         if self.recovery_distribution_enabled:
@@ -1850,6 +1997,7 @@ class MpsEmaAnchorMulticoinFusedRunner(MpsEmaAnchorMulticoinRunner):
         btc_risk_enabled: bool | None = None,
         equity_balance_diff_enabled: bool = False,
         entry_interval_enabled: bool = False,
+        high_exposure_enabled: bool = False,
     ):
         super().__init__(
             run,
@@ -1873,6 +2021,7 @@ class MpsEmaAnchorMulticoinFusedRunner(MpsEmaAnchorMulticoinRunner):
             btc_risk_enabled=btc_risk_enabled,
             equity_balance_diff_enabled=equity_balance_diff_enabled,
             entry_interval_enabled=entry_interval_enabled,
+            high_exposure_enabled=high_exposure_enabled,
         )
         if short_coin_overrides is None:
             short_coin_overrides = np.full(
@@ -1953,6 +2102,7 @@ class MpsEmaAnchorMulticoinFusedRunner(MpsEmaAnchorMulticoinRunner):
         equity_balance_diff,
         entry_interval_stats,
         entry_interval_counts,
+        high_exposure_output,
         recovery_samples,
         *,
         batch_size: int,
@@ -1976,6 +2126,8 @@ class MpsEmaAnchorMulticoinFusedRunner(MpsEmaAnchorMulticoinRunner):
             kernel_args += (equity_balance_diff,)
         if self.entry_interval_enabled:
             kernel_args += (entry_interval_stats, entry_interval_counts)
+        if self.high_exposure_enabled:
+            kernel_args += (high_exposure_output,)
         kernel_args += (
             daily,
             scalars,
@@ -2075,6 +2227,7 @@ class MpsTrailingMartingaleMulticoinRunner(MpsEmaAnchorMulticoinRunner):
         btc_risk_enabled: bool | None = None,
         equity_balance_diff_enabled: bool = False,
         entry_interval_enabled: bool = False,
+        high_exposure_enabled: bool = False,
     ):
         super().__init__(
             run,
@@ -2098,6 +2251,7 @@ class MpsTrailingMartingaleMulticoinRunner(MpsEmaAnchorMulticoinRunner):
             btc_risk_enabled=btc_risk_enabled,
             equity_balance_diff_enabled=equity_balance_diff_enabled,
             entry_interval_enabled=entry_interval_enabled,
+            high_exposure_enabled=high_exposure_enabled,
         )
 
     def _pack_params(self, params: np.ndarray) -> np.ndarray:
@@ -2128,6 +2282,7 @@ class MpsTrailingMartingaleMulticoinRunner(MpsEmaAnchorMulticoinRunner):
             self.btc_risk_enabled,
             self.equity_balance_diff_enabled,
             self.entry_interval_enabled,
+            self.high_exposure_enabled,
         )
 
     def _dispatch(
@@ -2143,6 +2298,7 @@ class MpsTrailingMartingaleMulticoinRunner(MpsEmaAnchorMulticoinRunner):
         equity_balance_diff,
         entry_interval_stats,
         entry_interval_counts,
+        high_exposure_output,
         recovery_samples,
         *,
         batch_size: int,
@@ -2168,6 +2324,8 @@ class MpsTrailingMartingaleMulticoinRunner(MpsEmaAnchorMulticoinRunner):
             kernel_args += (equity_balance_diff,)
         if self.entry_interval_enabled:
             kernel_args += (entry_interval_stats, entry_interval_counts)
+        if self.high_exposure_enabled:
+            kernel_args += (high_exposure_output,)
         kernel_args += (
             daily,
             scalars,
@@ -2218,6 +2376,7 @@ class MpsTrailingMartingaleMulticoinFusedRunner(
         btc_risk_enabled: bool | None = None,
         equity_balance_diff_enabled: bool = False,
         entry_interval_enabled: bool = False,
+        high_exposure_enabled: bool = False,
     ):
         super().__init__(
             run,
@@ -2241,6 +2400,7 @@ class MpsTrailingMartingaleMulticoinFusedRunner(
             btc_risk_enabled=btc_risk_enabled,
             equity_balance_diff_enabled=equity_balance_diff_enabled,
             entry_interval_enabled=entry_interval_enabled,
+            high_exposure_enabled=high_exposure_enabled,
         )
         if short_coin_overrides is None:
             short_coin_overrides = np.full(
@@ -2316,6 +2476,7 @@ class MpsTrailingMartingaleMulticoinFusedRunner(
         equity_balance_diff,
         entry_interval_stats,
         entry_interval_counts,
+        high_exposure_output,
         recovery_samples,
         *,
         batch_size: int,
@@ -2342,6 +2503,8 @@ class MpsTrailingMartingaleMulticoinFusedRunner(
             kernel_args += (equity_balance_diff,)
         if self.entry_interval_enabled:
             kernel_args += (entry_interval_stats, entry_interval_counts)
+        if self.high_exposure_enabled:
+            kernel_args += (high_exposure_output,)
         kernel_args += (
             daily,
             scalars,
@@ -2393,6 +2556,7 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
                 self.btc_risk_enabled,
                 self.equity_balance_diff_enabled,
                 self.entry_interval_enabled,
+                self.high_exposure_enabled,
             )
         if self.shader_topology == "short_no_hsl":
             return _trailing_martingale_short_no_hsl_shader_library(
@@ -2400,6 +2564,7 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
                 self.btc_risk_enabled,
                 self.equity_balance_diff_enabled,
                 self.entry_interval_enabled,
+                self.high_exposure_enabled,
             )
         return _trailing_martingale_shader_library(
             self.hsl_ema_tail_enabled,
@@ -2409,6 +2574,7 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
             self.btc_risk_enabled,
             self.equity_balance_diff_enabled,
             self.entry_interval_enabled,
+            self.high_exposure_enabled,
         )
 
     def _entry_interval_buffers(self, batch_size: int):
@@ -2475,6 +2641,7 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
             else None
         )
         equity_balance_diff = self._equity_balance_diff_buffer(batch_size)
+        high_exposure_output = self._high_exposure_buffer(batch_size)
         entry_interval_stats, entry_interval_counts = self._entry_interval_buffers(
             batch_size
         )
@@ -2496,32 +2663,52 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
             dispatched = time.perf_counter()
         else:
             dispatched = compiled
-        kernel_args = (
-            self.bars,
-            self.flags,
-            params_mps,
-            self.settings,
-            self._sizes[sizes_key],
-        )
-        if self.btc_prices_enabled:
-            kernel_args += (self.btc_prices,)
-        if self.equity_balance_diff_enabled:
-            kernel_args += (equity_balance_diff,)
-        if self.entry_interval_enabled:
-            kernel_args += (entry_interval_stats, entry_interval_counts)
-        kernel_args += (
-            daily,
-            scalars,
-            gaps,
-            rolling_pnl_values,
-            rolling_pnl_indices,
-        )
-        if self.recovery_distribution_enabled:
-            kernel_args += (recovery_samples,)
-        library.passivbot_trailing_martingale(
-            *kernel_args,
-            threads=(batch_size, 1, 1),
-        )
+        def dispatch_once():
+            kernel_args = (
+                self.bars,
+                self.flags,
+                params_mps,
+                self.settings,
+                self._sizes[sizes_key],
+            )
+            if self.btc_prices_enabled:
+                kernel_args += (self.btc_prices,)
+            if self.equity_balance_diff_enabled:
+                kernel_args += (equity_balance_diff,)
+            if self.entry_interval_enabled:
+                kernel_args += (entry_interval_stats, entry_interval_counts)
+            if self.high_exposure_enabled:
+                kernel_args += (high_exposure_output,)
+            kernel_args += (
+                daily,
+                scalars,
+                gaps,
+                rolling_pnl_values,
+                rolling_pnl_indices,
+            )
+            if self.recovery_distribution_enabled:
+                kernel_args += (recovery_samples,)
+            library.passivbot_trailing_martingale(
+                *kernel_args,
+                threads=(batch_size, 1, 1),
+            )
+
+        dispatch_once()
+        if self.high_exposure_enabled:
+            daily, scalars, gaps = self._output_buffers(batch_size)
+            rolling_pnl_values, rolling_pnl_indices = self._hsl_rolling_buffers(
+                batch_size
+            )
+            recovery_samples = (
+                self._recovery_sample_buffer(batch_size)
+                if self.recovery_distribution_enabled
+                else None
+            )
+            equity_balance_diff = self._equity_balance_diff_buffer(batch_size)
+            entry_interval_stats, entry_interval_counts = (
+                self._entry_interval_buffers(batch_size)
+            )
+            dispatch_once()
         if profile:
             torch.mps.synchronize()
         finished = time.perf_counter()
@@ -2534,6 +2721,11 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
         }
         output = _decode_directional_outputs(daily, scalars, gaps)
         output.update(_decode_equity_balance_diff_outputs(equity_balance_diff))
+        output.update(
+            _decode_high_exposure_outputs(
+                high_exposure_output, self.run_config.interval_ms
+            )
+        )
         output.update(
             _decode_entry_interval_outputs(
                 entry_interval_stats, entry_interval_counts

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -107,6 +107,14 @@ CORE_OUTPUT_KEYS = {
     "entry_interval_hist",
     "total_wallet_exposure_max",
     "total_wallet_exposure_mean",
+    "high_exposure_hours_mean_long",
+    "high_exposure_hours_max_long",
+    "high_exposure_days_mean_long",
+    "high_exposure_days_max_long",
+    "high_exposure_hours_mean_short",
+    "high_exposure_hours_max_short",
+    "high_exposure_days_mean_short",
+    "high_exposure_days_max_short",
 }
 
 DIRECTIONAL_HSL_OUTPUT_KEYS = {
@@ -1345,6 +1353,7 @@ class MpsSingleCoinProxy:
             BTC_INTRADAY_RISK_METRICS,
             ENTRY_INTERVAL_METRICS,
             EQUITY_BALANCE_DIFF_METRICS,
+            HIGH_EXPOSURE_METRICS,
             compute_objectives,
         )
         from optimization.gpu.mps_kernel import (
@@ -1363,6 +1372,9 @@ class MpsSingleCoinProxy:
         )
         self.equity_balance_diff_enabled = bool(
             self.needed_metrics & EQUITY_BALANCE_DIFF_METRICS
+        )
+        self.high_exposure_enabled = bool(
+            self.needed_metrics & HIGH_EXPOSURE_METRICS
         )
         btc_values = np.ascontiguousarray(
             np.asarray(btc, dtype=np.float64).reshape(-1)
@@ -1676,6 +1688,7 @@ class MpsSingleCoinProxy:
             btc_risk_enabled=self.btc_risk_enabled,
             equity_balance_diff_enabled=self.equity_balance_diff_enabled,
             entry_interval_enabled=self.entry_interval_enabled,
+            high_exposure_enabled=self.high_exposure_enabled,
         )
         if self.strategy_kind == "trailing_martingale":
             runner_kwargs["hsl_enabled"] = any_configured_hsl
@@ -2190,6 +2203,7 @@ class MpsMulticoinProxy:
             BTC_INTRADAY_RISK_METRICS,
             ENTRY_INTERVAL_METRICS,
             EQUITY_BALANCE_DIFF_METRICS,
+            HIGH_EXPOSURE_METRICS,
             compute_objectives,
         )
         from optimization.gpu.mps_kernel import (
@@ -2210,6 +2224,9 @@ class MpsMulticoinProxy:
         )
         self.equity_balance_diff_enabled = bool(
             self.needed_metrics & EQUITY_BALANCE_DIFF_METRICS
+        )
+        self.high_exposure_enabled = bool(
+            self.needed_metrics & HIGH_EXPOSURE_METRICS
         )
         btc_values = np.ascontiguousarray(
             np.asarray(btc, dtype=np.float64).reshape(-1)
@@ -2663,6 +2680,7 @@ class MpsMulticoinProxy:
             "btc_risk_enabled": self.btc_risk_enabled,
             "equity_balance_diff_enabled": self.equity_balance_diff_enabled,
             "entry_interval_enabled": self.entry_interval_enabled,
+            "high_exposure_enabled": self.high_exposure_enabled,
         }
         if self.shared_account_fused:
             fused_runner_cls = (

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -3611,6 +3611,22 @@ def test_gpu_foundation_accepts_entry_interval_metrics(metric):
 @pytest.mark.parametrize(
     "metric",
     [
+        f"high_exposure_{unit}_{stat}_{side}"
+        for unit in ("hours", "days")
+        for stat in ("mean", "max")
+        for side in ("long", "short")
+    ],
+)
+def test_gpu_foundation_accepts_high_exposure_metrics(metric):
+    config = _long_only_ema_config()
+    config["optimize"]["scoring"] = [{"goal": "min", "metric": metric}]
+
+    assert _validate_scope(config, _Evaluator()) == "bybit"
+
+
+@pytest.mark.parametrize(
+    "metric",
+    [
         "entry_initial_balance_pct_long",
         "entry_initial_balance_pct_short",
         "exposure_mean_ratio_usd",

--- a/tests/optimization/test_gpu_metrics.py
+++ b/tests/optimization/test_gpu_metrics.py
@@ -9,6 +9,7 @@ torch = pytest.importorskip("torch")
 
 from optimization.gpu.metrics import (
     ENTRY_INTERVAL_METRICS,
+    HIGH_EXPOSURE_METRICS,
     SUPPORTED_METRICS,
     _GAP_HIST_UPPER_STEPS,
     _btc_account_metrics,
@@ -36,6 +37,63 @@ from optimization.gpu.metrics import (
     _weighted_strategy_eq_metrics,
     compute_objectives,
 )
+
+
+def test_high_exposure_metrics_pass_through_opt_in_kernel_outputs():
+    day_eq = torch.tensor([[100.0]], dtype=torch.float64)
+    out = {
+        "day_end_eq": day_eq,
+        "day_min_eq": day_eq,
+        "day_max_dd": torch.zeros_like(day_eq),
+        "day_volume": torch.zeros_like(day_eq),
+        "day_has_fill": torch.zeros_like(day_eq, dtype=torch.bool),
+        "max_dd": torch.zeros(1),
+        "held_max_ms": torch.zeros(1),
+        "gap_hist": torch.zeros((1, 128), dtype=torch.int32),
+        "gap_max_ms": torch.zeros(1),
+        "first_fill_ts": torch.full((1,), float("nan")),
+        "last_fill_ts": torch.full((1,), float("nan")),
+        "recovery_max_ms": torch.zeros(1),
+        "last_high_ts": torch.zeros(1),
+        "first_eq_ts": torch.zeros(1),
+        "last_eq_ts": torch.zeros(1),
+        "liq_step": torch.full((1,), -1),
+    }
+    expected = {}
+    for index, name in enumerate(sorted(HIGH_EXPOSURE_METRICS), start=1):
+        value = index / 10.0
+        out[name] = torch.tensor([value], dtype=torch.float32)
+        expected[name] = value
+
+    metrics = compute_objectives(
+        out,
+        SimpleNamespace(
+            requested_start_ts_ms=0,
+            guard_ts_ms=0,
+            interval_ms=60_000,
+        ),
+        {"ts0": 0.0, "n": 1},
+        needed=HIGH_EXPOSURE_METRICS,
+    )
+
+    assert HIGH_EXPOSURE_METRICS <= set(SUPPORTED_METRICS)
+    assert set(metrics) == set(HIGH_EXPOSURE_METRICS)
+    for name, value in expected.items():
+        assert metrics[name].item() == pytest.approx(value)
+
+    missing = sorted(HIGH_EXPOSURE_METRICS)[0]
+    del out[missing]
+    with pytest.raises(RuntimeError, match="high-exposure output is missing"):
+        compute_objectives(
+            out,
+            SimpleNamespace(
+                requested_start_ts_ms=0,
+                guard_ts_ms=0,
+                interval_ms=60_000,
+            ),
+            {"ts0": 0.0, "n": 1},
+            needed=HIGH_EXPOSURE_METRICS,
+        )
 
 
 def test_btc_daily_peak_recovery_matches_non_strict_rust_contract():

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -37,6 +37,7 @@ from optimization.gpu.mps_kernel import (
     MpsEmaAnchorMulticoinFusedRunner,
     MpsTrailingMartingaleMulticoinFusedRunner,
     _decode_entry_interval_outputs,
+    _decode_high_exposure_outputs,
     _decode_multicoin_fused_outputs,
     _encode_max_realized_loss_pct,
     _pack_tm_parameter_matrix,
@@ -50,6 +51,7 @@ from optimization.gpu.mps_kernel import (
     _with_entry_interval,
     _with_hsl_ema_tail,
     _with_hsl_features,
+    _with_high_exposure,
     _with_recovery_distribution,
     strategy_eq_recovery_distribution_from_samples,
 )
@@ -59,6 +61,14 @@ from optimization.gpu.metrics import (
     compute_objectives,
 )
 from optimization.gpu.service import MpsMulticoinEmaProxy
+
+
+_HIGH_EXPOSURE_METRICS = {
+    f"high_exposure_{unit}_{stat}_{side}"
+    for unit in ("hours", "days")
+    for stat in ("mean", "max")
+    for side in ("long", "short")
+}
 
 
 def _assert_fill_scalar_contract(output):
@@ -579,6 +589,44 @@ def test_single_coin_size_buffer_packs_last_valid_before_recovery_fields(
     assert actual == [5, 17, 2, 13, 3, 9, 7, 11] + (
         [60, 4] if recovery_enabled else []
     )
+
+
+def test_high_exposure_decoder_converts_steps_to_mean_and_max_durations():
+    raw = torch.tensor(
+        [
+            [0.25, 0.50, 12.0, 9.0, 3.0, 8.0, 5.0, 2.0],
+            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        ]
+    )
+
+    decoded = _decode_high_exposure_outputs(raw, 5 * 60_000)
+
+    assert decoded["high_exposure_hours_mean_long"].tolist() == pytest.approx(
+        [1.0 / 3.0, 0.0]
+    )
+    assert decoded["high_exposure_hours_max_long"].tolist() == pytest.approx(
+        [0.75, 0.0]
+    )
+    assert decoded["high_exposure_hours_mean_short"].tolist() == pytest.approx(
+        [1.0 / 3.0, 0.0]
+    )
+    assert decoded["high_exposure_hours_max_short"].tolist() == pytest.approx(
+        [5.0 / 12.0, 0.0]
+    )
+    assert decoded["high_exposure_days_max_long"].tolist() == pytest.approx(
+        [0.75 / 24.0, 0.0]
+    )
+
+
+def test_high_exposure_feature_guard_is_opt_in_and_fail_closed():
+    source = "#ifndef PASSIVBOT_HIGH_EXPOSURE_ENABLED\ninline void record_high_exposure_fill() {}\n"
+
+    assert _with_high_exposure(source, False) == source
+    assert _with_high_exposure(source, True).startswith(
+        "#define PASSIVBOT_HIGH_EXPOSURE_ENABLED 1\n"
+    )
+    with pytest.raises(RuntimeError, match="shared high-exposure contract"):
+        _with_high_exposure("kernel void unrelated() {}", True)
 
 
 def test_trailing_martingale_runner_accepts_ordinary_market_execution(monkeypatch):
@@ -4432,14 +4480,17 @@ def test_mps_single_coin_service_dispatches_forced_delist_tail(strategy_kind):
             "equity_balance_diff_pos_max_usd",
             "equity_balance_diff_pos_mean_btc",
             "equity_balance_diff_pos_mean_usd",
-            "expected_shortfall_1pct_btc",
-            "gain_btc",
+                "expected_shortfall_1pct_btc",
+                "entry_interval_hours_max",
+                "gain_btc",
             "hard_stop_panic_close_loss_sum",
             "paper_loss_mean_ratio_btc",
             "paper_loss_mean_ratio_usd",
             "paper_loss_ratio_btc",
-            "paper_loss_ratio_usd",
-        },
+                "paper_loss_ratio_usd",
+                "strategy_eq_recovery_days_p99",
+        }
+        | _HIGH_EXPOSURE_METRICS,
     )
     result = proxy.evaluate([{}])[0]
     exact_fills, _, exact_analysis = run_backtest(
@@ -4454,6 +4505,12 @@ def test_mps_single_coin_service_dispatches_forced_delist_tail(strategy_kind):
     assert result["fills_count"] == 2.0
     assert result["fills_count"] == exact_analysis["fills_count"]
     assert len(exact_fills) == exact_analysis["fills_count"]
+    for metric in _HIGH_EXPOSURE_METRICS:
+        assert result[metric] == pytest.approx(
+            exact_analysis[metric], rel=2.0e-3, abs=1.0e-8
+        ), metric
+    assert np.isfinite(result["entry_interval_hours_max"])
+    assert np.isfinite(result["strategy_eq_recovery_days_p99"])
     assert result["hard_stop_panic_close_loss_sum"] > 0.0
     assert result["hard_stop_panic_close_loss_sum"] == pytest.approx(
         exact_analysis["hard_stop_panic_close_loss_sum"], rel=1.0e-5
@@ -4844,14 +4901,17 @@ def test_mps_multicoin_service_dispatches_forced_delist_tail(
             "equity_balance_diff_pos_max_usd",
             "equity_balance_diff_pos_mean_btc",
             "equity_balance_diff_pos_mean_usd",
-            "expected_shortfall_1pct_btc",
-            "gain_btc",
+                "expected_shortfall_1pct_btc",
+                "entry_interval_hours_max",
+                "gain_btc",
             "hard_stop_panic_close_loss_sum",
             "paper_loss_mean_ratio_btc",
             "paper_loss_mean_ratio_usd",
             "paper_loss_ratio_btc",
-            "paper_loss_ratio_usd",
-        },
+                "paper_loss_ratio_usd",
+                "strategy_eq_recovery_days_p99",
+        }
+        | _HIGH_EXPOSURE_METRICS,
     )
     result = proxy.evaluate([{}])[0]
     exact_fills, _, exact_analysis = run_backtest(
@@ -4866,6 +4926,12 @@ def test_mps_multicoin_service_dispatches_forced_delist_tail(
     assert result["fills_count"] == expected_fills
     assert result["fills_count"] == exact_analysis["fills_count"]
     assert len(exact_fills) == exact_analysis["fills_count"]
+    for metric in _HIGH_EXPOSURE_METRICS:
+        assert result[metric] == pytest.approx(
+            exact_analysis[metric], rel=2.0e-3, abs=1.0e-8
+        ), metric
+    assert np.isfinite(result["entry_interval_hours_max"])
+    assert np.isfinite(result["strategy_eq_recovery_days_p99"])
     exact_order_types = {row[13] for row in exact_fills}
     expected_panic_types = {
         f"close_panic_{side}" for side in enabled_sides

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -1091,14 +1091,16 @@ def test_multicoin_proxy_routes_dual_side_batch_through_fused_runner(
         "raw_drawdown_enabled",
         "raw_tail_enabled",
         "recovery_distribution_enabled",
+        "high_exposure_enabled",
     ),
     [
-        ({"hard_stop_time_in_red_pct"}, False, False, False, False),
-        ({"drawdown_worst_mean_1pct_ema_strategy_eq"}, True, False, False, False),
-        ({"drawdown_worst_strategy_eq_long"}, False, True, False, False),
-        ({"drawdown_worst_mean_1pct_strategy_eq_long"}, False, True, True, False),
-        ({"strategy_eq_recovery_days_p99"}, False, False, False, True),
-        ({"entry_interval_hours_p95"}, False, False, False, False),
+        ({"hard_stop_time_in_red_pct"}, False, False, False, False, False),
+        ({"drawdown_worst_mean_1pct_ema_strategy_eq"}, True, False, False, False, False),
+        ({"drawdown_worst_strategy_eq_long"}, False, True, False, False, False),
+        ({"drawdown_worst_mean_1pct_strategy_eq_long"}, False, True, True, False, False),
+        ({"strategy_eq_recovery_days_p99"}, False, False, False, True, False),
+        ({"entry_interval_hours_p95"}, False, False, False, False, False),
+        ({"high_exposure_days_max_long"}, False, False, False, False, True),
     ],
 )
 @pytest.mark.parametrize("dynamic_wel_by_tradability", [True, False])
@@ -1114,6 +1116,7 @@ def test_multicoin_proxy_constructs_fused_shared_account_runner(
     raw_drawdown_enabled,
     raw_tail_enabled,
     recovery_distribution_enabled,
+    high_exposure_enabled,
     dynamic_wel_by_tradability,
 ):
     torch = pytest.importorskip("torch")
@@ -1313,6 +1316,10 @@ def test_multicoin_proxy_constructs_fused_shared_account_runner(
     assert (
         constructed["kwargs"]["recovery_distribution_enabled"]
         is recovery_distribution_enabled
+    )
+    assert (
+        constructed["kwargs"]["high_exposure_enabled"]
+        is high_exposure_enabled
     )
     assert constructed["kwargs"]["hedge_mode"] is False
     assert constructed["kwargs"]["filter_by_min_effective_cost"] is True


### PR DESCRIPTION
## Summary
- add the eight `high_exposure_{hours,days}_{mean,max}_{long,short}` metrics to Apple MPS screening for EMA Anchor and Trailing Martingale
- cover single-coin, multi-coin, long-only, short-only, and fused long+short kernels with a shared opt-in Metal accumulator
- use a threshold pass followed by a duration pass only when this metric family is requested; ordinary GPU runs retain their one-dispatch ABI and cost
- keep exact Rust authoritative and document the same-candle fill-coalescing approximation

## Design
Exact Rust derives the threshold from the complete fill sequence, so a one-pass streaming duration calculation cannot be correct. The MPS runner therefore replays the same candidate batch once: pass 1 derives per-side daily-resampled TWE thresholds; pass 2 measures continuous above-threshold fill-to-fill durations. The compact output is eight float32 columns. Missing negotiated outputs fail closed before objective/limit reduction.

## Validation
- `cargo test --no-default-features`: 274 passed
- `cargo check --tests`: passed
- full `tests/optimization/test_gpu_metrics.py`, `test_gpu_service.py`, and `test_gpu_backend.py`: passed
- Rust GPU source-composition tests: 13 passed
- physical Apple M3 exact-Rust/MPS matrix: 8 passed across EMA/TM, single coin, and multi-coin long/short/fused, including the combined BTC-risk + equity/balance + recovery + TM entry-interval ABI
- representative default-path MPS smoke matrix: 12 passed
- all six high-exposure shader variants compiled on Apple M3
- end-to-end ALGO EMA Anchor optimizer smoke: 36 exact validations, 576 proxy evaluations, active `high_exposure_days_max_long` limit, no constraint mismatch, 3.3s optimizer wall time
- 2048-candidate x 720-candle replay benchmark: EMA 0.168s one-pass vs 0.356s opt-in two-pass (2.13x); TM 0.100s vs 0.186s (1.86x)

## Safety
- feature is additive and disabled unless a high-exposure metric is scored or constrained
- exact Rust validation and rolling rank/constraint drift gates remain mandatory
- no live bot, authenticated exchange, or remote process actions were performed