### PR TITLE
GPU: fail fast on accepted MPS limitations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- GPU optimization now runs an Apple MPS capability preflight before loading historical data.
+  Missing MPS support, unsupported strategies, positive `backtest.btc_collateral_cap`, and
+  unmodeled suite override paths fail immediately with the unsupported setting, the CPU-backend
+  fallback, and a documentation pointer. Successful starts log the strategy, zero-collateral
+  contract, and 64-coin-per-scenario ceiling. CPU optimization and backtesting do not import or
+  probe the optional GPU runtime.
+
 - Apple MPS optimization now supports the eight unweighted high-exposure duration metrics for
   EMA Anchor and Trailing Martingale across single-coin, multi-coin, long-only, short-only, and
   fused long+short runs. When one of these metrics is scored or limited, Metal performs an opt-in

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -420,6 +420,29 @@ The supported slice is intentionally narrow:
   stricter contiguous-candle requirement documented above, and a forced-delist endpoint must remain
   finite and positive after float32 packing because it supplies an executable close
 
+#### Deliberate current limitations
+
+The following boundaries are intentional rather than silent fallbacks:
+
+- `trailing_grid_v7` is outside the Apple MPS implementation. Use `optimize.backend: "pymoo"` or
+  `"deap"` for it; GPU optimization never substitutes EMA Anchor or Trailing Martingale behavior.
+- `backtest.btc_collateral_cap` must be zero. Positive BTC collateral changes the simulated
+  account state and is not approximated by the screening proxy; use a CPU optimizer when it is
+  required. BTC-denominated scoring with a zero collateral cap remains supported as described
+  below.
+- Each prepared single run or suite scenario is capped at 64 coins. Split the scenario universe or
+  use a CPU optimizer for a larger portfolio.
+- Only metrics and limits represented by the MPS screening surface are accepted. An unsupported
+  metric is named in the startup error and must be removed or run on a CPU backend. Exact Rust
+  validation does not turn an unmodeled proxy objective into a safe evolutionary search.
+- Suite scenario override paths require explicit proxy shadow semantics. Unmodeled paths fail
+  before historical-data preparation rather than being applied only to exact validations.
+
+GPU startup checks the strategy, zero-collateral contract, suite override paths, optional PyTorch
+installation, and MPS availability before historical-data preparation. The prepared-data stage
+then enforces the 64-coin ceiling and topology-specific requirements. CPU optimizers, backtesting,
+and live operation do not import or probe the optional GPU runtime.
+
 Unsupported combinations fail before optimization begins. Dual-side multi-coin EMA Anchor and
 Trailing Martingale use fused shared-account Metal kernels in hedge and one-way modes. Every
 accepted metric still comes from the unchanged exact Rust portfolio backtest, and classification,

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -475,6 +475,15 @@ def _materialize_gpu_override_template(
     return proxy_config
 
 
+def materialize_gpu_preparation_config(config: dict) -> dict:
+    """Finalize the immutable GPU template while preserving its strategy-shape guard."""
+
+    return _materialize_gpu_override_template(
+        config,
+        config.get("optimize", {}).get("enable_overrides", []),
+    )
+
+
 def _gpu_fixed_bound_context(
     config: dict,
     effective_config: dict,

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -352,6 +352,79 @@ def _validate_gpu_static_scope(config: dict) -> str:
     return strategy_kind
 
 
+def _validate_gpu_data_independent_scope(
+    config: dict,
+    *,
+    allow_suite: bool = False,
+) -> tuple[str, list[str], list[str]]:
+    """Validate GPU behavior which does not depend on prepared candles or coin count."""
+
+    strategy_kind = _validate_gpu_static_scope(config)
+    if bool(config.get("backtest", {}).get("suite_enabled")) and not allow_suite:
+        raise ValueError("Apple MPS GPU scope validation requires allow_suite=True")
+    if bool(config.get("backtest", {}).get("filter_by_min_effective_cost")):
+        liquidation_threshold = float(
+            config.get("backtest", {}).get("liquidation_threshold", 0.0)
+        )
+        if not math.isfinite(liquidation_threshold) or liquidation_threshold <= 0.0:
+            raise ValueError(
+                "GPU min-effective-cost filtering requires a finite positive "
+                "backtest.liquidation_threshold so the proxy has a proven lower "
+                "balance bound"
+            )
+    max_realized_loss_pct = float(
+        config.get("live", {}).get("max_realized_loss_pct", 1.0)
+    )
+    if not math.isfinite(max_realized_loss_pct) or max_realized_loss_pct < 0.0:
+        raise ValueError(
+            "GPU foundation requires a finite non-negative "
+            "live.max_realized_loss_pct"
+        )
+    enabled_sides = [
+        side for side in ("long", "short") if gpu_side_enabled(config, side)
+    ]
+    if not enabled_sides:
+        raise ValueError("GPU foundation requires at least one enabled side")
+    if bool(config.get("live", {}).get("market_orders_allowed")):
+        threshold = float(
+            config.get("live", {}).get("market_order_near_touch_threshold", 0.001)
+            or 0.0
+        )
+        if not math.isfinite(threshold) or threshold < 0.0:
+            raise ValueError(
+                "GPU market execution requires a finite non-negative "
+                "live.market_order_near_touch_threshold"
+            )
+    hsl_enabled_sides = [
+        side for side in enabled_sides if _gpu_hsl_side_enabled(config, side)
+    ]
+    if hsl_enabled_sides:
+        parse_pnls_max_lookback_days(
+            config.get("live", {}).get("pnls_max_lookback_days", 30.0),
+            field_name="live.pnls_max_lookback_days",
+        )
+        for side in hsl_enabled_sides:
+            hsl = config["bot"][side].get("hsl", {})
+            panic_order_type = str(
+                hsl.get("panic_close_order_type", "limit")
+            ).strip().lower()
+            if panic_order_type not in {"limit", "market"}:
+                raise ValueError(
+                    f"GPU HSL requires bot.{side}.hsl.panic_close_order_type "
+                    f"to be limit or market, got {panic_order_type!r}"
+                )
+    for side in enabled_sides:
+        risk = config["bot"][side].get("risk", {})
+        if strategy_kind != "trailing_martingale" and bool(
+            risk.get("position_exposure_enforcer_enabled", False)
+        ):
+            raise ValueError(
+                "GPU foundation requires "
+                f"bot.{side}.risk.position_exposure_enforcer_enabled=false"
+            )
+    return strategy_kind, enabled_sides, hsl_enabled_sides
+
+
 def _validate_gpu_suite_override_paths(
     proxy_config: dict,
     *,
@@ -390,15 +463,30 @@ def validate_gpu_preparation_scope(
 ) -> None:
     """Fail before historical-data preparation when immutable MPS scope is invalid."""
 
-    strategy_kind = _validate_gpu_static_scope(config)
     suite_cfg = suite_cfg or {}
+    suite_enabled = bool(suite_cfg.get("enabled"))
+    strategy_kind, _enabled_sides, _hsl_enabled_sides = (
+        _validate_gpu_data_independent_scope(
+            config,
+            allow_suite=suite_enabled,
+        )
+    )
     if bool(suite_cfg.get("enabled")):
+        from optimization.warmup import _apply_config_overrides
+
         for index, scenario in enumerate(suite_cfg.get("scenarios") or []):
             label = str(scenario.get("label") or f"scenario_{index + 1:02d}")
+            overrides = scenario.get("overrides") or {}
             _validate_gpu_suite_override_paths(
                 config,
                 label=label,
-                overrides=scenario.get("overrides") or {},
+                overrides=overrides,
+            )
+            scenario_config = deepcopy(config)
+            _apply_config_overrides(scenario_config, overrides)
+            _validate_gpu_data_independent_scope(
+                scenario_config,
+                allow_suite=True,
             )
 
     if torch_module is None:
@@ -1128,27 +1216,12 @@ def _validate_scope_config(
     coin_count: int,
     allow_suite: bool = False,
 ) -> str:
-    strategy_kind = _validate_gpu_static_scope(config)
-    if bool(config.get("backtest", {}).get("suite_enabled")) and not allow_suite:
-        raise ValueError("Apple MPS GPU scope validation requires allow_suite=True")
-    if bool(config.get("backtest", {}).get("filter_by_min_effective_cost")):
-        liquidation_threshold = float(
-            config.get("backtest", {}).get("liquidation_threshold", 0.0)
+    strategy_kind, enabled_sides, hsl_enabled_sides = (
+        _validate_gpu_data_independent_scope(
+            config,
+            allow_suite=allow_suite,
         )
-        if not math.isfinite(liquidation_threshold) or liquidation_threshold <= 0.0:
-            raise ValueError(
-                "GPU min-effective-cost filtering requires a finite positive "
-                "backtest.liquidation_threshold so the proxy has a proven lower "
-                "balance bound"
-            )
-    max_realized_loss_pct = float(
-        config.get("live", {}).get("max_realized_loss_pct", 1.0)
     )
-    if not math.isfinite(max_realized_loss_pct) or max_realized_loss_pct < 0.0:
-        raise ValueError(
-            "GPU foundation requires a finite non-negative "
-            "live.max_realized_loss_pct"
-        )
     exchanges = list(exchanges)
     if len(exchanges) != 1:
         raise ValueError(
@@ -1158,19 +1231,7 @@ def _validate_scope_config(
     coin_count = int(coin_count)
     if coin_count < 1:
         raise ValueError("GPU foundation requires at least one prepared coin")
-    enabled_sides = [side for side in ("long", "short") if gpu_side_enabled(config, side)]
-    if not enabled_sides:
-        raise ValueError("GPU foundation requires at least one enabled side")
     if bool(config.get("live", {}).get("market_orders_allowed")):
-        threshold = float(
-            config.get("live", {}).get("market_order_near_touch_threshold", 0.001)
-            or 0.0
-        )
-        if not math.isfinite(threshold) or threshold < 0.0:
-            raise ValueError(
-                "GPU market execution requires a finite non-negative "
-                "live.market_order_near_touch_threshold"
-            )
         if coin_count > 1:
             if strategy_kind == "trailing_martingale":
                 _validate_tm_multicoin_market_runtime_scope(
@@ -1194,17 +1255,10 @@ def _validate_scope_config(
         enabled_sides=enabled_sides,
         coin_count=coin_count,
     )
-    hsl_enabled_sides = [
-        side for side in enabled_sides if _gpu_hsl_side_enabled(config, side)
-    ]
     if hsl_enabled_sides:
         # Directional single-coin coin mode mirrors Rust's finite fill-event
         # PnL window. Other HSL topologies retain the conservative all-history
         # screening envelope; exact Rust validation remains authoritative.
-        parse_pnls_max_lookback_days(
-            config.get("live", {}).get("pnls_max_lookback_days", 30.0),
-            field_name="live.pnls_max_lookback_days",
-        )
         signal_mode = str(
             config.get("live", {}).get("hsl_signal_mode", "unified")
         ).strip().lower()
@@ -1216,29 +1270,6 @@ def _validate_scope_config(
                 coin_count > 1 and len(enabled_sides) == 2
             ),
         )
-        for side in hsl_enabled_sides:
-            hsl = config["bot"][side].get("hsl", {})
-            panic_order_type = str(
-                hsl.get("panic_close_order_type", "limit")
-            ).strip().lower()
-            if panic_order_type not in {"limit", "market"}:
-                raise ValueError(
-                    f"GPU HSL requires bot.{side}.hsl.panic_close_order_type "
-                    f"to be limit or market, got {panic_order_type!r}"
-                )
-    for side in enabled_sides:
-        side_config = config["bot"][side]
-        risk = side_config.get("risk", {})
-        required_disabled = []
-        if strategy_kind != "trailing_martingale":
-            required_disabled.append(
-                ("position_exposure_enforcer_enabled", False)
-            )
-        for key, expected in required_disabled:
-            if bool(risk.get(key, expected)) != expected:
-                raise ValueError(
-                    f"GPU foundation requires bot.{side}.risk.{key}={str(expected).lower()}"
-                )
     return exchange
 
 

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -28,6 +28,7 @@ from optimization.callback import build_pymoo_record_entry
 from optimization.fine_tune_anchors import ANCHOR_GENE_KEY, get_anchor_plan
 from optimization.gpu.model import (
     HSL_COIN_OVERRIDE_PATHS,
+    MPS_MULTICOIN_MAX_COINS,
     TRAILING_MARTINGALE_GATE_MODE_OVERRIDE_PATH,
     gpu_side_enabled,
     validate_hsl_override_patch,
@@ -287,6 +288,9 @@ GPU_STRATEGY_BOUND_MAPS = {
     "trailing_martingale": TRAILING_MARTINGALE_BOUND_MAP,
 }
 
+GPU_CAPABILITIES_DOC = "docs/optimizing.md#deliberate-current-limitations"
+GPU_SUPPORTED_STRATEGY_KINDS = frozenset(GPU_STRATEGY_BOUND_MAPS)
+
 GPU_SUPPORTED_OPTIMIZER_OVERRIDES = {
     "lossless_close_trailing",
     "mirror_short_from_long",
@@ -313,6 +317,114 @@ GPU_SUPPORTED_SUITE_NON_BOT_OVERRIDE_PATHS = {
     ("live", "max_realized_loss_pct"),
     ("live", "pnls_max_lookback_days"),
 }
+
+
+def _validate_gpu_static_scope(config: dict) -> str:
+    """Reject immutable GPU limitations without touching data or optional runtime state."""
+
+    strategy_kind = (
+        str(config.get("live", {}).get("strategy_kind", "")).strip().lower()
+    )
+    if strategy_kind not in GPU_SUPPORTED_STRATEGY_KINDS:
+        detail = (
+            "trailing_grid_v7 is deliberately outside the Apple MPS scope"
+            if strategy_kind == "trailing_grid_v7"
+            else f"strategy_kind={strategy_kind!r} is not implemented by Apple MPS"
+        )
+        raise ValueError(
+            "Apple MPS GPU optimization supports live.strategy_kind=ema_anchor or "
+            f"trailing_martingale only; {detail}. Use optimize.backend='pymoo' or "
+            f"'deap' for this configuration. See {GPU_CAPABILITIES_DOC}."
+        )
+
+    btc_collateral_cap = float(
+        config.get("backtest", {}).get("btc_collateral_cap", 0.0) or 0.0
+    )
+    if not math.isfinite(btc_collateral_cap) or btc_collateral_cap != 0.0:
+        raise ValueError(
+            "Apple MPS GPU optimization does not model "
+            "backtest.btc_collateral_cap; the GPU screening proxy requires "
+            f"backtest.btc_collateral_cap=0.0, got {btc_collateral_cap!r}. "
+            "Set it to zero or use optimize.backend='pymoo' or 'deap'; exact Rust "
+            "validation cannot make an unmodeled proxy search safe. "
+            f"See {GPU_CAPABILITIES_DOC}."
+        )
+    return strategy_kind
+
+
+def _validate_gpu_suite_override_paths(
+    proxy_config: dict,
+    *,
+    label: str,
+    overrides: dict,
+) -> None:
+    """Reject suite override paths which have no modeled MPS shadow semantics."""
+
+    from config.param_paths import require_existing_config_path
+
+    for dotted_path in overrides:
+        resolved = require_existing_config_path(proxy_config, dotted_path)
+        bot_side_override = (
+            len(resolved) >= 3
+            and resolved[0] == "bot"
+            and resolved[1] in {"long", "short"}
+        )
+        if (
+            not bot_side_override
+            and resolved not in GPU_SUPPORTED_SUITE_NON_BOT_OVERRIDE_PATHS
+        ):
+            raise ValueError(
+                f"Apple MPS GPU suite scenario {label!r} override "
+                f"{dotted_path!r} is outside the supported modeled scenario scope "
+                "and has no screening semantics. Remove the override or use "
+                "optimize.backend='pymoo' or 'deap'. "
+                f"See {GPU_CAPABILITIES_DOC}."
+            )
+
+
+def validate_gpu_preparation_scope(
+    config: dict,
+    suite_cfg: dict | None = None,
+    *,
+    torch_module=None,
+) -> None:
+    """Fail before historical-data preparation when immutable MPS scope is invalid."""
+
+    strategy_kind = _validate_gpu_static_scope(config)
+    suite_cfg = suite_cfg or {}
+    if bool(suite_cfg.get("enabled")):
+        for index, scenario in enumerate(suite_cfg.get("scenarios") or []):
+            label = str(scenario.get("label") or f"scenario_{index + 1:02d}")
+            _validate_gpu_suite_override_paths(
+                config,
+                label=label,
+                overrides=scenario.get("overrides") or {},
+            )
+
+    if torch_module is None:
+        try:
+            import torch as torch_module
+        except ModuleNotFoundError as exc:  # pragma: no cover - optional dependency path
+            raise ModuleNotFoundError(
+                "Apple MPS GPU optimization requires the optional 'gpu-mps' "
+                "dependencies; install Passivbot with "
+                "`pip install -e '.[full,gpu-mps]'`. "
+                f"See {GPU_CAPABILITIES_DOC}."
+            ) from exc
+    if not torch_module.backends.mps.is_available():
+        raise RuntimeError(
+            "Apple MPS GPU optimization was requested, but MPS is unavailable in "
+            "this process. Run on Apple Silicon with an MPS-enabled PyTorch build, "
+            "or use optimize.backend='pymoo' or 'deap'. "
+            f"See {GPU_CAPABILITIES_DOC}."
+        )
+
+    logging.info(
+        "GPU capability preflight passed | runtime=apple_mps | strategy=%s | "
+        "btc_collateral_cap=0 | max_coins_per_scenario=%d",
+        strategy_kind,
+        MPS_MULTICOIN_MAX_COINS,
+    )
 
 
 def _validate_gpu_optimizer_overrides(overrides_list, strategy_kind: str) -> set[str]:
@@ -1007,8 +1119,9 @@ def _validate_scope_config(
     coin_count: int,
     allow_suite: bool = False,
 ) -> str:
+    strategy_kind = _validate_gpu_static_scope(config)
     if bool(config.get("backtest", {}).get("suite_enabled")) and not allow_suite:
-        raise ValueError("GPU foundation does not support suite mode")
+        raise ValueError("Apple MPS GPU scope validation requires allow_suite=True")
     if bool(config.get("backtest", {}).get("filter_by_min_effective_cost")):
         liquidation_threshold = float(
             config.get("backtest", {}).get("liquidation_threshold", 0.0)
@@ -1019,8 +1132,6 @@ def _validate_scope_config(
                 "backtest.liquidation_threshold so the proxy has a proven lower "
                 "balance bound"
             )
-    if float(config.get("backtest", {}).get("btc_collateral_cap", 0.0) or 0.0) > 0.0:
-        raise ValueError("GPU foundation does not support backtest.btc_collateral_cap")
     max_realized_loss_pct = float(
         config.get("live", {}).get("max_realized_loss_pct", 1.0)
     )
@@ -1038,15 +1149,6 @@ def _validate_scope_config(
     coin_count = int(coin_count)
     if coin_count < 1:
         raise ValueError("GPU foundation requires at least one prepared coin")
-    strategy_kind = (
-        str(config.get("live", {}).get("strategy_kind", "")).strip().lower()
-    )
-    if strategy_kind not in GPU_STRATEGY_BOUND_MAPS:
-        raise ValueError(
-            "GPU foundation supports strategy_kind=ema_anchor or "
-            "trailing_martingale only; "
-            f"got {strategy_kind!r}"
-        )
     enabled_sides = [side for side in ("long", "short") if gpu_side_enabled(config, side)]
     if not enabled_sides:
         raise ValueError("GPU foundation requires at least one enabled side")
@@ -1066,12 +1168,12 @@ def _validate_scope_config(
                     config, enabled_sides
                 )
     if coin_count > 1:
-        from optimization.gpu.model import MPS_MULTICOIN_MAX_COINS
-
         if coin_count > MPS_MULTICOIN_MAX_COINS:
             raise ValueError(
-                "GPU multicoin foundation supports at most "
-                f"{MPS_MULTICOIN_MAX_COINS} coins; prepared {coin_count}"
+                "Apple MPS GPU optimization supports at most "
+                f"{MPS_MULTICOIN_MAX_COINS} prepared coins per scenario; got "
+                f"{coin_count}. Reduce the scenario coin universe or use "
+                "optimize.backend='pymoo' or 'deap'."
             )
         if len(enabled_sides) not in (1, 2):
             raise ValueError(
@@ -1447,8 +1549,6 @@ def _validate_scope(
 def _gpu_suite_scenario_inputs(proxy_config: dict, suite_evaluator) -> list[dict]:
     """Materialize fail-closed suite inputs for MPS screening."""
 
-    from config.param_paths import require_existing_config_path
-
     contexts = getattr(suite_evaluator, "contexts", None)
     get_data = getattr(suite_evaluator, "get_prepared_context_data", None)
     build_config = getattr(suite_evaluator, "build_scenario_candidate_config", None)
@@ -1460,21 +1560,11 @@ def _gpu_suite_scenario_inputs(proxy_config: dict, suite_evaluator) -> list[dict
     prepared = []
     for ctx in contexts:
         overrides = getattr(ctx, "overrides", {}) or {}
-        for dotted_path in overrides:
-            resolved = require_existing_config_path(proxy_config, dotted_path)
-            bot_side_override = (
-                len(resolved) >= 3
-                and resolved[0] == "bot"
-                and resolved[1] in {"long", "short"}
-            )
-            if (
-                not bot_side_override
-                and resolved not in GPU_SUPPORTED_SUITE_NON_BOT_OVERRIDE_PATHS
-            ):
-                raise ValueError(
-                    f"GPU suite scenario {ctx.label!r} override {dotted_path!r} is "
-                    "outside the supported modeled scenario scope"
-                )
+        _validate_gpu_suite_override_paths(
+            proxy_config,
+            label=str(ctx.label),
+            overrides=overrides,
+        )
         exchanges = list(ctx.exchanges)
         if not exchanges:
             raise ValueError(

--- a/src/optimize.py
+++ b/src/optimize.py
@@ -195,7 +195,6 @@ from optimization.config_adapter import (
 )
 from optimization.evaluation_payload import apply_evaluation_payload, build_evaluation_payload
 from optimization.warmup import (
-    _finalize_optimizer_vector_config,
     build_optimizer_data_config,
     build_optimizer_vector_config,
     compute_optimizer_per_coin_warmup_minutes,
@@ -2996,12 +2995,12 @@ def _run_gpu_preparation_preflight(
 
     if str(config.get("optimize", {}).get("backend", "")).strip().lower() != "gpu":
         return
-    from optimization.backends.gpu_backend import validate_gpu_preparation_scope
-
-    effective_config = _finalize_optimizer_vector_config(
-        deepcopy(config),
-        overrides_list=config.get("optimize", {}).get("enable_overrides", []),
+    from optimization.backends.gpu_backend import (
+        materialize_gpu_preparation_config,
+        validate_gpu_preparation_scope,
     )
+
+    effective_config = materialize_gpu_preparation_config(config)
     normalized_suite_cfg = dict(suite_cfg)
     if bool(normalized_suite_cfg.get("enabled")):
         scenarios, _reducer_cfg = build_scenarios(

--- a/src/optimize.py
+++ b/src/optimize.py
@@ -195,6 +195,7 @@ from optimization.config_adapter import (
 )
 from optimization.evaluation_payload import apply_evaluation_payload, build_evaluation_payload
 from optimization.warmup import (
+    _finalize_optimizer_vector_config,
     build_optimizer_data_config,
     build_optimizer_vector_config,
     compute_optimizer_per_coin_warmup_minutes,
@@ -2997,7 +2998,24 @@ def _run_gpu_preparation_preflight(
         return
     from optimization.backends.gpu_backend import validate_gpu_preparation_scope
 
-    validate_gpu_preparation_scope(config, dict(suite_cfg))
+    effective_config = _finalize_optimizer_vector_config(
+        deepcopy(config),
+        overrides_list=config.get("optimize", {}).get("enable_overrides", []),
+    )
+    normalized_suite_cfg = dict(suite_cfg)
+    if bool(normalized_suite_cfg.get("enabled")):
+        scenarios, _reducer_cfg = build_scenarios(
+            normalized_suite_cfg,
+            base_exchanges=effective_config.get("backtest", {}).get("exchanges"),
+        )
+        normalized_suite_cfg["scenarios"] = [
+            {
+                "label": scenario.label,
+                "overrides": dict(scenario.overrides or {}),
+            }
+            for scenario in scenarios
+        ]
+    validate_gpu_preparation_scope(effective_config, normalized_suite_cfg)
 
 
 def _materialize_resolved_gpu_suite_dates(

--- a/src/optimize.py
+++ b/src/optimize.py
@@ -2988,6 +2988,18 @@ def _materialize_gpu_suite_run_contract(
             backtest[key] = deepcopy(suite_cfg[key])
 
 
+def _run_gpu_preparation_preflight(
+    config: Dict[str, Any], suite_cfg: Mapping[str, Any]
+) -> None:
+    """Validate immutable Apple MPS requirements before loading historical data."""
+
+    if str(config.get("optimize", {}).get("backend", "")).strip().lower() != "gpu":
+        return
+    from optimization.backends.gpu_backend import validate_gpu_preparation_scope
+
+    validate_gpu_preparation_scope(config, dict(suite_cfg))
+
+
 def _materialize_resolved_gpu_suite_dates(
     config: Dict[str, Any], scenario_contexts: Sequence[ScenarioEvalContext]
 ) -> None:
@@ -3381,6 +3393,7 @@ async def main():
     manager = None
     pool_terminated = False
     try:
+        _run_gpu_preparation_preflight(config, suite_cfg)
         array_manager = SharedArrayManager()
         hlcvs_specs = {}
         btc_usd_specs = {}

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -1778,6 +1778,57 @@ def test_gpu_preparation_preflight_rejects_unmodeled_suite_override_early():
         )
 
 
+def test_gpu_preparation_preflight_validates_effective_bot_suite_values():
+    config = _long_only_ema_config()
+    runtime = MagicMock()
+    suite_cfg = {
+        "enabled": True,
+        "scenarios": [
+            {
+                "label": "unsupported_ema_repair",
+                "overrides": {
+                    "bot.long.risk.position_exposure_enforcer_enabled": True,
+                },
+            }
+        ],
+    }
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"bot\.long\.risk\.position_exposure_enforcer_enabled=false"
+        ),
+    ):
+        validate_gpu_preparation_scope(
+            config,
+            suite_cfg,
+            torch_module=runtime,
+        )
+
+    runtime.backends.mps.is_available.assert_not_called()
+
+
+def test_gpu_preparation_preflight_accepts_modeled_tm_exposure_repair_override():
+    config = _directional_tm_config(long_enabled=True, short_enabled=False)
+    suite_cfg = {
+        "enabled": True,
+        "scenarios": [
+            {
+                "label": "tm_repair",
+                "overrides": {
+                    "bot.long.risk.position_exposure_enforcer_enabled": True,
+                },
+            }
+        ],
+    }
+
+    validate_gpu_preparation_scope(
+        config,
+        suite_cfg,
+        torch_module=_fake_torch_with_mps(),
+    )
+
+
 def test_gpu_preparation_preflight_requires_available_mps():
     with pytest.raises(RuntimeError, match=r"MPS is unavailable.*pymoo"):
         validate_gpu_preparation_scope(

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -79,6 +79,7 @@ from optimization.backends.gpu_backend import (
     _validate_scope,
     _validate_tm_market_mode_bounds,
     _validate_tm_market_template_bounds,
+    validate_gpu_preparation_scope,
     _GPU_SUITE_METRICS_KEY,
     _GPU_SUITE_OBJECTIVES_KEY,
     _GPU_SUITE_VIOLATION_KEY,
@@ -1716,6 +1717,87 @@ def test_gpu_foundation_fails_closed_for_unsupported_scope(mutate, message):
 
     with pytest.raises(ValueError, match=message):
         _validate_scope(config, _Evaluator())
+
+
+def _fake_torch_with_mps(available=True):
+    return SimpleNamespace(
+        backends=SimpleNamespace(
+            mps=SimpleNamespace(is_available=lambda: available),
+        )
+    )
+
+
+def test_gpu_preparation_preflight_rejects_btc_collateral_before_runtime_probe():
+    config = _long_only_ema_config()
+    config["backtest"]["btc_collateral_cap"] = 0.5
+    runtime = MagicMock()
+
+    with pytest.raises(
+        ValueError,
+        match=r"btc_collateral_cap=0\.0.*pymoo.*exact Rust validation",
+    ):
+        validate_gpu_preparation_scope(config, torch_module=runtime)
+
+    runtime.backends.mps.is_available.assert_not_called()
+
+
+def test_gpu_preparation_preflight_explains_trailing_grid_cpu_fallback():
+    config = _long_only_ema_config()
+    config["live"]["strategy_kind"] = "trailing_grid_v7"
+
+    with pytest.raises(
+        ValueError,
+        match=r"trailing_grid_v7 is deliberately outside.*pymoo",
+    ):
+        validate_gpu_preparation_scope(
+            config,
+            torch_module=_fake_torch_with_mps(),
+        )
+
+
+def test_gpu_preparation_preflight_rejects_unmodeled_suite_override_early():
+    config = _long_only_ema_config()
+    suite_cfg = {
+        "enabled": True,
+        "scenarios": [
+            {
+                "label": "unsupported_collateral",
+                "overrides": {"backtest.btc_collateral_cap": 0.5},
+            }
+        ],
+    }
+
+    with pytest.raises(
+        ValueError,
+        match=r"unsupported_collateral.*btc_collateral_cap.*outside the supported modeled",
+    ):
+        validate_gpu_preparation_scope(
+            config,
+            suite_cfg,
+            torch_module=_fake_torch_with_mps(),
+        )
+
+
+def test_gpu_preparation_preflight_requires_available_mps():
+    with pytest.raises(RuntimeError, match=r"MPS is unavailable.*pymoo"):
+        validate_gpu_preparation_scope(
+            _long_only_ema_config(),
+            torch_module=_fake_torch_with_mps(False),
+        )
+
+
+def test_gpu_preparation_preflight_logs_capability_contract(caplog):
+    with caplog.at_level("INFO"):
+        validate_gpu_preparation_scope(
+            _long_only_ema_config(),
+            torch_module=_fake_torch_with_mps(),
+        )
+
+    assert (
+        "GPU capability preflight passed | runtime=apple_mps | "
+        "strategy=ema_anchor | btc_collateral_cap=0 | max_coins_per_scenario=64"
+        in caplog.text
+    )
 
 
 def test_gpu_foundation_accepts_ema_long_single():

--- a/tests/optimization/test_optimize.py
+++ b/tests/optimization/test_optimize.py
@@ -9,6 +9,7 @@ import logging
 import math
 import os
 import argparse
+import builtins
 import json
 import logging
 from multiprocessing.reduction import ForkingPickler
@@ -837,6 +838,47 @@ def test_materialize_gpu_suite_run_contract_does_not_change_cpu_config():
     )
 
     assert config["backtest"] == before
+
+
+def test_gpu_preparation_preflight_is_additive_to_cpu_backends(monkeypatch):
+    config = optimize.get_template_config()
+    config["optimize"]["backend"] = "pymoo"
+    config["live"]["strategy_kind"] = "trailing_grid_v7"
+    config["backtest"]["btc_collateral_cap"] = 1.0
+
+    original_import = builtins.__import__
+
+    def guarded_import(name, *args, **kwargs):
+        if name == "optimization.backends.gpu_backend":
+            raise AssertionError("CPU optimizer must not import or probe the GPU backend")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(
+        builtins,
+        "__import__",
+        guarded_import,
+    )
+
+    optimize._run_gpu_preparation_preflight(config, {"enabled": False})
+
+
+def test_gpu_preparation_preflight_delegates_effective_suite(monkeypatch):
+    config = optimize.get_template_config()
+    config["optimize"]["backend"] = "gpu"
+    suite_cfg = {"enabled": True, "scenarios": [{"label": "stress"}]}
+    calls = []
+
+    monkeypatch.setattr(
+        "optimization.backends.gpu_backend.validate_gpu_preparation_scope",
+        lambda actual_config, actual_suite: calls.append(
+            (actual_config, actual_suite)
+        ),
+    )
+
+    optimize._run_gpu_preparation_preflight(config, suite_cfg)
+
+    assert calls == [(config, suite_cfg)]
+    assert calls[0][1] is not suite_cfg
 
 
 def test_materialize_resolved_gpu_suite_dates_replaces_dynamic_tokens():

--- a/tests/optimization/test_optimize.py
+++ b/tests/optimization/test_optimize.py
@@ -865,7 +865,21 @@ def test_gpu_preparation_preflight_is_additive_to_cpu_backends(monkeypatch):
 def test_gpu_preparation_preflight_delegates_effective_suite(monkeypatch):
     config = optimize.get_template_config()
     config["optimize"]["backend"] = "gpu"
-    suite_cfg = {"enabled": True, "scenarios": [{"label": "stress"}]}
+    config["optimize"]["fixed_runtime_overrides"] = {
+        "backtest.btc_collateral_cap": 0.5,
+    }
+    suite_cfg = {
+        "enabled": True,
+        "scenarios": [
+            {
+                "label": "stress",
+                "overrides": {
+                    "backtest": {"starting_balance": 2_000.0},
+                    "bot": {"long": {"risk": {"n_positions": 1}}},
+                },
+            }
+        ],
+    }
     calls = []
 
     monkeypatch.setattr(
@@ -877,8 +891,35 @@ def test_gpu_preparation_preflight_delegates_effective_suite(monkeypatch):
 
     optimize._run_gpu_preparation_preflight(config, suite_cfg)
 
-    assert calls == [(config, suite_cfg)]
-    assert calls[0][1] is not suite_cfg
+    assert len(calls) == 1
+    effective_config, effective_suite = calls[0]
+    assert effective_config is not config
+    assert effective_config["backtest"]["btc_collateral_cap"] == 0.5
+    assert config["backtest"]["btc_collateral_cap"] == 0.0
+    assert effective_suite is not suite_cfg
+    assert effective_suite["scenarios"] == [
+        {
+            "label": "stress",
+            "overrides": {
+                "backtest.starting_balance": 2_000.0,
+                "bot.long.risk.n_positions": 1,
+            },
+        }
+    ]
+
+
+def test_gpu_preparation_preflight_rejects_effective_fixed_runtime_limitation():
+    config = optimize.get_template_config()
+    config["optimize"]["backend"] = "gpu"
+    config["optimize"]["fixed_runtime_overrides"] = {
+        "backtest.btc_collateral_cap": 0.5,
+    }
+
+    with pytest.raises(
+        ValueError,
+        match=r"btc_collateral_cap=0\.0.*got 0\.5.*pymoo",
+    ):
+        optimize._run_gpu_preparation_preflight(config, {"enabled": False})
 
 
 def test_materialize_resolved_gpu_suite_dates_replaces_dynamic_tokens():

--- a/tests/optimization/test_optimize.py
+++ b/tests/optimization/test_optimize.py
@@ -922,6 +922,26 @@ def test_gpu_preparation_preflight_rejects_effective_fixed_runtime_limitation():
         optimize._run_gpu_preparation_preflight(config, {"enabled": False})
 
 
+def test_gpu_preparation_preflight_rejects_fixed_strategy_switch():
+    config = optimize.get_template_config()
+    config["optimize"]["backend"] = "gpu"
+    source_strategy = config["live"]["strategy_kind"]
+    target_strategy = (
+        "trailing_martingale"
+        if source_strategy == "ema_anchor"
+        else "ema_anchor"
+    )
+    config["optimize"]["fixed_runtime_overrides"] = {
+        "live.strategy_kind": target_strategy,
+    }
+
+    with pytest.raises(
+        ValueError,
+        match=r"fixed_runtime_overrides may not change live\.strategy_kind",
+    ):
+        optimize._run_gpu_preparation_preflight(config, {"enabled": False})
+
+
 def test_materialize_resolved_gpu_suite_dates_replaces_dynamic_tokens():
     config = optimize.get_template_config()
     config["optimize"]["backend"] = "gpu"


### PR DESCRIPTION
## Summary

- fail fast on immutable Apple MPS requirements before historical-data preparation
- give actionable CPU fallbacks for unsupported strategies, positive BTC collateral, missing MPS, and unmodeled suite override paths
- log the successful MPS capability contract, including the strategy and 64-coin-per-scenario ceiling
- document deliberate current GPU limitations without changing CPU optimization, backtesting, or live startup

## Validation

- `PYTHONPATH=src .../python -m pytest -q tests/optimization/test_gpu_backend.py tests/optimization/test_optimize.py tests/optimization/test_backends.py`
- real CLI negative check: positive `backtest.btc_collateral_cap` exited before HLCV preparation with the setting, reason, CPU fallback, and docs pointer
- physical Apple M3 end-to-end smoke: EMA Anchor, BTC long-only, 8 Metal generations, 1,024 proxy evaluations, 64 exact Rust validations, clean completion
- `python src/tools/check_ai_docs.py` (0 errors; existing size warnings only)
- `mkdocs build`
- `git diff --check`

Exact Rust remains authoritative. This slice changes startup validation and documentation only; it does not change Metal strategy behavior or the CPU path.
