### PR TITLE
Add opt-in MPS profiling and reproducible benchmarks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Apple MPS optimization now provides disabled-by-default structured profiling for candidate
+  materialization and packing, buffer upload/clearing, cold and warm shader-library work, kernel
+  execution, device transfer, metric reduction, NSGA orchestration, exact-validation queue/work,
+  result persistence, and checkpointing. Profile records include actual dispatch shape,
+  candidate-bars, topology, optional metric features, and cold/warm state. A deterministic offline
+  `passivbot tool gpu-proxy-benchmark` harness covers long-history EMA Anchor and Trailing
+  Martingale, short-history multicoin, and coin-override workloads with fixed seeds, cold timing,
+  and warm p50 throughput. Profiling remains opt-in and exact Rust results remain authoritative.
+
 - Apple MPS optimization now keeps exact-analysis diagnostics separate from proxy objectives and
   proxy-side limits. Raw gain/PnL, positive equity-balance divergence, completed-only account
   recovery, raw or split fill activity, raw HSL event/absolute-loss metrics, legacy recovery/profit

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -711,6 +711,46 @@ Rust extension; it does not replace or modify the exact Rust backtester. Credit:
 metric-reduction work was adapted from RustyCZ's Passivbot GPU branch at commit `7c529bc73`; the
 MPS Metal integration and hybrid validation gates are specific to this implementation.
 
+#### Profiling Apple MPS optimization
+
+Set `PASSIVBOT_GPU_PROFILE=1` to emit structured `[gpu-profile]` JSON records. Profiling is disabled
+by default because its synchronization points deliberately trade throughput for trustworthy phase
+boundaries.
+
+```bash
+PASSIVBOT_GPU_PROFILE=1 passivbot optimize path/to/public-or-local-config.json
+```
+
+Each generation record separates NSGA ask/tell and orchestration from proxy work, exact-validation
+queue/wait and worker time, result persistence, and checkpoint writes. Each prepared proxy also
+reports candidate materialization and Metal parameter packing, upload/buffer clearing, runner-local
+cold compilation versus warm library lookup, kernel execution, device-to-host transfer, metric
+reduction, and remaining host overhead. Shape metadata includes requested and actual dispatch batch
+sizes, dispatch chunk and strategy-kernel counts, candidate-bars, candle/coin/side counts, requested
+optional metric features, and cold/warm dispatch counts. Exact Rust evaluation remains
+authoritative; profiling fields are diagnostic log output and are not added to retained optimization
+results.
+
+For comparable local MPS measurements, first confirm another optimizer is not using the device,
+then run each case in a fresh process. The harness uses only fixed-seed, in-memory synthetic candles
+and candidate matrices; it never reads exchange credentials, local cache data, configs, or prior
+optimization results.
+
+```bash
+passivbot tool gpu-proxy-benchmark --case ema-single-long
+passivbot tool gpu-proxy-benchmark --case tm-single-long
+passivbot tool gpu-proxy-benchmark --case ema-multicoin-short
+passivbot tool gpu-proxy-benchmark --case ema-multicoin-overrides
+```
+
+The single-coin cases default to 60,000 one-minute candles; the overhead-sensitive multicoin cases
+default to 4,320 candles and eight coins. Every report records the seed and workload shape, cold
+compile/run timing, a fixture hash, and warm p50 across five repeated runs, including
+candidates/second, kernel time, dispatch count, device transfer, and host overhead. Use identical
+arguments and immutable commits for before/after comparisons. Run one `--case` per process when
+comparing cold compilation; `--case all` is convenient for smoke checks but later cases may reuse
+process-local shader caches.
+
 ### Pymoo Configuration
 
 Pymoo-specific settings live under `optimize.pymoo`:

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -739,7 +739,7 @@ optimization results.
 ```bash
 passivbot tool gpu-proxy-benchmark --case ema-single-long
 passivbot tool gpu-proxy-benchmark --case tm-single-long
-passivbot tool gpu-proxy-benchmark --case ema-multicoin-short
+passivbot tool gpu-proxy-benchmark --case ema-multicoin-overhead
 passivbot tool gpu-proxy-benchmark --case ema-multicoin-overrides
 ```
 
@@ -747,9 +747,11 @@ The single-coin cases default to 60,000 one-minute candles; the overhead-sensiti
 default to 4,320 candles and eight coins. Every report records the seed and workload shape, cold
 compile/run timing, a fixture hash, and warm p50 across five repeated runs, including
 candidates/second, kernel time, dispatch count, device transfer, and host overhead. Use identical
-arguments and immutable commits for before/after comparisons. Run one `--case` per process when
-comparing cold compilation; `--case all` is convenient for smoke checks but later cases may reuse
-process-local shader caches.
+arguments and immutable commits for before/after comparisons. The harness calls the production
+proxy evaluation path, including its full output transfer, metric reduction, and result
+materialization. Run one `--case` per process when comparing cold compilation; `--case all` is
+convenient for smoke checks, and shared-cache hit/miss state still keeps later cold/warm labels
+accurate.
 
 ### Pymoo Configuration
 

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -95,11 +95,40 @@ def _submit_gpu_exact_validation(
     pool,
     vector,
     interrupt_check: InterruptCheck,
+    *,
+    profile: bool = False,
 ):
     """Refuse new exact CPU work once the GPU interrupt latch is set."""
 
     interrupt_check()
-    return pool.apply_async(_evaluate_pymoo_worker_from_globals, (vector,))
+    worker = (
+        _profiled_gpu_exact_worker
+        if profile
+        else _evaluate_pymoo_worker_from_globals
+    )
+    return pool.apply_async(worker, (vector,))
+
+
+def _profiled_gpu_exact_worker(vector):
+    """Attach opt-in worker time without changing persisted exact evidence."""
+
+    started = time.perf_counter()
+    payload = _evaluate_pymoo_worker_from_globals(vector)
+    if isinstance(payload, dict):
+        payload = dict(payload)
+        payload["__gpu_profile_worker_seconds__"] = time.perf_counter() - started
+    return payload
+
+
+def _log_gpu_profile(event: str, **payload) -> None:
+    logging.info(
+        "[gpu-profile] %s",
+        json.dumps(
+            {"schema_version": 1, "event": event, **payload},
+            sort_keys=True,
+            separators=(",", ":"),
+        ),
+    )
 
 
 def _checkpoint_gpu_interrupt(
@@ -3673,6 +3702,11 @@ def run_backend(
             (ctx, tuple(exchange_proxies), parameter_overrides)
             for ctx, exchange_proxies, parameter_overrides in scenario_proxy_groups.values()
         ]
+        profile_proxies = [
+            proxy
+            for _ctx, exchange_proxies, _parameter_overrides in scenario_proxies
+            for _exchange, proxy in exchange_proxies
+        ]
 
         def evaluate_proxy(candidates):
             return _evaluate_gpu_suite_proxies(
@@ -3694,6 +3728,7 @@ def run_backend(
             needed_metrics=needed_metrics,
             interrupt_check=interrupt_check,
         )
+        profile_proxies = [proxy]
 
         def evaluate_proxy(candidates):
             return proxy.evaluate(candidates)
@@ -3925,6 +3960,16 @@ def run_backend(
         )
 
     adapter = PymooEvaluatorAdapter(evaluator_for_pool, overrides_list=overrides_list)
+    profile_enabled = any(
+        bool(getattr(item, "profile_enabled", False)) for item in profile_proxies
+    )
+    profile_totals = {
+        "exact_queue_wait": 0.0,
+        "exact_work": 0.0,
+        "exact_result_processing": 0.0,
+        "persistence": 0.0,
+        "checkpointing": 0.0,
+    }
     workers = int(options["exact_workers"]) or int(config["optimize"]["n_cpus"])
     max_pending = int(options["max_pending_exact"]) or workers * 2
     if workers <= 0:
@@ -3975,7 +4020,12 @@ def run_backend(
         due = now - last_checkpoint_at >= float(options["checkpoint_interval_seconds"])
         if not force and (exact_done == last_checkpoint_exact or not due):
             return
+        profile_started = time.perf_counter() if profile_enabled else 0.0
         _save_checkpoint(checkpoint_path, checkpoint_state())
+        if profile_enabled:
+            profile_totals["checkpointing"] += (
+                time.perf_counter() - profile_started
+            )
         last_checkpoint_at = now
         last_checkpoint_exact = exact_done
 
@@ -4049,8 +4099,22 @@ def run_backend(
                 is_probe,
                 is_proxy_front,
                 digest,
+                submitted_at,
             ) = pending.pop(result)
             payload = result.get()
+            result_ready_at = time.perf_counter() if profile_enabled else 0.0
+            worker_seconds = (
+                float(payload.pop("__gpu_profile_worker_seconds__", 0.0))
+                if profile_enabled and isinstance(payload, dict)
+                else 0.0
+            )
+            if profile_enabled:
+                profile_totals["exact_work"] += worker_seconds
+                profile_totals["exact_queue_wait"] += max(
+                    0.0,
+                    result_ready_at - submitted_at - worker_seconds,
+                )
+                result_processing_started = time.perf_counter()
             PymooAsyncRecordingRunner._raise_if_worker_failure(payload, exact_done)
             exact_score = float(
                 objective_scale.score(np.asarray(payload["F"]).reshape(1, -1))[0]
@@ -4060,6 +4124,9 @@ def run_backend(
             )
             constraint_diagnostics = _constraint_diagnostics(
                 evaluator, proxy_metrics, payload
+            )
+            persistence_started = (
+                time.perf_counter() if profile_enabled else 0.0
             )
             record_exact(
                 vector,
@@ -4074,6 +4141,15 @@ def run_backend(
                     "constraint_diagnostics": constraint_diagnostics,
                 },
             )
+            if profile_enabled:
+                persistence_seconds = time.perf_counter() - persistence_started
+                profile_totals["persistence"] += persistence_seconds
+                profile_totals["exact_result_processing"] += max(
+                    0.0,
+                    time.perf_counter()
+                    - result_processing_started
+                    - persistence_seconds,
+                )
             exact_done += 1
             completed_hashes.add(digest)
             submitted_hashes.discard(digest)
@@ -4123,10 +4199,30 @@ def run_backend(
             # An MPS proxy may poll the latch between bounded Metal dispatches.
             # If interrupted there, the outer handler discards this incomplete
             # ask/tell transaction and retains the preceding safe checkpoint.
+            generation_profile_started = (
+                time.perf_counter() if profile_enabled else 0.0
+            )
+            ask_started = time.perf_counter() if profile_enabled else 0.0
             population = _ask_gpu_population(algorithm, interrupt_check)
+            ask_seconds = (
+                time.perf_counter() - ask_started if profile_enabled else 0.0
+            )
             generation_in_progress = True
             rows = np.asarray(population.get("X"), dtype=np.float64)
-            metric_rows = evaluate_proxy(parameter_dicts(rows))
+            materialization_started = (
+                time.perf_counter() if profile_enabled else 0.0
+            )
+            proxy_candidates = parameter_dicts(rows)
+            candidate_materialization_seconds = (
+                time.perf_counter() - materialization_started
+                if profile_enabled
+                else 0.0
+            )
+            proxy_started = time.perf_counter() if profile_enabled else 0.0
+            metric_rows = evaluate_proxy(proxy_candidates)
+            proxy_seconds = (
+                time.perf_counter() - proxy_started if profile_enabled else 0.0
+            )
             proxy_objectives, proxy_violations = proxy_fitness(metric_rows)
             proxy_evaluations += len(rows)
             if objective_scale.median is None:
@@ -4141,7 +4237,11 @@ def run_backend(
                     1.0e18,
                 ).reshape(-1, 1),
             )
+            tell_started = time.perf_counter() if profile_enabled else 0.0
             algorithm.tell(infills=population)
+            tell_seconds = (
+                time.perf_counter() - tell_started if profile_enabled else 0.0
+            )
             generation_in_progress = False
             generation += 1
             # PyTorch MPS may consume KeyboardInterrupt while waiting for a
@@ -4191,10 +4291,12 @@ def run_backend(
             )
             submitted_this_generation = 0
             for index, is_probe, is_proxy_front, vector, digest in exact_selections:
+                submitted_at = time.perf_counter() if profile_enabled else 0.0
                 result = _submit_gpu_exact_validation(
                     pool,
                     vector,
                     interrupt_check,
+                    profile=profile_enabled,
                 )
                 pending[result] = (
                     vector,
@@ -4204,6 +4306,7 @@ def run_backend(
                     bool(is_probe),
                     bool(is_proxy_front),
                     digest,
+                    submitted_at,
                 )
                 submitted_hashes.add(digest)
                 submitted_this_generation += 1
@@ -4213,6 +4316,49 @@ def run_backend(
                 submitted=submitted_this_generation,
                 pending=len(pending),
             )
+
+            if profile_enabled:
+                generation_wall_seconds = (
+                    time.perf_counter() - generation_profile_started
+                )
+                proxy_profile_records = [
+                    deepcopy(getattr(item, "last_profile", {}))
+                    for item in profile_proxies
+                ]
+                proxy_profile_wall = sum(
+                    float(item.get("wall_seconds", 0.0))
+                    for item in proxy_profile_records
+                )
+                accounted_seconds = (
+                    ask_seconds
+                    + candidate_materialization_seconds
+                    + proxy_seconds
+                    + tell_seconds
+                )
+                _log_gpu_profile(
+                    "generation",
+                    generation=generation,
+                    population_size=len(rows),
+                    proxy_profiles=proxy_profile_records,
+                    timings_seconds={
+                        "nsga_ask": ask_seconds,
+                        "candidate_materialization": (
+                            candidate_materialization_seconds
+                        ),
+                        "proxy_evaluation": proxy_seconds,
+                        "suite_or_proxy_reduction": max(
+                            0.0, proxy_seconds - proxy_profile_wall
+                        ),
+                        "nsga_tell": tell_seconds,
+                        "orchestration": max(
+                            0.0, generation_wall_seconds - accounted_seconds
+                        ),
+                        "wall": generation_wall_seconds,
+                    },
+                    exact_validation_cumulative_seconds=dict(profile_totals),
+                    exact_completed=exact_done,
+                    exact_inflight=len(pending),
+                )
 
             if generation == 1 or generation % 10 == 0:
                 elapsed = time.time() - start_time
@@ -4229,6 +4375,15 @@ def run_backend(
         while pending and exact_done < budget:
             consume_ready(wait_for_one=True)
         maybe_save_checkpoint(force=True)
+        if profile_enabled:
+            _log_gpu_profile(
+                "complete",
+                generations=generation,
+                proxy_evaluations=proxy_evaluations,
+                exact_completed=exact_done,
+                wall_seconds=time.time() - start_time,
+                exact_validation_cumulative_seconds=dict(profile_totals),
+            )
         logging.info(
             "GPU optimization complete | generations=%d proxy=%d exact=%d wall=%.1fs",
             generation,

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -101,21 +101,24 @@ def _submit_gpu_exact_validation(
     """Refuse new exact CPU work once the GPU interrupt latch is set."""
 
     interrupt_check()
-    worker = (
-        _profiled_gpu_exact_worker
-        if profile
-        else _evaluate_pymoo_worker_from_globals
-    )
-    return pool.apply_async(worker, (vector,))
+    if profile:
+        submitted_at = time.perf_counter()
+        return pool.apply_async(
+            _profiled_gpu_exact_worker, (vector, submitted_at)
+        )
+    return pool.apply_async(_evaluate_pymoo_worker_from_globals, (vector,))
 
 
-def _profiled_gpu_exact_worker(vector):
+def _profiled_gpu_exact_worker(vector, submitted_at):
     """Attach opt-in worker time without changing persisted exact evidence."""
 
     started = time.perf_counter()
     payload = _evaluate_pymoo_worker_from_globals(vector)
     if isinstance(payload, dict):
         payload = dict(payload)
+        payload["__gpu_profile_queue_wait_seconds__"] = max(
+            0.0, started - float(submitted_at)
+        )
         payload["__gpu_profile_worker_seconds__"] = time.perf_counter() - started
     return payload
 
@@ -4099,21 +4102,21 @@ def run_backend(
                 is_probe,
                 is_proxy_front,
                 digest,
-                submitted_at,
             ) = pending.pop(result)
             payload = result.get()
-            result_ready_at = time.perf_counter() if profile_enabled else 0.0
             worker_seconds = (
                 float(payload.pop("__gpu_profile_worker_seconds__", 0.0))
                 if profile_enabled and isinstance(payload, dict)
                 else 0.0
             )
+            queue_wait_seconds = (
+                float(payload.pop("__gpu_profile_queue_wait_seconds__", 0.0))
+                if profile_enabled and isinstance(payload, dict)
+                else 0.0
+            )
             if profile_enabled:
                 profile_totals["exact_work"] += worker_seconds
-                profile_totals["exact_queue_wait"] += max(
-                    0.0,
-                    result_ready_at - submitted_at - worker_seconds,
-                )
+                profile_totals["exact_queue_wait"] += queue_wait_seconds
                 result_processing_started = time.perf_counter()
             PymooAsyncRecordingRunner._raise_if_worker_failure(payload, exact_done)
             exact_score = float(
@@ -4291,7 +4294,6 @@ def run_backend(
             )
             submitted_this_generation = 0
             for index, is_probe, is_proxy_front, vector, digest in exact_selections:
-                submitted_at = time.perf_counter() if profile_enabled else 0.0
                 result = _submit_gpu_exact_validation(
                     pool,
                     vector,
@@ -4306,7 +4308,6 @@ def run_backend(
                     bool(is_probe),
                     bool(is_proxy_front),
                     digest,
-                    submitted_at,
                 )
                 submitted_hashes.add(digest)
                 submitted_this_generation += 1

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -134,6 +134,10 @@ def _log_gpu_profile(event: str, **payload) -> None:
     )
 
 
+def _gpu_profile_elapsed(started: float) -> float:
+    return max(0.0, time.perf_counter() - float(started))
+
+
 def _checkpoint_gpu_interrupt(
     *,
     generation_in_progress: bool,
@@ -3995,6 +3999,7 @@ def run_backend(
     pending = {}
     submitted_hashes: set[str] = set()
     start_time = time.time()
+    profile_started = time.perf_counter() if profile_enabled else 0.0
     proxy_evaluations = 0
     novelty_stall_generations = 0
     last_warning = None
@@ -4382,7 +4387,7 @@ def run_backend(
                 generations=generation,
                 proxy_evaluations=proxy_evaluations,
                 exact_completed=exact_done,
-                wall_seconds=time.time() - start_time,
+                wall_seconds=_gpu_profile_elapsed(profile_started),
                 exact_validation_cumulative_seconds=dict(profile_totals),
             )
         logging.info(

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -1118,7 +1118,8 @@ class MpsEmaAnchorRunner:
         self._recovery_buffers: dict[int, torch.Tensor] = {}
         self._equity_balance_diff_buffers: dict[int, torch.Tensor] = {}
         self._sizes: dict[tuple[int, int], torch.Tensor] = {}
-        self.last_profile: dict[str, float] = {}
+        self.last_profile: dict[str, float | int | bool] = {}
+        self._profile_dispatches = 0
 
     def _pack_params(self, params: np.ndarray) -> np.ndarray:
         params = _upgrade_legacy_single_coin_wel_params(
@@ -1241,9 +1242,9 @@ class MpsEmaAnchorRunner:
         return values
 
     def run(self, params: np.ndarray, *, profile: bool = False) -> dict:
-        started = time.perf_counter()
+        started = time.perf_counter() if profile else 0.0
         matrix = self._pack_params(params)
-        packed = time.perf_counter()
+        packed = time.perf_counter() if profile else 0.0
         params_mps = torch.as_tensor(matrix, device="mps")
         batch_size = int(matrix.shape[0])
         daily, scalars, gaps = self._output_buffers(batch_size)
@@ -1266,7 +1267,8 @@ class MpsEmaAnchorRunner:
                 dtype=torch.int32,
                 device="mps",
             )
-        prepared = time.perf_counter()
+        prepared = time.perf_counter() if profile else 0.0
+        cold = self._profile_dispatches == 0
         library = _shader_library(
             self.hsl_ema_tail_enabled,
             self.hsl_raw_drawdown_enabled,
@@ -1275,7 +1277,7 @@ class MpsEmaAnchorRunner:
             self.btc_risk_enabled,
             self.equity_balance_diff_enabled,
         )
-        compiled = time.perf_counter()
+        compiled = time.perf_counter() if profile else 0.0
         if profile:
             torch.mps.synchronize()
             dispatched = time.perf_counter()
@@ -1310,20 +1312,31 @@ class MpsEmaAnchorRunner:
         dispatch_once()
         if profile:
             torch.mps.synchronize()
-        finished = time.perf_counter()
-        self.last_profile = {
-            "cpu_pack_seconds": packed - started,
-            "upload_and_zero_seconds": prepared - packed,
-            "compile_seconds": compiled - prepared,
-            "pre_dispatch_sync_seconds": dispatched - compiled,
-            "kernel_seconds": finished - dispatched,
-        }
+            finished = time.perf_counter()
+            self.last_profile = {
+                "cpu_pack_seconds": packed - started,
+                "upload_and_zero_seconds": prepared - packed,
+                "compile_seconds": compiled - prepared,
+                "pre_dispatch_sync_seconds": dispatched - compiled,
+                "kernel_seconds": finished - dispatched,
+                "batch_size": batch_size,
+                "dispatch_count": 1,
+                "cold": cold,
+            }
+        else:
+            self.last_profile = {}
+        self._profile_dispatches += 1
         output = _decode_directional_outputs(daily, scalars, gaps)
         output.update(_decode_equity_balance_diff_outputs(equity_balance_diff))
         if self.recovery_distribution_enabled:
             output["strategy_eq_recovery_samples"] = recovery_samples
             output["strategy_eq_recovery_sample_interval_days"] = (
                 self.recovery_stride * self.run_config.interval_ms / 86_400_000.0
+            )
+        if profile:
+            torch.mps.synchronize()
+            self.last_profile["metric_decode_seconds"] = (
+                time.perf_counter() - finished
             )
         return output
 
@@ -1530,7 +1543,8 @@ class MpsEmaAnchorMulticoinRunner:
         self._entry_interval_count_buffers: dict[int, torch.Tensor] = {}
         self._sizes: dict[tuple[int, int], torch.Tensor] = {}
         self._full_end_steps: dict[int, torch.Tensor] = {}
-        self.last_profile: dict[str, float] = {}
+        self.last_profile: dict[str, float | int | bool] = {}
+        self._profile_dispatches = 0
         self.start_minute_of_day = int(data["start_minute_of_day"])
         self.start_minute_of_hour = int(data["start_minute_of_hour"])
         self.requested_start_idx = max(
@@ -1735,9 +1749,9 @@ class MpsEmaAnchorMulticoinRunner:
         profile: bool = False,
         end_steps: np.ndarray | None = None,
     ) -> dict:
-        started = time.perf_counter()
+        started = time.perf_counter() if profile else 0.0
         matrix = self._pack_params(params)
-        packed = time.perf_counter()
+        packed = time.perf_counter() if profile else 0.0
         params_mps = torch.as_tensor(matrix, device="mps")
         batch_size = int(matrix.shape[0])
         end_steps_mps = self._end_steps(end_steps, batch_size)
@@ -1772,9 +1786,10 @@ class MpsEmaAnchorMulticoinRunner:
                 dtype=torch.int32,
                 device="mps",
             )
-        prepared = time.perf_counter()
+        prepared = time.perf_counter() if profile else 0.0
+        cold = self._profile_dispatches == 0
         library = self._library()
-        compiled = time.perf_counter()
+        compiled = time.perf_counter() if profile else 0.0
         if profile:
             torch.mps.synchronize()
             dispatched = time.perf_counter()
@@ -1797,14 +1812,20 @@ class MpsEmaAnchorMulticoinRunner:
         )
         if profile:
             torch.mps.synchronize()
-        finished = time.perf_counter()
-        self.last_profile = {
-            "cpu_pack_seconds": packed - started,
-            "upload_and_zero_seconds": prepared - packed,
-            "compile_seconds": compiled - prepared,
-            "pre_dispatch_sync_seconds": dispatched - compiled,
-            "kernel_seconds": finished - dispatched,
-        }
+            finished = time.perf_counter()
+            self.last_profile = {
+                "cpu_pack_seconds": packed - started,
+                "upload_and_zero_seconds": prepared - packed,
+                "compile_seconds": compiled - prepared,
+                "pre_dispatch_sync_seconds": dispatched - compiled,
+                "kernel_seconds": finished - dispatched,
+                "batch_size": batch_size,
+                "dispatch_count": 1,
+                "cold": cold,
+            }
+        else:
+            self.last_profile = {}
+        self._profile_dispatches += 1
         output = self._decode(daily, scalars, gaps)
         output.update(_decode_equity_balance_diff_outputs(equity_balance_diff))
         output.update(
@@ -1819,6 +1840,11 @@ class MpsEmaAnchorMulticoinRunner:
             )
         if self.collect_coin_fill_counts:
             output["coin_fill_counts"] = coin_fill_counts
+        if profile:
+            torch.mps.synchronize()
+            self.last_profile["metric_decode_seconds"] = (
+                time.perf_counter() - finished
+            )
         return output
 
 
@@ -2463,9 +2489,9 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
         )
 
     def run(self, params: np.ndarray, *, profile: bool = False) -> dict:
-        started = time.perf_counter()
+        started = time.perf_counter() if profile else 0.0
         matrix = self._pack_params(params)
-        packed = time.perf_counter()
+        packed = time.perf_counter() if profile else 0.0
         params_mps = torch.as_tensor(matrix, device="mps")
         batch_size = int(matrix.shape[0])
         daily, scalars, gaps = self._output_buffers(batch_size)
@@ -2491,9 +2517,10 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
                 dtype=torch.int32,
                 device="mps",
             )
-        prepared = time.perf_counter()
+        prepared = time.perf_counter() if profile else 0.0
+        cold = self._profile_dispatches == 0
         library = self._shader_library()
-        compiled = time.perf_counter()
+        compiled = time.perf_counter() if profile else 0.0
         if profile:
             torch.mps.synchronize()
             dispatched = time.perf_counter()
@@ -2530,14 +2557,20 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
         dispatch_once()
         if profile:
             torch.mps.synchronize()
-        finished = time.perf_counter()
-        self.last_profile = {
-            "cpu_pack_seconds": packed - started,
-            "upload_and_zero_seconds": prepared - packed,
-            "compile_seconds": compiled - prepared,
-            "pre_dispatch_sync_seconds": dispatched - compiled,
-            "kernel_seconds": finished - dispatched,
-        }
+            finished = time.perf_counter()
+            self.last_profile = {
+                "cpu_pack_seconds": packed - started,
+                "upload_and_zero_seconds": prepared - packed,
+                "compile_seconds": compiled - prepared,
+                "pre_dispatch_sync_seconds": dispatched - compiled,
+                "kernel_seconds": finished - dispatched,
+                "batch_size": batch_size,
+                "dispatch_count": 1,
+                "cold": cold,
+            }
+        else:
+            self.last_profile = {}
+        self._profile_dispatches += 1
         output = _decode_directional_outputs(daily, scalars, gaps)
         output.update(_decode_equity_balance_diff_outputs(equity_balance_diff))
         output.update(
@@ -2549,5 +2582,10 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
             output["strategy_eq_recovery_samples"] = recovery_samples
             output["strategy_eq_recovery_sample_interval_days"] = (
                 self.recovery_stride * self.run_config.interval_ms / 86_400_000.0
+            )
+        if profile:
+            torch.mps.synchronize()
+            self.last_profile["metric_decode_seconds"] = (
+                time.perf_counter() - finished
             )
         return output

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -453,6 +453,12 @@ def _decode_entry_interval_outputs(stats, counts) -> dict:
     }
 
 
+def _cached_library_with_miss(loader, *args):
+    misses_before = loader.cache_info().misses
+    library = loader(*args)
+    return library, loader.cache_info().misses > misses_before
+
+
 @lru_cache(maxsize=16)
 def _shader_library(
     hsl_ema_tail_enabled: bool = False,
@@ -1119,7 +1125,6 @@ class MpsEmaAnchorRunner:
         self._equity_balance_diff_buffers: dict[int, torch.Tensor] = {}
         self._sizes: dict[tuple[int, int], torch.Tensor] = {}
         self.last_profile: dict[str, float | int | bool] = {}
-        self._profile_dispatches = 0
 
     def _pack_params(self, params: np.ndarray) -> np.ndarray:
         params = _upgrade_legacy_single_coin_wel_params(
@@ -1268,8 +1273,8 @@ class MpsEmaAnchorRunner:
                 device="mps",
             )
         prepared = time.perf_counter() if profile else 0.0
-        cold = self._profile_dispatches == 0
-        library = _shader_library(
+        library, cold = _cached_library_with_miss(
+            _shader_library,
             self.hsl_ema_tail_enabled,
             self.hsl_raw_drawdown_enabled,
             self.hsl_raw_tail_enabled,
@@ -1325,7 +1330,6 @@ class MpsEmaAnchorRunner:
             }
         else:
             self.last_profile = {}
-        self._profile_dispatches += 1
         output = _decode_directional_outputs(daily, scalars, gaps)
         output.update(_decode_equity_balance_diff_outputs(equity_balance_diff))
         if self.recovery_distribution_enabled:
@@ -1544,7 +1548,6 @@ class MpsEmaAnchorMulticoinRunner:
         self._sizes: dict[tuple[int, int], torch.Tensor] = {}
         self._full_end_steps: dict[int, torch.Tensor] = {}
         self.last_profile: dict[str, float | int | bool] = {}
-        self._profile_dispatches = 0
         self.start_minute_of_day = int(data["start_minute_of_day"])
         self.start_minute_of_hour = int(data["start_minute_of_hour"])
         self.requested_start_idx = max(
@@ -1676,7 +1679,11 @@ class MpsEmaAnchorMulticoinRunner:
         )
 
     def _library(self):
-        return _ema_anchor_multicoin_shader_library(
+        loader, args = self._library_cache_call()
+        return loader(*args)
+
+    def _library_cache_call(self):
+        return _ema_anchor_multicoin_shader_library, (
             self.hsl_ema_tail_enabled,
             self.hsl_raw_drawdown_enabled,
             self.hsl_raw_tail_enabled,
@@ -1787,8 +1794,8 @@ class MpsEmaAnchorMulticoinRunner:
                 device="mps",
             )
         prepared = time.perf_counter() if profile else 0.0
-        cold = self._profile_dispatches == 0
-        library = self._library()
+        loader, library_args = self._library_cache_call()
+        library, cold = _cached_library_with_miss(loader, *library_args)
         compiled = time.perf_counter() if profile else 0.0
         if profile:
             torch.mps.synchronize()
@@ -1825,7 +1832,6 @@ class MpsEmaAnchorMulticoinRunner:
             }
         else:
             self.last_profile = {}
-        self._profile_dispatches += 1
         output = self._decode(daily, scalars, gaps)
         output.update(_decode_equity_balance_diff_outputs(equity_balance_diff))
         output.update(
@@ -2148,7 +2154,11 @@ class MpsTrailingMartingaleMulticoinRunner(MpsEmaAnchorMulticoinRunner):
         )
 
     def _library(self):
-        return _trailing_martingale_multicoin_shader_library(
+        loader, args = self._library_cache_call()
+        return loader(*args)
+
+    def _library_cache_call(self):
+        return _trailing_martingale_multicoin_shader_library, (
             self.hsl_ema_tail_enabled,
             self.hsl_raw_drawdown_enabled,
             self.hsl_raw_tail_enabled,
@@ -2416,21 +2426,25 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
             self.hsl_raw_tail_enabled = False
 
     def _shader_library(self):
+        loader, args = self._shader_library_cache_call()
+        return loader(*args)
+
+    def _shader_library_cache_call(self):
         if self.shader_topology == "long_no_hsl":
-            return _trailing_martingale_long_no_hsl_shader_library(
+            return _trailing_martingale_long_no_hsl_shader_library, (
                 self.recovery_distribution_enabled,
                 self.btc_risk_enabled,
                 self.equity_balance_diff_enabled,
                 self.entry_interval_enabled,
             )
         if self.shader_topology == "short_no_hsl":
-            return _trailing_martingale_short_no_hsl_shader_library(
+            return _trailing_martingale_short_no_hsl_shader_library, (
                 self.recovery_distribution_enabled,
                 self.btc_risk_enabled,
                 self.equity_balance_diff_enabled,
                 self.entry_interval_enabled,
             )
-        return _trailing_martingale_shader_library(
+        return _trailing_martingale_shader_library, (
             self.hsl_ema_tail_enabled,
             self.hsl_raw_drawdown_enabled,
             self.hsl_raw_tail_enabled,
@@ -2518,8 +2532,8 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
                 device="mps",
             )
         prepared = time.perf_counter() if profile else 0.0
-        cold = self._profile_dispatches == 0
-        library = self._shader_library()
+        loader, library_args = self._shader_library_cache_call()
+        library, cold = _cached_library_with_miss(loader, *library_args)
         compiled = time.perf_counter() if profile else 0.0
         if profile:
             torch.mps.synchronize()
@@ -2570,7 +2584,6 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
             }
         else:
             self.last_profile = {}
-        self._profile_dispatches += 1
         output = _decode_directional_outputs(daily, scalars, gaps)
         output.update(_decode_equity_balance_diff_outputs(equity_balance_diff))
         output.update(

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -180,7 +180,9 @@ def _new_gpu_proxy_profile(proxy, candidates, runners, *, coin_count, side_count
         "dispatch_count": 0,
         "cold_dispatch_count": 0,
         "warm_dispatch_count": 0,
-        "candidate_bars": len(candidates) * candle_count,
+        "candidate_bars": (
+            len(candidates) * candle_count * int(coin_count) * int(side_count)
+        ),
         "kernel_candidate_bars": 0,
         "candle_count": candle_count,
         "coin_count": int(coin_count),
@@ -190,7 +192,7 @@ def _new_gpu_proxy_profile(proxy, candidates, runners, *, coin_count, side_count
     }
 
 
-def _add_gpu_runner_profile(profile: dict, runner) -> None:
+def _add_gpu_runner_profile(profile: dict, runner, *, side_count: int = 1) -> None:
     runner_profile = getattr(runner, "last_profile", {}) or {}
     if not runner_profile:
         return
@@ -202,7 +204,11 @@ def _add_gpu_runner_profile(profile: dict, runner) -> None:
     profile["cold_dispatch_count"] += dispatch_count if cold else 0
     profile["warm_dispatch_count"] += 0 if cold else dispatch_count
     profile["kernel_candidate_bars"] += (
-        batch_size * int(getattr(runner, "n", 0)) * dispatch_count
+        batch_size
+        * int(getattr(runner, "n", 0))
+        * int(getattr(runner, "n_coins", 1))
+        * int(side_count)
+        * dispatch_count
     )
     timings = profile["timings_seconds"]
     timings["candidate_packing"] += float(
@@ -1892,7 +1898,11 @@ class MpsSingleCoinProxy:
                 profile=self.profile_enabled,
             )
             if profile is not None:
-                _add_gpu_runner_profile(profile, self.runner)
+                _add_gpu_runner_profile(
+                    profile,
+                    self.runner,
+                    side_count=profile["side_count"],
+                )
             interrupt_check()
             stage_started = (
                 time.perf_counter() if self.profile_enabled else 0.0
@@ -2987,7 +2997,11 @@ class MpsMulticoinProxy:
                     profile=self.profile_enabled,
                 )
                 if profile is not None:
-                    _add_gpu_runner_profile(profile, fused_runner)
+                    _add_gpu_runner_profile(
+                        profile,
+                        fused_runner,
+                        side_count=len(self.sides),
+                    )
                 interrupt_check()
                 stage_started = (
                     time.perf_counter() if self.profile_enabled else 0.0

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -124,6 +124,15 @@ _GPU_PROFILE_TIMING_KEYS = (
     "host_overhead",
 )
 
+_GPU_PROFILE_RUNNER_TIMING_KEYS = (
+    "candidate_packing",
+    "upload_and_buffer_clear",
+    "cold_compilation",
+    "warm_library_lookup",
+    "kernel_execution",
+    "metric_reduction",
+)
+
 
 def _gpu_profile_features(proxy, runners) -> dict[str, bool]:
     runners = tuple(runners)
@@ -192,7 +201,39 @@ def _new_gpu_proxy_profile(proxy, candidates, runners, *, coin_count, side_count
     }
 
 
-def _add_gpu_runner_profile(profile: dict, runner, *, side_count: int = 1) -> None:
+def _gpu_profile_runner_seconds(timings: dict) -> float:
+    return sum(
+        float(timings.get(key, 0.0))
+        for key in _GPU_PROFILE_RUNNER_TIMING_KEYS
+    )
+
+
+def _gpu_profile_unattributed_seconds(
+    timings: dict,
+    elapsed_seconds: float,
+    *,
+    device_to_host_before: float,
+    runner_seconds_before: float,
+) -> float:
+    extra_device_to_host = (
+        float(timings["device_to_host"]) - float(device_to_host_before)
+    )
+    extra_runner_seconds = (
+        _gpu_profile_runner_seconds(timings) - float(runner_seconds_before)
+    )
+    return max(
+        0.0,
+        float(elapsed_seconds) - extra_device_to_host - extra_runner_seconds,
+    )
+
+
+def _add_gpu_runner_profile(
+    profile: dict,
+    runner,
+    *,
+    side_count: int = 1,
+    effective_candidate_steps=None,
+) -> None:
     runner_profile = getattr(runner, "last_profile", {}) or {}
     if not runner_profile:
         return
@@ -203,9 +244,22 @@ def _add_gpu_runner_profile(profile: dict, runner, *, side_count: int = 1) -> No
     profile["dispatch_count"] += dispatch_count
     profile["cold_dispatch_count"] += dispatch_count if cold else 0
     profile["warm_dispatch_count"] += 0 if cold else dispatch_count
+    runner_steps = int(getattr(runner, "n", 0))
+    if effective_candidate_steps is None:
+        candidate_steps = batch_size * runner_steps
+    else:
+        candidate_steps_array = np.asarray(
+            effective_candidate_steps, dtype=np.int64
+        ).reshape(-1)
+        if len(candidate_steps_array) != batch_size:
+            raise RuntimeError(
+                "profiled effective candidate steps do not match the dispatch batch"
+            )
+        candidate_steps = int(
+            np.clip(candidate_steps_array, 0, runner_steps).sum()
+        )
     profile["kernel_candidate_bars"] += (
-        batch_size
-        * int(getattr(runner, "n", 0))
+        candidate_steps
         * int(getattr(runner, "n_coins", 1))
         * int(side_count)
         * dispatch_count
@@ -586,7 +640,7 @@ def _mps_strategy_eq_recovery_distribution(output: dict, needed_metrics):
     return strategy_eq_recovery_distribution_from_samples(
         output["strategy_eq_recovery_samples"],
         sample_interval_days=output["strategy_eq_recovery_sample_interval_days"],
-    ).cpu()
+    )
 
 
 def _directional_coin_hsl_lookback_bars(
@@ -1288,7 +1342,9 @@ def _refresh_hedged_multicoin_hsl_at_portfolio_cutoff(
             parameter_matrices[side][indices], **run_kwargs
         )
         if runner_profile_callback is not None:
-            runner_profile_callback(runners[side])
+            runner_profile_callback(
+                runners[side], effective_candidate_steps=end_steps
+            )
         interrupt_check()
         transfer_started = time.perf_counter() if profile else 0.0
         for key in DIRECTIONAL_HSL_OUTPUT_KEYS:
@@ -3074,6 +3130,11 @@ class MpsMulticoinProxy:
                 if profile is not None
                 else 0.0
             )
+            stage_runner_seconds_before = (
+                _gpu_profile_runner_seconds(profile["timings_seconds"])
+                if profile is not None
+                else 0.0
+            )
             if fused_runner is None and len(self.sides) == 1:
                 side = self.sides[0]
                 output = side_outputs[side]
@@ -3109,7 +3170,9 @@ class MpsMulticoinProxy:
                     interrupt_check=interrupt_check,
                     profile=self.profile_enabled,
                     runner_profile_callback=(
-                        lambda runner: _add_gpu_runner_profile(profile, runner)
+                        lambda runner, **kwargs: _add_gpu_runner_profile(
+                            profile, runner, **kwargs
+                        )
                         if profile is not None
                         else None
                     ),
@@ -3166,16 +3229,12 @@ class MpsMulticoinProxy:
                 output, self.run, self.metrics_data, needed=self.needed_metrics
             )
             if profile is not None:
-                extra_device_to_host = (
-                    profile["timings_seconds"]["device_to_host"]
-                    - stage_device_to_host_before
-                )
                 profile["timings_seconds"]["metric_reduction"] += (
-                    max(
-                        0.0,
-                        time.perf_counter()
-                        - stage_started
-                        - extra_device_to_host,
+                    _gpu_profile_unattributed_seconds(
+                        profile["timings_seconds"],
+                        time.perf_counter() - stage_started,
+                        device_to_host_before=stage_device_to_host_before,
+                        runner_seconds_before=stage_runner_seconds_before,
                     )
                 )
                 stage_started = time.perf_counter()

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -5,6 +5,7 @@ from dataclasses import replace
 import hashlib
 import logging
 import os
+import time
 
 import numpy as np
 
@@ -108,6 +109,131 @@ CORE_OUTPUT_KEYS = {
     "total_wallet_exposure_max",
     "total_wallet_exposure_mean",
 }
+
+
+_GPU_PROFILE_TIMING_KEYS = (
+    "candidate_materialization",
+    "candidate_packing",
+    "upload_and_buffer_clear",
+    "cold_compilation",
+    "warm_library_lookup",
+    "kernel_execution",
+    "device_to_host",
+    "metric_reduction",
+    "result_materialization",
+    "host_overhead",
+)
+
+
+def _gpu_profile_features(proxy, runners) -> dict[str, bool]:
+    runners = tuple(runners)
+    return {
+        "btc_analysis": bool(getattr(proxy, "btc_analysis_enabled", False)),
+        "btc_intraday_risk": bool(getattr(proxy, "btc_risk_enabled", False)),
+        "equity_balance_diff": bool(
+            getattr(proxy, "equity_balance_diff_enabled", False)
+        ),
+        "entry_interval": bool(getattr(proxy, "entry_interval_enabled", False)),
+        "strategy_eq_recovery_distribution": any(
+            bool(getattr(runner, "recovery_distribution_enabled", False))
+            for runner in runners
+        ),
+        "hsl_ema_tail": any(
+            bool(getattr(runner, "hsl_ema_tail_enabled", False))
+            for runner in runners
+        ),
+        "hsl_raw_drawdown": any(
+            bool(getattr(runner, "hsl_raw_drawdown_enabled", False))
+            for runner in runners
+        ),
+        "hsl_raw_tail": any(
+            bool(getattr(runner, "hsl_raw_tail_enabled", False))
+            for runner in runners
+        ),
+        "coin_fill_counts": any(
+            bool(getattr(runner, "collect_coin_fill_counts", False))
+            for runner in runners
+        ),
+    }
+
+
+def _new_gpu_proxy_profile(proxy, candidates, runners, *, coin_count, side_count):
+    candle_count = max(
+        (int(getattr(runner, "n", 0)) for runner in runners), default=0
+    )
+    dispatch_batch_size = int(
+        getattr(proxy, "dispatch_batch_size", getattr(proxy, "batch_size", 0))
+    )
+    return {
+        "schema_version": 1,
+        "scope": "proxy_evaluation",
+        "strategy": str(getattr(proxy, "strategy_kind", "unknown")),
+        "candidate_count": len(candidates),
+        "configured_batch_size": int(getattr(proxy, "batch_size", 0)),
+        "dispatch_batch_size": dispatch_batch_size,
+        "dispatch_chunk_count": (
+            (len(candidates) + dispatch_batch_size - 1) // dispatch_batch_size
+            if dispatch_batch_size > 0
+            else 0
+        ),
+        "actual_dispatch_batch_sizes": [],
+        "dispatch_count": 0,
+        "cold_dispatch_count": 0,
+        "warm_dispatch_count": 0,
+        "candidate_bars": len(candidates) * candle_count,
+        "kernel_candidate_bars": 0,
+        "candle_count": candle_count,
+        "coin_count": int(coin_count),
+        "side_count": int(side_count),
+        "requested_metric_features": _gpu_profile_features(proxy, runners),
+        "timings_seconds": {key: 0.0 for key in _GPU_PROFILE_TIMING_KEYS},
+    }
+
+
+def _add_gpu_runner_profile(profile: dict, runner) -> None:
+    runner_profile = getattr(runner, "last_profile", {}) or {}
+    if not runner_profile:
+        return
+    batch_size = int(runner_profile.get("batch_size", 0))
+    dispatch_count = int(runner_profile.get("dispatch_count", 1))
+    cold = bool(runner_profile.get("cold", False))
+    profile["actual_dispatch_batch_sizes"].append(batch_size)
+    profile["dispatch_count"] += dispatch_count
+    profile["cold_dispatch_count"] += dispatch_count if cold else 0
+    profile["warm_dispatch_count"] += 0 if cold else dispatch_count
+    profile["kernel_candidate_bars"] += (
+        batch_size * int(getattr(runner, "n", 0)) * dispatch_count
+    )
+    timings = profile["timings_seconds"]
+    timings["candidate_packing"] += float(
+        runner_profile.get("cpu_pack_seconds", 0.0)
+    )
+    timings["upload_and_buffer_clear"] += float(
+        runner_profile.get("upload_and_zero_seconds", 0.0)
+    ) + float(runner_profile.get("pre_dispatch_sync_seconds", 0.0))
+    compile_seconds = float(runner_profile.get("compile_seconds", 0.0))
+    timings["cold_compilation" if cold else "warm_library_lookup"] += (
+        compile_seconds
+    )
+    timings["kernel_execution"] += float(
+        runner_profile.get("kernel_seconds", 0.0)
+    )
+    timings["metric_reduction"] += float(
+        runner_profile.get("metric_decode_seconds", 0.0)
+    )
+
+
+def _finish_gpu_proxy_profile(profile: dict, started: float) -> dict:
+    profile["actual_dispatch_batch_sizes"] = list(
+        profile["actual_dispatch_batch_sizes"]
+    )
+    profile["wall_seconds"] = time.perf_counter() - started
+    accounted = sum(profile["timings_seconds"].values())
+    profile["timings_seconds"]["host_overhead"] = max(
+        0.0,
+        profile["wall_seconds"] - accounted,
+    )
+    return profile
 
 DIRECTIONAL_HSL_OUTPUT_KEYS = {
     "hsl_long_enabled",
@@ -1124,6 +1250,9 @@ def _refresh_hedged_multicoin_hsl_at_portfolio_cutoff(
     combined_output: dict,
     start_minute_of_day: int,
     interrupt_check=None,
+    profile: bool = False,
+    runner_profile_callback=None,
+    profile_timings: dict | None = None,
 ) -> bool:
     """Replace full-run directional HSL summaries at a portfolio cutoff.
 
@@ -1146,12 +1275,22 @@ def _refresh_hedged_multicoin_hsl_at_portfolio_cutoff(
     interrupt_check = interrupt_check or (lambda: None)
     for side in ("long", "short"):
         interrupt_check()
+        run_kwargs = {"end_steps": end_steps}
+        if profile:
+            run_kwargs["profile"] = True
         truncated = runners[side].run(
-            parameter_matrices[side][indices], end_steps=end_steps
+            parameter_matrices[side][indices], **run_kwargs
         )
+        if runner_profile_callback is not None:
+            runner_profile_callback(runners[side])
         interrupt_check()
+        transfer_started = time.perf_counter() if profile else 0.0
         for key in DIRECTIONAL_HSL_OUTPUT_KEYS:
             side_outputs[side][key][cutoff_mask] = truncated[key].cpu()
+        if profile_timings is not None:
+            profile_timings["device_to_host"] += (
+                time.perf_counter() - transfer_started
+            )
     return True
 
 
@@ -1379,6 +1518,7 @@ class MpsSingleCoinProxy:
             "yes",
             "y",
         }
+        self.last_profile: dict = {}
         self.strategy_kind = str(
             config.get("live", {}).get("strategy_kind", "")
         ).strip().lower()
@@ -1718,6 +1858,20 @@ class MpsSingleCoinProxy:
     def evaluate(self, candidates: list[dict]) -> list[dict]:
         results: list[dict] = []
         torch = self._torch
+        profile_started = time.perf_counter() if self.profile_enabled else 0.0
+        profile = (
+            _new_gpu_proxy_profile(
+                self,
+                candidates,
+                (self.runner,),
+                coin_count=1,
+                side_count=int(bool(getattr(self.runner, "long_enabled", True)))
+                + int(bool(getattr(self.runner, "short_enabled", False))),
+            )
+            if self.profile_enabled
+            else None
+        )
+        self.last_profile = {}
         dispatch_batch_size = getattr(
             self, "dispatch_batch_size", self.batch_size
         )
@@ -1725,22 +1879,47 @@ class MpsSingleCoinProxy:
         for start in range(0, len(candidates), dispatch_batch_size):
             interrupt_check()
             chunk = candidates[start : start + dispatch_batch_size]
+            stage_started = (
+                time.perf_counter() if self.profile_enabled else 0.0
+            )
             parameter_matrix = self._parameter_matrix(chunk)
+            if profile is not None:
+                profile["timings_seconds"]["candidate_materialization"] += (
+                    time.perf_counter() - stage_started
+                )
             output = self.runner.run(
                 parameter_matrix,
                 profile=self.profile_enabled,
             )
+            if profile is not None:
+                _add_gpu_runner_profile(profile, self.runner)
             interrupt_check()
+            stage_started = (
+                time.perf_counter() if self.profile_enabled else 0.0
+            )
             recovery_distribution = _mps_strategy_eq_recovery_distribution(
                 output, self.needed_metrics
             )
+            if profile is not None:
+                torch.mps.synchronize()
+                profile["timings_seconds"]["metric_reduction"] += (
+                    time.perf_counter() - stage_started
+                )
+                stage_started = time.perf_counter()
             output = {
                 key: value.cpu()
                 for key, value in output.items()
                 if key in CORE_OUTPUT_KEYS | DIRECTIONAL_HSL_OUTPUT_KEYS
             }
             if recovery_distribution is not None:
-                output["strategy_eq_recovery_distribution"] = recovery_distribution
+                output["strategy_eq_recovery_distribution"] = (
+                    recovery_distribution.cpu()
+                )
+            if profile is not None:
+                profile["timings_seconds"]["device_to_host"] += (
+                    time.perf_counter() - stage_started
+                )
+                stage_started = time.perf_counter()
             timestamp_origin = float(self.metrics_data["ts0"])
             for key in (
                 "first_fill_ts",
@@ -1776,12 +1955,25 @@ class MpsSingleCoinProxy:
                 self.metrics_data,
                 needed=self.needed_metrics,
             )
+            if profile is not None:
+                profile["timings_seconds"]["metric_reduction"] += (
+                    time.perf_counter() - stage_started
+                )
+                stage_started = time.perf_counter()
             arrays = {
                 name: value.detach().cpu().numpy() for name, value in objectives.items()
             }
             results.extend(
                 {name: float(values[index]) for name, values in arrays.items()}
                 for index in range(len(chunk))
+            )
+            if profile is not None:
+                profile["timings_seconds"]["result_materialization"] += (
+                    time.perf_counter() - stage_started
+                )
+        if profile is not None:
+            self.last_profile = _finish_gpu_proxy_profile(
+                profile, profile_started
             )
         return results
 
@@ -2223,6 +2415,7 @@ class MpsMulticoinProxy:
         self.profile_enabled = os.environ.get(
             "PASSIVBOT_GPU_PROFILE", ""
         ).strip().lower() in {"1", "true", "yes", "y"}
+        self.last_profile: dict = {}
 
         values = np.asarray(hlcvs)
         if values.ndim != 3:
@@ -2743,6 +2936,30 @@ class MpsMulticoinProxy:
         results: list[dict] = []
         torch = self._torch
         fused_runner = getattr(self, "fused_runner", None)
+        profile_runners = (
+            (fused_runner,)
+            if fused_runner is not None
+            else tuple(self.runners[side] for side in self.sides)
+        )
+        profile_started = time.perf_counter() if self.profile_enabled else 0.0
+        profile = (
+            _new_gpu_proxy_profile(
+                self,
+                candidates,
+                profile_runners,
+                coin_count=max(
+                    (
+                        int(getattr(runner, "n_coins", 1))
+                        for runner in profile_runners
+                    ),
+                    default=1,
+                ),
+                side_count=len(self.sides),
+            )
+            if self.profile_enabled
+            else None
+        )
+        self.last_profile = {}
         dispatch_batch_size = getattr(
             self, "dispatch_batch_size", self.batch_size
         )
@@ -2750,9 +2967,16 @@ class MpsMulticoinProxy:
         for start in range(0, len(candidates), dispatch_batch_size):
             interrupt_check()
             chunk = candidates[start : start + dispatch_batch_size]
+            stage_started = (
+                time.perf_counter() if self.profile_enabled else 0.0
+            )
             parameter_matrices = {
                 side: self._parameter_matrix(chunk, side) for side in self.sides
             }
+            if profile is not None:
+                profile["timings_seconds"]["candidate_materialization"] += (
+                    time.perf_counter() - stage_started
+                )
             if fused_runner is not None:
                 fused_parameters = np.concatenate(
                     (parameter_matrices["long"], parameter_matrices["short"]),
@@ -2762,15 +2986,32 @@ class MpsMulticoinProxy:
                     fused_parameters,
                     profile=self.profile_enabled,
                 )
+                if profile is not None:
+                    _add_gpu_runner_profile(profile, fused_runner)
                 interrupt_check()
+                stage_started = (
+                    time.perf_counter() if self.profile_enabled else 0.0
+                )
                 recovery_distribution = _mps_strategy_eq_recovery_distribution(
                     raw_output, self.needed_metrics
                 )
+                if profile is not None:
+                    torch.mps.synchronize()
+                    profile["timings_seconds"]["metric_reduction"] += (
+                        time.perf_counter() - stage_started
+                    )
+                    stage_started = time.perf_counter()
                 output = {
                     key: value.cpu()
                     for key, value in raw_output.items()
                     if key in CORE_OUTPUT_KEYS | DIRECTIONAL_HSL_OUTPUT_KEYS
                 }
+                if recovery_distribution is not None:
+                    recovery_distribution = recovery_distribution.cpu()
+                if profile is not None:
+                    profile["timings_seconds"]["device_to_host"] += (
+                        time.perf_counter() - stage_started
+                    )
             else:
                 raw_side_outputs = {}
                 for side in self.sides:
@@ -2778,7 +3019,12 @@ class MpsMulticoinProxy:
                         parameter_matrices[side],
                         profile=self.profile_enabled,
                     )
+                    if profile is not None:
+                        _add_gpu_runner_profile(profile, self.runners[side])
                     interrupt_check()
+                stage_started = (
+                    time.perf_counter() if self.profile_enabled else 0.0
+                )
                 recovery_distribution = (
                     _mps_strategy_eq_recovery_distribution(
                         raw_side_outputs[self.sides[0]], self.needed_metrics
@@ -2786,6 +3032,12 @@ class MpsMulticoinProxy:
                     if len(self.sides) == 1
                     else None
                 )
+                if profile is not None:
+                    torch.mps.synchronize()
+                    profile["timings_seconds"]["metric_reduction"] += (
+                        time.perf_counter() - stage_started
+                    )
+                    stage_started = time.perf_counter()
                 side_outputs = {
                     side: {
                         key: value.cpu()
@@ -2794,6 +3046,20 @@ class MpsMulticoinProxy:
                     }
                     for side in self.sides
                 }
+                if recovery_distribution is not None:
+                    recovery_distribution = recovery_distribution.cpu()
+                if profile is not None:
+                    profile["timings_seconds"]["device_to_host"] += (
+                        time.perf_counter() - stage_started
+                    )
+            stage_started = (
+                time.perf_counter() if self.profile_enabled else 0.0
+            )
+            stage_device_to_host_before = (
+                profile["timings_seconds"]["device_to_host"]
+                if profile is not None
+                else 0.0
+            )
             if fused_runner is None and len(self.sides) == 1:
                 side = self.sides[0]
                 output = side_outputs[side]
@@ -2827,6 +3093,15 @@ class MpsMulticoinProxy:
                         "long"
                     ].start_minute_of_day,
                     interrupt_check=interrupt_check,
+                    profile=self.profile_enabled,
+                    runner_profile_callback=(
+                        lambda runner: _add_gpu_runner_profile(profile, runner)
+                        if profile is not None
+                        else None
+                    ),
+                    profile_timings=(
+                        profile["timings_seconds"] if profile is not None else None
+                    ),
                 ):
                     output = _combine_hedged_multicoin_outputs(
                         side_outputs["long"],
@@ -2876,6 +3151,20 @@ class MpsMulticoinProxy:
             objectives = self._compute_objectives(
                 output, self.run, self.metrics_data, needed=self.needed_metrics
             )
+            if profile is not None:
+                extra_device_to_host = (
+                    profile["timings_seconds"]["device_to_host"]
+                    - stage_device_to_host_before
+                )
+                profile["timings_seconds"]["metric_reduction"] += (
+                    max(
+                        0.0,
+                        time.perf_counter()
+                        - stage_started
+                        - extra_device_to_host,
+                    )
+                )
+                stage_started = time.perf_counter()
             arrays = {
                 name: value.detach().cpu().numpy()
                 for name, value in objectives.items()
@@ -2883,6 +3172,14 @@ class MpsMulticoinProxy:
             results.extend(
                 {name: float(values[index]) for name, values in arrays.items()}
                 for index in range(len(chunk))
+            )
+            if profile is not None:
+                profile["timings_seconds"]["result_materialization"] += (
+                    time.perf_counter() - stage_started
+                )
+        if profile is not None:
+            self.last_profile = _finish_gpu_proxy_profile(
+                profile, profile_started
             )
         return results
 

--- a/src/passivbot_cli/main.py
+++ b/src/passivbot_cli/main.py
@@ -147,7 +147,6 @@ TOOL_COMMANDS: dict[str, CommandSpec] = {
     "gpu-proxy-benchmark": CommandSpec(
         "tools.gpu_proxy_benchmark",
         "benchmark deterministic Apple MPS proxy workloads",
-        requires_full=True,
     ),
     "live-smoke-report": CommandSpec(
         "tools.live_smoke_report",

--- a/src/passivbot_cli/main.py
+++ b/src/passivbot_cli/main.py
@@ -144,6 +144,11 @@ TOOL_COMMANDS: dict[str, CommandSpec] = {
         "tools.hsl_replay_benchmark",
         "benchmark the offline coin-HSL replay hot path",
     ),
+    "gpu-proxy-benchmark": CommandSpec(
+        "tools.gpu_proxy_benchmark",
+        "benchmark deterministic Apple MPS proxy workloads",
+        requires_full=True,
+    ),
     "live-smoke-report": CommandSpec(
         "tools.live_smoke_report",
         "summarize local live monitor events and text logs",

--- a/src/tools/gpu_proxy_benchmark.py
+++ b/src/tools/gpu_proxy_benchmark.py
@@ -24,7 +24,7 @@ from optimization.gpu.model import (
 CASES = (
     "ema-single-long",
     "tm-single-long",
-    "ema-multicoin-short",
+    "ema-multicoin-overhead",
     "ema-multicoin-overrides",
 )
 DEFAULT_SEED = 7
@@ -193,6 +193,15 @@ def _build_case(
         MpsEmaAnchorRunner,
         MpsTrailingMartingaleRunner,
     )
+    from optimization.gpu.metrics import compute_objectives
+    from optimization.gpu.service import MpsMulticoinProxy, MpsSingleCoinProxy
+
+    needed_metrics = {
+        "adg_strategy_eq",
+        "drawdown_worst_strategy_eq",
+        "fills_per_day",
+    }
+    base_values = _base_parameter_values()
 
     if name in {"ema-single-long", "tm-single-long"}:
         hlcvs, timestamps = _synthetic_hlcvs(single_bars, 1, seed)
@@ -226,14 +235,51 @@ def _build_case(
                 candidates,
                 seed,
             )
-        matrix = np.concatenate((side_matrix, side_matrix), axis=1)
+        proxy = MpsSingleCoinProxy.__new__(MpsSingleCoinProxy)
+        proxy.batch_size = candidates
+        proxy.dispatch_batch_size = candidates
+        proxy.interrupt_check = lambda: None
+        proxy._torch = __import__("torch")
+        proxy.profile_enabled = True
+        proxy.last_profile = {}
+        proxy.metrics_data = data
+        proxy.run = run
+        proxy.needed_metrics = needed_metrics
+        proxy.strategy_kind = (
+            "ema_anchor" if name == "ema-single-long" else "trailing_martingale"
+        )
+        proxy.entry_interval_enabled = False
+        proxy.btc_analysis_enabled = False
+        proxy.btc_risk_enabled = False
+        proxy.equity_balance_diff_enabled = False
+        proxy.param_keys = (
+            EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS
+            if name == "ema-single-long"
+            else TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS
+        )
+        proxy.base_params = {
+            side: {key: base_values[key] for key in proxy.param_keys}
+            for side in ("long", "short")
+        }
+        proxy.static_coin_override_params = {}
+        proxy.base_total_wallet_exposure_limits = {"long": 1.0, "short": 0.0}
+        proxy.base_n_positions = {"long": 1.0, "short": 0.0}
+        proxy.runner = runner
+        proxy._compute_objectives = compute_objectives
+        candidate_dicts = [
+            {
+                f"long_{key}": float(row[index])
+                for index, key in enumerate(proxy.param_keys)
+            }
+            for row in side_matrix
+        ]
         return (
-            runner,
-            matrix,
+            proxy,
+            candidate_dicts,
             single_bars,
             1,
             1,
-            _fixture_sha256(hlcvs, timestamps, matrix),
+            _fixture_sha256(hlcvs, timestamps, side_matrix),
         )
 
     hlcvs, timestamps = _synthetic_hlcvs(multicoin_bars, coins, seed)
@@ -266,9 +312,36 @@ def _build_case(
         coin_overrides=overrides,
     )
     matrix = _parameter_matrix(EMA_ANCHOR_MULTICOIN_PARAM_KEYS, candidates, seed)
+    proxy = MpsMulticoinProxy.__new__(MpsMulticoinProxy)
+    proxy.batch_size = candidates
+    proxy.dispatch_batch_size = candidates
+    proxy.interrupt_check = lambda: None
+    proxy._torch = __import__("torch")
+    proxy.profile_enabled = True
+    proxy.last_profile = {}
+    proxy.metrics_data = data
+    proxy.run = runs[0]
+    proxy.sides = ["long"]
+    proxy.needed_metrics = needed_metrics
+    proxy.strategy_kind = "ema_anchor"
+    proxy.entry_interval_enabled = False
+    proxy.btc_analysis_enabled = False
+    proxy.btc_risk_enabled = False
+    proxy.equity_balance_diff_enabled = False
+    proxy.param_keys = EMA_ANCHOR_MULTICOIN_PARAM_KEYS
+    proxy.base_params = {"long": {key: base_values[key] for key in proxy.param_keys}}
+    proxy.base_total_wallet_exposure_limits = {"long": 1.0, "short": 0.0}
+    proxy.base_n_positions = {"long": 4.0, "short": 0.0}
+    proxy.fused_runner = None
+    proxy.runners = {"long": runner}
+    proxy._compute_objectives = compute_objectives
+    candidate_dicts = [
+        {f"long_{key}": float(row[index]) for index, key in enumerate(proxy.param_keys)}
+        for row in matrix
+    ]
     return (
-        runner,
-        matrix,
+        proxy,
+        candidate_dicts,
         multicoin_bars,
         coins,
         1,
@@ -281,33 +354,54 @@ def _build_case(
     )
 
 
-def _run_once(runner, matrix) -> dict:
-    import torch
-
+def _run_once(proxy, candidates) -> dict:
     started = time.perf_counter()
-    output = runner.run(matrix, profile=True)
-    transfer_started = time.perf_counter()
-    for key in ("balance", "max_dd", "fill_count"):
-        value = output.get(key)
-        if value is not None:
-            value.detach().cpu()
-    device_to_host_seconds = time.perf_counter() - transfer_started
+    proxy.evaluate(candidates)
     wall_seconds = time.perf_counter() - started
-    profile = dict(runner.last_profile)
-    timed = sum(
-        float(value) for key, value in profile.items() if key.endswith("_seconds")
-    )
-    profile.update(
-        {
-            "device_to_host_seconds": device_to_host_seconds,
-            "host_overhead_seconds": max(
-                0.0, wall_seconds - timed - device_to_host_seconds
-            ),
-            "wall_seconds": wall_seconds,
-            "candidates_per_second": len(matrix) / max(wall_seconds, 1.0e-12),
-        }
-    )
-    return profile
+    profile = dict(getattr(proxy, "last_profile", {}) or {})
+    if profile:
+        timings = profile["timings_seconds"]
+        compile_seconds = float(timings["cold_compilation"]) + float(
+            timings["warm_library_lookup"]
+        )
+        kernel_seconds = float(timings["kernel_execution"])
+        device_to_host_seconds = float(timings["device_to_host"])
+        host_overhead_seconds = float(timings["host_overhead"])
+        cold = bool(profile["cold_dispatch_count"])
+        batch_size = max(profile["actual_dispatch_batch_sizes"], default=0)
+        dispatch_count = int(profile["dispatch_count"])
+    else:
+        runners = tuple(getattr(proxy, "runners", {}).values()) or (proxy.runner,)
+        runner_profiles = [dict(runner.last_profile) for runner in runners]
+        compile_seconds = sum(
+            float(item.get("compile_seconds", 0.0)) for item in runner_profiles
+        )
+        kernel_seconds = sum(
+            float(item.get("kernel_seconds", 0.0)) for item in runner_profiles
+        )
+        device_to_host_seconds = 0.0
+        timed = sum(
+            float(value)
+            for item in runner_profiles
+            for key, value in item.items()
+            if key.endswith("_seconds")
+        )
+        host_overhead_seconds = max(0.0, wall_seconds - timed)
+        cold = False
+        batch_size = len(candidates)
+        dispatch_count = len(runner_profiles)
+    return {
+        "batch_size": batch_size,
+        "candidates_per_second": len(candidates) / max(wall_seconds, 1.0e-12),
+        "cold": cold,
+        "compile_seconds": compile_seconds,
+        "device_to_host_seconds": device_to_host_seconds,
+        "dispatch_count": dispatch_count,
+        "host_overhead_seconds": host_overhead_seconds,
+        "kernel_seconds": kernel_seconds,
+        "proxy_profile": profile,
+        "wall_seconds": wall_seconds,
+    }
 
 
 def run_benchmark_case(
@@ -320,7 +414,7 @@ def run_benchmark_case(
     coins: int,
     seed: int,
 ) -> dict:
-    runner, matrix, bars, coin_count, side_count, fixture_sha256 = _build_case(
+    proxy, candidate_dicts, bars, coin_count, side_count, fixture_sha256 = _build_case(
         name,
         candidates=candidates,
         single_bars=single_bars,
@@ -328,8 +422,8 @@ def run_benchmark_case(
         coins=coins,
         seed=seed,
     )
-    cold = _run_once(runner, matrix)
-    warm = [_run_once(runner, matrix) for _ in range(warm_runs)]
+    cold = _run_once(proxy, candidate_dicts)
+    warm = [_run_once(proxy, candidate_dicts) for _ in range(warm_runs)]
 
     def median(key):
         return statistics.median(float(item[key]) for item in warm)
@@ -342,9 +436,9 @@ def run_benchmark_case(
         "candle_count": bars,
         "coin_count": coin_count,
         "side_count": side_count,
-        "candidate_bars": candidates * bars,
-        "kernel_candidate_bars": candidates * bars,
-        "actual_dispatch_batch_size": int(cold.get("batch_size", len(matrix))),
+        "candidate_bars": candidates * bars * coin_count * side_count,
+        "kernel_candidate_bars": candidates * bars * coin_count * side_count,
+        "actual_dispatch_batch_size": int(cold["batch_size"]),
         "dispatch_chunk_count": 1,
         "dispatch_count_per_run": 1,
         "cold": cold,

--- a/src/tools/gpu_proxy_benchmark.py
+++ b/src/tools/gpu_proxy_benchmark.py
@@ -20,12 +20,6 @@ from optimization.gpu.model import (
     build_mps_data,
     build_mps_multicoin_data,
 )
-from optimization.gpu.mps_kernel import (
-    MpsEmaAnchorMulticoinRunner,
-    MpsEmaAnchorRunner,
-    MpsTrailingMartingaleRunner,
-)
-
 
 CASES = (
     "ema-single-long",
@@ -194,6 +188,12 @@ def _build_case(
     coins: int,
     seed: int,
 ):
+    from optimization.gpu.mps_kernel import (
+        MpsEmaAnchorMulticoinRunner,
+        MpsEmaAnchorRunner,
+        MpsTrailingMartingaleRunner,
+    )
+
     if name in {"ema-single-long", "tm-single-long"}:
         hlcvs, timestamps = _synthetic_hlcvs(single_bars, 1, seed)
         market, run = _market_and_run(timestamps, single_bars)

--- a/src/tools/gpu_proxy_benchmark.py
+++ b/src/tools/gpu_proxy_benchmark.py
@@ -1,0 +1,446 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import platform
+import statistics
+import time
+
+import numpy as np
+
+from optimization.gpu.model import (
+    EMA_ANCHOR_COIN_OVERRIDE_COLS,
+    EMA_ANCHOR_COIN_OVERRIDE_WALLET_EXPOSURE_COLUMN,
+    EMA_ANCHOR_MULTICOIN_PARAM_KEYS,
+    EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS,
+    ProxyMarket,
+    ProxyRun,
+    TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS,
+    build_mps_data,
+    build_mps_multicoin_data,
+)
+from optimization.gpu.mps_kernel import (
+    MpsEmaAnchorMulticoinRunner,
+    MpsEmaAnchorRunner,
+    MpsTrailingMartingaleRunner,
+)
+
+
+CASES = (
+    "ema-single-long",
+    "tm-single-long",
+    "ema-multicoin-short",
+    "ema-multicoin-overrides",
+)
+DEFAULT_SEED = 7
+MAX_CANDIDATES = 4096
+MAX_WARM_RUNS = 20
+MAX_SINGLE_BARS = 525_600
+MAX_MULTICOIN_BARS = 100_000
+MAX_COINS = 64
+MAX_DISPATCH_CANDIDATE_BARS = 500_000_000
+
+
+def _base_parameter_values() -> dict[str, float]:
+    return {
+        "base_qty_pct": 0.08,
+        "ema_span_0": 60.0,
+        "ema_span_1": 240.0,
+        "entry_double_down_factor": 1.25,
+        "offset": 0.01,
+        "offset_psize_weight": 0.0,
+        "offset_volatility_1h_weight": 0.0,
+        "offset_volatility_1m_weight": 0.0,
+        "offset_volatility_ema_span_1h": 120.0,
+        "offset_volatility_ema_span_1m": 60.0,
+        "volatility_ema_span_1h": 120.0,
+        "volatility_ema_span_1m": 60.0,
+        "entry_initial_ema_dist": 0.01,
+        "entry_initial_qty_pct": 0.08,
+        "entry_threshold_base_pct": 0.01,
+        "entry_threshold_we_weight": 0.0,
+        "entry_threshold_volatility_1h_weight": 0.0,
+        "entry_threshold_volatility_1m_weight": 0.0,
+        "entry_retracement_base_pct": 0.001,
+        "entry_retracement_we_weight": 0.0,
+        "entry_retracement_volatility_1h_weight": 0.0,
+        "entry_retracement_volatility_1m_weight": 0.0,
+        "close_qty_pct": 0.5,
+        "close_threshold_base_pct": 0.01,
+        "close_threshold_we_weight": 0.0,
+        "close_threshold_volatility_1h_weight": 0.0,
+        "close_threshold_volatility_1m_weight": 0.0,
+        "close_retracement_base_pct": 0.001,
+        "close_retracement_volatility_1h_weight": 0.0,
+        "close_retracement_volatility_1m_weight": 0.0,
+        "entry_cooldown_minutes": 0.0,
+        "total_wallet_exposure_limit": 1.0,
+        "gate_initial": 1.0,
+        "gate_reentry": 1.0,
+        "forager_volume_ema_span_1m": 120.0,
+        "forager_volatility_ema_span_1m": 60.0,
+        "forager_volume_drop_pct": 0.0,
+        "forager_score_weights_volume": 1.0,
+        "forager_score_weights_ema_readiness": 0.0,
+        "forager_score_weights_volatility": 0.0,
+        "n_positions": 4.0,
+        "we_excess_allowance_pct": 0.0,
+        "we_excess_allowance_legacy_raw": 0.0,
+        "twel_entry_gate_enabled": 1.0,
+        "twel_enforcer_threshold": 1.0,
+        "wel_enforcer_enabled": 0.0,
+        "wel_enforcer_threshold": 1.0,
+        "twel_enforcer_enabled": 0.0,
+        "twel_enforcer_reduce_portfolio": 0.0,
+        "unstuck_enabled": 0.0,
+        "unstuck_ema_gating_enabled": 1.0,
+        "unstuck_close_pct": 0.1,
+        "unstuck_ema_dist": 0.0,
+        "unstuck_loss_allowance_pct": 0.1,
+        "unstuck_threshold": 0.5,
+        "hsl_enabled": 0.0,
+        "hsl_red_threshold": 0.2,
+        "hsl_ema_span_minutes": 60.0,
+        "hsl_cooldown_minutes_after_red": 0.0,
+        "hsl_no_restart_drawdown_threshold": 1.0,
+        "hsl_restart_policy": 1.0,
+        "hsl_tier_ratio_yellow": 0.5,
+        "hsl_tier_ratio_orange": 0.75,
+        "hsl_orange_graceful_stop": 0.0,
+        "hsl_signal_mode": 0.0,
+        "hsl_slot_count": 1.0,
+        "wallet_exposure_limit": -1.0,
+    }
+
+
+def _parameter_matrix(keys, candidates: int, seed: int) -> np.ndarray:
+    values = _base_parameter_values()
+    base = np.asarray([values[key] for key in keys], dtype=np.float64)
+    matrix = np.repeat(base[None, :], candidates, axis=0)
+    rng = np.random.default_rng(seed)
+    variable_keys = [
+        key
+        for key in (
+            "base_qty_pct",
+            "ema_span_0",
+            "ema_span_1",
+            "offset",
+            "entry_initial_ema_dist",
+            "entry_initial_qty_pct",
+            "entry_threshold_base_pct",
+            "close_threshold_base_pct",
+        )
+        if key in keys
+    ]
+    for key in variable_keys:
+        column = keys.index(key)
+        matrix[:, column] *= rng.uniform(0.75, 1.25, size=candidates)
+    return np.ascontiguousarray(matrix)
+
+
+def _synthetic_hlcvs(bars: int, coins: int, seed: int):
+    rng = np.random.default_rng(seed)
+    steps = np.arange(bars, dtype=np.float64)
+    values = np.empty((bars, coins, 4), dtype=np.float64)
+    for coin in range(coins):
+        phase = coin * 0.73
+        trend = steps * (0.0004 + coin * 0.00002)
+        wave = np.sin(steps / (37.0 + coin * 3.0) + phase) * (1.5 + coin * 0.1)
+        noise = rng.normal(0.0, 0.03, size=bars).cumsum()
+        close = 100.0 + coin * 15.0 + trend + wave + noise
+        spread = 0.15 + np.abs(np.sin(steps / 19.0 + phase)) * 0.2
+        values[:, coin, 0] = close + spread
+        values[:, coin, 1] = close - spread
+        values[:, coin, 2] = close
+        values[:, coin, 3] = 100.0 + coin * 10.0
+    timestamps = 1_700_000_000_000 + steps.astype(np.int64) * 60_000
+    return values, timestamps
+
+
+def _fixture_sha256(*arrays) -> str:
+    digest = hashlib.sha256()
+    for value in arrays:
+        array = np.ascontiguousarray(value)
+        digest.update(str(array.dtype).encode())
+        digest.update(str(array.shape).encode())
+        digest.update(array.tobytes())
+    return digest.hexdigest()
+
+
+def _market_and_run(timestamps, bars: int):
+    market = ProxyMarket(0.001, 0.01, 0.001, 5.0, 1.0, 0.0002)
+    run = ProxyRun(
+        1_000.0,
+        60,
+        60,
+        int(timestamps[0]),
+        int(timestamps[0]),
+        int(timestamps[0]),
+        60_000,
+        0.05,
+        0,
+        bars - 1,
+    )
+    return market, run
+
+
+def _build_case(
+    name: str,
+    *,
+    candidates: int,
+    single_bars: int,
+    multicoin_bars: int,
+    coins: int,
+    seed: int,
+):
+    if name in {"ema-single-long", "tm-single-long"}:
+        hlcvs, timestamps = _synthetic_hlcvs(single_bars, 1, seed)
+        market, run = _market_and_run(timestamps, single_bars)
+        data = build_mps_data(
+            hlcvs[:, 0, 0],
+            hlcvs[:, 0, 1],
+            hlcvs[:, 0, 2],
+            timestamps,
+            run,
+            market,
+        )
+        if name == "ema-single-long":
+            runner = MpsEmaAnchorRunner(
+                market, run, data, long_enabled=True, short_enabled=False
+            )
+            side_matrix = _parameter_matrix(
+                EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS, candidates, seed
+            )
+        else:
+            runner = MpsTrailingMartingaleRunner(
+                market,
+                run,
+                data,
+                long_enabled=True,
+                short_enabled=False,
+                hsl_enabled=False,
+            )
+            side_matrix = _parameter_matrix(
+                TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS,
+                candidates,
+                seed,
+            )
+        matrix = np.concatenate((side_matrix, side_matrix), axis=1)
+        return (
+            runner,
+            matrix,
+            single_bars,
+            1,
+            1,
+            _fixture_sha256(hlcvs, timestamps, matrix),
+        )
+
+    hlcvs, timestamps = _synthetic_hlcvs(multicoin_bars, coins, seed)
+    markets_and_runs = [
+        _market_and_run(timestamps, multicoin_bars) for _ in range(coins)
+    ]
+    markets = [item[0] for item in markets_and_runs]
+    runs = [item[1] for item in markets_and_runs]
+    data = build_mps_multicoin_data(
+        hlcvs,
+        timestamps,
+        runs,
+        markets,
+        include_hourly_ranges=True,
+    )
+    overrides = None
+    if name == "ema-multicoin-overrides":
+        overrides = np.full(
+            (coins, EMA_ANCHOR_COIN_OVERRIDE_COLS),
+            np.nan,
+            dtype=np.float32,
+        )
+        overrides[0, EMA_ANCHOR_COIN_OVERRIDE_WALLET_EXPOSURE_COLUMN] = 0.5
+        if coins > 1:
+            overrides[1, 0] = 0.04
+    runner = MpsEmaAnchorMulticoinRunner(
+        runs[0],
+        data,
+        side="long",
+        coin_overrides=overrides,
+    )
+    matrix = _parameter_matrix(EMA_ANCHOR_MULTICOIN_PARAM_KEYS, candidates, seed)
+    return (
+        runner,
+        matrix,
+        multicoin_bars,
+        coins,
+        1,
+        _fixture_sha256(
+            hlcvs,
+            timestamps,
+            matrix,
+            overrides if overrides is not None else np.empty((0,), dtype=np.float32),
+        ),
+    )
+
+
+def _run_once(runner, matrix) -> dict:
+    import torch
+
+    started = time.perf_counter()
+    output = runner.run(matrix, profile=True)
+    transfer_started = time.perf_counter()
+    for key in ("balance", "max_dd", "fill_count"):
+        value = output.get(key)
+        if value is not None:
+            value.detach().cpu()
+    device_to_host_seconds = time.perf_counter() - transfer_started
+    wall_seconds = time.perf_counter() - started
+    profile = dict(runner.last_profile)
+    timed = sum(
+        float(value) for key, value in profile.items() if key.endswith("_seconds")
+    )
+    profile.update(
+        {
+            "device_to_host_seconds": device_to_host_seconds,
+            "host_overhead_seconds": max(
+                0.0, wall_seconds - timed - device_to_host_seconds
+            ),
+            "wall_seconds": wall_seconds,
+            "candidates_per_second": len(matrix) / max(wall_seconds, 1.0e-12),
+        }
+    )
+    return profile
+
+
+def run_benchmark_case(
+    name: str,
+    *,
+    candidates: int,
+    warm_runs: int,
+    single_bars: int,
+    multicoin_bars: int,
+    coins: int,
+    seed: int,
+) -> dict:
+    runner, matrix, bars, coin_count, side_count, fixture_sha256 = _build_case(
+        name,
+        candidates=candidates,
+        single_bars=single_bars,
+        multicoin_bars=multicoin_bars,
+        coins=coins,
+        seed=seed,
+    )
+    cold = _run_once(runner, matrix)
+    warm = [_run_once(runner, matrix) for _ in range(warm_runs)]
+
+    def median(key):
+        return statistics.median(float(item[key]) for item in warm)
+
+    return {
+        "case": name,
+        "seed": seed,
+        "fixture_sha256": fixture_sha256,
+        "candidate_count": candidates,
+        "candle_count": bars,
+        "coin_count": coin_count,
+        "side_count": side_count,
+        "candidate_bars": candidates * bars,
+        "kernel_candidate_bars": candidates * bars,
+        "actual_dispatch_batch_size": int(cold.get("batch_size", len(matrix))),
+        "dispatch_chunk_count": 1,
+        "dispatch_count_per_run": 1,
+        "cold": cold,
+        "warm": {
+            "runs": warm_runs,
+            "wall_seconds_p50": median("wall_seconds"),
+            "kernel_seconds_p50": median("kernel_seconds"),
+            "device_to_host_seconds_p50": median("device_to_host_seconds"),
+            "host_overhead_seconds_p50": median("host_overhead_seconds"),
+            "candidates_per_second_p50": median("candidates_per_second"),
+        },
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run deterministic, in-memory Apple MPS proxy benchmarks. No "
+            "exchange, cache, config, or result files are accessed."
+        )
+    )
+    parser.add_argument("--case", choices=(*CASES, "all"), default="all")
+    parser.add_argument("--candidates", type=int, default=256)
+    parser.add_argument("--warm-runs", type=int, default=5)
+    parser.add_argument("--single-bars", type=int, default=60_000)
+    parser.add_argument("--multicoin-bars", type=int, default=4_320)
+    parser.add_argument("--coins", type=int, default=8)
+    parser.add_argument("--seed", type=int, default=DEFAULT_SEED)
+    parser.add_argument("--compact", action="store_true")
+    return parser
+
+
+def _bounded_positive(parser, name: str, value: int, maximum: int) -> int:
+    if value <= 0:
+        parser.error(f"{name} must be greater than zero")
+    if value > maximum:
+        parser.error(f"{name} must be at most {maximum}")
+    return value
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    candidates = _bounded_positive(
+        parser, "--candidates", args.candidates, MAX_CANDIDATES
+    )
+    warm_runs = _bounded_positive(parser, "--warm-runs", args.warm_runs, MAX_WARM_RUNS)
+    single_bars = _bounded_positive(
+        parser, "--single-bars", args.single_bars, MAX_SINGLE_BARS
+    )
+    multicoin_bars = _bounded_positive(
+        parser,
+        "--multicoin-bars",
+        args.multicoin_bars,
+        MAX_MULTICOIN_BARS,
+    )
+    coins = _bounded_positive(parser, "--coins", args.coins, MAX_COINS)
+    if coins < 2:
+        parser.error("--coins must be at least two")
+    selected = CASES if args.case == "all" else (args.case,)
+    if any(name.endswith("single-long") for name in selected):
+        if candidates * single_bars > MAX_DISPATCH_CANDIDATE_BARS:
+            parser.error("single-coin candidate-bars exceed the safe benchmark limit")
+    if any(name.startswith("ema-multicoin") for name in selected):
+        if candidates * multicoin_bars * coins > MAX_DISPATCH_CANDIDATE_BARS:
+            parser.error("multicoin candidate-bars exceed the safe benchmark limit")
+
+    import torch
+
+    if not torch.backends.mps.is_available():
+        parser.error("Apple MPS is unavailable in this process")
+    report = {
+        "schema_version": 1,
+        "environment": {
+            "machine": platform.machine(),
+            "macos": platform.mac_ver()[0],
+            "python": platform.python_version(),
+            "torch": torch.__version__,
+            "mps_available": True,
+        },
+        "cases": [
+            run_benchmark_case(
+                name,
+                candidates=candidates,
+                warm_runs=warm_runs,
+                single_bars=single_bars,
+                multicoin_bars=multicoin_bars,
+                coins=coins,
+                seed=args.seed,
+            )
+            for name in selected
+        ],
+    }
+    print(json.dumps(report, indent=None if args.compact else 2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/tools/gpu_proxy_benchmark.py
+++ b/src/tools/gpu_proxy_benchmark.py
@@ -479,6 +479,21 @@ def _bounded_positive(parser, name: str, value: int, maximum: int) -> int:
     return value
 
 
+def _require_mps_torch(parser):
+    try:
+        import torch
+    except ModuleNotFoundError as exc:
+        if exc.name == "torch" or str(exc.name).startswith("torch."):
+            parser.error(
+                "Apple MPS benchmarking requires the optional GPU dependencies; "
+                'install with python3 -m pip install -e ".[full,gpu-mps]"'
+            )
+        raise
+    if not torch.backends.mps.is_available():
+        parser.error("Apple MPS is unavailable in this process")
+    return torch
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
@@ -506,10 +521,7 @@ def main(argv: list[str] | None = None) -> int:
         if candidates * multicoin_bars * coins > MAX_DISPATCH_CANDIDATE_BARS:
             parser.error("multicoin candidate-bars exceed the safe benchmark limit")
 
-    import torch
-
-    if not torch.backends.mps.is_available():
-        parser.error("Apple MPS is unavailable in this process")
+    torch = _require_mps_torch(parser)
     report = {
         "schema_version": 1,
         "environment": {

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -51,6 +51,8 @@ from optimization.backends.gpu_backend import (
     _gpu_suite_scenario_inputs,
     _gpu_suite_search_context,
     _materialize_gpu_override_template,
+    _log_gpu_profile,
+    _profiled_gpu_exact_worker,
     _DriftMonitor,
     _ObjectiveScale,
     _recover_durable_validations,
@@ -122,6 +124,40 @@ def test_gpu_exact_submission_checks_interrupt_before_apply_async():
 
     interrupt_check.assert_called_once_with()
     pool.apply_async.assert_not_called()
+
+
+def test_gpu_exact_submission_uses_profiled_worker_only_when_enabled():
+    pool = MagicMock()
+    interrupt_check = MagicMock()
+
+    _submit_gpu_exact_validation(
+        pool, [1.0], interrupt_check, profile=True
+    )
+
+    assert pool.apply_async.call_args.args == (
+        _profiled_gpu_exact_worker,
+        ([1.0],),
+    )
+
+
+def test_gpu_profile_log_is_structured_json(caplog):
+    with caplog.at_level("INFO"):
+        _log_gpu_profile(
+            "generation", generation=3, timings_seconds={"wall": 1.25}
+        )
+
+    line = next(
+        message
+        for message in caplog.messages
+        if message.startswith("[gpu-profile] ")
+    )
+    payload = json.loads(line.removeprefix("[gpu-profile] "))
+    assert payload == {
+        "schema_version": 1,
+        "event": "generation",
+        "generation": 3,
+        "timings_seconds": {"wall": 1.25},
+    }
 
 
 def test_gpu_interrupt_discards_incomplete_ask_tell_without_checkpointing():

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -40,6 +40,7 @@ from optimization.backends.gpu_backend import (
     _gpu_hsl_parameter_active,
     _gpu_nsga2_checkpoint_contract,
     _gpu_pinned_hsl_bound_contract,
+    _gpu_profile_elapsed,
     _validate_hsl_bound_contracts,
     _validate_hsl_metric_topology,
     _gpu_suite_enabled,
@@ -181,6 +182,20 @@ def test_gpu_profile_log_is_structured_json(caplog):
         "generation": 3,
         "timings_seconds": {"wall": 1.25},
     }
+
+
+def test_gpu_profile_elapsed_uses_monotonic_clock(monkeypatch):
+    monkeypatch.setattr(
+        "optimization.backends.gpu_backend.time.perf_counter", lambda: 15.5
+    )
+    monkeypatch.setattr(
+        "optimization.backends.gpu_backend.time.time",
+        lambda: (_ for _ in ()).throw(
+            AssertionError("profile duration used the wall clock")
+        ),
+    )
+
+    assert _gpu_profile_elapsed(10.0) == pytest.approx(5.5)
 
 
 def test_gpu_interrupt_discards_incomplete_ask_tell_without_checkpointing():

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -488,7 +488,8 @@ def test_trailing_martingale_bound_map_covers_both_directional_shapes():
 
 def test_cpu_runtime_imports_do_not_import_torch_or_mps_kernel():
     script = (
-        "import json, sys; import backtest, passivbot, optimization.backends; "
+        "import json, sys; import backtest, passivbot, optimization.backends, "
+        "tools.gpu_proxy_benchmark; "
         "print(json.dumps({"
         "'torch': 'torch' in sys.modules, "
         "'mps_kernel': 'optimization.gpu.mps_kernel' in sys.modules"

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -126,9 +126,14 @@ def test_gpu_exact_submission_checks_interrupt_before_apply_async():
     pool.apply_async.assert_not_called()
 
 
-def test_gpu_exact_submission_uses_profiled_worker_only_when_enabled():
+def test_gpu_exact_submission_uses_profiled_worker_only_when_enabled(
+    monkeypatch,
+):
     pool = MagicMock()
     interrupt_check = MagicMock()
+    monkeypatch.setattr(
+        "optimization.backends.gpu_backend.time.perf_counter", lambda: 12.5
+    )
 
     _submit_gpu_exact_validation(
         pool, [1.0], interrupt_check, profile=True
@@ -136,8 +141,26 @@ def test_gpu_exact_submission_uses_profiled_worker_only_when_enabled():
 
     assert pool.apply_async.call_args.args == (
         _profiled_gpu_exact_worker,
-        ([1.0],),
+        ([1.0], 12.5),
     )
+
+
+def test_gpu_profiled_exact_worker_records_actual_queue_wait(monkeypatch):
+    ticks = iter((10.0, 14.0))
+    monkeypatch.setattr(
+        "optimization.backends.gpu_backend.time.perf_counter",
+        lambda: next(ticks),
+    )
+    monkeypatch.setattr(
+        "optimization.backends.gpu_backend._evaluate_pymoo_worker_from_globals",
+        lambda vector: {"F": vector},
+    )
+
+    payload = _profiled_gpu_exact_worker([1.0], 7.0)
+
+    assert payload["F"] == [1.0]
+    assert payload["__gpu_profile_queue_wait_seconds__"] == pytest.approx(3.0)
+    assert payload["__gpu_profile_worker_seconds__"] == pytest.approx(4.0)
 
 
 def test_gpu_profile_log_is_structured_json(caplog):

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -5443,6 +5443,37 @@ def _multicoin_exposure_fixture(
 @pytest.mark.skipif(
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
+@pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
+def test_mps_runner_profile_distinguishes_cold_warm_and_disabled(strategy_kind):
+    runner, row = _multicoin_exposure_fixture(strategy_kind, "long")
+    matrix = np.asarray([row], dtype=np.float64)
+
+    runner.run(matrix, profile=True)
+    cold = dict(runner.last_profile)
+    runner.run(matrix, profile=True)
+    warm = dict(runner.last_profile)
+    runner.run(matrix)
+
+    assert cold["cold"] is True
+    assert warm["cold"] is False
+    assert cold["batch_size"] == 1
+    assert cold["dispatch_count"] == 1
+    for key in (
+        "cpu_pack_seconds",
+        "upload_and_zero_seconds",
+        "compile_seconds",
+        "pre_dispatch_sync_seconds",
+        "kernel_seconds",
+        "metric_decode_seconds",
+    ):
+        assert cold[key] >= 0.0
+        assert warm[key] >= 0.0
+    assert runner.last_profile == {}
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
 @pytest.mark.parametrize("topology", ["long", "short", "fused"])
 def test_mps_tm_multicoin_entry_intervals_remain_coin_and_side_local(topology):
     count = 45

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -1,4 +1,5 @@
 import ast
+from functools import lru_cache
 import inspect
 import textwrap
 
@@ -44,6 +45,7 @@ from optimization.gpu.mps_kernel import (
     MpsTrailingMartingaleRunner,
     MpsTrailingMartingaleMulticoinFusedRunner,
     _decode_entry_interval_outputs,
+    _cached_library_with_miss,
     _decode_multicoin_fused_outputs,
     _encode_max_realized_loss_pct,
     _pack_tm_parameter_matrix,
@@ -99,6 +101,19 @@ def test_strategy_runner_valid_evaluation_has_one_kernel_dispatch(
 
     assert len(dispatch_calls) == 1
     assert "high_exposure" not in source
+
+
+def test_profiled_library_classifies_shared_cache_miss_not_runner_age():
+    @lru_cache(maxsize=1)
+    def loader(value):
+        return object()
+
+    first, first_missed = _cached_library_with_miss(loader, 1)
+    second, second_missed = _cached_library_with_miss(loader, 1)
+
+    assert first is second
+    assert first_missed is True
+    assert second_missed is False
 
 
 def _assert_fill_scalar_contract(output):
@@ -5446,13 +5461,16 @@ def _multicoin_exposure_fixture(
 @pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
 def test_mps_runner_profile_distinguishes_cold_warm_and_disabled(strategy_kind):
     runner, row = _multicoin_exposure_fixture(strategy_kind, "long")
+    second_runner, _row = _multicoin_exposure_fixture(strategy_kind, "long")
     matrix = np.asarray([row], dtype=np.float64)
+    loader, _args = runner._library_cache_call()
+    loader.cache_clear()
 
     runner.run(matrix, profile=True)
     cold = dict(runner.last_profile)
-    runner.run(matrix, profile=True)
-    warm = dict(runner.last_profile)
-    runner.run(matrix)
+    second_runner.run(matrix, profile=True)
+    warm = dict(second_runner.last_profile)
+    second_runner.run(matrix)
 
     assert cold["cold"] is True
     assert warm["cold"] is False
@@ -5468,7 +5486,7 @@ def test_mps_runner_profile_distinguishes_cold_warm_and_disabled(strategy_kind):
     ):
         assert cold[key] >= 0.0
         assert warm[key] >= 0.0
-    assert runner.last_profile == {}
+    assert second_runner.last_profile == {}
 
 
 @pytest.mark.skipif(

--- a/tests/optimization/test_gpu_proxy_benchmark.py
+++ b/tests/optimization/test_gpu_proxy_benchmark.py
@@ -1,3 +1,5 @@
+import sys
+
 import numpy as np
 import pytest
 
@@ -10,6 +12,7 @@ from tools.gpu_proxy_benchmark import (
     _bounded_positive,
     _fixture_sha256,
     _parameter_matrix,
+    _require_mps_torch,
     build_parser,
 )
 
@@ -40,6 +43,19 @@ def test_gpu_proxy_benchmark_rejects_non_positive_sizes():
         _bounded_positive(parser, "--candidates", 0, 10)
     with pytest.raises(SystemExit):
         _bounded_positive(parser, "--candidates", 11, 10)
+
+
+def test_gpu_proxy_benchmark_reports_missing_optional_gpu_dependencies(
+    monkeypatch, capsys
+):
+    parser = build_parser()
+    monkeypatch.setitem(sys.modules, "torch", None)
+
+    with pytest.raises(SystemExit) as exc:
+        _require_mps_torch(parser)
+
+    assert exc.value.code == 2
+    assert ".[full,gpu-mps]" in capsys.readouterr().err
 
 
 def test_gpu_proxy_benchmark_fixture_hash_covers_shape_dtype_and_values():

--- a/tests/optimization/test_gpu_proxy_benchmark.py
+++ b/tests/optimization/test_gpu_proxy_benchmark.py
@@ -1,0 +1,51 @@
+import numpy as np
+import pytest
+
+from optimization.gpu.model import (
+    EMA_ANCHOR_MULTICOIN_PARAM_KEYS,
+    EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS,
+    TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS,
+)
+from tools.gpu_proxy_benchmark import (
+    _bounded_positive,
+    _fixture_sha256,
+    _parameter_matrix,
+    build_parser,
+)
+
+
+@pytest.mark.parametrize(
+    "keys",
+    (
+        EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS,
+        TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS,
+        EMA_ANCHOR_MULTICOIN_PARAM_KEYS,
+    ),
+)
+def test_gpu_proxy_benchmark_candidate_matrix_is_fixed_and_finite(keys):
+    first = _parameter_matrix(keys, 8, 7)
+    second = _parameter_matrix(keys, 8, 7)
+    changed = _parameter_matrix(keys, 8, 8)
+
+    assert first.shape == (8, len(keys))
+    assert np.array_equal(first, second)
+    assert np.isfinite(first).all()
+    assert not np.array_equal(first, changed)
+
+
+def test_gpu_proxy_benchmark_rejects_non_positive_sizes():
+    parser = build_parser()
+
+    with pytest.raises(SystemExit):
+        _bounded_positive(parser, "--candidates", 0, 10)
+    with pytest.raises(SystemExit):
+        _bounded_positive(parser, "--candidates", 11, 10)
+
+
+def test_gpu_proxy_benchmark_fixture_hash_covers_shape_dtype_and_values():
+    baseline = np.asarray([[1.0, 2.0]], dtype=np.float64)
+
+    assert _fixture_sha256(baseline) == _fixture_sha256(baseline.copy())
+    assert _fixture_sha256(baseline) != _fixture_sha256(baseline.astype(np.float32))
+    assert _fixture_sha256(baseline) != _fixture_sha256(baseline.reshape(2, 1))
+    assert _fixture_sha256(baseline) != _fixture_sha256(baseline + 1.0)

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -45,6 +45,8 @@ from optimization.gpu.service import (
     _gpu_proxy_execution_checkpoint_contract,
     _mps_dispatch_batch_size,
     _mps_strategy_eq_recovery_distribution,
+    _new_gpu_proxy_profile,
+    _add_gpu_runner_profile,
     _multicoin_exposure_eligible_coins,
     _position_exposure_enforcer_params,
     _prepared_single_coin_side_enabled,
@@ -486,6 +488,31 @@ def test_single_coin_proxy_profile_is_empty_when_disabled(monkeypatch):
     proxy.evaluate([{"value": 1.0}])
 
     assert proxy.last_profile == {}
+
+
+def test_gpu_profile_candidate_bars_include_coin_and_side_topology():
+    proxy = SimpleNamespace(
+        batch_size=4,
+        dispatch_batch_size=4,
+        strategy_kind="ema_anchor",
+    )
+    runner = SimpleNamespace(
+        n=100,
+        n_coins=8,
+        last_profile={
+            "batch_size": 1,
+            "dispatch_count": 1,
+            "cold": False,
+        },
+    )
+    profile = _new_gpu_proxy_profile(
+        proxy, [{}], (runner,), coin_count=8, side_count=2
+    )
+
+    _add_gpu_runner_profile(profile, runner, side_count=2)
+
+    assert profile["candidate_bars"] == 1_600
+    assert profile["kernel_candidate_bars"] == 1_600
 
 
 def test_single_coin_proxy_honors_interrupt_between_mps_dispatches():

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -43,6 +43,7 @@ from optimization.gpu.service import (
     _directional_gross_pnl_outputs,
     _hsl_params,
     _gpu_proxy_execution_checkpoint_contract,
+    _gpu_profile_unattributed_seconds,
     _mps_dispatch_batch_size,
     _mps_strategy_eq_recovery_distribution,
     _new_gpu_proxy_profile,
@@ -305,7 +306,9 @@ def test_recovery_distribution_postprocessor_is_opt_in_and_fail_closed(monkeypat
 
     samples = object()
     expected = SimpleNamespace()
-    expected.cpu = lambda: expected
+    expected.cpu = lambda: (_ for _ in ()).throw(
+        AssertionError("recovery distribution left MPS during reduction")
+    )
     called = {}
 
     def fake_postprocessor(values, *, sample_interval_days):
@@ -513,6 +516,55 @@ def test_gpu_profile_candidate_bars_include_coin_and_side_topology():
 
     assert profile["candidate_bars"] == 1_600
     assert profile["kernel_candidate_bars"] == 1_600
+
+
+def test_gpu_profile_candidate_bars_use_truncated_effective_steps():
+    proxy = SimpleNamespace(
+        batch_size=4,
+        dispatch_batch_size=4,
+        strategy_kind="ema_anchor",
+    )
+    runner = SimpleNamespace(
+        n=100,
+        n_coins=8,
+        last_profile={
+            "batch_size": 2,
+            "dispatch_count": 1,
+            "cold": False,
+        },
+    )
+    profile = _new_gpu_proxy_profile(
+        proxy, [{}, {}], (runner,), coin_count=8, side_count=2
+    )
+
+    _add_gpu_runner_profile(
+        profile,
+        runner,
+        side_count=2,
+        effective_candidate_steps=np.asarray([10, 20]),
+    )
+
+    assert profile["candidate_bars"] == 3_200
+    assert profile["kernel_candidate_bars"] == 480
+
+
+def test_gpu_profile_unattributed_seconds_excludes_nested_runner_and_transfer():
+    timings = {
+        "device_to_host": 3.0,
+        "candidate_packing": 1.0,
+        "upload_and_buffer_clear": 1.0,
+        "cold_compilation": 1.0,
+        "warm_library_lookup": 0.0,
+        "kernel_execution": 2.0,
+        "metric_reduction": 2.0,
+    }
+
+    assert _gpu_profile_unattributed_seconds(
+        timings,
+        12.0,
+        device_to_host_before=1.0,
+        runner_seconds_before=2.0,
+    ) == pytest.approx(5.0)
 
 
 def test_single_coin_proxy_honors_interrupt_between_mps_dispatches():
@@ -897,12 +949,18 @@ def test_refresh_hedged_multicoin_hsl_replays_only_cutoff_candidates():
         "short": np.asarray([[3.0], [4.0]]),
     }
 
+    profiled_steps = []
     refreshed = _refresh_hedged_multicoin_hsl_at_portfolio_cutoff(
         side_outputs=side_outputs,
         runners=runners,
         parameter_matrices=matrices,
         combined_output={"liq_step": torch.tensor([-1.0, 2.0])},
         start_minute_of_day=60,
+        runner_profile_callback=(
+            lambda _runner, *, effective_candidate_steps: profiled_steps.append(
+                effective_candidate_steps.copy()
+            )
+        ),
     )
 
     assert refreshed
@@ -910,6 +968,7 @@ def test_refresh_hedged_multicoin_hsl_replays_only_cutoff_candidates():
     assert runners["short"].calls[0][0].tolist() == [[4.0]]
     assert runners["long"].calls[0][1].tolist() == [2820]
     assert runners["short"].calls[0][1].tolist() == [2820]
+    assert [steps.tolist() for steps in profiled_steps] == [[2820], [2820]]
     assert side_outputs["long"]["hsl_triggers_long"].tolist() == [10.0, 3.0]
     assert side_outputs["short"]["hsl_triggers_short"].tolist() == [10.0, 4.0]
 

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -420,6 +420,74 @@ def test_single_coin_proxy_preserves_order_across_bounded_dispatches():
     assert calls == [[0.0, 1.0], [2.0, 3.0], [4.0]]
 
 
+def test_single_coin_proxy_profile_records_dispatch_shape_and_timings(monkeypatch):
+    torch = pytest.importorskip("torch")
+    proxy, calls = _minimal_single_coin_proxy()
+    proxy.profile_enabled = True
+    proxy.strategy_kind = "ema_anchor"
+    proxy.runner.n = 100
+    proxy.runner.long_enabled = True
+    proxy.runner.short_enabled = False
+    original_run = proxy.runner.run
+
+    def profiled_run(parameters, **kwargs):
+        output = original_run(parameters, **kwargs)
+        proxy.runner.last_profile = {
+            "cpu_pack_seconds": 0.001,
+            "upload_and_zero_seconds": 0.002,
+            "compile_seconds": 0.003,
+            "pre_dispatch_sync_seconds": 0.004,
+            "kernel_seconds": 0.005,
+            "metric_decode_seconds": 0.006,
+            "batch_size": len(parameters),
+            "dispatch_count": 1,
+            "cold": len(calls) == 1,
+        }
+        return output
+
+    proxy.runner.run = profiled_run
+    monkeypatch.setattr(torch.mps, "synchronize", lambda: None)
+
+    proxy.evaluate([{"value": float(index)} for index in range(5)])
+
+    profile = proxy.last_profile
+    assert profile["candidate_count"] == 5
+    assert profile["dispatch_batch_size"] == 2
+    assert profile["dispatch_chunk_count"] == 3
+    assert profile["actual_dispatch_batch_sizes"] == [2, 2, 1]
+    assert profile["dispatch_count"] == 3
+    assert profile["cold_dispatch_count"] == 1
+    assert profile["warm_dispatch_count"] == 2
+    assert profile["candidate_bars"] == 500
+    assert profile["kernel_candidate_bars"] == 500
+    assert profile["coin_count"] == 1
+    assert profile["side_count"] == 1
+    assert profile["timings_seconds"]["kernel_execution"] == pytest.approx(
+        0.015
+    )
+    assert profile["timings_seconds"]["cold_compilation"] == pytest.approx(
+        0.003
+    )
+    assert profile["timings_seconds"]["warm_library_lookup"] == pytest.approx(
+        0.006
+    )
+    assert profile["wall_seconds"] >= 0.0
+
+
+def test_single_coin_proxy_profile_is_empty_when_disabled(monkeypatch):
+    proxy, _calls = _minimal_single_coin_proxy()
+    monkeypatch.setattr(
+        "optimization.gpu.service.time.perf_counter",
+        lambda: (_ for _ in ()).throw(
+            AssertionError("disabled proxy profiling read the clock")
+        ),
+    )
+
+    proxy.evaluate([{"value": 1.0}])
+
+    assert proxy.last_profile == {}
+
+
 def test_single_coin_proxy_honors_interrupt_between_mps_dispatches():
     checks = 0
 

--- a/tests/test_passivbot_cli.py
+++ b/tests/test_passivbot_cli.py
@@ -840,7 +840,7 @@ def test_ticker_endpoint_probe_dispatch_forwards_module_and_prog(monkeypatch):
     assert captured["prog_env"] == "passivbot tool ticker-endpoint-probe"
 
 
-def test_gpu_proxy_benchmark_dispatch_forwards_module_and_prog(monkeypatch):
+def test_gpu_proxy_benchmark_owns_its_gpu_dependency_gate(monkeypatch):
     captured = {}
 
     def fake_invoke_module_main(module_name):
@@ -850,7 +850,9 @@ def test_gpu_proxy_benchmark_dispatch_forwards_module_and_prog(monkeypatch):
         return True, 0
 
     monkeypatch.setattr(cli_main, "_invoke_module_main", fake_invoke_module_main)
-    monkeypatch.setattr(cli_main, "_missing_full_install_markers", lambda: [])
+    monkeypatch.setattr(
+        cli_main, "_missing_full_install_markers", lambda: ["aiohttp"]
+    )
 
     assert (
         cli_main.main(

--- a/tests/test_passivbot_cli.py
+++ b/tests/test_passivbot_cli.py
@@ -840,6 +840,36 @@ def test_ticker_endpoint_probe_dispatch_forwards_module_and_prog(monkeypatch):
     assert captured["prog_env"] == "passivbot tool ticker-endpoint-probe"
 
 
+def test_gpu_proxy_benchmark_dispatch_forwards_module_and_prog(monkeypatch):
+    captured = {}
+
+    def fake_invoke_module_main(module_name):
+        captured["module_name"] = module_name
+        captured["argv"] = sys.argv[:]
+        captured["prog_env"] = os.environ.get("PASSIVBOT_CLI_PROG")
+        return True, 0
+
+    monkeypatch.setattr(cli_main, "_invoke_module_main", fake_invoke_module_main)
+    monkeypatch.setattr(cli_main, "_missing_full_install_markers", lambda: [])
+
+    assert (
+        cli_main.main(
+            ["tool", "gpu-proxy-benchmark", "--case", "ema-single-long"]
+        )
+        == 0
+    )
+
+    assert captured == {
+        "module_name": "tools.gpu_proxy_benchmark",
+        "argv": [
+            "passivbot tool gpu-proxy-benchmark",
+            "--case",
+            "ema-single-long",
+        ],
+        "prog_env": "passivbot tool gpu-proxy-benchmark",
+    }
+
+
 def test_unknown_command_exits_with_error():
     with pytest.raises(SystemExit) as exc:
         cli_main.main(["unknown"])


### PR DESCRIPTION
## Summary

- make `PASSIVBOT_GPU_PROFILE=1` emit structured per-generation timing for proxy phases, NSGA ask/tell/orchestration, exact-validation queue/work, persistence, and checkpointing
- report dispatch chunks and kernel dispatches, actual batch sizes, topology-aware candidate-bars, candle/coin/side counts, optional metric features, and shared Metal-library cold/warm state
- add a bounded, deterministic, in-memory `passivbot tool gpu-proxy-benchmark` harness covering long-history single-coin EMA Anchor and Trailing Martingale, short-history multicoin overhead, and a coin-override case
- exercise the complete production proxy path in the harness, including full output transfer, metric reduction, and result materialization
- keep profiling disabled by default, keep ordinary CPU imports free of the optional MPS runtime, and keep exact Rust results authoritative

## Validation

- complete Python test suite: passed locally
- full Apple MPS suite: 717 passed
- opt-in real single-coin and multicoin proxy profiling tests: passed
- Rust: `cargo test --no-default-features` (274 passed)
- Rust: `cargo check --tests`
- AI docs checker: 0 errors (two pre-existing size warnings)
- focused CLI, GPU service/backend, benchmark, optimizer, shared-cache classification, topology/truncated-work accounting, nested-phase accounting, exact-worker timing, monotonic completion timing, GPU-specific dependency handling, and CPU no-MPS-import regression tests: passed

## Immutable benchmark comparison

Base `5009202751c55783d9440252588b158a06af7a39`; implementation `9b55f05a61b9409609f332de46bdb15f8d3e6866`. Each case ran in a fresh process through the complete production proxy evaluation path with seed 7, 256 candidates, five warm repeats, and matching fixture SHA-256 values. Single-coin cases use 60,000 bars; multicoin cases use 4,320 bars across eight coins. Warm p50 is separate from the first cold compilation run.

| case | base/head warm p50 cand/s | delta | base/head kernel p50 | base/head wall p50 |
|---|---:|---:|---:|---:|
| EMA single long | 372.23 / 372.29 | +0.01% | 0.64807 / 0.64950 s | 0.68774 / 0.68764 s |
| TM single long | 422.87 / 423.50 | +0.15% | 0.56251 / 0.56078 s | 0.60538 / 0.60449 s |
| EMA multicoin overhead | 496.00 / 490.57 | -1.10% | 0.47802 / 0.48333 s | 0.51613 / 0.52185 s |
| EMA multicoin overrides | 486.39 / 487.00 | +0.13% | 0.49121 / 0.48671 s | 0.52633 / 0.52567 s |

These measurements establish a reproducible baseline; the default path remains effectively flat within run-to-run noise, so this PR does not claim a speedup. Profiling synchronization is opt-in. No benchmark outputs, private configs, cache data, historical data, or optimization results are committed.
