### PR TITLE
Speed up one-side EMA Anchor MPS screening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Apple MPS EMA Anchor optimization now compiles a one-side kernel when HSL is disabled, allowing
+  Metal to eliminate the inactive side and HSL state from the hot candle loop. Dual-side and HSL
+  runs keep the generic kernel, and exact Rust validation remains authoritative. The offline GPU
+  benchmark also accepts an independent dispatch batch size so saturation studies can hold the
+  candidate matrix constant while varying only dispatch chunking.
+
 - Apple MPS optimization now provides disabled-by-default structured profiling for candidate
   materialization and packing, buffer upload/clearing, cold and warm shader-library work, kernel
   execution, device transfer, metric reduction, NSGA orchestration, exact-validation queue/work,

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -741,6 +741,9 @@ passivbot tool gpu-proxy-benchmark --case ema-single-long
 passivbot tool gpu-proxy-benchmark --case tm-single-long
 passivbot tool gpu-proxy-benchmark --case ema-multicoin-overhead
 passivbot tool gpu-proxy-benchmark --case ema-multicoin-overrides
+# Hold one candidate matrix constant while measuring dispatch chunking:
+passivbot tool gpu-proxy-benchmark --case ema-single-long \
+  --candidates 4096 --dispatch-batch-size 1024
 ```
 
 The single-coin cases default to 60,000 one-minute candles; the overhead-sensitive multicoin cases
@@ -751,7 +754,9 @@ arguments and immutable commits for before/after comparisons. The harness calls 
 proxy evaluation path, including its full output transfer, metric reduction, and result
 materialization. Run one `--case` per process when comparing cold compilation; `--case all` is
 convenient for smoke checks, and shared-cache hit/miss state still keeps later cold/warm labels
-accurate.
+accurate. `--dispatch-batch-size` defaults to `--candidates`; setting it lower preserves the fixed
+candidate matrix and reports the actual chunk and strategy-dispatch counts, which isolates dispatch
+saturation from population-size changes.
 
 ### Pymoo Configuration
 

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -29,6 +29,10 @@ const MPS_TRAILING_LONG_NO_HSL_PREAMBLE: &str =
     "#define PASSIVBOT_TRAILING_LONG_ONLY 1\n#define PASSIVBOT_TRAILING_HSL_DISABLED 1\n";
 const MPS_TRAILING_SHORT_NO_HSL_PREAMBLE: &str =
     "#define PASSIVBOT_TRAILING_SHORT_ONLY 1\n#define PASSIVBOT_TRAILING_HSL_DISABLED 1\n";
+const MPS_EMA_LONG_NO_HSL_PREAMBLE: &str =
+    "#define PASSIVBOT_EMA_LONG_ONLY 1\n#define PASSIVBOT_EMA_HSL_DISABLED 1\n";
+const MPS_EMA_SHORT_NO_HSL_PREAMBLE: &str =
+    "#define PASSIVBOT_EMA_SHORT_ONLY 1\n#define PASSIVBOT_EMA_HSL_DISABLED 1\n";
 
 fn compose_hsl_source(body: &str) -> String {
     assert_eq!(
@@ -81,8 +85,16 @@ fn compose_trailing_topology_source(preamble: &str) -> String {
     )
 }
 
+fn compose_ema_topology_source(preamble: &str) -> String {
+    format!("{preamble}{}", compose_hsl_source(MPS_EMA_ANCHOR_BODY))
+}
+
 pub static MPS_EMA_ANCHOR_SOURCE: LazyLock<String> =
     LazyLock::new(|| compose_hsl_source(MPS_EMA_ANCHOR_BODY));
+pub static MPS_EMA_ANCHOR_LONG_NO_HSL_SOURCE: LazyLock<String> =
+    LazyLock::new(|| compose_ema_topology_source(MPS_EMA_LONG_NO_HSL_PREAMBLE));
+pub static MPS_EMA_ANCHOR_SHORT_NO_HSL_SOURCE: LazyLock<String> =
+    LazyLock::new(|| compose_ema_topology_source(MPS_EMA_SHORT_NO_HSL_PREAMBLE));
 pub static MPS_EMA_ANCHOR_MULTICOIN_SOURCE: LazyLock<String> =
     LazyLock::new(|| compose_multicoin_source(MPS_EMA_ANCHOR_MULTICOIN_BODY));
 pub static MPS_TRAILING_MARTINGALE_SOURCE: LazyLock<String> =
@@ -96,6 +108,14 @@ pub static MPS_TRAILING_MARTINGALE_MULTICOIN_SOURCE: LazyLock<String> =
 
 pub fn mps_ema_anchor_source() -> &'static str {
     MPS_EMA_ANCHOR_SOURCE.as_str()
+}
+
+pub fn mps_ema_anchor_long_no_hsl_source() -> &'static str {
+    MPS_EMA_ANCHOR_LONG_NO_HSL_SOURCE.as_str()
+}
+
+pub fn mps_ema_anchor_short_no_hsl_source() -> &'static str {
+    MPS_EMA_ANCHOR_SHORT_NO_HSL_SOURCE.as_str()
 }
 
 pub fn mps_ema_anchor_multicoin_source() -> &'static str {
@@ -429,6 +449,8 @@ mod tests {
         }
         for source in [
             mps_ema_anchor_source(),
+            mps_ema_anchor_long_no_hsl_source(),
+            mps_ema_anchor_short_no_hsl_source(),
             mps_ema_anchor_multicoin_source(),
             mps_trailing_martingale_source(),
             mps_trailing_martingale_long_no_hsl_source(),
@@ -455,6 +477,8 @@ mod tests {
         }
         for source in [
             mps_ema_anchor_source(),
+            mps_ema_anchor_long_no_hsl_source(),
+            mps_ema_anchor_short_no_hsl_source(),
             mps_ema_anchor_multicoin_source(),
             mps_trailing_martingale_source(),
             mps_trailing_martingale_long_no_hsl_source(),
@@ -480,6 +504,8 @@ mod tests {
         }
         for source in [
             mps_ema_anchor_source(),
+            mps_ema_anchor_long_no_hsl_source(),
+            mps_ema_anchor_short_no_hsl_source(),
             mps_ema_anchor_multicoin_source(),
             mps_trailing_martingale_source(),
             mps_trailing_martingale_long_no_hsl_source(),
@@ -498,6 +524,8 @@ mod tests {
             MPS_TRAILING_MARTINGALE_BODY,
             MPS_TRAILING_MARTINGALE_MULTICOIN_BODY,
             mps_ema_anchor_source(),
+            mps_ema_anchor_long_no_hsl_source(),
+            mps_ema_anchor_short_no_hsl_source(),
             mps_ema_anchor_multicoin_source(),
             mps_trailing_martingale_source(),
             mps_trailing_martingale_long_no_hsl_source(),
@@ -535,6 +563,33 @@ mod tests {
         assert!(!generic.contains("#define PASSIVBOT_TRAILING_LONG_ONLY 1"));
         assert!(!generic.contains("#define PASSIVBOT_TRAILING_SHORT_ONLY 1"));
         assert!(!generic.contains("#define PASSIVBOT_TRAILING_HSL_DISABLED 1"));
+    }
+
+    #[test]
+    fn ema_anchor_specialized_sources_pin_one_side_without_hsl() {
+        let variants = [
+            (
+                mps_ema_anchor_long_no_hsl_source(),
+                "#define PASSIVBOT_EMA_LONG_ONLY 1",
+            ),
+            (
+                mps_ema_anchor_short_no_hsl_source(),
+                "#define PASSIVBOT_EMA_SHORT_ONLY 1",
+            ),
+        ];
+        for (source, side_define) in variants {
+            assert!(source.starts_with(side_define));
+            assert!(source.contains("#define PASSIVBOT_EMA_HSL_DISABLED 1"));
+            assert!(source.contains("#if defined(PASSIVBOT_EMA_LONG_ONLY)"));
+            assert!(source.contains("#elif defined(PASSIVBOT_EMA_SHORT_ONLY)"));
+            assert!(source.contains("#if defined(PASSIVBOT_EMA_HSL_DISABLED)"));
+            assert_shared_hsl_contract(source);
+            assert_directional_hsl_accounting_contract(source);
+        }
+        let generic = mps_ema_anchor_source();
+        assert!(!generic.contains("#define PASSIVBOT_EMA_LONG_ONLY 1"));
+        assert!(!generic.contains("#define PASSIVBOT_EMA_SHORT_ONLY 1"));
+        assert!(!generic.contains("#define PASSIVBOT_EMA_HSL_DISABLED 1"));
     }
 
     #[test]

--- a/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
@@ -1168,8 +1168,16 @@ inline void passivbot_single_coin_impl(
     const float starting_balance = settings[6];
     const float liq_floor = settings[7];
     const float interval_ms = settings[8];
+#if defined(PASSIVBOT_EMA_LONG_ONLY)
+    const bool long_enabled = true;
+    const bool short_enabled = false;
+#elif defined(PASSIVBOT_EMA_SHORT_ONLY)
+    const bool long_enabled = false;
+    const bool short_enabled = true;
+#else
     const bool long_enabled = settings[9] > 0.5f;
     const bool short_enabled = settings[10] > 0.5f;
+#endif
     const bool hedge_mode = settings[11] > 0.5f;
     const bool filter_by_min_effective_cost = settings[12] > 0.5f;
     const float max_effective_min_cost = settings[13];
@@ -1196,6 +1204,10 @@ inline void passivbot_single_coin_impl(
 #if PASSIVBOT_HSL_EMA_TAIL_ENABLED
     HslDrawdownEmaTailStats long_hsl_ema_tail = init_hsl_drawdown_ema_tail_stats();
     HslDrawdownEmaTailStats short_hsl_ema_tail = init_hsl_drawdown_ema_tail_stats();
+#endif
+#if defined(PASSIVBOT_EMA_HSL_DISABLED)
+    long_hsl.enabled = false;
+    short_hsl.enabled = false;
 #endif
     const bool long_coin_hsl_rolling = long_hsl.enabled
         && long_hsl.signal_mode == HSL_SIGNAL_COIN && pnl_lookback_bars > 0;

--- a/passivbot-rust/src/lib.rs
+++ b/passivbot-rust/src/lib.rs
@@ -39,6 +39,16 @@ fn mps_ema_anchor_source_py() -> &'static str {
 }
 
 #[pyfunction]
+fn mps_ema_anchor_long_no_hsl_source_py() -> &'static str {
+    gpu::mps_ema_anchor_long_no_hsl_source()
+}
+
+#[pyfunction]
+fn mps_ema_anchor_short_no_hsl_source_py() -> &'static str {
+    gpu::mps_ema_anchor_short_no_hsl_source()
+}
+
+#[pyfunction]
 fn mps_ema_anchor_multicoin_source_py() -> &'static str {
     gpu::mps_ema_anchor_multicoin_source()
 }
@@ -81,6 +91,8 @@ fn passivbot_rust(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<EquityHardStopRuntimePy>()?;
     m.add_function(wrap_pyfunction!(runtime_build_info, m)?)?;
     m.add_function(wrap_pyfunction!(mps_ema_anchor_source_py, m)?)?;
+    m.add_function(wrap_pyfunction!(mps_ema_anchor_long_no_hsl_source_py, m)?)?;
+    m.add_function(wrap_pyfunction!(mps_ema_anchor_short_no_hsl_source_py, m)?)?;
     m.add_function(wrap_pyfunction!(mps_ema_anchor_multicoin_source_py, m)?)?;
     m.add_function(wrap_pyfunction!(
         mps_ema_anchor_multicoin_long_source_py,

--- a/src/optimization/gpu/model.py
+++ b/src/optimization/gpu/model.py
@@ -48,10 +48,10 @@ def validate_single_coin_hsl_signal_topology(
     )
 
 
-def trailing_martingale_shader_topology(
+def single_coin_shader_topology(
     *, long_enabled: bool, short_enabled: bool, hsl_enabled: bool
 ) -> str:
-    """Select a topology variant only when compile-time assumptions are exact."""
+    """Select a one-side variant only when compile-time assumptions are exact."""
 
     if hsl_enabled:
         return "generic"

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -23,7 +23,7 @@ from optimization.gpu.model import (
     TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS,
     TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS,
     encode_tm_retracement_base_pct,
-    trailing_martingale_shader_topology,
+    single_coin_shader_topology,
 )
 
 
@@ -479,6 +479,44 @@ def _shader_library(
         raw_tail_enabled=hsl_raw_tail_enabled,
     )
     source = _with_recovery_distribution(source, recovery_distribution_enabled)
+    source = _with_btc_risk(source, btc_risk_enabled)
+    source = _with_equity_balance_diff(source, equity_balance_diff_enabled)
+    return torch.mps.compile_shader(source)
+
+
+@lru_cache(maxsize=4)
+def _ema_anchor_long_no_hsl_shader_library(
+    recovery_distribution_enabled: bool = False,
+    btc_risk_enabled: bool = False,
+    equity_balance_diff_enabled: bool = False,
+):
+    if not torch.backends.mps.is_available():
+        raise RuntimeError("Apple MPS is not available in this process")
+    import passivbot_rust
+
+    source = _with_recovery_distribution(
+        passivbot_rust.mps_ema_anchor_long_no_hsl_source_py(),
+        recovery_distribution_enabled,
+    )
+    source = _with_btc_risk(source, btc_risk_enabled)
+    source = _with_equity_balance_diff(source, equity_balance_diff_enabled)
+    return torch.mps.compile_shader(source)
+
+
+@lru_cache(maxsize=4)
+def _ema_anchor_short_no_hsl_shader_library(
+    recovery_distribution_enabled: bool = False,
+    btc_risk_enabled: bool = False,
+    equity_balance_diff_enabled: bool = False,
+):
+    if not torch.backends.mps.is_available():
+        raise RuntimeError("Apple MPS is not available in this process")
+    import passivbot_rust
+
+    source = _with_recovery_distribution(
+        passivbot_rust.mps_ema_anchor_short_no_hsl_source_py(),
+        recovery_distribution_enabled,
+    )
     source = _with_btc_risk(source, btc_risk_enabled)
     source = _with_equity_balance_diff(source, equity_balance_diff_enabled)
     return torch.mps.compile_shader(source)
@@ -952,6 +990,7 @@ class MpsEmaAnchorRunner:
         market_order_near_touch_threshold: float = 0.001,
         hsl_panic_market_long: bool = False,
         hsl_panic_market_short: bool = False,
+        hsl_enabled: bool = True,
         pnl_lookback_bars: int = 0,
         hsl_ema_tail_enabled: bool = False,
         hsl_raw_drawdown_enabled: bool = False,
@@ -1019,6 +1058,15 @@ class MpsEmaAnchorRunner:
         self.hsl_ema_tail_enabled = bool(hsl_ema_tail_enabled)
         self.hsl_raw_drawdown_enabled = bool(hsl_raw_drawdown_enabled)
         self.hsl_raw_tail_enabled = bool(hsl_raw_tail_enabled)
+        self.shader_topology = single_coin_shader_topology(
+            long_enabled=self.long_enabled,
+            short_enabled=self.short_enabled,
+            hsl_enabled=bool(hsl_enabled),
+        )
+        if self.shader_topology != "generic":
+            self.hsl_ema_tail_enabled = False
+            self.hsl_raw_drawdown_enabled = False
+            self.hsl_raw_tail_enabled = False
         self.recovery_distribution_enabled = bool(recovery_distribution_enabled)
         self.rolling_capacity = (
             MPS_DIRECTIONAL_HSL_ROLLING_CAPACITY
@@ -1125,6 +1173,28 @@ class MpsEmaAnchorRunner:
         self._equity_balance_diff_buffers: dict[int, torch.Tensor] = {}
         self._sizes: dict[tuple[int, int], torch.Tensor] = {}
         self.last_profile: dict[str, float | int | bool] = {}
+
+    def _shader_library_cache_call(self):
+        if self.shader_topology == "long_no_hsl":
+            return _ema_anchor_long_no_hsl_shader_library, (
+                self.recovery_distribution_enabled,
+                self.btc_risk_enabled,
+                self.equity_balance_diff_enabled,
+            )
+        if self.shader_topology == "short_no_hsl":
+            return _ema_anchor_short_no_hsl_shader_library, (
+                self.recovery_distribution_enabled,
+                self.btc_risk_enabled,
+                self.equity_balance_diff_enabled,
+            )
+        return _shader_library, (
+            self.hsl_ema_tail_enabled,
+            self.hsl_raw_drawdown_enabled,
+            self.hsl_raw_tail_enabled,
+            self.recovery_distribution_enabled,
+            self.btc_risk_enabled,
+            self.equity_balance_diff_enabled,
+        )
 
     def _pack_params(self, params: np.ndarray) -> np.ndarray:
         params = _upgrade_legacy_single_coin_wel_params(
@@ -1273,15 +1343,8 @@ class MpsEmaAnchorRunner:
                 device="mps",
             )
         prepared = time.perf_counter() if profile else 0.0
-        library, cold = _cached_library_with_miss(
-            _shader_library,
-            self.hsl_ema_tail_enabled,
-            self.hsl_raw_drawdown_enabled,
-            self.hsl_raw_tail_enabled,
-            self.recovery_distribution_enabled,
-            self.btc_risk_enabled,
-            self.equity_balance_diff_enabled,
-        )
+        loader, library_args = self._shader_library_cache_call()
+        library, cold = _cached_library_with_miss(loader, *library_args)
         compiled = time.perf_counter() if profile else 0.0
         if profile:
             torch.mps.synchronize()
@@ -2412,7 +2475,7 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
         self.entry_interval_enabled = bool(entry_interval_enabled)
         self._entry_interval_stat_buffers: dict[int, torch.Tensor] = {}
         self._entry_interval_count_buffers: dict[int, torch.Tensor] = {}
-        self.shader_topology = trailing_martingale_shader_topology(
+        self.shader_topology = single_coin_shader_topology(
             long_enabled=self.long_enabled,
             short_enabled=self.short_enabled,
             hsl_enabled=bool(hsl_enabled),

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -1881,8 +1881,7 @@ class MpsSingleCoinProxy:
             equity_balance_diff_enabled=self.equity_balance_diff_enabled,
             entry_interval_enabled=self.entry_interval_enabled,
         )
-        if self.strategy_kind == "trailing_martingale":
-            runner_kwargs["hsl_enabled"] = any_configured_hsl
+        runner_kwargs["hsl_enabled"] = any_configured_hsl
         self.runner = runner_cls(
             self.market,
             self.run,

--- a/src/tools/gpu_proxy_benchmark.py
+++ b/src/tools/gpu_proxy_benchmark.py
@@ -183,6 +183,7 @@ def _build_case(
     name: str,
     *,
     candidates: int,
+    dispatch_batch_size: int,
     single_bars: int,
     multicoin_bars: int,
     coins: int,
@@ -216,7 +217,12 @@ def _build_case(
         )
         if name == "ema-single-long":
             runner = MpsEmaAnchorRunner(
-                market, run, data, long_enabled=True, short_enabled=False
+                market,
+                run,
+                data,
+                long_enabled=True,
+                short_enabled=False,
+                hsl_enabled=False,
             )
             side_matrix = _parameter_matrix(
                 EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS, candidates, seed
@@ -237,7 +243,7 @@ def _build_case(
             )
         proxy = MpsSingleCoinProxy.__new__(MpsSingleCoinProxy)
         proxy.batch_size = candidates
-        proxy.dispatch_batch_size = candidates
+        proxy.dispatch_batch_size = dispatch_batch_size
         proxy.interrupt_check = lambda: None
         proxy._torch = __import__("torch")
         proxy.profile_enabled = True
@@ -314,7 +320,7 @@ def _build_case(
     matrix = _parameter_matrix(EMA_ANCHOR_MULTICOIN_PARAM_KEYS, candidates, seed)
     proxy = MpsMulticoinProxy.__new__(MpsMulticoinProxy)
     proxy.batch_size = candidates
-    proxy.dispatch_batch_size = candidates
+    proxy.dispatch_batch_size = dispatch_batch_size
     proxy.interrupt_check = lambda: None
     proxy._torch = __import__("torch")
     proxy.profile_enabled = True
@@ -408,6 +414,7 @@ def run_benchmark_case(
     name: str,
     *,
     candidates: int,
+    dispatch_batch_size: int,
     warm_runs: int,
     single_bars: int,
     multicoin_bars: int,
@@ -417,6 +424,7 @@ def run_benchmark_case(
     proxy, candidate_dicts, bars, coin_count, side_count, fixture_sha256 = _build_case(
         name,
         candidates=candidates,
+        dispatch_batch_size=dispatch_batch_size,
         single_bars=single_bars,
         multicoin_bars=multicoin_bars,
         coins=coins,
@@ -428,6 +436,7 @@ def run_benchmark_case(
     def median(key):
         return statistics.median(float(item[key]) for item in warm)
 
+    cold_profile = cold["proxy_profile"]
     return {
         "case": name,
         "seed": seed,
@@ -437,10 +446,17 @@ def run_benchmark_case(
         "coin_count": coin_count,
         "side_count": side_count,
         "candidate_bars": candidates * bars * coin_count * side_count,
-        "kernel_candidate_bars": candidates * bars * coin_count * side_count,
+        "kernel_candidate_bars": int(
+            cold_profile.get(
+                "kernel_candidate_bars",
+                candidates * bars * coin_count * side_count,
+            )
+        ),
         "actual_dispatch_batch_size": int(cold["batch_size"]),
-        "dispatch_chunk_count": 1,
-        "dispatch_count_per_run": 1,
+        "dispatch_chunk_count": int(
+            cold_profile.get("dispatch_chunk_count", cold["dispatch_count"])
+        ),
+        "dispatch_count_per_run": int(cold["dispatch_count"]),
         "cold": cold,
         "warm": {
             "runs": warm_runs,
@@ -462,6 +478,11 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--case", choices=(*CASES, "all"), default="all")
     parser.add_argument("--candidates", type=int, default=256)
+    parser.add_argument(
+        "--dispatch-batch-size",
+        type=int,
+        help="Candidates per MPS dispatch (defaults to --candidates)",
+    )
     parser.add_argument("--warm-runs", type=int, default=5)
     parser.add_argument("--single-bars", type=int, default=60_000)
     parser.add_argument("--multicoin-bars", type=int, default=4_320)
@@ -500,6 +521,16 @@ def main(argv: list[str] | None = None) -> int:
     candidates = _bounded_positive(
         parser, "--candidates", args.candidates, MAX_CANDIDATES
     )
+    dispatch_batch_size = (
+        candidates
+        if args.dispatch_batch_size is None
+        else _bounded_positive(
+            parser,
+            "--dispatch-batch-size",
+            args.dispatch_batch_size,
+            candidates,
+        )
+    )
     warm_runs = _bounded_positive(parser, "--warm-runs", args.warm_runs, MAX_WARM_RUNS)
     single_bars = _bounded_positive(
         parser, "--single-bars", args.single_bars, MAX_SINGLE_BARS
@@ -535,6 +566,7 @@ def main(argv: list[str] | None = None) -> int:
             run_benchmark_case(
                 name,
                 candidates=candidates,
+                dispatch_batch_size=dispatch_batch_size,
                 warm_runs=warm_runs,
                 single_bars=single_bars,
                 multicoin_bars=multicoin_bars,

--- a/src/tools/gpu_proxy_benchmark.py
+++ b/src/tools/gpu_proxy_benchmark.py
@@ -546,10 +546,10 @@ def main(argv: list[str] | None = None) -> int:
         parser.error("--coins must be at least two")
     selected = CASES if args.case == "all" else (args.case,)
     if any(name.endswith("single-long") for name in selected):
-        if candidates * single_bars > MAX_DISPATCH_CANDIDATE_BARS:
+        if dispatch_batch_size * single_bars > MAX_DISPATCH_CANDIDATE_BARS:
             parser.error("single-coin candidate-bars exceed the safe benchmark limit")
     if any(name.startswith("ema-multicoin") for name in selected):
-        if candidates * multicoin_bars * coins > MAX_DISPATCH_CANDIDATE_BARS:
+        if dispatch_batch_size * multicoin_bars * coins > MAX_DISPATCH_CANDIDATE_BARS:
             parser.error("multicoin candidate-bars exceed the safe benchmark limit")
 
     torch = _require_mps_torch(parser)

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -8618,6 +8618,7 @@ def test_mps_ema_anchor_near_touch_market_entry_uses_next_close_and_taker_fee(si
         "long_enabled": side == "long",
         "short_enabled": side == "short",
         "hedge_mode": True,
+        "hsl_enabled": False,
     }
 
     resting = MpsEmaAnchorRunner(market, run, data, **common).run(parameters)
@@ -8632,12 +8633,32 @@ def test_mps_ema_anchor_near_touch_market_entry_uses_next_close_and_taker_fee(si
         **common,
     )
     promoted = promoted_runner.run(parameters)
+    generic = MpsEmaAnchorRunner(
+        market,
+        run,
+        data,
+        market_orders_allowed=True,
+        market_order_near_touch_threshold=0.001,
+        market_order_slippage_pct=0.01,
+        taker_fee=market.taker_fee,
+        **{**common, "hsl_enabled": True},
+    ).run(parameters)
     torch.mps.synchronize()
 
     assert promoted_runner.settings[19].item() == 1.0
     assert promoted_runner.settings[20].item() == pytest.approx(0.001)
+    assert promoted_runner.shader_topology == f"{side}_no_hsl"
     assert resting["fill_count"].item() == 0.0
     assert promoted["fill_count"].item() == 1.0
+    assert promoted.keys() == generic.keys()
+    for key in promoted:
+        torch.testing.assert_close(
+            promoted[key].cpu(),
+            generic[key].cpu(),
+            rtol=1.0e-6,
+            atol=1.0e-6,
+            equal_nan=True,
+        )
     if side == "long":
         expected_qty = 1.001
         expected_price = 101.0

--- a/tests/optimization/test_gpu_proxy_benchmark.py
+++ b/tests/optimization/test_gpu_proxy_benchmark.py
@@ -14,6 +14,7 @@ from tools.gpu_proxy_benchmark import (
     _parameter_matrix,
     _require_mps_torch,
     build_parser,
+    main,
     run_benchmark_case,
 )
 
@@ -53,6 +54,77 @@ def test_gpu_proxy_benchmark_accepts_independent_dispatch_batch_size():
 
     assert args.candidates == 4096
     assert args.dispatch_batch_size == 512
+
+
+@pytest.mark.parametrize(
+    "case, extra_args",
+    (
+        ("ema-single-long", ["--single-bars", "525600"]),
+        (
+            "ema-multicoin-overhead",
+            ["--multicoin-bars", "100000", "--coins", "32"],
+        ),
+    ),
+)
+def test_gpu_proxy_benchmark_applies_safety_limit_per_dispatch(
+    monkeypatch, case, extra_args
+):
+    class FakeTorch:
+        __version__ = "test"
+
+    monkeypatch.setattr(
+        "tools.gpu_proxy_benchmark._require_mps_torch", lambda _parser: FakeTorch()
+    )
+    monkeypatch.setattr(
+        "tools.gpu_proxy_benchmark.run_benchmark_case",
+        lambda *_args, **_kwargs: {},
+    )
+
+    assert (
+        main(
+            [
+                "--case",
+                case,
+                "--candidates",
+                "4096",
+                "--dispatch-batch-size",
+                "1",
+                "--warm-runs",
+                "1",
+                *extra_args,
+                "--compact",
+            ]
+        )
+        == 0
+    )
+
+
+@pytest.mark.parametrize(
+    "case, extra_args",
+    (
+        ("ema-single-long", ["--single-bars", "525600"]),
+        (
+            "ema-multicoin-overhead",
+            ["--multicoin-bars", "100000", "--coins", "32"],
+        ),
+    ),
+)
+def test_gpu_proxy_benchmark_rejects_oversized_dispatch(case, extra_args):
+    with pytest.raises(SystemExit):
+        main(
+            [
+                "--case",
+                case,
+                "--candidates",
+                "4096",
+                "--dispatch-batch-size",
+                "4096",
+                "--warm-runs",
+                "1",
+                *extra_args,
+                "--compact",
+            ]
+        )
 
 
 def test_gpu_proxy_benchmark_reports_profiled_dispatch_chunks(monkeypatch):

--- a/tests/optimization/test_gpu_proxy_benchmark.py
+++ b/tests/optimization/test_gpu_proxy_benchmark.py
@@ -14,6 +14,7 @@ from tools.gpu_proxy_benchmark import (
     _parameter_matrix,
     _require_mps_torch,
     build_parser,
+    run_benchmark_case,
 )
 
 
@@ -43,6 +44,55 @@ def test_gpu_proxy_benchmark_rejects_non_positive_sizes():
         _bounded_positive(parser, "--candidates", 0, 10)
     with pytest.raises(SystemExit):
         _bounded_positive(parser, "--candidates", 11, 10)
+
+
+def test_gpu_proxy_benchmark_accepts_independent_dispatch_batch_size():
+    args = build_parser().parse_args(
+        ["--candidates", "4096", "--dispatch-batch-size", "512"]
+    )
+
+    assert args.candidates == 4096
+    assert args.dispatch_batch_size == 512
+
+
+def test_gpu_proxy_benchmark_reports_profiled_dispatch_chunks(monkeypatch):
+    class FakeProxy:
+        def evaluate(self, _candidates):
+            self.last_profile = {
+                "actual_dispatch_batch_sizes": [2, 2, 2, 2],
+                "cold_dispatch_count": 0,
+                "dispatch_chunk_count": 4,
+                "dispatch_count": 4,
+                "kernel_candidate_bars": 80,
+                "timings_seconds": {
+                    "cold_compilation": 0.0,
+                    "device_to_host": 0.1,
+                    "host_overhead": 0.2,
+                    "kernel_execution": 0.3,
+                    "warm_library_lookup": 0.0,
+                },
+            }
+
+    monkeypatch.setattr(
+        "tools.gpu_proxy_benchmark._build_case",
+        lambda *_args, **_kwargs: (FakeProxy(), [{}] * 8, 10, 1, 1, "fixture"),
+    )
+
+    report = run_benchmark_case(
+        "ema-single-long",
+        candidates=8,
+        dispatch_batch_size=2,
+        warm_runs=1,
+        single_bars=10,
+        multicoin_bars=10,
+        coins=2,
+        seed=7,
+    )
+
+    assert report["actual_dispatch_batch_size"] == 2
+    assert report["dispatch_chunk_count"] == 4
+    assert report["dispatch_count_per_run"] == 4
+    assert report["kernel_candidate_bars"] == 80
 
 
 def test_gpu_proxy_benchmark_reports_missing_optional_gpu_dependencies(

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -20,7 +20,7 @@ from optimization.gpu.model import (
     TRAILING_MARTINGALE_PARAM_KEYS,
     flatten_trailing_martingale_params,
     gpu_side_enabled,
-    trailing_martingale_shader_topology,
+    single_coin_shader_topology,
     validate_hsl_signal_topology,
     validate_single_coin_hsl_signal_topology,
 )
@@ -348,11 +348,11 @@ def test_recovery_distribution_postprocessor_is_opt_in_and_fail_closed(monkeypat
         (False, True, True, "generic"),
     ],
 )
-def test_trailing_martingale_shader_topology_is_fail_closed(
+def test_single_coin_shader_topology_is_fail_closed(
     long_enabled, short_enabled, hsl_enabled, expected
 ):
     assert (
-        trailing_martingale_shader_topology(
+        single_coin_shader_topology(
             long_enabled=long_enabled,
             short_enabled=short_enabled,
             hsl_enabled=hsl_enabled,


### PR DESCRIPTION
## Summary

- compile dedicated one-side/no-HSL EMA Anchor Metal sources while retaining the generic source for dual-side or HSL-enabled evaluations
- let the deterministic GPU benchmark hold its candidate matrix constant while varying dispatch batch size, and report actual profile-derived dispatch counts
- add source-contract, routing, benchmark, and on-device parity coverage; document the benchmark control and changelog entry

Exact Rust backtests and validation remain authoritative. CPU bot, backtest, and optimizer paths are unchanged.

## Performance

Fixed-seed synthetic EMA Anchor fixture `bdbd4f99abdd7715dd4ad0d3447b632450e25a2639e25456417049e675d63ee1`, 4,096 candidates in one dispatch, 60,000 candles, warm p50 of five runs on Apple M3:

| Measurement | Before | After |
| --- | ---: | ---: |
| Candidates/second | 1,466 | 5,689 |
| Kernel time | 2.705 s | 0.626 s |

The Trailing Martingale and multicoin control cases remained within about 1.1% of their baselines. A controlled 256–4,096 dispatch-size sweep also confirmed that the existing 4,096 default was the best tested size, so this change does not alter it.

## Validation

- `cargo test --manifest-path passivbot-rust/Cargo.toml --no-default-features` (275 passed)
- `cargo check --manifest-path passivbot-rust/Cargo.toml --tests`
- rebuilt and verified the Python Rust extension with the repository helper
- focused Apple MPS source, exact-parity, HSL, and one-side specialization tests
- `pytest tests/optimization/test_gpu_backend.py tests/optimization/test_gpu_service.py tests/optimization/test_gpu_proxy_benchmark.py tests/test_passivbot_cli.py` (820 passed)
- `python src/tools/check_ai_docs.py` (0 errors)
- `git diff --check`
