### PR TITLE
Add TM+HSL MPS dispatch observability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Long-running Apple MPS proxy generations now emit rate-limited dispatch progress with elapsed
+  time and ETA after 30 seconds, while opt-in profiles record each dispatch chunk's wall time. The
+  deterministic offline benchmark adds a single-side Trailing Martingale case with HSL enabled so
+  HSL-heavy dispatch sizing and kernel changes can be measured directly.
+
 - Apple MPS EMA Anchor optimization now compiles a one-side kernel when HSL is disabled, allowing
   Metal to eliminate the inactive side and HSL state from the hot candle loop. Dual-side and HSL
   runs keep the generic kernel, and exact Rust validation remains authoritative. The offline GPU

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -729,7 +729,9 @@ reduction, and remaining host overhead. Shape metadata includes requested and ac
 sizes, dispatch chunk and strategy-kernel counts, candidate-bars, candle/coin/side counts, requested
 optional metric features, and cold/warm dispatch counts. Exact Rust evaluation remains
 authoritative; profiling fields are diagnostic log output and are not added to retained optimization
-results.
+results. Chunked proxy generations that run for at least 30 seconds also emit rate-limited ordinary
+progress with completed chunks and candidates, elapsed time, and ETA. This progress remains
+available without enabling profiling or adding synchronization points.
 
 For comparable local MPS measurements, first confirm another optimizer is not using the device,
 then run each case in a fresh process. The harness uses only fixed-seed, in-memory synthetic candles
@@ -739,6 +741,7 @@ optimization results.
 ```bash
 passivbot tool gpu-proxy-benchmark --case ema-single-long
 passivbot tool gpu-proxy-benchmark --case tm-single-long
+passivbot tool gpu-proxy-benchmark --case tm-single-long-hsl
 passivbot tool gpu-proxy-benchmark --case ema-multicoin-overhead
 passivbot tool gpu-proxy-benchmark --case ema-multicoin-overrides
 # Hold one candidate matrix constant while measuring dispatch chunking:
@@ -749,13 +752,15 @@ passivbot tool gpu-proxy-benchmark --case ema-single-long \
 The single-coin cases default to 60,000 one-minute candles; the overhead-sensitive multicoin cases
 default to 4,320 candles and eight coins. Every report records the seed and workload shape, cold
 compile/run timing, a fixture hash, and warm p50 across five repeated runs, including
-candidates/second, kernel time, dispatch count, device transfer, and host overhead. Use identical
-arguments and immutable commits for before/after comparisons. The harness calls the production
-proxy evaluation path, including its full output transfer, metric reduction, and result
-materialization. Run one `--case` per process when comparing cold compilation; `--case all` is
-convenient for smoke checks, and shared-cache hit/miss state still keeps later cold/warm labels
-accurate. `--dispatch-batch-size` defaults to `--candidates`; setting it lower preserves the fixed
-candidate matrix and reports the actual chunk and strategy-dispatch counts, which isolates dispatch
+candidates/second, kernel time, maximum chunk wall time, dispatch count, device transfer, and host
+overhead. The HSL case uses the same fixed candles and candidate generation as ordinary Trailing
+Martingale while enabling a deterministic long-side HSL lifecycle. Use identical arguments and
+immutable commits for before/after comparisons. The harness calls the production proxy evaluation
+path, including its full output transfer, metric reduction, and result materialization. Run one
+`--case` per process when comparing cold compilation; `--case all` is convenient for smoke checks,
+and shared-cache hit/miss state still keeps later cold/warm labels accurate.
+`--dispatch-batch-size` defaults to `--candidates`; setting it lower preserves the fixed candidate
+matrix and reports the actual chunk and strategy-dispatch counts, which isolates dispatch
 saturation from population-size changes.
 
 ### Pymoo Configuration

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -133,6 +133,65 @@ _GPU_PROFILE_RUNNER_TIMING_KEYS = (
     "metric_reduction",
 )
 
+_GPU_DISPATCH_PROGRESS_INTERVAL_SECONDS = 30.0
+
+
+def _new_gpu_dispatch_progress(candidate_count: int, dispatch_batch_size: int):
+    if candidate_count <= dispatch_batch_size:
+        return None
+    started = time.monotonic()
+    return {
+        "candidate_count": int(candidate_count),
+        "dispatch_batch_size": int(dispatch_batch_size),
+        "started": started,
+        "last_log": started,
+        "total_chunks": (
+            int(candidate_count) + int(dispatch_batch_size) - 1
+        )
+        // int(dispatch_batch_size),
+    }
+
+
+def _update_gpu_dispatch_progress(
+    progress,
+    *,
+    completed_candidates: int,
+    strategy: str,
+) -> None:
+    if progress is None:
+        return
+    now = time.monotonic()
+    elapsed = now - float(progress["started"])
+    completed_candidates = min(
+        int(completed_candidates), int(progress["candidate_count"])
+    )
+    completed_chunks = min(
+        (completed_candidates + int(progress["dispatch_batch_size"]) - 1)
+        // int(progress["dispatch_batch_size"]),
+        int(progress["total_chunks"]),
+    )
+    complete = completed_candidates >= int(progress["candidate_count"])
+    if elapsed < _GPU_DISPATCH_PROGRESS_INTERVAL_SECONDS or (
+        not complete
+        and now - float(progress["last_log"])
+        < _GPU_DISPATCH_PROGRESS_INTERVAL_SECONDS
+    ):
+        return
+    rate = completed_candidates / max(elapsed, 1.0e-12)
+    remaining = int(progress["candidate_count"]) - completed_candidates
+    logging.info(
+        "GPU proxy dispatch progress | strategy=%s chunks=%d/%d "
+        "candidates=%d/%d elapsed=%.1fs eta=%.1fs",
+        strategy,
+        completed_chunks,
+        int(progress["total_chunks"]),
+        completed_candidates,
+        int(progress["candidate_count"]),
+        elapsed,
+        remaining / max(rate, 1.0e-12),
+    )
+    progress["last_log"] = now
+
 
 def _gpu_profile_features(proxy, runners) -> dict[str, bool]:
     runners = tuple(runners)
@@ -186,6 +245,7 @@ def _new_gpu_proxy_profile(proxy, candidates, runners, *, coin_count, side_count
             else 0
         ),
         "actual_dispatch_batch_sizes": [],
+        "dispatch_chunk_wall_seconds": [],
         "dispatch_count": 0,
         "cold_dispatch_count": 0,
         "warm_dispatch_count": 0,
@@ -1937,7 +1997,13 @@ class MpsSingleCoinProxy:
             self, "dispatch_batch_size", self.batch_size
         )
         interrupt_check = getattr(self, "interrupt_check", lambda: None)
+        progress = _new_gpu_dispatch_progress(
+            len(candidates), dispatch_batch_size
+        )
         for start in range(0, len(candidates), dispatch_batch_size):
+            chunk_profile_started = (
+                time.perf_counter() if profile is not None else 0.0
+            )
             interrupt_check()
             chunk = candidates[start : start + dispatch_batch_size]
             stage_started = (
@@ -2036,6 +2102,14 @@ class MpsSingleCoinProxy:
                 profile["timings_seconds"]["result_materialization"] += (
                     time.perf_counter() - stage_started
                 )
+                profile["dispatch_chunk_wall_seconds"].append(
+                    time.perf_counter() - chunk_profile_started
+                )
+            _update_gpu_dispatch_progress(
+                progress,
+                completed_candidates=start + len(chunk),
+                strategy=str(getattr(self, "strategy_kind", "unknown")),
+            )
         if profile is not None:
             self.last_profile = _finish_gpu_proxy_profile(
                 profile, profile_started
@@ -3029,7 +3103,13 @@ class MpsMulticoinProxy:
             self, "dispatch_batch_size", self.batch_size
         )
         interrupt_check = getattr(self, "interrupt_check", lambda: None)
+        progress = _new_gpu_dispatch_progress(
+            len(candidates), dispatch_batch_size
+        )
         for start in range(0, len(candidates), dispatch_batch_size):
+            chunk_profile_started = (
+                time.perf_counter() if profile is not None else 0.0
+            )
             interrupt_check()
             chunk = candidates[start : start + dispatch_batch_size]
             stage_started = (
@@ -3249,6 +3329,14 @@ class MpsMulticoinProxy:
                 profile["timings_seconds"]["result_materialization"] += (
                     time.perf_counter() - stage_started
                 )
+                profile["dispatch_chunk_wall_seconds"].append(
+                    time.perf_counter() - chunk_profile_started
+                )
+            _update_gpu_dispatch_progress(
+                progress,
+                completed_candidates=start + len(chunk),
+                strategy=str(getattr(self, "strategy_kind", "unknown")),
+            )
         if profile is not None:
             self.last_profile = _finish_gpu_proxy_profile(
                 profile, profile_started

--- a/src/tools/gpu_proxy_benchmark.py
+++ b/src/tools/gpu_proxy_benchmark.py
@@ -24,8 +24,12 @@ from optimization.gpu.model import (
 CASES = (
     "ema-single-long",
     "tm-single-long",
+    "tm-single-long-hsl",
     "ema-multicoin-overhead",
     "ema-multicoin-overrides",
+)
+SINGLE_COIN_CASES = frozenset(
+    {"ema-single-long", "tm-single-long", "tm-single-long-hsl"}
 )
 DEFAULT_SEED = 7
 MAX_CANDIDATES = 4096
@@ -108,8 +112,15 @@ def _base_parameter_values() -> dict[str, float]:
     }
 
 
-def _parameter_matrix(keys, candidates: int, seed: int) -> np.ndarray:
+def _parameter_matrix(
+    keys,
+    candidates: int,
+    seed: int,
+    *,
+    value_overrides: dict[str, float] | None = None,
+) -> np.ndarray:
     values = _base_parameter_values()
+    values.update(value_overrides or {})
     base = np.asarray([values[key] for key in keys], dtype=np.float64)
     matrix = np.repeat(base[None, :], candidates, axis=0)
     rng = np.random.default_rng(seed)
@@ -204,7 +215,7 @@ def _build_case(
     }
     base_values = _base_parameter_values()
 
-    if name in {"ema-single-long", "tm-single-long"}:
+    if name in SINGLE_COIN_CASES:
         hlcvs, timestamps = _synthetic_hlcvs(single_bars, 1, seed)
         market, run = _market_and_run(timestamps, single_bars)
         data = build_mps_data(
@@ -214,6 +225,20 @@ def _build_case(
             timestamps,
             run,
             market,
+        )
+        hsl_enabled = name == "tm-single-long-hsl"
+        hsl_value_overrides = (
+            {
+                "hsl_enabled": 1.0,
+                "hsl_red_threshold": 0.02,
+                "hsl_ema_span_minutes": 60.0,
+                "hsl_cooldown_minutes_after_red": 1_440.0,
+                "hsl_restart_policy": 1.0,
+                "entry_double_down_factor": 2.0,
+                "total_wallet_exposure_limit": 5.0,
+            }
+            if hsl_enabled
+            else {}
         )
         if name == "ema-single-long":
             runner = MpsEmaAnchorRunner(
@@ -234,12 +259,13 @@ def _build_case(
                 data,
                 long_enabled=True,
                 short_enabled=False,
-                hsl_enabled=False,
+                hsl_enabled=hsl_enabled,
             )
             side_matrix = _parameter_matrix(
                 TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS,
                 candidates,
                 seed,
+                value_overrides=hsl_value_overrides,
             )
         proxy = MpsSingleCoinProxy.__new__(MpsSingleCoinProxy)
         proxy.batch_size = candidates
@@ -264,7 +290,10 @@ def _build_case(
             else TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS
         )
         proxy.base_params = {
-            side: {key: base_values[key] for key in proxy.param_keys}
+            side: {
+                key: hsl_value_overrides.get(key, base_values[key])
+                for key in proxy.param_keys
+            }
             for side in ("long", "short")
         }
         proxy.static_coin_override_params = {}
@@ -376,6 +405,13 @@ def _run_once(proxy, candidates) -> dict:
         cold = bool(profile["cold_dispatch_count"])
         batch_size = max(profile["actual_dispatch_batch_sizes"], default=0)
         dispatch_count = int(profile["dispatch_count"])
+        dispatch_chunk_wall_seconds_max = max(
+            (
+                float(value)
+                for value in profile.get("dispatch_chunk_wall_seconds", ())
+            ),
+            default=0.0,
+        )
     else:
         runners = tuple(getattr(proxy, "runners", {}).values()) or (proxy.runner,)
         runner_profiles = [dict(runner.last_profile) for runner in runners]
@@ -396,6 +432,7 @@ def _run_once(proxy, candidates) -> dict:
         cold = False
         batch_size = len(candidates)
         dispatch_count = len(runner_profiles)
+        dispatch_chunk_wall_seconds_max = wall_seconds
     return {
         "batch_size": batch_size,
         "candidates_per_second": len(candidates) / max(wall_seconds, 1.0e-12),
@@ -403,6 +440,7 @@ def _run_once(proxy, candidates) -> dict:
         "compile_seconds": compile_seconds,
         "device_to_host_seconds": device_to_host_seconds,
         "dispatch_count": dispatch_count,
+        "dispatch_chunk_wall_seconds_max": dispatch_chunk_wall_seconds_max,
         "host_overhead_seconds": host_overhead_seconds,
         "kernel_seconds": kernel_seconds,
         "proxy_profile": profile,
@@ -457,6 +495,9 @@ def run_benchmark_case(
             cold_profile.get("dispatch_chunk_count", cold["dispatch_count"])
         ),
         "dispatch_count_per_run": int(cold["dispatch_count"]),
+        "dispatch_chunk_wall_seconds_max": float(
+            cold["dispatch_chunk_wall_seconds_max"]
+        ),
         "cold": cold,
         "warm": {
             "runs": warm_runs,
@@ -464,6 +505,9 @@ def run_benchmark_case(
             "kernel_seconds_p50": median("kernel_seconds"),
             "device_to_host_seconds_p50": median("device_to_host_seconds"),
             "host_overhead_seconds_p50": median("host_overhead_seconds"),
+            "dispatch_chunk_wall_seconds_max_p50": median(
+                "dispatch_chunk_wall_seconds_max"
+            ),
             "candidates_per_second_p50": median("candidates_per_second"),
         },
     }
@@ -545,7 +589,7 @@ def main(argv: list[str] | None = None) -> int:
     if coins < 2:
         parser.error("--coins must be at least two")
     selected = CASES if args.case == "all" else (args.case,)
-    if any(name.endswith("single-long") for name in selected):
+    if any(name in SINGLE_COIN_CASES for name in selected):
         if dispatch_batch_size * single_bars > MAX_DISPATCH_CANDIDATE_BARS:
             parser.error("single-coin candidate-bars exceed the safe benchmark limit")
     if any(name.startswith("ema-multicoin") for name in selected):

--- a/tests/optimization/test_gpu_proxy_benchmark.py
+++ b/tests/optimization/test_gpu_proxy_benchmark.py
@@ -56,6 +56,31 @@ def test_gpu_proxy_benchmark_accepts_independent_dispatch_batch_size():
     assert args.dispatch_batch_size == 512
 
 
+def test_gpu_proxy_benchmark_exposes_single_side_tm_hsl_case():
+    args = build_parser().parse_args(["--case", "tm-single-long-hsl"])
+    matrix = _parameter_matrix(
+        TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS,
+        2,
+        7,
+        value_overrides={"hsl_enabled": 1.0, "hsl_red_threshold": 0.03},
+    )
+
+    assert args.case == "tm-single-long-hsl"
+    assert np.all(
+        matrix[:, TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS.index("hsl_enabled")]
+        == 1.0
+    )
+    assert np.all(
+        matrix[
+            :,
+            TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS.index(
+                "hsl_red_threshold"
+            ),
+        ]
+        == 0.03
+    )
+
+
 @pytest.mark.parametrize(
     "case, extra_args",
     (
@@ -135,6 +160,7 @@ def test_gpu_proxy_benchmark_reports_profiled_dispatch_chunks(monkeypatch):
                 "cold_dispatch_count": 0,
                 "dispatch_chunk_count": 4,
                 "dispatch_count": 4,
+                "dispatch_chunk_wall_seconds": [0.4, 0.3, 0.2, 0.1],
                 "kernel_candidate_bars": 80,
                 "timings_seconds": {
                     "cold_compilation": 0.0,
@@ -164,6 +190,10 @@ def test_gpu_proxy_benchmark_reports_profiled_dispatch_chunks(monkeypatch):
     assert report["actual_dispatch_batch_size"] == 2
     assert report["dispatch_chunk_count"] == 4
     assert report["dispatch_count_per_run"] == 4
+    assert report["dispatch_chunk_wall_seconds_max"] == pytest.approx(0.4)
+    assert report["warm"]["dispatch_chunk_wall_seconds_max_p50"] == pytest.approx(
+        0.4
+    )
     assert report["kernel_candidate_bars"] == 80
 
 

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -46,7 +46,9 @@ from optimization.gpu.service import (
     _gpu_profile_unattributed_seconds,
     _mps_dispatch_batch_size,
     _mps_strategy_eq_recovery_distribution,
+    _new_gpu_dispatch_progress,
     _new_gpu_proxy_profile,
+    _update_gpu_dispatch_progress,
     _add_gpu_runner_profile,
     _multicoin_exposure_eligible_coins,
     _position_exposure_enforcer_params,
@@ -463,6 +465,8 @@ def test_single_coin_proxy_profile_records_dispatch_shape_and_timings(monkeypatc
     assert profile["dispatch_count"] == 3
     assert profile["cold_dispatch_count"] == 1
     assert profile["warm_dispatch_count"] == 2
+    assert len(profile["dispatch_chunk_wall_seconds"]) == 3
+    assert all(value >= 0.0 for value in profile["dispatch_chunk_wall_seconds"])
     assert profile["candidate_bars"] == 500
     assert profile["kernel_candidate_bars"] == 500
     assert profile["coin_count"] == 1
@@ -477,6 +481,34 @@ def test_single_coin_proxy_profile_records_dispatch_shape_and_timings(monkeypatc
         0.006
     )
     assert profile["wall_seconds"] >= 0.0
+
+
+def test_gpu_dispatch_progress_is_rate_limited_and_reports_eta(
+    monkeypatch, caplog
+):
+    readings = iter((100.0, 120.0, 131.0, 162.0))
+    monkeypatch.setattr(
+        "optimization.gpu.service.time.monotonic", lambda: next(readings)
+    )
+    progress = _new_gpu_dispatch_progress(8, 2)
+
+    _update_gpu_dispatch_progress(
+        progress, completed_candidates=2, strategy="trailing_martingale"
+    )
+    assert not caplog.records
+
+    with caplog.at_level("INFO"):
+        _update_gpu_dispatch_progress(
+            progress, completed_candidates=4, strategy="trailing_martingale"
+        )
+        _update_gpu_dispatch_progress(
+            progress, completed_candidates=8, strategy="trailing_martingale"
+        )
+
+    assert "chunks=2/4" in caplog.records[0].message
+    assert "candidates=4/8" in caplog.records[0].message
+    assert "eta=" in caplog.records[0].message
+    assert "chunks=4/4" in caplog.records[1].message
 
 
 def test_single_coin_proxy_profile_is_empty_when_disabled(monkeypatch):


### PR DESCRIPTION
## Summary

- add a deterministic single-side Trailing Martingale benchmark with HSL enabled and repeatable trigger/restart episodes
- record maximum outer dispatch-chunk wall time alongside existing phase timings
- emit rate-limited progress and ETA for chunked proxy evaluations that exceed 30 seconds, without enabling profiling or adding synchronization points

Exact Rust validation remains authoritative. CPU optimizer, backtest, and live paths are unchanged.

## Evidence

Fixed-seed synthetic one-year TM+HSL fixture `eb0fc718107d57a61708ff5354f74b52ee8422e0357202455fd6fea546f35c52`, 512 candidates, warm p50 of two runs on Apple M3:

| Dispatch batch | Candidates/s | Max chunk wall |
| ---: | ---: | ---: |
| 64 | 6.60 | 9.71 s |
| 128 | 13.10 | 9.79 s |
| 142 | 13.67 | 9.60 s |
| 256 | 23.71 | 10.83 s |
| 512 | 34.71 | 14.75 s |

This PR deliberately changes observability and benchmark coverage only. The sweep establishes the immutable workload for a dependent performance change.

## Validation

- `pytest tests/optimization/test_gpu_proxy_benchmark.py tests/optimization/test_gpu_service.py tests/optimization/test_gpu_backend.py` (778 passed)
- on-device HSL fixture check: 13 triggers and 13 restarts across 32 candidates / 60,000 candles
- sequential Apple MPS dispatch sweeps at 60,000 and 525,600 candles
- `python src/tools/check_ai_docs.py` (0 errors; existing size warnings only)
- Python compile checks and `git diff --check`
- `mkdocs build --strict` reaches the existing warnings for two release-note links to `../CHANGELOG.md`
