### PR TITLE
Specialize one-side TM+HSL MPS kernels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Apple MPS single-coin Trailing Martingale optimization now compiles dedicated long-only and
+  short-only kernels while HSL is enabled, allowing Metal to eliminate the inactive strategy side
+  without removing HSL lifecycle or opt-in metric features. The existing dispatch safety envelope
+  remains unchanged. Dual-side, EMA Anchor, multi-coin, HSL-disabled, and CPU paths retain their
+  existing kernel and dispatch contracts, and exact Rust validation remains authoritative.
+
 - Long-running Apple MPS proxy generations now emit rate-limited dispatch progress with elapsed
   time and ETA after 30 seconds, while opt-in profiles record each dispatch chunk's wall time. The
   deterministic offline benchmark adds a single-side Trailing Martingale case with HSL enabled so

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -29,6 +29,8 @@ const MPS_TRAILING_LONG_NO_HSL_PREAMBLE: &str =
     "#define PASSIVBOT_TRAILING_LONG_ONLY 1\n#define PASSIVBOT_TRAILING_HSL_DISABLED 1\n";
 const MPS_TRAILING_SHORT_NO_HSL_PREAMBLE: &str =
     "#define PASSIVBOT_TRAILING_SHORT_ONLY 1\n#define PASSIVBOT_TRAILING_HSL_DISABLED 1\n";
+const MPS_TRAILING_LONG_HSL_PREAMBLE: &str = "#define PASSIVBOT_TRAILING_LONG_ONLY 1\n";
+const MPS_TRAILING_SHORT_HSL_PREAMBLE: &str = "#define PASSIVBOT_TRAILING_SHORT_ONLY 1\n";
 const MPS_EMA_LONG_NO_HSL_PREAMBLE: &str =
     "#define PASSIVBOT_EMA_LONG_ONLY 1\n#define PASSIVBOT_EMA_HSL_DISABLED 1\n";
 const MPS_EMA_SHORT_NO_HSL_PREAMBLE: &str =
@@ -99,6 +101,10 @@ pub static MPS_EMA_ANCHOR_MULTICOIN_SOURCE: LazyLock<String> =
     LazyLock::new(|| compose_multicoin_source(MPS_EMA_ANCHOR_MULTICOIN_BODY));
 pub static MPS_TRAILING_MARTINGALE_SOURCE: LazyLock<String> =
     LazyLock::new(|| compose_hsl_source(MPS_TRAILING_MARTINGALE_BODY));
+pub static MPS_TRAILING_MARTINGALE_LONG_HSL_SOURCE: LazyLock<String> =
+    LazyLock::new(|| compose_trailing_topology_source(MPS_TRAILING_LONG_HSL_PREAMBLE));
+pub static MPS_TRAILING_MARTINGALE_SHORT_HSL_SOURCE: LazyLock<String> =
+    LazyLock::new(|| compose_trailing_topology_source(MPS_TRAILING_SHORT_HSL_PREAMBLE));
 pub static MPS_TRAILING_MARTINGALE_LONG_NO_HSL_SOURCE: LazyLock<String> =
     LazyLock::new(|| compose_trailing_topology_source(MPS_TRAILING_LONG_NO_HSL_PREAMBLE));
 pub static MPS_TRAILING_MARTINGALE_SHORT_NO_HSL_SOURCE: LazyLock<String> =
@@ -128,6 +134,14 @@ pub fn mps_ema_anchor_multicoin_long_source() -> &'static str {
 
 pub fn mps_trailing_martingale_source() -> &'static str {
     MPS_TRAILING_MARTINGALE_SOURCE.as_str()
+}
+
+pub fn mps_trailing_martingale_long_hsl_source() -> &'static str {
+    MPS_TRAILING_MARTINGALE_LONG_HSL_SOURCE.as_str()
+}
+
+pub fn mps_trailing_martingale_short_hsl_source() -> &'static str {
+    MPS_TRAILING_MARTINGALE_SHORT_HSL_SOURCE.as_str()
 }
 
 pub fn mps_trailing_martingale_long_no_hsl_source() -> &'static str {
@@ -453,6 +467,8 @@ mod tests {
             mps_ema_anchor_short_no_hsl_source(),
             mps_ema_anchor_multicoin_source(),
             mps_trailing_martingale_source(),
+            mps_trailing_martingale_long_hsl_source(),
+            mps_trailing_martingale_short_hsl_source(),
             mps_trailing_martingale_long_no_hsl_source(),
             mps_trailing_martingale_short_no_hsl_source(),
             mps_trailing_martingale_multicoin_source(),
@@ -539,20 +555,35 @@ mod tests {
     }
 
     #[test]
-    fn trailing_martingale_specialized_sources_pin_one_side_without_hsl() {
+    fn trailing_martingale_specialized_sources_pin_one_side() {
         let variants = [
+            (
+                mps_trailing_martingale_long_hsl_source(),
+                "#define PASSIVBOT_TRAILING_LONG_ONLY 1",
+                false,
+            ),
+            (
+                mps_trailing_martingale_short_hsl_source(),
+                "#define PASSIVBOT_TRAILING_SHORT_ONLY 1",
+                false,
+            ),
             (
                 mps_trailing_martingale_long_no_hsl_source(),
                 "#define PASSIVBOT_TRAILING_LONG_ONLY 1",
+                true,
             ),
             (
                 mps_trailing_martingale_short_no_hsl_source(),
                 "#define PASSIVBOT_TRAILING_SHORT_ONLY 1",
+                true,
             ),
         ];
-        for (source, side_define) in variants {
+        for (source, side_define, hsl_disabled) in variants {
             assert!(source.starts_with(side_define));
-            assert!(source.contains("#define PASSIVBOT_TRAILING_HSL_DISABLED 1"));
+            assert_eq!(
+                source.contains("#define PASSIVBOT_TRAILING_HSL_DISABLED 1"),
+                hsl_disabled
+            );
             assert!(source.contains("#if defined(PASSIVBOT_TRAILING_LONG_ONLY)"));
             assert!(source.contains("#elif defined(PASSIVBOT_TRAILING_SHORT_ONLY)"));
             assert!(source.contains("#if defined(PASSIVBOT_TRAILING_HSL_DISABLED)"));

--- a/passivbot-rust/src/lib.rs
+++ b/passivbot-rust/src/lib.rs
@@ -64,6 +64,16 @@ fn mps_trailing_martingale_source_py() -> &'static str {
 }
 
 #[pyfunction]
+fn mps_trailing_martingale_long_hsl_source_py() -> &'static str {
+    gpu::mps_trailing_martingale_long_hsl_source()
+}
+
+#[pyfunction]
+fn mps_trailing_martingale_short_hsl_source_py() -> &'static str {
+    gpu::mps_trailing_martingale_short_hsl_source()
+}
+
+#[pyfunction]
 fn mps_trailing_martingale_long_no_hsl_source_py() -> &'static str {
     gpu::mps_trailing_martingale_long_no_hsl_source()
 }
@@ -99,6 +109,14 @@ fn passivbot_rust(m: &Bound<'_, PyModule>) -> PyResult<()> {
         m
     )?)?;
     m.add_function(wrap_pyfunction!(mps_trailing_martingale_source_py, m)?)?;
+    m.add_function(wrap_pyfunction!(
+        mps_trailing_martingale_long_hsl_source_py,
+        m
+    )?)?;
+    m.add_function(wrap_pyfunction!(
+        mps_trailing_martingale_short_hsl_source_py,
+        m
+    )?)?;
     m.add_function(wrap_pyfunction!(
         mps_trailing_martingale_long_no_hsl_source_py,
         m

--- a/src/optimization/gpu/model.py
+++ b/src/optimization/gpu/model.py
@@ -49,16 +49,20 @@ def validate_single_coin_hsl_signal_topology(
 
 
 def single_coin_shader_topology(
-    *, long_enabled: bool, short_enabled: bool, hsl_enabled: bool
+    *,
+    long_enabled: bool,
+    short_enabled: bool,
+    hsl_enabled: bool,
+    hsl_one_side_enabled: bool = False,
 ) -> str:
     """Select a one-side variant only when compile-time assumptions are exact."""
 
-    if hsl_enabled:
+    if hsl_enabled and not hsl_one_side_enabled:
         return "generic"
     if long_enabled and not short_enabled:
-        return "long_no_hsl"
+        return "long_hsl" if hsl_enabled else "long_no_hsl"
     if short_enabled and not long_enabled:
-        return "short_no_hsl"
+        return "short_hsl" if hsl_enabled else "short_no_hsl"
     return "generic"
 
 

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -549,6 +549,60 @@ def _trailing_martingale_shader_library(
     return torch.mps.compile_shader(source)
 
 
+@lru_cache(maxsize=16)
+def _trailing_martingale_long_hsl_shader_library(
+    hsl_ema_tail_enabled: bool = False,
+    hsl_raw_drawdown_enabled: bool = False,
+    hsl_raw_tail_enabled: bool = False,
+    recovery_distribution_enabled: bool = False,
+    btc_risk_enabled: bool = False,
+    equity_balance_diff_enabled: bool = False,
+    entry_interval_enabled: bool = False,
+):
+    if not torch.backends.mps.is_available():
+        raise RuntimeError("Apple MPS is not available in this process")
+    import passivbot_rust
+
+    source = _with_hsl_features(
+        passivbot_rust.mps_trailing_martingale_long_hsl_source_py(),
+        ema_tail_enabled=hsl_ema_tail_enabled,
+        raw_drawdown_enabled=hsl_raw_drawdown_enabled,
+        raw_tail_enabled=hsl_raw_tail_enabled,
+    )
+    source = _with_recovery_distribution(source, recovery_distribution_enabled)
+    source = _with_btc_risk(source, btc_risk_enabled)
+    source = _with_equity_balance_diff(source, equity_balance_diff_enabled)
+    source = _with_entry_interval(source, entry_interval_enabled)
+    return torch.mps.compile_shader(source)
+
+
+@lru_cache(maxsize=16)
+def _trailing_martingale_short_hsl_shader_library(
+    hsl_ema_tail_enabled: bool = False,
+    hsl_raw_drawdown_enabled: bool = False,
+    hsl_raw_tail_enabled: bool = False,
+    recovery_distribution_enabled: bool = False,
+    btc_risk_enabled: bool = False,
+    equity_balance_diff_enabled: bool = False,
+    entry_interval_enabled: bool = False,
+):
+    if not torch.backends.mps.is_available():
+        raise RuntimeError("Apple MPS is not available in this process")
+    import passivbot_rust
+
+    source = _with_hsl_features(
+        passivbot_rust.mps_trailing_martingale_short_hsl_source_py(),
+        ema_tail_enabled=hsl_ema_tail_enabled,
+        raw_drawdown_enabled=hsl_raw_drawdown_enabled,
+        raw_tail_enabled=hsl_raw_tail_enabled,
+    )
+    source = _with_recovery_distribution(source, recovery_distribution_enabled)
+    source = _with_btc_risk(source, btc_risk_enabled)
+    source = _with_equity_balance_diff(source, equity_balance_diff_enabled)
+    source = _with_entry_interval(source, entry_interval_enabled)
+    return torch.mps.compile_shader(source)
+
+
 @lru_cache(maxsize=4)
 def _trailing_martingale_long_no_hsl_shader_library(
     recovery_distribution_enabled: bool = False,
@@ -2479,11 +2533,12 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
             long_enabled=self.long_enabled,
             short_enabled=self.short_enabled,
             hsl_enabled=bool(hsl_enabled),
+            hsl_one_side_enabled=True,
         )
         # The specialized no-HSL kernels retain the original 66-column ABI.
         # Every EMA-tail metric is identically zero when HSL is disabled, so
         # keep that faster topology and let the decoder synthesize zeroes.
-        if self.shader_topology != "generic":
+        if self.shader_topology.endswith("_no_hsl"):
             self.hsl_ema_tail_enabled = False
             self.hsl_raw_drawdown_enabled = False
             self.hsl_raw_tail_enabled = False
@@ -2493,6 +2548,26 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
         return loader(*args)
 
     def _shader_library_cache_call(self):
+        if self.shader_topology == "long_hsl":
+            return _trailing_martingale_long_hsl_shader_library, (
+                self.hsl_ema_tail_enabled,
+                self.hsl_raw_drawdown_enabled,
+                self.hsl_raw_tail_enabled,
+                self.recovery_distribution_enabled,
+                self.btc_risk_enabled,
+                self.equity_balance_diff_enabled,
+                self.entry_interval_enabled,
+            )
+        if self.shader_topology == "short_hsl":
+            return _trailing_martingale_short_hsl_shader_library, (
+                self.hsl_ema_tail_enabled,
+                self.hsl_raw_drawdown_enabled,
+                self.hsl_raw_tail_enabled,
+                self.recovery_distribution_enabled,
+                self.btc_risk_enabled,
+                self.equity_balance_diff_enabled,
+                self.entry_interval_enabled,
+            )
         if self.shader_topology == "long_no_hsl":
             return _trailing_martingale_long_no_hsl_shader_library, (
                 self.recovery_distribution_enabled,

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -602,6 +602,40 @@ def test_trailing_martingale_no_hsl_specialization_keeps_base_scalar_abi(
     assert runner.hsl_raw_tail_enabled is False
 
 
+def test_trailing_martingale_hsl_specialization_keeps_requested_features(
+    monkeypatch,
+):
+    from optimization.gpu.mps_kernel import (
+        MpsEmaAnchorRunner,
+        MpsTrailingMartingaleRunner,
+    )
+
+    def fake_base_init(self, *args, **kwargs):
+        self.long_enabled = False
+        self.short_enabled = True
+        self.hsl_ema_tail_enabled = bool(kwargs["hsl_ema_tail_enabled"])
+        self.hsl_raw_drawdown_enabled = bool(
+            kwargs["hsl_raw_drawdown_enabled"]
+        )
+        self.hsl_raw_tail_enabled = bool(kwargs["hsl_raw_tail_enabled"])
+
+    monkeypatch.setattr(MpsEmaAnchorRunner, "__init__", fake_base_init)
+    runner = MpsTrailingMartingaleRunner(
+        None,
+        None,
+        None,
+        hsl_enabled=True,
+        hsl_ema_tail_enabled=True,
+        hsl_raw_drawdown_enabled=True,
+        hsl_raw_tail_enabled=True,
+    )
+
+    assert runner.shader_topology == "short_hsl"
+    assert runner.hsl_ema_tail_enabled is True
+    assert runner.hsl_raw_drawdown_enabled is True
+    assert runner.hsl_raw_tail_enabled is True
+
+
 @pytest.mark.parametrize("recovery_enabled", [False, True])
 @pytest.mark.parametrize("runner_name", ["ema_anchor", "trailing_martingale"])
 def test_single_coin_size_buffer_packs_last_valid_before_recovery_fields(
@@ -14459,7 +14493,7 @@ def test_mps_single_coin_hsl_panics_and_permanently_halts(strategy_kind, side):
             inactive + recursive_close_hsl,
         ]
     )
-    output = runner_cls(
+    runner = runner_cls(
         market,
         run,
         data,
@@ -14469,7 +14503,24 @@ def test_mps_single_coin_hsl_panics_and_permanently_halts(strategy_kind, side):
         hsl_ema_tail_enabled=True,
         hsl_raw_drawdown_enabled=True,
         hsl_raw_tail_enabled=True,
-    ).run(np.asarray(rows, dtype=np.float64))
+    )
+    output = runner.run(np.asarray(rows, dtype=np.float64))
+    generic_output = None
+    if strategy_kind == "trailing_martingale":
+        assert runner.shader_topology == f"{side}_hsl"
+        generic_runner = runner_cls(
+            market,
+            run,
+            data,
+            long_enabled=side == "long",
+            short_enabled=side == "short",
+            pnl_lookback_bars=5,
+            hsl_ema_tail_enabled=True,
+            hsl_raw_drawdown_enabled=True,
+            hsl_raw_tail_enabled=True,
+        )
+        generic_runner.shader_topology = "generic"
+        generic_output = generic_runner.run(np.asarray(rows, dtype=np.float64))
     market_runner = runner_cls(
         market,
         run,
@@ -14509,6 +14560,17 @@ def test_mps_single_coin_hsl_panics_and_permanently_halts(strategy_kind, side):
         max_realized_loss_pct=0.0,
     ).run(np.asarray([rows[9]], dtype=np.float64))
     torch.mps.synchronize()
+
+    if generic_output is not None:
+        assert output.keys() == generic_output.keys()
+        for key in output:
+            torch.testing.assert_close(
+                output[key].cpu(),
+                generic_output[key].cpu(),
+                rtol=1.0e-6,
+                atol=1.0e-6,
+                equal_nan=True,
+            )
 
     size_key = "psize" if side == "long" else "short_psize"
     assert output[size_key][0].item() > 0.0

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -341,23 +341,38 @@ def test_recovery_distribution_postprocessor_is_opt_in_and_fail_closed(monkeypat
 
 
 @pytest.mark.parametrize(
-    ("long_enabled", "short_enabled", "hsl_enabled", "expected"),
+    (
+        "long_enabled",
+        "short_enabled",
+        "hsl_enabled",
+        "hsl_one_side_enabled",
+        "expected",
+    ),
     [
-        (True, False, False, "long_no_hsl"),
-        (False, True, False, "short_no_hsl"),
-        (True, True, False, "generic"),
-        (True, False, True, "generic"),
-        (False, True, True, "generic"),
+        (True, False, False, False, "long_no_hsl"),
+        (False, True, False, False, "short_no_hsl"),
+        (True, True, False, False, "generic"),
+        (True, False, True, False, "generic"),
+        (False, True, True, False, "generic"),
+        (True, False, True, True, "long_hsl"),
+        (False, True, True, True, "short_hsl"),
+        (True, True, True, True, "generic"),
+        (False, False, True, True, "generic"),
     ],
 )
 def test_single_coin_shader_topology_is_fail_closed(
-    long_enabled, short_enabled, hsl_enabled, expected
+    long_enabled,
+    short_enabled,
+    hsl_enabled,
+    hsl_one_side_enabled,
+    expected,
 ):
     assert (
         single_coin_shader_topology(
             long_enabled=long_enabled,
             short_enabled=short_enabled,
             hsl_enabled=hsl_enabled,
+            hsl_one_side_enabled=hsl_one_side_enabled,
         )
         == expected
     )


### PR DESCRIPTION
## Summary

- export Rust-owned long-only and short-only Trailing Martingale Metal sources that keep HSL enabled
- route only exact one-side TM+HSL topologies to those sources while EMA Anchor, dual-side, multicoin, and HSL-disabled routing remain unchanged
- preserve optional HSL tail, recovery-distribution, BTC-risk, equity-balance, and entry-interval feature composition
- retain the existing 500M candidate-bar dispatch safety envelope and exact Rust validation authority

## Performance

Deterministic in-memory benchmark on Apple M3, with identical arguments on base 57eb06f4c42ab229fbddaed974f0e7188611c0fd and head b8cf7e2f24c561ef7aedd6726ef55ad716e221fb:

    passivbot tool gpu-proxy-benchmark --case tm-single-long-hsl --candidates 512 --dispatch-batch-size 142 --warm-runs 2 --single-bars 525600 --seed 7 --compact

Fixture SHA-256: 4b1e8bc2489699ce0c76a98414fccdfde7190b86ccad8749b0bc281be985ff44

| warm p50 | base | head | change |
| --- | ---: | ---: | ---: |
| wall seconds | 36.917 | 27.963 | -24.3% |
| candidates/second | 13.869 | 18.310 | +32.0% |
| kernel seconds | 36.766 | 27.831 | -24.3% |
| maximum chunk seconds | 9.292 | 7.003 | -24.6% |

Both runs used batch 142 and four strategy dispatches. The dispatch safety cap is unchanged.

## Validation

- cargo test --manifest-path passivbot-rust/Cargo.toml --no-default-features: 275 passed
- cargo check --manifest-path passivbot-rust/Cargo.toml --tests
- focused real-MPS long/short specialized-vs-generic parity plus directional smoke: 7 passed
- tests/optimization/test_gpu_service.py, test_gpu_backend.py, and test_gpu_proxy_benchmark.py
- CPU-mode tests/optimization/test_gpu_mps.py
- rebuilt and verified the stamped Python extension against the current Rust source fingerprint
- src/tools/check_ai_docs.py: 0 errors, 2 existing word-count warnings
- mkdocs build --strict reaches the existing release-note links to ../CHANGELOG.md and stops on those two pre-existing warnings