### PR TITLE
Optimize one-sided Trailing Martingale HSL kernels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@ All notable user-facing changes will be documented in this file.
 
 - Apple MPS single-coin Trailing Martingale optimization now compiles dedicated long-only and
   short-only kernels while HSL is enabled, allowing Metal to eliminate the inactive strategy side
-  without removing HSL lifecycle or opt-in metric features. The existing dispatch safety envelope
-  remains unchanged. Dual-side, EMA Anchor, multi-coin, HSL-disabled, and CPU paths retain their
-  existing kernel and dispatch contracts, and exact Rust validation remains authoritative.
+  and use a one-controller HSL update. HSL lifecycle, drawdown, tail, and recovery accumulators are
+  compiled only when requested by a proxy objective or limit; controller behavior remains active
+  when those diagnostics are omitted. The existing dispatch safety envelope remains unchanged.
+  Dual-side, EMA Anchor, multi-coin, HSL-disabled, and CPU paths retain their existing kernel and
+  dispatch contracts, and exact Rust validation remains authoritative.
 
 - Long-running Apple MPS proxy generations now emit rate-limited dispatch progress with elapsed
   time and ETA after 30 seconds, while opt-in profiles record each dispatch chunk's wall time. The

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -596,12 +596,14 @@ The backend is hybrid rather than a replacement backtester:
    price finalization, and their ordering relative to aligned quantity steps is retained across
    float32 transport. Tick-aligned computed targets remain on their exchange tick; residual
    float32 arithmetic drift is measured by exact validation.
-   For HSL-disabled, one-sided single-coin Trailing Martingale runs, the backend automatically
-   selects a Rust-owned long-only or short-only Metal variant. Compile-time side and HSL constants
-   let Metal remove unreachable controller and opposite-side work without changing candidate
-   ordering or optimizer semantics. Dual-side and HSL-enabled runs retain the generic kernel. The
-   selected variant is logged as `GPU MPS specialized kernel selected`; exact Rust validation and
-   the normal drift gates remain authoritative.
+   For one-sided single-coin Trailing Martingale runs, the backend automatically selects a
+   Rust-owned long-only or short-only Metal variant, including supported coin-HSL configurations.
+   Compile-time side constants remove the opposite-side fill, indicator, trailing, and HSL update
+   paths. HSL lifecycle and drawdown telemetry is compiled only when a requested proxy objective or
+   limit consumes it; ordinary strategy-equity and fill metrics keep the controller behavior but
+   omit those unused accumulators. Dual-side runs retain the generic kernel. The selected variant
+   is logged as `GPU MPS specialized kernel selected`; exact Rust validation and the normal drift
+   gates remain authoritative.
 3. In suite mode, the same candidate batch is screened once per scenario and reduced with the
    canonical suite scoring and limit contract.
 4. Diverse proxy-front candidates and broad drift probes are sent to the unchanged Rust backtester.

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -587,6 +587,7 @@ mod tests {
             assert!(source.contains("#if defined(PASSIVBOT_TRAILING_LONG_ONLY)"));
             assert!(source.contains("#elif defined(PASSIVBOT_TRAILING_SHORT_ONLY)"));
             assert!(source.contains("#if defined(PASSIVBOT_TRAILING_HSL_DISABLED)"));
+            assert!(source.contains("update_one_side_hsl("));
             assert_shared_hsl_contract(source);
             assert_directional_hsl_accounting_contract(source);
         }

--- a/passivbot-rust/src/gpu/mps_hsl_common.metal
+++ b/passivbot-rust/src/gpu/mps_hsl_common.metal
@@ -15,6 +15,10 @@
 #define PASSIVBOT_HSL_RAW_TAIL_ENABLED 0
 #endif
 
+#ifndef PASSIVBOT_HSL_DIAGNOSTICS_ENABLED
+#define PASSIVBOT_HSL_DIAGNOSTICS_ENABLED 1
+#endif
+
 #define HSL_EMA_TAIL_BINS 32
 
 constant int HSL_SIGNAL_UNIFIED = 0;
@@ -162,7 +166,9 @@ struct HslState {
     float slot_count;
     bool initialized;
     float drawdown_ema;
+#if PASSIVBOT_HSL_DIAGNOSTICS_ENABLED
     float drawdown_ema_max;
+#endif
     float peak_strategy_pnl;
     float no_restart_peak_strategy_equity;
     float coin_realized_baseline;
@@ -181,9 +187,12 @@ struct HslState {
     float pending_stop_k;
     float current_red_start_k;
     float current_halt_start_k;
+#if PASSIVBOT_HSL_DIAGNOSTICS_ENABLED
     float last_restart_k;
+#endif
     float triggers;
     float restarts;
+#if PASSIVBOT_HSL_DIAGNOSTICS_ENABLED
     float halt_duration_sum_steps;
     float halt_duration_max_steps;
     float halt_duration_count;
@@ -202,6 +211,7 @@ struct HslState {
     float panic_loss_drawdown_sum;
     float panic_loss_drawdown_max;
     float panic_loss_drawdown_count;
+#endif
 };
 
 inline void prepare_coin_hsl_rolling_signal(
@@ -477,7 +487,9 @@ inline HslState load_hsl(
     h.slot_count = fmax(round(params[ho + 10]), 1.0f);
     h.initialized = false;
     h.drawdown_ema = 0.0f;
+#if PASSIVBOT_HSL_DIAGNOSTICS_ENABLED
     h.drawdown_ema_max = 0.0f;
+#endif
     h.peak_strategy_pnl = -INFINITY;
     h.no_restart_peak_strategy_equity = 0.0f;
     h.coin_realized_baseline = 0.0f;
@@ -496,9 +508,12 @@ inline HslState load_hsl(
     h.pending_stop_k = -1.0f;
     h.current_red_start_k = -1.0f;
     h.current_halt_start_k = -1.0f;
+#if PASSIVBOT_HSL_DIAGNOSTICS_ENABLED
     h.last_restart_k = -1.0f;
+#endif
     h.triggers = 0.0f;
     h.restarts = 0.0f;
+#if PASSIVBOT_HSL_DIAGNOSTICS_ENABLED
     h.halt_duration_sum_steps = 0.0f;
     h.halt_duration_max_steps = 0.0f;
     h.halt_duration_count = 0.0f;
@@ -517,6 +532,7 @@ inline HslState load_hsl(
     h.panic_loss_drawdown_sum = 0.0f;
     h.panic_loss_drawdown_max = 0.0f;
     h.panic_loss_drawdown_count = 0.0f;
+#endif
     return h;
 }
 
@@ -658,7 +674,9 @@ inline void update_hsl_from_signal(
         return;
     }
     h.drawdown_ema = fma(h.alpha, drawdown_raw - h.drawdown_ema, h.drawdown_ema);
+#if PASSIVBOT_HSL_DIAGNOSTICS_ENABLED
     h.drawdown_ema_max = fmax(h.drawdown_ema_max, fabs(h.drawdown_ema));
+#endif
     float score = fmin(drawdown_raw, fmax(h.drawdown_ema, 0.0f));
     const float cmp_eps = 1.0e-12f;
     h.red_active_now = score + cmp_eps >= h.red_threshold;
@@ -686,7 +704,9 @@ inline void update_hsl_from_signal(
                 h.halted = true;
                 h.current_halt_start_k = h.pending_stop_k;
                 h.triggers += 1.0f;
+#if PASSIVBOT_HSL_DIAGNOSTICS_ENABLED
                 h.equity_at_halt = strategy_equity;
+#endif
                 if (h.signal_mode == HSL_SIGNAL_COIN) {
                     h.coin_realized_baseline = realized_pnl;
                     h.coin_realized_peak = 0.0f;
@@ -708,6 +728,7 @@ inline void update_hsl_from_signal(
                         ),
                         0.9999999403953552f
                     );
+#if PASSIVBOT_HSL_DIAGNOSTICS_ENABLED
                 float stop_drawdown_raw = fmax(
                     h.pending_drawdown_raw,
                     fmax(
@@ -747,6 +768,7 @@ inline void update_hsl_from_signal(
                     h.panic_event_start_equity = -1.0f;
                     h.panic_event_loss = 0.0f;
                 }
+#endif
                 bool terminal = h.restart_policy == 2
                     || (h.restart_policy == 1
                         && fmax(no_restart_drawdown_raw, h.pending_drawdown_ema)
@@ -778,6 +800,23 @@ inline void update_hsl(
     )) return;
     update_hsl_from_signal(
         h, signal, realized_pnl, has_position, has_blocking_orders, kf, interval_ms
+    );
+}
+
+inline void update_one_side_hsl(
+    thread HslState& hsl,
+    float balance,
+    float starting_balance,
+    float realized_pnl,
+    float unrealized_pnl,
+    bool has_position,
+    bool has_blocking_orders,
+    float kf,
+    float interval_ms
+) {
+    update_hsl(
+        hsl, balance, starting_balance, realized_pnl, unrealized_pnl,
+        has_position, has_blocking_orders, kf, interval_ms
     );
 }
 
@@ -830,19 +869,23 @@ inline void try_restart_hsl(thread HslState& h, float kf, float current_equity) 
     if (!h.enabled || !h.halted || h.no_restart_latched
         || h.cooldown_until_k < 0.0f || kf < h.cooldown_until_k) return;
     if (h.current_halt_start_k >= 0.0f) {
+#if PASSIVBOT_HSL_DIAGNOSTICS_ENABLED
         float duration = fmax(kf - h.current_halt_start_k, 0.0f);
         h.halt_duration_sum_steps += duration;
         h.halt_duration_max_steps = fmax(h.halt_duration_max_steps, duration);
         h.halt_duration_count += 1.0f;
+#endif
         h.current_halt_start_k = -1.0f;
     }
     h.restarts += 1.0f;
+#if PASSIVBOT_HSL_DIAGNOSTICS_ENABLED
     if (h.signal_mode != HSL_SIGNAL_COIN && h.equity_at_halt > 0.0f) {
         h.halt_to_restart_equity_loss += fmax(
             h.equity_at_halt - current_equity, 0.0f
         );
     }
     h.last_restart_k = kf;
+#endif
     h.initialized = false;
     h.drawdown_ema = 0.0f;
     h.peak_strategy_pnl = -INFINITY;
@@ -860,6 +903,7 @@ inline void record_hsl_panic_fill(
     float net_pnl,
     float current_equity
 ) {
+#if PASSIVBOT_HSL_DIAGNOSTICS_ENABLED
     if (h.panic_event_start_equity < 0.0f) {
         h.panic_event_start_equity = fmax(current_equity, 1.0e-12f);
     }
@@ -867,6 +911,11 @@ inline void record_hsl_panic_fill(
     h.panic_event_loss += panic_loss;
     h.panic_close_loss_sum += panic_loss;
     h.panic_close_loss_max = fmax(h.panic_close_loss_max, panic_loss);
+#else
+    (void)h;
+    (void)net_pnl;
+    (void)current_equity;
+#endif
 }
 
 // Keep every HSL scalar reduction in one contract. Existing one-side kernels
@@ -945,6 +994,7 @@ inline void accumulate_hsl_output(
     bool short_side,
     float last_equity_k
 ) {
+#if PASSIVBOT_HSL_DIAGNOSTICS_ENABLED
     // Forced delist closes are panic fills even when HSL itself is disabled.
     // Exact Rust reports their loss metrics independently of controller
     // enablement, so retain those fields before filtering HSL-only telemetry.
@@ -995,6 +1045,12 @@ inline void accumulate_hsl_output(
     output.flatten_time_count += h.flatten_time_count;
     output.restart_retrigger_count += h.restart_retrigger_count;
     output.halt_to_restart_equity_loss += h.halt_to_restart_equity_loss;
+#else
+    (void)output;
+    (void)h;
+    (void)short_side;
+    (void)last_equity_k;
+#endif
 }
 
 inline void write_hsl_output_aggregate(

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -1802,8 +1802,10 @@ inline void passivbot_single_coin_impl(
     short_side.market_order_near_touch_threshold = market_order_near_touch_threshold;
     HslState long_hsl = load_hsl(params, po, 40);
     HslState short_hsl = load_hsl(params, po + SIDE_PARAMS, 40);
+#if PASSIVBOT_HSL_DIAGNOSTICS_ENABLED
     HslStrategyEquityStats long_hsl_strategy_eq = init_hsl_strategy_equity_stats();
     HslStrategyEquityStats short_hsl_strategy_eq = init_hsl_strategy_equity_stats();
+#endif
 #if PASSIVBOT_HSL_EMA_TAIL_ENABLED
     HslDrawdownEmaTailStats long_hsl_ema_tail = init_hsl_drawdown_ema_tail_stats();
     HslDrawdownEmaTailStats short_hsl_ema_tail = init_hsl_drawdown_ema_tail_stats();
@@ -1880,10 +1882,12 @@ inline void passivbot_single_coin_impl(
 #ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
     int recovery_start_k = -1;
 #endif
+#if PASSIVBOT_HSL_DIAGNOSTICS_ENABLED
     float hsl_tier_samples_total = 0.0f;
     float hsl_tier_samples_yellow = 0.0f;
     float hsl_tier_samples_orange = 0.0f;
     float hsl_tier_samples_red = 0.0f;
+#endif
 
     int cur_day = flags[2];
     bool day_touched = false;
@@ -1960,6 +1964,10 @@ inline void passivbot_single_coin_impl(
         }
 
         bool long_close_fill = false;
+        bool long_entry_fill = false;
+        bool short_close_fill = false;
+        bool short_entry_fill = false;
+#if !defined(PASSIVBOT_TRAILING_SHORT_ONLY)
         bool long_close_ready = valid && alive && long_enabled
             && long_side.close_qty > 0.0f && long_side.psize > 0.0f;
         bool long_secondary_close_fill = valid && alive && long_enabled
@@ -2560,7 +2568,7 @@ inline void passivbot_single_coin_impl(
 
         bool long_entry_passive_reachable = long_side.entry_qty > 0.0f
             && long_side.entry_ticks > low_nonfill_max_tick;
-        bool long_entry_fill = valid && alive && long_enabled
+        long_entry_fill = valid && alive && long_enabled
             && long_side.entry_qty > 0.0f
             && (long_side.entry_market
                 || long_entry_passive_reachable);
@@ -2718,8 +2726,9 @@ inline void passivbot_single_coin_impl(
             }
             long_side.entry_qty = 0.0f;
         }
+#endif
 
-        bool short_close_fill = false;
+#if !defined(PASSIVBOT_TRAILING_LONG_ONLY)
         bool short_close_ready = valid && alive && short_enabled
             && short_side.close_qty > 0.0f && short_side.psize > 0.0f;
         bool short_secondary_close_fill = valid && alive && short_enabled
@@ -3317,7 +3326,7 @@ inline void passivbot_single_coin_impl(
 
         bool short_entry_passive_reachable = short_side.entry_qty > 0.0f
             && short_side.entry_ticks <= high_fill_max_tick;
-        bool short_entry_fill = valid && alive && short_enabled
+        short_entry_fill = valid && alive && short_enabled
             && short_side.entry_qty > 0.0f
             && (short_side.entry_market
                 || short_entry_passive_reachable);
@@ -3469,6 +3478,7 @@ inline void passivbot_single_coin_impl(
             }
             short_side.entry_qty = 0.0f;
         }
+#endif
 
         // Exact Rust generates this candle's bundles first, then force-closes and
         // clears both bundles.  Closing here and suppressing only that dead order
@@ -3477,9 +3487,14 @@ inline void passivbot_single_coin_impl(
             && last_valid + 1400 < T;
         bool forced_delist_closed_any = false;
         if (forced_delist && alive && balance > 0.0f) {
+#if !defined(PASSIVBOT_TRAILING_SHORT_ONLY)
+#if defined(PASSIVBOT_TRAILING_LONG_ONLY)
+            float short_unrealized = 0.0f;
+#else
             float short_unrealized = short_side.psize > 0.0f
                 ? short_side.psize * c_mult * (short_side.pprice - close)
                 : 0.0f;
+#endif
             bool forced_long_close = force_close_delisted_position(
                 long_side.psize, long_side.pprice, long_side.pos_open_k,
                 long_hsl, true, close, short_unrealized, price_step,
@@ -3493,9 +3508,17 @@ inline void passivbot_single_coin_impl(
                 long_coin_hsl_rolling, profit_sum, loss_sum, profit_sum_long,
                 loss_sum_long, held_max_min, held_sum_min, held_count, day_volume
             );
+#else
+            bool forced_long_close = false;
+#endif
+#if !defined(PASSIVBOT_TRAILING_LONG_ONLY)
+#if defined(PASSIVBOT_TRAILING_SHORT_ONLY)
+            float long_unrealized = 0.0f;
+#else
             float long_unrealized = long_side.psize > 0.0f
                 ? long_side.psize * c_mult * (close - long_side.pprice)
                 : 0.0f;
+#endif
             bool forced_short_close = force_close_delisted_position(
                 short_side.psize, short_side.pprice, short_side.pos_open_k,
                 short_hsl, false, close, long_unrealized, price_step,
@@ -3509,19 +3532,27 @@ inline void passivbot_single_coin_impl(
                 short_coin_hsl_rolling, profit_sum, loss_sum, profit_sum_short,
                 loss_sum_short, held_max_min, held_sum_min, held_count, day_volume
             );
+#else
+            bool forced_short_close = false;
+#endif
             long_close_fill = long_close_fill || forced_long_close;
             short_close_fill = short_close_fill || forced_short_close;
             forced_delist_closed_any = forced_long_close || forced_short_close;
             if (forced_delist_closed_any) {
+#if !defined(PASSIVBOT_TRAILING_SHORT_ONLY)
                 long_side.entry_qty = 0.0f;
                 long_side.close_qty = 0.0f;
                 long_side.secondary_close_qty = 0.0f;
+#endif
+#if !defined(PASSIVBOT_TRAILING_LONG_ONLY)
                 short_side.entry_qty = 0.0f;
                 short_side.close_qty = 0.0f;
                 short_side.secondary_close_qty = 0.0f;
+#endif
             }
         }
 
+#if !defined(PASSIVBOT_TRAILING_SHORT_ONLY)
         if (long_close_fill || long_entry_fill) {
             if (long_position_last_fill_k >= 0.0f) {
                 position_unchanged_max_min = fmax(
@@ -3530,6 +3561,8 @@ inline void passivbot_single_coin_impl(
             }
             long_position_last_fill_k = long_side.psize > 0.0f ? kf : -1.0f;
         }
+#endif
+#if !defined(PASSIVBOT_TRAILING_LONG_ONLY)
         if (short_close_fill || short_entry_fill) {
             if (short_position_last_fill_k >= 0.0f) {
                 position_unchanged_max_min = fmax(
@@ -3538,6 +3571,7 @@ inline void passivbot_single_coin_impl(
             }
             short_position_last_fill_k = short_side.psize > 0.0f ? kf : -1.0f;
         }
+#endif
 
         bool any_fill = long_close_fill || long_entry_fill
             || short_close_fill || short_entry_fill;
@@ -3556,24 +3590,32 @@ inline void passivbot_single_coin_impl(
             last_fill_k = kf;
         }
 
+#if !defined(PASSIVBOT_TRAILING_SHORT_ONLY)
         if (long_enabled) {
             update_indicators(long_side, close, log_range, hour_lr, valid, hour_valid);
         }
+#endif
+#if !defined(PASSIVBOT_TRAILING_LONG_ONLY)
         if (short_enabled) {
             update_indicators(short_side, close, log_range, hour_lr, valid, hour_valid);
         }
+#endif
+#if !defined(PASSIVBOT_TRAILING_SHORT_ONLY)
         if (long_enabled) {
             update_trailing(
                 long_side, high, low, close, valid,
                 long_close_fill || long_entry_fill
             );
         }
+#endif
+#if !defined(PASSIVBOT_TRAILING_LONG_ONLY)
         if (short_enabled) {
             update_trailing(
                 short_side, high, low, close, valid,
                 short_close_fill || short_entry_fill
             );
         }
+#endif
 
         bool gen = can_gen && alive;
         eq_started = eq_started || gen;
@@ -3837,6 +3879,103 @@ inline void passivbot_single_coin_impl(
         }
         const bool hsl_step = gen || (eq_started && after_valid_tail);
         if (hsl_step && alive && balance > 0.0f && equity > liq_floor) {
+#if defined(PASSIVBOT_TRAILING_LONG_ONLY)
+            bool long_blocking_orders = valid && long_hsl_mode != 3 && (
+                long_side.entry_qty > 0.0f || long_side.close_qty > 0.0f
+                    || long_side.secondary_close_qty > 0.0f
+            );
+            prepare_coin_hsl_rolling_signal(
+                long_hsl, long_rolling_pnl,
+                rolling_pnl_values, rolling_pnl_indices,
+                long_rolling_base, rolling_capacity, int(kf),
+                pnl_lookback_bars, realized_pnl_cumsum_long
+            );
+            float long_triggers_before = long_hsl.triggers;
+            const bool long_hsl_sample_enabled = long_hsl.enabled
+                && (long_hsl.signal_mode == HSL_SIGNAL_COIN || !long_hsl.halted);
+#if PASSIVBOT_HSL_DIAGNOSTICS_ENABLED
+            if (long_hsl_sample_enabled) {
+                update_hsl_strategy_equity_stats(
+                    long_hsl_strategy_eq,
+                    starting_balance + realized_pnl_cumsum_long + long_unreal,
+                    di
+                );
+            }
+#endif
+            update_one_side_hsl(
+                long_hsl, balance, starting_balance,
+                realized_pnl_cumsum_long, long_unreal,
+                long_side.psize > 0.0f, long_blocking_orders,
+                kf, interval_ms
+            );
+#if PASSIVBOT_HSL_EMA_TAIL_ENABLED
+            if (long_hsl_sample_enabled) {
+                update_hsl_drawdown_ema_tail_stats(
+                    long_hsl_ema_tail, long_hsl.drawdown_ema
+                );
+            }
+#endif
+            if (long_hsl.triggers > long_triggers_before) {
+                reset_hsl_rolling_pnl_window(long_rolling_pnl);
+            }
+#if PASSIVBOT_HSL_DIAGNOSTICS_ENABLED
+            if (long_hsl.enabled) {
+                hsl_tier_samples_total += 1.0f;
+                hsl_tier_samples_yellow += long_hsl.tier == 1 ? 1.0f : 0.0f;
+                hsl_tier_samples_orange += long_hsl.tier == 2 ? 1.0f : 0.0f;
+                hsl_tier_samples_red += long_hsl.tier == 3 ? 1.0f : 0.0f;
+            }
+#endif
+            try_restart_hsl(long_hsl, kf, equity);
+#elif defined(PASSIVBOT_TRAILING_SHORT_ONLY)
+            bool short_blocking_orders = valid && short_hsl_mode != 3 && (
+                short_side.entry_qty > 0.0f || short_side.close_qty > 0.0f
+                    || short_side.secondary_close_qty > 0.0f
+            );
+            prepare_coin_hsl_rolling_signal(
+                short_hsl, short_rolling_pnl,
+                rolling_pnl_values, rolling_pnl_indices,
+                short_rolling_base, rolling_capacity, int(kf),
+                pnl_lookback_bars, realized_pnl_cumsum_short
+            );
+            float short_triggers_before = short_hsl.triggers;
+            const bool short_hsl_sample_enabled = short_hsl.enabled
+                && (short_hsl.signal_mode == HSL_SIGNAL_COIN || !short_hsl.halted);
+#if PASSIVBOT_HSL_DIAGNOSTICS_ENABLED
+            if (short_hsl_sample_enabled) {
+                update_hsl_strategy_equity_stats(
+                    short_hsl_strategy_eq,
+                    starting_balance + realized_pnl_cumsum_short + short_unreal,
+                    di
+                );
+            }
+#endif
+            update_one_side_hsl(
+                short_hsl, balance, starting_balance,
+                realized_pnl_cumsum_short, short_unreal,
+                short_side.psize > 0.0f, short_blocking_orders,
+                kf, interval_ms
+            );
+#if PASSIVBOT_HSL_EMA_TAIL_ENABLED
+            if (short_hsl_sample_enabled) {
+                update_hsl_drawdown_ema_tail_stats(
+                    short_hsl_ema_tail, short_hsl.drawdown_ema
+                );
+            }
+#endif
+            if (short_hsl.triggers > short_triggers_before) {
+                reset_hsl_rolling_pnl_window(short_rolling_pnl);
+            }
+#if PASSIVBOT_HSL_DIAGNOSTICS_ENABLED
+            if (short_hsl.enabled) {
+                hsl_tier_samples_total += 1.0f;
+                hsl_tier_samples_yellow += short_hsl.tier == 1 ? 1.0f : 0.0f;
+                hsl_tier_samples_orange += short_hsl.tier == 2 ? 1.0f : 0.0f;
+                hsl_tier_samples_red += short_hsl.tier == 3 ? 1.0f : 0.0f;
+            }
+#endif
+            try_restart_hsl(short_hsl, kf, equity);
+#else
             bool long_blocking_orders = valid && long_hsl_mode != 3 && (
                 long_side.entry_qty > 0.0f || long_side.close_qty > 0.0f
                     || long_side.secondary_close_qty > 0.0f
@@ -3866,6 +4005,7 @@ inline void passivbot_single_coin_impl(
             const bool short_hsl_sample_enabled = hsl_modes_valid && short_enabled
                 && short_hsl.enabled
                 && (short_hsl.signal_mode == HSL_SIGNAL_COIN || !short_hsl.halted);
+#if PASSIVBOT_HSL_DIAGNOSTICS_ENABLED
             if (long_hsl_sample_enabled) {
                 update_hsl_strategy_equity_stats(
                     long_hsl_strategy_eq,
@@ -3886,6 +4026,7 @@ inline void passivbot_single_coin_impl(
                     di
                 );
             }
+#endif
             bool hsl_update_valid = update_dual_side_hsl(
                 long_hsl, short_hsl, balance, starting_balance,
                 realized_pnl_cumsum_last,
@@ -3918,6 +4059,7 @@ inline void passivbot_single_coin_impl(
                 alive = false;
                 liq_day = di;
             }
+#if PASSIVBOT_HSL_DIAGNOSTICS_ENABLED
             if (hsl_update_valid && (long_hsl.enabled || short_hsl.enabled)) {
                 int hsl_tier = max(long_hsl.tier, short_hsl.tier);
                 hsl_tier_samples_total += 1.0f;
@@ -3925,10 +4067,12 @@ inline void passivbot_single_coin_impl(
                 hsl_tier_samples_orange += hsl_tier == 2 ? 1.0f : 0.0f;
                 hsl_tier_samples_red += hsl_tier == 3 ? 1.0f : 0.0f;
             }
+#endif
             if (hsl_update_valid) {
                 try_restart_hsl(long_hsl, kf, equity);
                 try_restart_hsl(short_hsl, kf, equity);
             }
+#endif
         }
         // Exact Rust records an equity sample at every tracked timestamp.
         // Invalid candles are non-tradable and contribute balance-only equity,
@@ -4083,6 +4227,7 @@ inline void passivbot_single_coin_impl(
     scalars[so + 15] = short_side.psize;
     scalars[so + 16] = short_side.pprice;
     scalars[so + 17] = 0.0f;
+#if PASSIVBOT_HSL_DIAGNOSTICS_ENABLED
     float long_terminal_count = long_hsl.halted
         && long_hsl.current_halt_start_k >= 0.0f && last_eq_k >= 0.0f
         ? 1.0f : 0.0f;
@@ -4148,6 +4293,11 @@ inline void passivbot_single_coin_impl(
         short_hsl.panic_loss_drawdown_max
     );
     scalars[so + 42] = panic_drawdown_count;
+#else
+    for (int column = 18; column <= 42; ++column) {
+        scalars[so + column] = 0.0f;
+    }
+#endif
     scalars[so + 43] = profit_sum;
     scalars[so + 44] = loss_sum;
     scalars[so + 45] = position_unchanged_max_min * interval_ms;
@@ -4169,6 +4319,7 @@ inline void passivbot_single_coin_impl(
     scalars[so + 59] = loss_sum_long;
     scalars[so + 60] = profit_sum_short;
     scalars[so + 61] = loss_sum_short;
+#if PASSIVBOT_HSL_DIAGNOSTICS_ENABLED
     scalars[so + 62] = long_hsl.enabled ? long_hsl.drawdown_ema_max : 0.0f;
     scalars[so + 63] = short_hsl.enabled ? short_hsl.drawdown_ema_max : 0.0f;
     scalars[so + 64] = hsl_strategy_equity_recovery_max_steps(
@@ -4177,6 +4328,12 @@ inline void passivbot_single_coin_impl(
     scalars[so + 65] = hsl_strategy_equity_recovery_max_steps(
         short_hsl_strategy_eq
     ) * interval_ms;
+#else
+    scalars[so + 62] = 0.0f;
+    scalars[so + 63] = 0.0f;
+    scalars[so + 64] = 0.0f;
+    scalars[so + 65] = 0.0f;
+#endif
 #if PASSIVBOT_HSL_EMA_TAIL_ENABLED
     scalars[so + 66] = hsl_drawdown_ema_mean_worst_1pct(long_hsl_ema_tail);
     scalars[so + 67] = hsl_drawdown_ema_mean_worst_1pct(short_hsl_ema_tail);

--- a/src/optimization/gpu/metric_registry.py
+++ b/src/optimization/gpu/metric_registry.py
@@ -78,6 +78,45 @@ GPU_EXACT_ONLY_METRICS = frozenset(
     }
 )
 
+HARD_STOP_LIFECYCLE_METRICS = frozenset(
+    {
+        "hard_stop_duration_minutes_max",
+        "hard_stop_duration_minutes_mean",
+        "hard_stop_flatten_time_minutes_mean",
+        "hard_stop_post_restart_retrigger_pct",
+        "hard_stop_restarts",
+        "hard_stop_restarts_long",
+        "hard_stop_restarts_per_year",
+        "hard_stop_restarts_per_year_long",
+        "hard_stop_restarts_per_year_short",
+        "hard_stop_restarts_short",
+        "hard_stop_time_in_orange_pct",
+        "hard_stop_time_in_red_pct",
+        "hard_stop_time_in_yellow_pct",
+        "hard_stop_trigger_drawdown_mean",
+        "hard_stop_triggers",
+        "hard_stop_triggers_long",
+        "hard_stop_triggers_per_year",
+        "hard_stop_triggers_short",
+    }
+)
+HARD_STOP_PANIC_LOSS_METRICS = frozenset(
+    {
+        "hard_stop_halt_to_restart_equity_loss_pct",
+        "hard_stop_panic_close_loss_drawdown_pct_max",
+        "hard_stop_panic_close_loss_drawdown_pct_mean",
+        "hard_stop_panic_close_loss_drawdown_pct_min",
+        "hard_stop_panic_close_loss_max",
+        "hard_stop_panic_close_loss_sum",
+    }
+)
+HARD_STOP_PROXY_METRICS = tuple(
+    sorted(
+        (HARD_STOP_LIFECYCLE_METRICS | HARD_STOP_PANIC_LOSS_METRICS)
+        - GPU_EXACT_ONLY_METRICS
+    )
+)
+
 
 def reject_exact_only_gpu_metric_names(metric_names) -> frozenset[str]:
     raw = frozenset(str(name).strip() for name in metric_names)

--- a/src/optimization/gpu/metrics.py
+++ b/src/optimization/gpu/metrics.py
@@ -13,6 +13,9 @@ import torch
 
 from optimization.gpu.metric_registry import (
     GPU_EXACT_ONLY_METRICS,
+    HARD_STOP_LIFECYCLE_METRICS,
+    HARD_STOP_PANIC_LOSS_METRICS,
+    HARD_STOP_PROXY_METRICS,
     reject_exact_only_gpu_metric_names,
 )
 
@@ -293,34 +296,8 @@ _FILL_GAP_HISTOGRAM_METRICS = {
     "fills_gap_p95_hours",
     "fills_gap_p99_hours",
 }
-_HARD_STOP_LIFECYCLE_METRICS = {
-    "hard_stop_duration_minutes_max",
-    "hard_stop_duration_minutes_mean",
-    "hard_stop_flatten_time_minutes_mean",
-    "hard_stop_post_restart_retrigger_pct",
-    "hard_stop_restarts",
-    "hard_stop_restarts_long",
-    "hard_stop_restarts_per_year",
-    "hard_stop_restarts_per_year_long",
-    "hard_stop_restarts_per_year_short",
-    "hard_stop_restarts_short",
-    "hard_stop_time_in_orange_pct",
-    "hard_stop_time_in_red_pct",
-    "hard_stop_time_in_yellow_pct",
-    "hard_stop_trigger_drawdown_mean",
-    "hard_stop_triggers",
-    "hard_stop_triggers_long",
-    "hard_stop_triggers_per_year",
-    "hard_stop_triggers_short",
-}
-_HARD_STOP_PANIC_LOSS_METRICS = {
-    "hard_stop_halt_to_restart_equity_loss_pct",
-    "hard_stop_panic_close_loss_drawdown_pct_max",
-    "hard_stop_panic_close_loss_drawdown_pct_mean",
-    "hard_stop_panic_close_loss_drawdown_pct_min",
-    "hard_stop_panic_close_loss_max",
-    "hard_stop_panic_close_loss_sum",
-}
+_HARD_STOP_LIFECYCLE_METRICS = HARD_STOP_LIFECYCLE_METRICS
+_HARD_STOP_PANIC_LOSS_METRICS = HARD_STOP_PANIC_LOSS_METRICS
 _HARD_STOP_EMA_DRAWDOWN_METRICS = {
     "drawdown_worst_ema_strategy_eq",
     "drawdown_worst_ema_strategy_eq_long",
@@ -351,14 +328,6 @@ _STRATEGY_EQ_RECOVERY_DISTRIBUTION_METRICS = {
     "strategy_eq_recovery_days_mean_worst_5pct",
     "strategy_eq_recovery_days_mean_worst_1pct",
 }
-HARD_STOP_PROXY_METRICS = tuple(
-    sorted(
-        (_HARD_STOP_LIFECYCLE_METRICS | _HARD_STOP_PANIC_LOSS_METRICS)
-        - GPU_EXACT_ONLY_METRICS
-    )
-)
-
-
 def _loss_profit_ratio(loss_sum: torch.Tensor, profit_sum: torch.Tensor):
     """Match Rust's capped gross close-fill loss/profit ratio contract."""
 

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -51,6 +51,9 @@ MPS_ENTRY_INTERVAL_COUNT_COLS = 129
 _HSL_EMA_TAIL_DEFINE = "#define PASSIVBOT_HSL_EMA_TAIL_ENABLED 1\n"
 _HSL_RAW_DRAWDOWN_DEFINE = "#define PASSIVBOT_HSL_RAW_DRAWDOWN_ENABLED 1\n"
 _HSL_RAW_TAIL_DEFINE = "#define PASSIVBOT_HSL_RAW_TAIL_ENABLED 1\n"
+_HSL_DIAGNOSTICS_DISABLE_DEFINE = (
+    "#define PASSIVBOT_HSL_DIAGNOSTICS_ENABLED 0\n"
+)
 _RECOVERY_DISTRIBUTION_DEFINE = (
     "#define PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED 1\n"
 )
@@ -78,9 +81,18 @@ def _with_hsl_features(
     ema_tail_enabled: bool,
     raw_drawdown_enabled: bool,
     raw_tail_enabled: bool,
+    diagnostics_enabled: bool = True,
 ) -> str:
     if raw_tail_enabled and not raw_drawdown_enabled:
         raise ValueError("HSL raw-tail metrics require raw-drawdown metrics")
+    if not diagnostics_enabled and (
+        ema_tail_enabled or raw_drawdown_enabled or raw_tail_enabled
+    ):
+        raise ValueError("HSL diagnostic feature outputs require diagnostics")
+    if not diagnostics_enabled:
+        if "#ifndef PASSIVBOT_HSL_DIAGNOSTICS_ENABLED" not in source:
+            raise RuntimeError("MPS source is missing the HSL diagnostics feature guard")
+        source = _HSL_DIAGNOSTICS_DISABLE_DEFINE + source
     source = _with_hsl_ema_tail(source, ema_tail_enabled)
     if raw_drawdown_enabled:
         if "#ifndef PASSIVBOT_HSL_RAW_DRAWDOWN_ENABLED" not in source:
@@ -531,6 +543,7 @@ def _trailing_martingale_shader_library(
     btc_risk_enabled: bool = False,
     equity_balance_diff_enabled: bool = False,
     entry_interval_enabled: bool = False,
+    hsl_diagnostics_enabled: bool = True,
 ):
     if not torch.backends.mps.is_available():
         raise RuntimeError("Apple MPS is not available in this process")
@@ -541,6 +554,7 @@ def _trailing_martingale_shader_library(
         ema_tail_enabled=hsl_ema_tail_enabled,
         raw_drawdown_enabled=hsl_raw_drawdown_enabled,
         raw_tail_enabled=hsl_raw_tail_enabled,
+        diagnostics_enabled=hsl_diagnostics_enabled,
     )
     source = _with_recovery_distribution(source, recovery_distribution_enabled)
     source = _with_btc_risk(source, btc_risk_enabled)
@@ -558,6 +572,7 @@ def _trailing_martingale_long_hsl_shader_library(
     btc_risk_enabled: bool = False,
     equity_balance_diff_enabled: bool = False,
     entry_interval_enabled: bool = False,
+    hsl_diagnostics_enabled: bool = True,
 ):
     if not torch.backends.mps.is_available():
         raise RuntimeError("Apple MPS is not available in this process")
@@ -568,6 +583,7 @@ def _trailing_martingale_long_hsl_shader_library(
         ema_tail_enabled=hsl_ema_tail_enabled,
         raw_drawdown_enabled=hsl_raw_drawdown_enabled,
         raw_tail_enabled=hsl_raw_tail_enabled,
+        diagnostics_enabled=hsl_diagnostics_enabled,
     )
     source = _with_recovery_distribution(source, recovery_distribution_enabled)
     source = _with_btc_risk(source, btc_risk_enabled)
@@ -585,6 +601,7 @@ def _trailing_martingale_short_hsl_shader_library(
     btc_risk_enabled: bool = False,
     equity_balance_diff_enabled: bool = False,
     entry_interval_enabled: bool = False,
+    hsl_diagnostics_enabled: bool = True,
 ):
     if not torch.backends.mps.is_available():
         raise RuntimeError("Apple MPS is not available in this process")
@@ -595,6 +612,7 @@ def _trailing_martingale_short_hsl_shader_library(
         ema_tail_enabled=hsl_ema_tail_enabled,
         raw_drawdown_enabled=hsl_raw_drawdown_enabled,
         raw_tail_enabled=hsl_raw_tail_enabled,
+        diagnostics_enabled=hsl_diagnostics_enabled,
     )
     source = _with_recovery_distribution(source, recovery_distribution_enabled)
     source = _with_btc_risk(source, btc_risk_enabled)
@@ -2522,10 +2540,18 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
         self,
         *args,
         hsl_enabled: bool = True,
+        hsl_diagnostics_enabled: bool = True,
         entry_interval_enabled: bool = False,
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
+        self.hsl_diagnostics_enabled = bool(hsl_diagnostics_enabled)
+        if not self.hsl_diagnostics_enabled and (
+            self.hsl_ema_tail_enabled
+            or self.hsl_raw_drawdown_enabled
+            or self.hsl_raw_tail_enabled
+        ):
+            raise ValueError("HSL diagnostic feature outputs require diagnostics")
         self.entry_interval_enabled = bool(entry_interval_enabled)
         self._entry_interval_stat_buffers: dict[int, torch.Tensor] = {}
         self._entry_interval_count_buffers: dict[int, torch.Tensor] = {}
@@ -2557,6 +2583,7 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
                 self.btc_risk_enabled,
                 self.equity_balance_diff_enabled,
                 self.entry_interval_enabled,
+                self.hsl_diagnostics_enabled,
             )
         if self.shader_topology == "short_hsl":
             return _trailing_martingale_short_hsl_shader_library, (
@@ -2567,6 +2594,7 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
                 self.btc_risk_enabled,
                 self.equity_balance_diff_enabled,
                 self.entry_interval_enabled,
+                self.hsl_diagnostics_enabled,
             )
         if self.shader_topology == "long_no_hsl":
             return _trailing_martingale_long_no_hsl_shader_library, (
@@ -2590,6 +2618,7 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
             self.btc_risk_enabled,
             self.equity_balance_diff_enabled,
             self.entry_interval_enabled,
+            self.hsl_diagnostics_enabled,
         )
 
     def _entry_interval_buffers(self, batch_size: int):

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -10,6 +10,7 @@ import time
 import numpy as np
 
 from config.shared_bot import flatten_shared_bot_side
+from optimization.gpu.metric_registry import HARD_STOP_PROXY_METRICS
 from optimization.gpu.model import (
     EMA_ANCHOR_COIN_OVERRIDE_ALLOWANCE_PCT_COLUMN,
     EMA_ANCHOR_COIN_OVERRIDE_COLS,
@@ -688,8 +689,6 @@ _HSL_STRATEGY_EQ_RECOVERY_METRICS = {
 
 def _hsl_diagnostics_needed(needed_metrics) -> bool:
     """Return whether the requested proxy surface needs HSL-only telemetry."""
-    from optimization.gpu.metrics import HARD_STOP_PROXY_METRICS
-
     return bool(
         set(needed_metrics)
         & (

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -218,6 +218,10 @@ def _gpu_profile_features(proxy, runners) -> dict[str, bool]:
             bool(getattr(runner, "hsl_raw_tail_enabled", False))
             for runner in runners
         ),
+        "hsl_diagnostics": any(
+            bool(getattr(runner, "hsl_diagnostics_enabled", False))
+            for runner in runners
+        ),
         "coin_fill_counts": any(
             bool(getattr(runner, "collect_coin_fill_counts", False))
             for runner in runners
@@ -661,6 +665,11 @@ _HSL_EMA_TAIL_METRICS = {
     "drawdown_worst_mean_1pct_ema_strategy_eq_long",
     "drawdown_worst_mean_1pct_ema_strategy_eq_short",
 }
+_HSL_EMA_DRAWDOWN_METRICS = {
+    "drawdown_worst_ema_strategy_eq",
+    "drawdown_worst_ema_strategy_eq_long",
+    "drawdown_worst_ema_strategy_eq_short",
+}
 _HSL_RAW_DRAWDOWN_METRICS = {
     "drawdown_worst_strategy_eq_long",
     "drawdown_worst_strategy_eq_short",
@@ -669,6 +678,31 @@ _HSL_RAW_TAIL_METRICS = {
     "drawdown_worst_mean_1pct_strategy_eq_long",
     "drawdown_worst_mean_1pct_strategy_eq_short",
 }
+_HSL_STRATEGY_EQ_RECOVERY_METRICS = {
+    "peak_recovery_hours_strategy_eq_long",
+    "peak_recovery_hours_strategy_eq_short",
+    "peak_recovery_days_strategy_eq_long",
+    "peak_recovery_days_strategy_eq_short",
+}
+
+
+def _hsl_diagnostics_needed(needed_metrics) -> bool:
+    """Return whether the requested proxy surface needs HSL-only telemetry."""
+    from optimization.gpu.metrics import HARD_STOP_PROXY_METRICS
+
+    return bool(
+        set(needed_metrics)
+        & (
+            set(HARD_STOP_PROXY_METRICS)
+            | _HSL_EMA_DRAWDOWN_METRICS
+            | _HSL_EMA_TAIL_METRICS
+            | _HSL_RAW_DRAWDOWN_METRICS
+            | _HSL_RAW_TAIL_METRICS
+            | _HSL_STRATEGY_EQ_RECOVERY_METRICS
+        )
+    )
+
+
 _STRATEGY_EQ_RECOVERY_DISTRIBUTION_METRICS = {
     "strategy_eq_recovery_days_mean",
     "strategy_eq_recovery_days_median",
@@ -1941,6 +1975,10 @@ class MpsSingleCoinProxy:
             equity_balance_diff_enabled=self.equity_balance_diff_enabled,
             entry_interval_enabled=self.entry_interval_enabled,
         )
+        if self.strategy_kind == "trailing_martingale":
+            runner_kwargs["hsl_diagnostics_enabled"] = _hsl_diagnostics_needed(
+                self.needed_metrics
+            )
         runner_kwargs["hsl_enabled"] = any_configured_hsl
         self.runner = runner_cls(
             self.market,

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -475,6 +475,34 @@ def test_hsl_raw_tail_source_variant_is_separately_opt_in_and_guarded():
         )
 
 
+def test_hsl_diagnostics_source_variant_is_opt_out_and_fail_closed():
+    source = "#ifndef PASSIVBOT_HSL_DIAGNOSTICS_ENABLED\nbody"
+
+    assert _with_hsl_features(
+        source,
+        ema_tail_enabled=False,
+        raw_drawdown_enabled=False,
+        raw_tail_enabled=False,
+        diagnostics_enabled=False,
+    ) == ("#define PASSIVBOT_HSL_DIAGNOSTICS_ENABLED 0\n" + source)
+    with pytest.raises(ValueError, match="require diagnostics"):
+        _with_hsl_features(
+            source,
+            ema_tail_enabled=True,
+            raw_drawdown_enabled=False,
+            raw_tail_enabled=False,
+            diagnostics_enabled=False,
+        )
+    with pytest.raises(RuntimeError, match="diagnostics feature guard"):
+        _with_hsl_features(
+            "body",
+            ema_tail_enabled=False,
+            raw_drawdown_enabled=False,
+            raw_tail_enabled=False,
+            diagnostics_enabled=False,
+        )
+
+
 def test_recovery_distribution_source_variant_is_opt_in_and_guarded():
     source = "#ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED\nbody"
 
@@ -634,6 +662,116 @@ def test_trailing_martingale_hsl_specialization_keeps_requested_features(
     assert runner.hsl_ema_tail_enabled is True
     assert runner.hsl_raw_drawdown_enabled is True
     assert runner.hsl_raw_tail_enabled is True
+
+
+def test_trailing_martingale_hsl_specialization_disables_unrequested_diagnostics(
+    monkeypatch,
+):
+    from optimization.gpu.mps_kernel import (
+        MpsEmaAnchorRunner,
+        MpsTrailingMartingaleRunner,
+    )
+
+    def fake_base_init(self, *args, **kwargs):
+        self.long_enabled = True
+        self.short_enabled = False
+        self.hsl_ema_tail_enabled = False
+        self.hsl_raw_drawdown_enabled = False
+        self.hsl_raw_tail_enabled = False
+        self.recovery_distribution_enabled = False
+        self.btc_risk_enabled = False
+        self.equity_balance_diff_enabled = False
+
+    monkeypatch.setattr(MpsEmaAnchorRunner, "__init__", fake_base_init)
+    runner = MpsTrailingMartingaleRunner(
+        None,
+        None,
+        None,
+        hsl_enabled=True,
+        hsl_diagnostics_enabled=False,
+    )
+
+    assert runner.shader_topology == "long_hsl"
+    assert runner.hsl_diagnostics_enabled is False
+    assert runner._shader_library_cache_call()[1][-1] is False
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+def test_mps_tm_hsl_diagnostic_opt_out_preserves_strategy_outputs():
+    count = 30
+    close = np.full(count, 100.0)
+    close[8:] = 70.0
+    high = close * 1.02
+    low = close * 0.98
+    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    market = ProxyMarket(0.001, 0.01, 0.001, 0.0, 1.0, 0.0)
+    run = ProxyRun(
+        1_000.0,
+        1,
+        1,
+        int(timestamps[0]),
+        int(timestamps[0]),
+        int(timestamps[0]),
+        60_000,
+        0.05,
+        0,
+        count - 1,
+    )
+    data = build_mps_data(high, low, close, timestamps, run, market)
+    row = _tm_single_row(initial_ema_dist=0.0)
+    row[6] = 0.5
+    row[7] = 0.5
+    row[16] = 0.5
+    for key, value in {
+        "hsl_enabled": 1.0,
+        "hsl_red_threshold": 0.01,
+        "hsl_ema_span_minutes": 1.0,
+        "hsl_cooldown_minutes_after_red": 0.0,
+        "hsl_no_restart_drawdown_threshold": 1.0,
+        "hsl_restart_policy": 2.0,
+        "hsl_tier_ratio_yellow": 0.5,
+        "hsl_tier_ratio_orange": 0.75,
+        "hsl_orange_graceful_stop": 0.0,
+        "hsl_signal_mode": 2.0,
+        "hsl_slot_count": 1.0,
+    }.items():
+        row[TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS.index(key)] = value
+    matrix = np.asarray([row + row], dtype=np.float64)
+
+    full = MpsTrailingMartingaleRunner(
+        market,
+        run,
+        data,
+        long_enabled=True,
+        short_enabled=False,
+        hsl_enabled=True,
+        hsl_diagnostics_enabled=True,
+    ).run(matrix)
+    lean = MpsTrailingMartingaleRunner(
+        market,
+        run,
+        data,
+        long_enabled=True,
+        short_enabled=False,
+        hsl_enabled=True,
+        hsl_diagnostics_enabled=False,
+    ).run(matrix)
+    torch.mps.synchronize()
+
+    for key in (
+        "day_end_eq",
+        "day_min_eq",
+        "day_max_dd",
+        "fill_count",
+        "psize",
+        "pprice",
+        "liq_step",
+    ):
+        torch.testing.assert_close(lean[key], full[key], rtol=0.0, atol=0.0)
+    assert full["hsl_triggers_long"].item() > 0.0
+    assert lean["hsl_triggers_long"].item() == 0.0
 
 
 @pytest.mark.parametrize("recovery_enabled", [False, True])

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -41,9 +41,10 @@ from optimization.gpu.service import (
     _directional_coin_hsl_lookback_bars,
     _directional_entry_initial_metrics,
     _directional_gross_pnl_outputs,
-    _hsl_params,
     _gpu_proxy_execution_checkpoint_contract,
     _gpu_profile_unattributed_seconds,
+    _hsl_params,
+    _hsl_diagnostics_needed,
     _mps_dispatch_batch_size,
     _mps_strategy_eq_recovery_distribution,
     _new_gpu_dispatch_progress,
@@ -842,6 +843,19 @@ def test_directional_hsl_output_contract_retains_lifecycle_and_panic_scalars():
         "hsl_drawdown_raw_mean_worst_1pct_long",
         "hsl_drawdown_raw_mean_worst_1pct_short",
     } <= DIRECTIONAL_HSL_OUTPUT_KEYS
+
+
+def test_hsl_diagnostics_are_requested_only_for_hsl_metric_families():
+    assert not _hsl_diagnostics_needed(
+        {
+            "adg_strategy_eq",
+            "drawdown_worst_strategy_eq",
+            "fills_per_day",
+        }
+    )
+    assert _hsl_diagnostics_needed({"hard_stop_triggers_per_year"})
+    assert _hsl_diagnostics_needed({"drawdown_worst_ema_strategy_eq_long"})
+    assert _hsl_diagnostics_needed({"peak_recovery_days_strategy_eq_long"})
 
 
 def test_combine_hedged_multicoin_hsl_outputs_reduces_pside_episodes():


### PR DESCRIPTION
## Summary

- specialize one-sided Trailing Martingale coin-HSL updates so Metal skips the inactive fill, indicator, trailing, and HSL-controller paths
- compile HSL diagnostic accumulators only when a requested GPU objective or limit consumes them
- preserve the generic dual-side shader, fail-closed feature selection, and exact Rust validation authority

## Validation

- `cargo test --manifest-path passivbot-rust/Cargo.toml --no-default-features` (275 passed)
- `cargo check --manifest-path passivbot-rust/Cargo.toml --tests`
- focused Python CPU-backend and GPU service/kernel suite
- full real-MPS GPU suite; five EMA service regressions found and fixed, with all affected tests passing on rerun
- real-MPS long/short specialized-vs-generic HSL parity plus diagnostic-enabled/disabled strategy-output parity
- rebuilt native extension and verified its source fingerprint

## Benchmark

Fixed public `tm-single-long-hsl` fixture, 512 candidates, 525,600 bars, seed 7, dispatch cap 142, warm p50 over two runs:

- before: 18.31 candidates/s, 27.96 s wall
- after: 20.58 candidates/s, 24.88 s wall

That is about 12.4% higher throughput with the same workload and unchanged dispatch safety envelope.
