### PR TITLE
Reduce default GPU population to 1024

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- The Apple MPS optimizer now defaults to a 1024-candidate NSGA-II population instead of 4096,
+  allowing long-history runs to reach exact Rust validation four times sooner. Explicit population
+  sizes and the independent 4096-candidate dispatch-batch upper bound remain unchanged.
+
 - Apple MPS single-coin Trailing Martingale optimization now compiles dedicated long-only and
   short-only kernels while HSL is enabled, allowing Metal to eliminate the inactive strategy side
   and use a one-controller HSL update. HSL lifecycle, drawdown, tail, and recovery accumulators are

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -637,7 +637,7 @@ GPU-specific settings live under `optimize.gpu`:
       "drift_window": 128,
       "exact_workers": 0,
       "max_pending_exact": 0,
-      "population_size": 4096,
+      "population_size": 1024,
       "validate_per_generation": 8
     }
   }
@@ -647,7 +647,9 @@ GPU-specific settings live under `optimize.gpu`:
 The CPU-side NSGA-II proposal stage uses the same `optimize.pymoo.shared` crossover, mutation, and
 duplicate-elimination controls as the ordinary pymoo optimizer.
 
-- `population_size` is the NSGA-II proxy population.
+- `population_size` is the NSGA-II proxy population. The default is 1024 so long-history runs
+  reach their first exact Rust validation batch four times sooner than the former 4096 default.
+  Larger explicit populations remain supported.
 - `batch_size` is the requested upper bound on candidates per MPS dispatch. Because Apple Silicon
   shares the GPU with WindowServer, the backend transparently splits a batch when its
   candidates-by-candles-by-coins-by-enabled-sides workload would make one Metal command buffer too

--- a/src/config/schema.py
+++ b/src/config/schema.py
@@ -509,7 +509,7 @@ def get_template_config():
                         "drift_window": 128,
                         "exact_workers": 0,
                         "max_pending_exact": 0,
-                        "population_size": 4096,
+                        "population_size": 1024,
                         "validate_per_generation": 8
                     },
                     "pymoo": {

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -52,7 +52,7 @@ from utils import to_standard_exchange_name
 
 
 GPU_DEFAULTS = {
-    "population_size": 4096,
+    "population_size": 1024,
     "batch_size": 4096,
     "checkpoint_interval_seconds": 5.0,
     "validate_per_generation": 8,

--- a/tests/optimization/test_backends.py
+++ b/tests/optimization/test_backends.py
@@ -70,7 +70,7 @@ def test_format_config_accepts_gpu_backend():
     out = format_config(current, verbose=False)
 
     assert out["optimize"]["backend"] == "gpu"
-    assert out["optimize"]["gpu"]["population_size"] == 4096
+    assert out["optimize"]["gpu"]["population_size"] == 1024
 
 
 def test_format_config_rejects_unknown_backend():

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -274,7 +274,7 @@ def _directional_tm_config(*, long_enabled: bool, short_enabled: bool):
 
 def test_gpu_options_are_additive_and_validate_ranges():
     config = _long_only_ema_config()
-    assert _resolve_options(config)["population_size"] == 4096
+    assert _resolve_options(config)["population_size"] == 1024
 
     config["optimize"]["gpu"]["batch_size"] = 0
     with pytest.raises(ValueError, match="batch_size"):


### PR DESCRIPTION
## Summary

- reduce the default Apple MPS NSGA-II population from 4096 to 1024
- retain the independent 4096-candidate dispatch-batch upper bound and support explicit larger populations
- document the latency tradeoff and update default-contract tests

## Why

Long-history GPU runs previously waited for all 4096 proxy evaluations before starting exact Rust validation. A 1024 default reaches the first exact-validation batch four times sooner without changing proxy semantics, exact Rust authority, or the work performed per candidate.

## Validation

- `PYTHONPATH=src python -m pytest tests/optimization/test_gpu_backend.py tests/optimization/test_backends.py tests/test_config_utils_helpers.py -q` (769 passed)
- `git diff --check`
- bounded long-history, one-sided HSL MPS acceptance: default resolved to 1024, one generation completed in seven safety-bounded dispatches, exact validation began, and interrupt between dispatches shut down cleanly

