### PR TITLE
Specialize inactive Trailing Martingale GPU paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Apple MPS single-coin Trailing Martingale screening now selects dispatch-proven Metal variants
+  that compile out recursive entry/close grids when every active candidate uses positive
+  retracement, and compile out WEL/TWEL enforcers plus auto-unstuck when every active candidate has
+  those reducers disabled. Ordinary market execution and the realized-loss gate are likewise
+  removed only when their fixed run settings disable them. Mixed or enabled-feature dispatches
+  keep the full kernel. HSL configured only on an exposure-disabled side no longer promotes the
+  active side to an HSL kernel. Exact Rust validation remains unchanged and authoritative.
+
 - The Apple MPS optimizer now defaults to a 1024-candidate NSGA-II population instead of 4096,
   allowing long-history runs to reach exact Rust validation four times sooner. Explicit population
   sizes and the independent 4096-candidate dispatch-batch upper bound remain unchanged.

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -731,11 +731,22 @@ reports candidate materialization and Metal parameter packing, upload/buffer cle
 cold compilation versus warm library lookup, kernel execution, device-to-host transfer, metric
 reduction, and remaining host overhead. Shape metadata includes requested and actual dispatch batch
 sizes, dispatch chunk and strategy-kernel counts, candidate-bars, candle/coin/side counts, requested
-optional metric features, and cold/warm dispatch counts. Exact Rust evaluation remains
+optional metric features, dispatch-proven Trailing Martingale specializations, and cold/warm
+dispatch counts. Exact Rust evaluation remains
 authoritative; profiling fields are diagnostic log output and are not added to retained optimization
 results. Chunked proxy generations that run for at least 30 seconds also emit rate-limited ordinary
 progress with completed chunks and candidates, elapsed time, and ETA. This progress remains
 available without enabling profiling or adding synchronization points.
+
+Single-coin Trailing Martingale runners inspect the packed rows in each dispatch before choosing a
+cached Metal library. When every enabled-side candidate has positive entry or close retracement,
+the corresponding recursive grid path is compiled out. When every enabled-side candidate disables
+the position/total-exposure enforcers and auto-unstuck, those reducer paths are compiled out as a
+group. Fixed run settings similarly specialize ordinary market execution and the realized-loss
+gate. A mixed dispatch keeps each relevant full path, so this changes compiled work rather than
+proxy semantics. A run may record an additional cold compile if its dispatch feature shape changes.
+HSL topology likewise considers enabled sides only; an HSL setting left on an exposure-disabled
+side does not make the active side pay for an HSL controller.
 
 For comparable local MPS measurements, first confirm another optimizer is not using the device,
 then run each case in a fresh process. The harness uses only fixed-seed, in-memory synthetic candles

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -1182,7 +1182,7 @@ mod tests {
         assert!(!source.contains("strategy_wel_qty = reducer_qty"));
         assert!(source.contains("realized_loss_proxy_allows_close"));
         assert!(source.contains("const float max_realized_loss_pct = settings[14]"));
-        assert!(source.contains("const bool loss_gate_enabled = max_realized_loss_pct < 1.0f"));
+        assert!(source.contains("const bool loss_gate_enabled = !PASSIVBOT_TM_LOSS_GATE_DISABLED"));
         assert!(source.contains("const float taker_fee = settings[15]"));
         assert!(source.contains("const float market_order_slippage_pct = fmax(settings[16], 0.0f)"));
         assert!(source.contains("const bool long_hsl_panic_market = settings[17] > 0.5f"));
@@ -1190,7 +1190,10 @@ mod tests {
         assert!(source.contains("market_execution ? taker_fee : maker_fee"));
         assert!(source.contains("close * (1.0f - market_order_slippage_pct)"));
         assert!(source.contains("close * (1.0f + market_order_slippage_pct)"));
-        assert!(source.contains("const bool market_orders_allowed = settings[19] > 0.5f"));
+        assert!(source.contains("const bool market_orders_allowed = !PASSIVBOT_TM_MARKET_ORDERS_DISABLED"));
+        assert!(source.contains("#ifndef PASSIVBOT_TM_TRAILING_ENTRY_ONLY"));
+        assert!(source.contains("#ifndef PASSIVBOT_TM_TRAILING_CLOSE_ONLY"));
+        assert!(source.contains("#ifndef PASSIVBOT_TM_REDUCERS_DISABLED"));
         assert!(source
             .contains("const float market_order_near_touch_threshold = fmax(settings[20], 0.0f)"));
         assert!(source.contains("should_use_ordinary_market_execution("));

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -1,6 +1,22 @@
 #include <metal_stdlib>
 using namespace metal;
 
+#ifndef PASSIVBOT_TM_TRAILING_ENTRY_ONLY
+#define PASSIVBOT_TM_TRAILING_ENTRY_ONLY 0
+#endif
+#ifndef PASSIVBOT_TM_TRAILING_CLOSE_ONLY
+#define PASSIVBOT_TM_TRAILING_CLOSE_ONLY 0
+#endif
+#ifndef PASSIVBOT_TM_REDUCERS_DISABLED
+#define PASSIVBOT_TM_REDUCERS_DISABLED 0
+#endif
+#ifndef PASSIVBOT_TM_MARKET_ORDERS_DISABLED
+#define PASSIVBOT_TM_MARKET_ORDERS_DISABLED 0
+#endif
+#ifndef PASSIVBOT_TM_LOSS_GATE_DISABLED
+#define PASSIVBOT_TM_LOSS_GATE_DISABLED 0
+#endif
+
 #if PASSIVBOT_BTC_RISK_ENABLED
 constant int DAILY_COLS = 11;
 #else
@@ -450,11 +466,14 @@ inline TmSide load_side(constant float* p, int o, float seed) {
     }
     s.entry_cap = s.twel_entry_gate_enabled
         ? fmin(s.allowed_wel, gate_cap) : s.allowed_wel;
-    s.wel_enforcer_enabled = p[o + 31] > 0.5f;
+    s.wel_enforcer_enabled = !PASSIVBOT_TM_REDUCERS_DISABLED
+        && p[o + 31] > 0.5f;
     s.wel_enforcer_threshold = p[o + 32];
-    s.twel_enforcer_enabled = p[o + 33] > 0.5f;
+    s.twel_enforcer_enabled = !PASSIVBOT_TM_REDUCERS_DISABLED
+        && p[o + 33] > 0.5f;
     s.twel_enforcer_threshold = twel_threshold;
-    s.unstuck_enabled = p[o + 34] > 0.5f;
+    s.unstuck_enabled = !PASSIVBOT_TM_REDUCERS_DISABLED
+        && p[o + 34] > 0.5f;
     s.unstuck_ema_gating_enabled = p[o + 35] > 0.5f;
     s.unstuck_close_pct = p[o + 36];
     s.unstuck_ema_dist = p[o + 37];
@@ -927,7 +946,8 @@ inline void generate_orders(
     );
     float threshold = fmax(s.entry_threshold_base, 0.0f) * tm;
     float retracement = fmax(s.entry_retracement_base, 0.0f) * rm;
-    bool trailing_entry = s.entry_retracement_base > 0.0f;
+    const bool trailing_entry = PASSIVBOT_TM_TRAILING_ENTRY_ONLY
+        || s.entry_retracement_base > 0.0f;
     bool retraced_entry = is_long
         ? s.max_since_min > s.min_since_open * (1.0f + retracement)
         : s.min_since_max < s.max_since_open * (1.0f - retracement);
@@ -1104,7 +1124,8 @@ inline void generate_orders(
             + s.vol1m * s.close_retracement_v1m,
         1.0f
     );
-    bool trailing_close = s.close_retracement_base > 0.0f;
+    const bool trailing_close = PASSIVBOT_TM_TRAILING_CLOSE_ONLY
+        || s.close_retracement_base > 0.0f;
     bool retraced_close = is_long
         ? s.min_since_max < s.max_since_open * (1.0f - cr)
         : s.max_since_min > s.min_since_open * (1.0f + cr);
@@ -1784,11 +1805,13 @@ inline void passivbot_single_coin_impl(
     const float market_order_slippage_pct = fmax(settings[16], 0.0f);
     const bool long_hsl_panic_market = settings[17] > 0.5f;
     const bool short_hsl_panic_market = settings[18] > 0.5f;
-    const bool market_orders_allowed = settings[19] > 0.5f;
+    const bool market_orders_allowed = !PASSIVBOT_TM_MARKET_ORDERS_DISABLED
+        && settings[19] > 0.5f;
     const float market_order_near_touch_threshold = fmax(settings[20], 0.0f);
     const int pnl_lookback_bars = max(sizes[6], 0);
     const int rolling_capacity = sizes[5];
-    const bool loss_gate_enabled = max_realized_loss_pct < 1.0f;
+    const bool loss_gate_enabled = !PASSIVBOT_TM_LOSS_GATE_DISABLED
+        && max_realized_loss_pct < 1.0f;
     const float log_bin_scale = 127.0f / log(4000001.0f);
 
     const int po = int(b) * P;
@@ -1975,7 +1998,8 @@ inline void passivbot_single_coin_impl(
             && (long_side.secondary_close_market
                 || long_side.secondary_close_ticks <= high_fill_max_tick)
             && long_side.psize > 0.0f;
-        bool long_recursive_close = long_side.close_retracement_base <= 0.0f;
+        const bool long_recursive_close = !PASSIVBOT_TM_TRAILING_CLOSE_ONLY
+            && long_side.close_retracement_base <= 0.0f;
         bool long_close_fill_ready = long_close_ready
             && ((long_side.close_is_panic && long_hsl_panic_market)
                 || long_side.close_market
@@ -2715,7 +2739,8 @@ inline void passivbot_single_coin_impl(
                 // candle. Market promotion guarantees rung zero's execution,
                 // but does not itself authorize expansion.
                 if (rung == 0 && !long_entry_passive_reachable) break;
-                if (long_side.entry_retracement_base > 0.0f
+                if (PASSIVBOT_TM_TRAILING_ENTRY_ONLY
+                    || long_side.entry_retracement_base > 0.0f
                     || long_side.cooldown_min != 0.0f) break;
                 generate_long_orders(
                     ladder_side, ladder_balance, ep, qty_step,
@@ -2736,7 +2761,8 @@ inline void passivbot_single_coin_impl(
             && (short_side.secondary_close_market
                 || short_side.secondary_close_ticks > low_nonfill_max_tick)
             && short_side.psize > 0.0f;
-        bool short_recursive_close = short_side.close_retracement_base <= 0.0f;
+        const bool short_recursive_close = !PASSIVBOT_TM_TRAILING_CLOSE_ONLY
+            && short_side.close_retracement_base <= 0.0f;
         bool short_close_fill_ready = short_close_ready
             && ((short_side.close_is_panic && short_hsl_panic_market)
                 || short_side.close_market
@@ -3467,7 +3493,8 @@ inline void passivbot_single_coin_impl(
                 previous_ticks = entry_ticks;
                 ladder_touch_ticks = max(ladder_touch_ticks, entry_ticks);
                 if (rung == 0 && !short_entry_passive_reachable) break;
-                if (short_side.entry_retracement_base > 0.0f
+                if (PASSIVBOT_TM_TRAILING_ENTRY_ONLY
+                    || short_side.entry_retracement_base > 0.0f
                     || short_side.cooldown_min != 0.0f) break;
                 generate_short_orders(
                     ladder_side, ladder_balance, ep, qty_step,

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -65,6 +65,17 @@ _EQUITY_BALANCE_DIFF_DEFINE = (
     "#define PASSIVBOT_EQUITY_BALANCE_DIFF_ENABLED 1\n"
 )
 _ENTRY_INTERVAL_DEFINE = "#define PASSIVBOT_ENTRY_INTERVAL_ENABLED 1\n"
+_TM_TRAILING_ENTRY_ONLY_DEFINE = (
+    "#define PASSIVBOT_TM_TRAILING_ENTRY_ONLY 1\n"
+)
+_TM_TRAILING_CLOSE_ONLY_DEFINE = (
+    "#define PASSIVBOT_TM_TRAILING_CLOSE_ONLY 1\n"
+)
+_TM_REDUCERS_DISABLED_DEFINE = "#define PASSIVBOT_TM_REDUCERS_DISABLED 1\n"
+_TM_MARKET_ORDERS_DISABLED_DEFINE = (
+    "#define PASSIVBOT_TM_MARKET_ORDERS_DISABLED 1\n"
+)
+_TM_LOSS_GATE_DISABLED_DEFINE = "#define PASSIVBOT_TM_LOSS_GATE_DISABLED 1\n"
 
 
 def _with_hsl_ema_tail(source: str, enabled: bool) -> str:
@@ -153,6 +164,53 @@ def _with_entry_interval(source: str, enabled: bool) -> str:
     return _ENTRY_INTERVAL_DEFINE + source
 
 
+def _with_tm_dispatch_features(
+    source: str,
+    *,
+    trailing_entry_only: bool,
+    trailing_close_only: bool,
+    reducers_disabled: bool,
+    market_orders_disabled: bool,
+    loss_gate_disabled: bool,
+) -> str:
+    features = (
+        (
+            trailing_entry_only,
+            "#ifndef PASSIVBOT_TM_TRAILING_ENTRY_ONLY",
+            _TM_TRAILING_ENTRY_ONLY_DEFINE,
+        ),
+        (
+            trailing_close_only,
+            "#ifndef PASSIVBOT_TM_TRAILING_CLOSE_ONLY",
+            _TM_TRAILING_CLOSE_ONLY_DEFINE,
+        ),
+        (
+            reducers_disabled,
+            "#ifndef PASSIVBOT_TM_REDUCERS_DISABLED",
+            _TM_REDUCERS_DISABLED_DEFINE,
+        ),
+        (
+            market_orders_disabled,
+            "#ifndef PASSIVBOT_TM_MARKET_ORDERS_DISABLED",
+            _TM_MARKET_ORDERS_DISABLED_DEFINE,
+        ),
+        (
+            loss_gate_disabled,
+            "#ifndef PASSIVBOT_TM_LOSS_GATE_DISABLED",
+            _TM_LOSS_GATE_DISABLED_DEFINE,
+        ),
+    )
+    for enabled, marker, define in features:
+        if not enabled:
+            continue
+        if marker not in source:
+            raise RuntimeError(
+                f"MPS source is missing the TM dispatch feature guard {marker}"
+            )
+        source = define + source
+    return source
+
+
 def _encode_max_realized_loss_pct(value: float) -> float:
     """Encode a float64 loss fraction without loosening its Metal budget."""
 
@@ -204,6 +262,59 @@ def _pack_tm_parameter_matrix(
                     np.finfo(np.float64).tiny
                 )
     return matrix
+
+
+def _tm_dispatch_specialization(
+    matrix: np.ndarray,
+    *,
+    long_enabled: bool,
+    short_enabled: bool,
+    market_orders_allowed: bool,
+    loss_gate_enabled: bool,
+) -> tuple[bool, bool, bool, bool, bool]:
+    """Prove dispatch-wide TM features before compiling away inactive paths."""
+
+    side_width = len(TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS)
+    active_offsets = [
+        side_index * side_width
+        for side_index, enabled in enumerate((long_enabled, short_enabled))
+        if enabled
+    ]
+
+    def all_active_rows(predicate, key: str) -> bool:
+        key_index = TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS.index(key)
+        return bool(
+            active_offsets
+            and matrix.shape[0] > 0
+            and all(predicate(matrix[:, offset + key_index]) for offset in active_offsets)
+        )
+
+    trailing_entry_only = all_active_rows(
+        lambda values: np.all(np.isfinite(values) & (values > 0.0)),
+        "entry_retracement_base_pct",
+    )
+    trailing_close_only = all_active_rows(
+        lambda values: np.all(np.isfinite(values) & (values > 0.0)),
+        "close_retracement_base_pct",
+    )
+    reducers_disabled = all(
+        all_active_rows(
+            lambda values: np.all(np.isfinite(values) & (values <= 0.5)),
+            key,
+        )
+        for key in (
+            "wel_enforcer_enabled",
+            "twel_enforcer_enabled",
+            "unstuck_enabled",
+        )
+    )
+    return (
+        trailing_entry_only,
+        trailing_close_only,
+        reducers_disabled,
+        not market_orders_allowed,
+        not loss_gate_enabled,
+    )
 
 
 def _upgrade_legacy_single_coin_wel_params(
@@ -536,6 +647,11 @@ def _ema_anchor_short_no_hsl_shader_library(
 
 @lru_cache(maxsize=16)
 def _trailing_martingale_shader_library(
+    trailing_entry_only: bool = False,
+    trailing_close_only: bool = False,
+    reducers_disabled: bool = False,
+    market_orders_disabled: bool = False,
+    loss_gate_disabled: bool = False,
     hsl_ema_tail_enabled: bool = False,
     hsl_raw_drawdown_enabled: bool = False,
     hsl_raw_tail_enabled: bool = False,
@@ -549,8 +665,16 @@ def _trailing_martingale_shader_library(
         raise RuntimeError("Apple MPS is not available in this process")
     import passivbot_rust
 
-    source = _with_hsl_features(
+    source = _with_tm_dispatch_features(
         passivbot_rust.mps_trailing_martingale_source_py(),
+        trailing_entry_only=trailing_entry_only,
+        trailing_close_only=trailing_close_only,
+        reducers_disabled=reducers_disabled,
+        market_orders_disabled=market_orders_disabled,
+        loss_gate_disabled=loss_gate_disabled,
+    )
+    source = _with_hsl_features(
+        source,
         ema_tail_enabled=hsl_ema_tail_enabled,
         raw_drawdown_enabled=hsl_raw_drawdown_enabled,
         raw_tail_enabled=hsl_raw_tail_enabled,
@@ -565,6 +689,11 @@ def _trailing_martingale_shader_library(
 
 @lru_cache(maxsize=16)
 def _trailing_martingale_long_hsl_shader_library(
+    trailing_entry_only: bool = False,
+    trailing_close_only: bool = False,
+    reducers_disabled: bool = False,
+    market_orders_disabled: bool = False,
+    loss_gate_disabled: bool = False,
     hsl_ema_tail_enabled: bool = False,
     hsl_raw_drawdown_enabled: bool = False,
     hsl_raw_tail_enabled: bool = False,
@@ -578,8 +707,16 @@ def _trailing_martingale_long_hsl_shader_library(
         raise RuntimeError("Apple MPS is not available in this process")
     import passivbot_rust
 
-    source = _with_hsl_features(
+    source = _with_tm_dispatch_features(
         passivbot_rust.mps_trailing_martingale_long_hsl_source_py(),
+        trailing_entry_only=trailing_entry_only,
+        trailing_close_only=trailing_close_only,
+        reducers_disabled=reducers_disabled,
+        market_orders_disabled=market_orders_disabled,
+        loss_gate_disabled=loss_gate_disabled,
+    )
+    source = _with_hsl_features(
+        source,
         ema_tail_enabled=hsl_ema_tail_enabled,
         raw_drawdown_enabled=hsl_raw_drawdown_enabled,
         raw_tail_enabled=hsl_raw_tail_enabled,
@@ -594,6 +731,11 @@ def _trailing_martingale_long_hsl_shader_library(
 
 @lru_cache(maxsize=16)
 def _trailing_martingale_short_hsl_shader_library(
+    trailing_entry_only: bool = False,
+    trailing_close_only: bool = False,
+    reducers_disabled: bool = False,
+    market_orders_disabled: bool = False,
+    loss_gate_disabled: bool = False,
     hsl_ema_tail_enabled: bool = False,
     hsl_raw_drawdown_enabled: bool = False,
     hsl_raw_tail_enabled: bool = False,
@@ -607,8 +749,16 @@ def _trailing_martingale_short_hsl_shader_library(
         raise RuntimeError("Apple MPS is not available in this process")
     import passivbot_rust
 
-    source = _with_hsl_features(
+    source = _with_tm_dispatch_features(
         passivbot_rust.mps_trailing_martingale_short_hsl_source_py(),
+        trailing_entry_only=trailing_entry_only,
+        trailing_close_only=trailing_close_only,
+        reducers_disabled=reducers_disabled,
+        market_orders_disabled=market_orders_disabled,
+        loss_gate_disabled=loss_gate_disabled,
+    )
+    source = _with_hsl_features(
+        source,
         ema_tail_enabled=hsl_ema_tail_enabled,
         raw_drawdown_enabled=hsl_raw_drawdown_enabled,
         raw_tail_enabled=hsl_raw_tail_enabled,
@@ -621,8 +771,13 @@ def _trailing_martingale_short_hsl_shader_library(
     return torch.mps.compile_shader(source)
 
 
-@lru_cache(maxsize=4)
+@lru_cache(maxsize=8)
 def _trailing_martingale_long_no_hsl_shader_library(
+    trailing_entry_only: bool = False,
+    trailing_close_only: bool = False,
+    reducers_disabled: bool = False,
+    market_orders_disabled: bool = False,
+    loss_gate_disabled: bool = False,
     recovery_distribution_enabled: bool = False,
     btc_risk_enabled: bool = False,
     equity_balance_diff_enabled: bool = False,
@@ -632,8 +787,16 @@ def _trailing_martingale_long_no_hsl_shader_library(
         raise RuntimeError("Apple MPS is not available in this process")
     import passivbot_rust
 
-    source = _with_recovery_distribution(
+    source = _with_tm_dispatch_features(
         passivbot_rust.mps_trailing_martingale_long_no_hsl_source_py(),
+        trailing_entry_only=trailing_entry_only,
+        trailing_close_only=trailing_close_only,
+        reducers_disabled=reducers_disabled,
+        market_orders_disabled=market_orders_disabled,
+        loss_gate_disabled=loss_gate_disabled,
+    )
+    source = _with_recovery_distribution(
+        source,
         recovery_distribution_enabled,
     )
     source = _with_btc_risk(source, btc_risk_enabled)
@@ -642,8 +805,13 @@ def _trailing_martingale_long_no_hsl_shader_library(
     return torch.mps.compile_shader(source)
 
 
-@lru_cache(maxsize=4)
+@lru_cache(maxsize=8)
 def _trailing_martingale_short_no_hsl_shader_library(
+    trailing_entry_only: bool = False,
+    trailing_close_only: bool = False,
+    reducers_disabled: bool = False,
+    market_orders_disabled: bool = False,
+    loss_gate_disabled: bool = False,
     recovery_distribution_enabled: bool = False,
     btc_risk_enabled: bool = False,
     equity_balance_diff_enabled: bool = False,
@@ -653,8 +821,16 @@ def _trailing_martingale_short_no_hsl_shader_library(
         raise RuntimeError("Apple MPS is not available in this process")
     import passivbot_rust
 
-    source = _with_recovery_distribution(
+    source = _with_tm_dispatch_features(
         passivbot_rust.mps_trailing_martingale_short_no_hsl_source_py(),
+        trailing_entry_only=trailing_entry_only,
+        trailing_close_only=trailing_close_only,
+        reducers_disabled=reducers_disabled,
+        market_orders_disabled=market_orders_disabled,
+        loss_gate_disabled=loss_gate_disabled,
+    )
+    source = _with_recovery_distribution(
+        source,
         recovery_distribution_enabled,
     )
     source = _with_btc_risk(source, btc_risk_enabled)
@@ -1102,6 +1278,8 @@ class MpsEmaAnchorRunner:
         encoded_max_realized_loss_pct = _encode_max_realized_loss_pct(
             max_realized_loss_pct
         )
+        self.loss_gate_enabled = encoded_max_realized_loss_pct < 1.0
+        self.market_orders_allowed = bool(market_orders_allowed)
         taker_fee = market.maker_fee if taker_fee is None else float(taker_fee)
         market_order_slippage_pct = float(market_order_slippage_pct)
         market_order_near_touch_threshold = float(
@@ -2573,9 +2751,21 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
         loader, args = self._shader_library_cache_call()
         return loader(*args)
 
-    def _shader_library_cache_call(self):
+    def _shader_library_cache_call(
+        self,
+        dispatch_features: tuple[bool, bool, bool, bool, bool] | None = None,
+    ):
+        if dispatch_features is None:
+            dispatch_features = (
+                False,
+                False,
+                False,
+                not getattr(self, "market_orders_allowed", False),
+                not getattr(self, "loss_gate_enabled", False),
+            )
         if self.shader_topology == "long_hsl":
             return _trailing_martingale_long_hsl_shader_library, (
+                *dispatch_features,
                 self.hsl_ema_tail_enabled,
                 self.hsl_raw_drawdown_enabled,
                 self.hsl_raw_tail_enabled,
@@ -2587,6 +2777,7 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
             )
         if self.shader_topology == "short_hsl":
             return _trailing_martingale_short_hsl_shader_library, (
+                *dispatch_features,
                 self.hsl_ema_tail_enabled,
                 self.hsl_raw_drawdown_enabled,
                 self.hsl_raw_tail_enabled,
@@ -2598,6 +2789,7 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
             )
         if self.shader_topology == "long_no_hsl":
             return _trailing_martingale_long_no_hsl_shader_library, (
+                *dispatch_features,
                 self.recovery_distribution_enabled,
                 self.btc_risk_enabled,
                 self.equity_balance_diff_enabled,
@@ -2605,12 +2797,14 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
             )
         if self.shader_topology == "short_no_hsl":
             return _trailing_martingale_short_no_hsl_shader_library, (
+                *dispatch_features,
                 self.recovery_distribution_enabled,
                 self.btc_risk_enabled,
                 self.equity_balance_diff_enabled,
                 self.entry_interval_enabled,
             )
         return _trailing_martingale_shader_library, (
+            *dispatch_features,
             self.hsl_ema_tail_enabled,
             self.hsl_raw_drawdown_enabled,
             self.hsl_raw_tail_enabled,
@@ -2672,6 +2866,13 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
     def run(self, params: np.ndarray, *, profile: bool = False) -> dict:
         started = time.perf_counter() if profile else 0.0
         matrix = self._pack_params(params)
+        dispatch_features = _tm_dispatch_specialization(
+            matrix,
+            long_enabled=self.long_enabled,
+            short_enabled=self.short_enabled,
+            market_orders_allowed=self.market_orders_allowed,
+            loss_gate_enabled=self.loss_gate_enabled,
+        )
         packed = time.perf_counter() if profile else 0.0
         params_mps = torch.as_tensor(matrix, device="mps")
         batch_size = int(matrix.shape[0])
@@ -2699,7 +2900,7 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
                 device="mps",
             )
         prepared = time.perf_counter() if profile else 0.0
-        loader, library_args = self._shader_library_cache_call()
+        loader, library_args = self._shader_library_cache_call(dispatch_features)
         library, cold = _cached_library_with_miss(loader, *library_args)
         compiled = time.perf_counter() if profile else 0.0
         if profile:
@@ -2748,6 +2949,13 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
                 "batch_size": batch_size,
                 "dispatch_count": 1,
                 "cold": cold,
+                "dispatch_specialization": {
+                    "trailing_entry_only": dispatch_features[0],
+                    "trailing_close_only": dispatch_features[1],
+                    "reducers_disabled": dispatch_features[2],
+                    "market_orders_disabled": dispatch_features[3],
+                    "loss_gate_disabled": dispatch_features[4],
+                },
             }
         else:
             self.last_profile = {}

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -250,6 +250,7 @@ def _new_gpu_proxy_profile(proxy, candidates, runners, *, coin_count, side_count
             else 0
         ),
         "actual_dispatch_batch_sizes": [],
+        "dispatch_specializations": [],
         "dispatch_chunk_wall_seconds": [],
         "dispatch_count": 0,
         "cold_dispatch_count": 0,
@@ -306,6 +307,9 @@ def _add_gpu_runner_profile(
     dispatch_count = int(runner_profile.get("dispatch_count", 1))
     cold = bool(runner_profile.get("cold", False))
     profile["actual_dispatch_batch_sizes"].append(batch_size)
+    dispatch_specialization = runner_profile.get("dispatch_specialization")
+    if dispatch_specialization is not None:
+        profile["dispatch_specializations"].append(dict(dispatch_specialization))
     profile["dispatch_count"] += dispatch_count
     profile["cold_dispatch_count"] += dispatch_count if cold else 0
     profile["warm_dispatch_count"] += 0 if cold else dispatch_count
@@ -1733,9 +1737,6 @@ class MpsSingleCoinProxy:
             for side, bot in (("long", long_bot), ("short", short_bot))
             if self.enabled[side] and bool(bot.get("hsl_enabled"))
         ]
-        any_configured_hsl = any(
-            bool(bot.get("hsl_enabled")) for bot in (long_bot, short_bot)
-        )
         signal_mode = (
             backtest_params.get("equity_hard_stop_loss", {})
             .get("signal_mode", "unified")
@@ -1978,7 +1979,7 @@ class MpsSingleCoinProxy:
             runner_kwargs["hsl_diagnostics_enabled"] = _hsl_diagnostics_needed(
                 self.needed_metrics
             )
-        runner_kwargs["hsl_enabled"] = any_configured_hsl
+        runner_kwargs["hsl_enabled"] = bool(hsl_enabled_sides)
         self.runner = runner_cls(
             self.market,
             self.run,

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -49,6 +49,7 @@ from optimization.gpu.mps_kernel import (
     _decode_multicoin_fused_outputs,
     _encode_max_realized_loss_pct,
     _pack_tm_parameter_matrix,
+    _tm_dispatch_specialization,
     _scale_directional_minute_parameters,
     _scale_ema_multicoin_coin_overrides,
     _scale_tm_multicoin_coin_overrides,
@@ -60,6 +61,7 @@ from optimization.gpu.mps_kernel import (
     _with_hsl_ema_tail,
     _with_hsl_features,
     _with_recovery_distribution,
+    _with_tm_dispatch_features,
     strategy_eq_recovery_distribution_from_samples,
 )
 from optimization.gpu.metrics import (
@@ -4565,7 +4567,10 @@ def test_mps_multicoin_recovery_samples_all_internal_nan_candle(
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
 @pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
-def test_mps_single_coin_service_dispatches_forced_delist_tail(strategy_kind):
+@pytest.mark.parametrize("inactive_hsl_enabled", [False, True])
+def test_mps_single_coin_service_dispatches_forced_delist_tail(
+    strategy_kind, inactive_hsl_enabled
+):
     from backtest import run_backtest
     from config.schema import get_template_config
     from optimization.gpu.service import MpsSingleCoinProxy
@@ -4614,7 +4619,9 @@ def test_mps_single_coin_service_dispatches_forced_delist_tail(strategy_kind):
         risk["we_excess_allowance_pct"] = 0.0
         risk["position_exposure_enforcer_enabled"] = False
         risk["total_exposure_enforcer_enabled"] = False
-        config["bot"][side]["hsl"]["enabled"] = False
+        config["bot"][side]["hsl"]["enabled"] = (
+            inactive_hsl_enabled if not enabled else False
+        )
         config["bot"][side]["unstuck"]["enabled"] = False
     if strategy_kind == "ema_anchor":
         config["bot"]["long"]["strategy"]["ema_anchor"].update(
@@ -4664,6 +4671,7 @@ def test_mps_single_coin_service_dispatches_forced_delist_tail(strategy_kind):
             "strategy_eq_recovery_days_p99",
         },
     )
+    assert proxy.runner.shader_topology == "long_no_hsl"
     result = proxy.evaluate([{}])[0]
     exact_fills, _, exact_analysis = run_backtest(
         hlcvs,
@@ -12505,6 +12513,85 @@ def _tm_single_row(
     ) + [-1.0]
 
 
+def test_tm_dispatch_specialization_requires_every_enabled_side_and_row():
+    row = _tm_single_row()
+    matrix = np.asarray([row + row, row + row], dtype=np.float32)
+
+    assert _tm_dispatch_specialization(
+        matrix,
+        long_enabled=True,
+        short_enabled=False,
+        market_orders_allowed=False,
+        loss_gate_enabled=False,
+    ) == (True, True, True, True, True)
+
+    entry_column = TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS.index(
+        "entry_retracement_base_pct"
+    )
+    matrix[1, entry_column] = 0.0
+    assert _tm_dispatch_specialization(
+        matrix,
+        long_enabled=True,
+        short_enabled=False,
+        market_orders_allowed=True,
+        loss_gate_enabled=True,
+    ) == (False, True, True, False, False)
+
+    matrix[1, entry_column] = 0.001
+    side_width = len(TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS)
+    short_wel_column = side_width + TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS.index(
+        "wel_enforcer_enabled"
+    )
+    matrix[:, short_wel_column] = 1.0
+    assert _tm_dispatch_specialization(
+        matrix,
+        long_enabled=True,
+        short_enabled=False,
+        market_orders_allowed=False,
+        loss_gate_enabled=False,
+    )[2] is True
+    assert _tm_dispatch_specialization(
+        matrix,
+        long_enabled=True,
+        short_enabled=True,
+        market_orders_allowed=False,
+        loss_gate_enabled=False,
+    )[2] is False
+
+
+def test_tm_dispatch_feature_defines_are_opt_in_and_guarded():
+    import passivbot_rust
+
+    source = passivbot_rust.mps_trailing_martingale_long_no_hsl_source_py()
+    transformed = _with_tm_dispatch_features(
+        source,
+        trailing_entry_only=True,
+        trailing_close_only=True,
+        reducers_disabled=True,
+        market_orders_disabled=True,
+        loss_gate_disabled=True,
+    )
+
+    for name in (
+        "PASSIVBOT_TM_TRAILING_ENTRY_ONLY",
+        "PASSIVBOT_TM_TRAILING_CLOSE_ONLY",
+        "PASSIVBOT_TM_REDUCERS_DISABLED",
+        "PASSIVBOT_TM_MARKET_ORDERS_DISABLED",
+        "PASSIVBOT_TM_LOSS_GATE_DISABLED",
+    ):
+        assert f"#define {name} 1" in transformed
+        assert f"#ifndef {name}" in transformed
+
+    assert _with_tm_dispatch_features(
+        source,
+        trailing_entry_only=False,
+        trailing_close_only=False,
+        reducers_disabled=False,
+        market_orders_disabled=False,
+        loss_gate_disabled=False,
+    ) == source
+
+
 @pytest.mark.skipif(
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
@@ -20011,13 +20098,19 @@ def test_mps_trailing_martingale_shader_contract_and_directional_smoke(
     assert source.count("float reducer_fee_rate = reducer_market") == 4
     assert "realized_loss_proxy_allows_close" in source
     assert "const float max_realized_loss_pct = settings[14]" in source
-    assert "const bool loss_gate_enabled = max_realized_loss_pct < 1.0f" in source
+    assert "const bool loss_gate_enabled = !PASSIVBOT_TM_LOSS_GATE_DISABLED" in source
     assert "const float taker_fee = settings[15]" in source
     assert "const float market_order_slippage_pct = fmax(settings[16], 0.0f)" in source
     assert "const bool long_hsl_panic_market = settings[17] > 0.5f" in source
     assert "const bool short_hsl_panic_market = settings[18] > 0.5f" in source
     assert "market_execution ? taker_fee : maker_fee" in source
-    assert "const bool market_orders_allowed = settings[19] > 0.5f" in source
+    assert (
+        "const bool market_orders_allowed = !PASSIVBOT_TM_MARKET_ORDERS_DISABLED"
+        in source
+    )
+    assert "#ifndef PASSIVBOT_TM_TRAILING_ENTRY_ONLY" in source
+    assert "#ifndef PASSIVBOT_TM_TRAILING_CLOSE_ONLY" in source
+    assert "#ifndef PASSIVBOT_TM_REDUCERS_DISABLED" in source
     assert (
         "const float market_order_near_touch_threshold = fmax(settings[20], 0.0f)"
         in source

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -465,6 +465,13 @@ def test_single_coin_proxy_profile_records_dispatch_shape_and_timings(monkeypatc
             "batch_size": len(parameters),
             "dispatch_count": 1,
             "cold": len(calls) == 1,
+            "dispatch_specialization": {
+                "trailing_entry_only": True,
+                "trailing_close_only": True,
+                "reducers_disabled": True,
+                "market_orders_disabled": True,
+                "loss_gate_disabled": True,
+            },
         }
         return output
 
@@ -478,6 +485,15 @@ def test_single_coin_proxy_profile_records_dispatch_shape_and_timings(monkeypatc
     assert profile["dispatch_batch_size"] == 2
     assert profile["dispatch_chunk_count"] == 3
     assert profile["actual_dispatch_batch_sizes"] == [2, 2, 1]
+    assert profile["dispatch_specializations"] == [
+        {
+            "trailing_entry_only": True,
+            "trailing_close_only": True,
+            "reducers_disabled": True,
+            "market_orders_disabled": True,
+            "loss_gate_disabled": True,
+        }
+    ] * 3
     assert profile["dispatch_count"] == 3
     assert profile["cold_dispatch_count"] == 1
     assert profile["warm_dispatch_count"] == 2


### PR DESCRIPTION
## Summary

- select dispatch-proven single-coin Trailing Martingale Metal variants from the packed candidate rows
- compile out recursive entry/close grids only when every enabled-side candidate uses positive retracement
- compile out WEL/TWEL enforcers and auto-unstuck only when every enabled-side candidate disables all three reducers
- specialize fixed-off ordinary market execution and realized-loss gating
- ignore HSL configured only on an exposure-disabled side when selecting the active one-side shader topology
- expose the selected dispatch feature flags in opt-in GPU profiles

Mixed or active-feature dispatches retain the full paths. Exact Rust validation, CPU optimization, backtests, and live behavior are unchanged.

## Deterministic Apple MPS benchmark

Fixed seed 7, 512 candidates, 525,600 synthetic one-minute candles, one long side, one dispatch, warm p50 of three runs:

| Case | Base candidates/s | PR candidates/s | Speedup | Base wall | PR wall |
| --- | ---: | ---: | ---: | ---: | ---: |
| `tm-single-long` | 96.37 | 191.01 | 1.98x | 5.313s | 2.680s |
| `tm-single-long-hsl` | 20.58 | 134.47 | 6.53x | 24.88s | 3.807s |

The no-HSL result also matches the initial TM MPS kernel on the identical fixture (190.76 candidates/s in-kernel at `5258a9ac6`) while retaining the current proxy contract.

## Validation

- `cargo test --no-default-features` (275 passed)
- `cargo check --tests`
- repository-owned release extension rebuild and source-fingerprint verification
- complete `tests/optimization/test_gpu_mps.py` real-MPS suite
- `tests/optimization/test_gpu_service.py`, `tests/optimization/test_gpu_proxy_benchmark.py`, and `tests/optimization/test_gpu_backend.py`
- CPU optimizer suite plus the torch/MPS import-boundary regression
- `git diff --check`

