### PR TITLE
Add opt-in GPU successive halving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Apple MPS single-coin Trailing Martingale optimization now offers disabled-by-default
+  successive-halving proxy screening. The default opt-in ladder evaluates 1024 candidates on 25%
+  of history, 512 on 50%, and 256 on the complete history, while preserving the existing
+  candidate-bars dispatch safety envelope. Only complete-history survivors are eligible for exact
+  Rust validation and proxy/exact drift evidence; CPU optimization, backtests, live behavior, and
+  ordinary GPU runs are unchanged.
+
 - Apple MPS single-coin Trailing Martingale screening now selects dispatch-proven Metal variants
   that compile out recursive entry/close grids when every active candidate uses positive
   retracement, and compile out WEL/TWEL enforcers plus auto-unstuck when every active candidate has

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -638,6 +638,12 @@ GPU-specific settings live under `optimize.gpu`:
       "exact_workers": 0,
       "max_pending_exact": 0,
       "population_size": 1024,
+      "successive_halving": {
+        "enabled": false,
+        "history_fractions": [0.25, 0.5, 1.0],
+        "min_survivors": 64,
+        "survival_fraction": 0.5
+      },
       "validate_per_generation": 8
     }
   }
@@ -659,6 +665,18 @@ duplicate-elimination controls as the ordinary pymoo optimizer.
   that incomplete ask/tell transaction is discarded and the last complete checkpoint is retained.
   A topology whose single candidate already exceeds the safety envelope fails closed with guidance
   to shorten the date range or reduce its coin count.
+- `successive_halving.enabled` opts a non-suite, single-coin Trailing Martingale run into
+  progressively longer history prefixes. The default `history_fractions` are 25%, 50%, and 100%;
+  after each partial rung, constraint-aware Pareto selection retains `survival_fraction` (50% by
+  default), subject to `min_survivors` (64 by default). With the default 1024 population this means
+  1024 candidates at 25%, 512 at 50%, and 256 at full history. Shorter rungs use the same 500
+  million candidate-bars safety envelope, so they can safely dispatch more candidates together;
+  the cap itself is not raised. Partial-rung rows are marked ineligible in NSGA-II, and only the
+  full-history survivors may enter exact Rust validation, proxy-front selection, broad probes, or
+  drift evidence. The ladder is disabled by default because progressive prefixes trade some
+  search breadth for throughput and emphasize the earlier part of the configured period. Its
+  policy is included in checkpoint identity. EMA Anchor, multicoin, and suite runs fail closed if
+  this opt-in is requested.
 - `validate_per_generation` caps exact candidates selected from each proxy generation.
 - `drift_probes` reserves at least part of that validation budget for candidates away from the
   proxy front.

--- a/src/config/schema.py
+++ b/src/config/schema.py
@@ -510,6 +510,12 @@ def get_template_config():
                         "exact_workers": 0,
                         "max_pending_exact": 0,
                         "population_size": 1024,
+                        "successive_halving": {
+                            "enabled": False,
+                            "history_fractions": [0.25, 0.5, 1.0],
+                            "min_survivors": 64,
+                            "survival_fraction": 0.5,
+                        },
                         "validate_per_generation": 8
                     },
                     "pymoo": {

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -62,6 +62,12 @@ GPU_DEFAULTS = {
     "drift_halt": 0.60,
     "exact_workers": 0,
     "max_pending_exact": 0,
+    "successive_halving": {
+        "enabled": False,
+        "history_fractions": [0.25, 0.5, 1.0],
+        "survival_fraction": 0.5,
+        "min_survivors": 64,
+    },
 }
 
 MIN_DRIFT_PROBES = 8
@@ -511,6 +517,19 @@ def validate_gpu_preparation_scope(
             allow_suite=suite_enabled,
         )
     )
+    halving_config = (
+        config.get("optimize", {}).get("gpu", {}).get("successive_halving", {})
+        or {}
+    )
+    if not isinstance(halving_config, dict):
+        raise TypeError("optimize.gpu.successive_halving must be an object")
+    if bool(halving_config.get("enabled")) and (
+        strategy_kind != "trailing_martingale" or suite_enabled
+    ):
+        raise ValueError(
+            "optimize.gpu.successive_halving currently requires a non-suite, "
+            "single-coin trailing_martingale optimization"
+        )
     if bool(suite_cfg.get("enabled")):
         from optimization.warmup import _apply_config_overrides
 
@@ -986,6 +1005,57 @@ def _resolve_options(config: dict) -> dict:
     for key, default in GPU_DEFAULTS.items():
         if key in (configured or {}):
             options[key] = type(default)(configured[key])
+    halving = dict(GPU_DEFAULTS["successive_halving"])
+    configured_halving = options.get("successive_halving")
+    if configured_halving is not None and not isinstance(configured_halving, dict):
+        raise TypeError("optimize.gpu.successive_halving must be an object")
+    halving.update(configured_halving or {})
+    unknown_halving = sorted(
+        set(halving) - set(GPU_DEFAULTS["successive_halving"])
+    )
+    if unknown_halving:
+        raise ValueError(
+            "unknown optimize.gpu.successive_halving settings: "
+            + ", ".join(unknown_halving)
+        )
+    halving["enabled"] = bool(halving["enabled"])
+    try:
+        fractions = [float(value) for value in halving["history_fractions"]]
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            "optimize.gpu.successive_halving.history_fractions must be an array "
+            "of finite fractions"
+        ) from exc
+    if (
+        not fractions
+        or any(
+            not math.isfinite(value) or value <= 0.0 or value > 1.0
+            for value in fractions
+        )
+        or any(right <= left for left, right in zip(fractions, fractions[1:]))
+        or not math.isclose(fractions[-1], 1.0, rel_tol=0.0, abs_tol=1.0e-12)
+    ):
+        raise ValueError(
+            "optimize.gpu.successive_halving.history_fractions must be strictly "
+            "increasing finite values in (0, 1] ending at 1.0"
+        )
+    survival_fraction = float(halving["survival_fraction"])
+    if not math.isfinite(survival_fraction) or not 0.0 < survival_fraction <= 1.0:
+        raise ValueError(
+            "optimize.gpu.successive_halving.survival_fraction must be greater "
+            "than zero and at most one"
+        )
+    min_survivors = int(halving["min_survivors"])
+    if min_survivors <= 0:
+        raise ValueError(
+            "optimize.gpu.successive_halving.min_survivors must be greater than zero"
+        )
+    halving.update(
+        history_fractions=fractions,
+        survival_fraction=survival_fraction,
+        min_survivors=min_survivors,
+    )
+    options["successive_halving"] = halving
     for key in (
         "population_size",
         "batch_size",
@@ -1017,6 +1087,13 @@ def _resolve_options(config: dict) -> dict:
             "optimize.gpu.drift_probes must be less than "
             "optimize.gpu.validate_per_generation so proxy-front safety evidence "
             "is always collected"
+        )
+    if halving["enabled"] and min(
+        min_survivors, int(options["population_size"])
+    ) < validations:
+        raise ValueError(
+            "optimize.gpu.successive_halving.min_survivors must be at least "
+            "optimize.gpu.validate_per_generation"
         )
     exact_workers = int(options["exact_workers"]) or int(
         config.get("optimize", {}).get("n_cpus", 0)
@@ -2076,6 +2153,142 @@ def _normalized_farthest_indices(values: np.ndarray, count: int) -> list[int]:
     return chosen
 
 
+def _successive_halving_survivor_indices(
+    objectives: np.ndarray,
+    violations: np.ndarray,
+    *,
+    count: int,
+) -> np.ndarray:
+    """Select a deterministic constraint-aware, Pareto-diverse rung subset."""
+
+    from pymoo.util.nds.non_dominated_sorting import NonDominatedSorting
+
+    objectives = np.asarray(objectives, dtype=np.float64)
+    violations = np.asarray(violations, dtype=np.float64)
+    if objectives.ndim != 2 or len(objectives) != len(violations):
+        raise ValueError("successive-halving objectives and violations must align")
+    count = min(max(0, int(count)), len(objectives))
+    if count == 0:
+        return np.empty(0, dtype=np.int64)
+
+    feasible = np.flatnonzero(np.isfinite(violations) & (violations <= 0.0))
+    feasible_ids = set(map(int, feasible))
+    infeasible = np.asarray(
+        sorted(
+            (
+                int(index)
+                for index in range(len(objectives))
+                if int(index) not in feasible_ids
+            ),
+            key=lambda index: (
+                float(violations[index])
+                if np.isfinite(violations[index])
+                else float("inf"),
+                index,
+            ),
+        ),
+        dtype=np.int64,
+    )
+    selected: list[int] = []
+    if len(feasible):
+        for front_local in NonDominatedSorting().do(objectives[feasible]):
+            front = feasible[np.asarray(front_local, dtype=np.int64)]
+            remaining = count - len(selected)
+            if remaining <= 0:
+                break
+            if len(front) <= remaining:
+                selected.extend(map(int, front))
+                continue
+            diverse = _normalized_farthest_indices(objectives[front], remaining)
+            selected.extend(int(front[index]) for index in diverse)
+            break
+    if len(selected) < count:
+        selected.extend(map(int, infeasible[: count - len(selected)]))
+    return np.asarray(selected, dtype=np.int64)
+
+
+def _evaluate_successive_halving(
+    candidates: list[dict],
+    *,
+    policy: dict,
+    evaluate_proxy,
+    proxy_fitness,
+    interrupt_check: InterruptCheck,
+    stage_callback=None,
+) -> tuple[list[dict], np.ndarray, np.ndarray, np.ndarray, list[dict]]:
+    """Evaluate progressively longer prefixes and return full-rung eligibility."""
+
+    active = np.arange(len(candidates), dtype=np.int64)
+    metric_rows: list[dict | None] = [None] * len(candidates)
+    objectives = None
+    violations = np.full(len(candidates), np.inf, dtype=np.float64)
+    trace: list[dict] = []
+    fractions = list(policy["history_fractions"])
+    for rung, fraction in enumerate(fractions):
+        interrupt_check()
+        stage_candidates = [candidates[int(index)] for index in active]
+        stage_metrics = evaluate_proxy(
+            stage_candidates,
+            history_fraction=float(fraction),
+        )
+        stage_objectives, stage_violations = proxy_fitness(stage_metrics)
+        if stage_callback is not None:
+            stage_callback(rung + 1, float(fraction), len(active))
+        if objectives is None:
+            objectives = np.full(
+                (len(candidates), stage_objectives.shape[1]),
+                np.nan,
+                dtype=np.float64,
+            )
+        objectives[active] = stage_objectives
+        violations[active] = stage_violations
+        for local_index, source_index in enumerate(active):
+            metric_rows[int(source_index)] = dict(stage_metrics[local_index])
+
+        final_rung = rung == len(fractions) - 1
+        survivor_count = len(active)
+        if not final_rung:
+            survivor_count = min(
+                len(active),
+                max(
+                    int(policy["min_survivors"]),
+                    int(math.ceil(len(active) * float(policy["survival_fraction"]))),
+                ),
+            )
+        trace.append(
+            {
+                "rung": rung + 1,
+                "history_fraction": float(fraction),
+                "candidate_count": int(len(active)),
+                "survivor_count": int(survivor_count),
+            }
+        )
+        if final_rung:
+            break
+        local_survivors = _successive_halving_survivor_indices(
+            stage_objectives,
+            stage_violations,
+            count=survivor_count,
+        )
+        active = active[local_survivors]
+
+    if objectives is None or any(row is None for row in metric_rows):
+        raise RuntimeError("successive-halving proxy evaluation produced incomplete rows")
+    full_rung_indices = active.copy()
+    rejected = np.ones(len(candidates), dtype=bool)
+    rejected[full_rung_indices] = False
+    # Partial-history rows remain useful as weak proposal evidence, but must
+    # never outrank or masquerade as full-history proxy evidence.
+    violations[rejected] = np.inf
+    return (
+        [dict(row) for row in metric_rows if row is not None],
+        objectives,
+        violations,
+        full_rung_indices,
+        trace,
+    )
+
+
 def _select_validation_indices(
     objectives: np.ndarray,
     scores: np.ndarray,
@@ -2702,12 +2915,13 @@ def _gpu_search_checkpoint_contract(
     optimizer_overrides,
     sig_digits,
     algorithm_contract,
+    proxy_evaluation_policy=None,
 ) -> dict:
     """Fingerprint fixed and dormant search inputs omitted from active genes."""
 
     if not (len(key_paths) == len(bounds) == len(base_vector)):
         raise ValueError("GPU checkpoint search contract shape mismatch")
-    return {
+    contract = {
         "version": 1,
         "sig_digits": int(sig_digits),
         "dimensions": [
@@ -2734,6 +2948,10 @@ def _gpu_search_checkpoint_contract(
         "optimizer_overrides": sorted(str(value) for value in optimizer_overrides),
         "algorithm": deepcopy(algorithm_contract),
     }
+    if proxy_evaluation_policy is not None:
+        contract["version"] = 2
+        contract["proxy_evaluation"] = deepcopy(proxy_evaluation_policy)
+    return contract
 
 
 def _save_checkpoint(path: str | None, state: dict) -> None:
@@ -3365,6 +3583,16 @@ def run_backend(
             evaluator.shared_hlcvs_np[exchange].shape[1]
         )
         suite_multicoin_sides = None
+    halving_policy = options["successive_halving"]
+    if halving_policy["enabled"] and (
+        suite_enabled
+        or max_coin_count != 1
+        or strategy_kind != "trailing_martingale"
+    ):
+        raise ValueError(
+            "optimize.gpu.successive_halving currently requires a non-suite, "
+            "single-coin trailing_martingale optimization"
+        )
     if max_coin_count > 1:
         multicoin_sides = (
             list(suite_multicoin_sides)
@@ -3715,7 +3943,13 @@ def run_backend(
             for _exchange, proxy in exchange_proxies
         ]
 
-        def evaluate_proxy(candidates):
+        def evaluate_proxy(candidates, *, history_fraction=1.0):
+            if not math.isclose(
+                float(history_fraction), 1.0, rel_tol=0.0, abs_tol=1.0e-12
+            ):
+                raise ValueError(
+                    "GPU suite proxy evaluation does not support partial history"
+                )
             return _evaluate_gpu_suite_proxies(
                 evaluator_for_pool,
                 scenario_proxies,
@@ -3737,8 +3971,13 @@ def run_backend(
         )
         profile_proxies = [proxy]
 
-        def evaluate_proxy(candidates):
-            return proxy.evaluate(candidates)
+        def evaluate_proxy(candidates, *, history_fraction=1.0):
+            end_step = (
+                proxy.end_step_for_history_fraction(history_fraction)
+                if float(history_fraction) < 1.0
+                else None
+            )
+            return proxy.evaluate(candidates, end_step=end_step)
 
     active_low = np.asarray(
         [bound.low for _name, _index, bound in active], dtype=np.float64
@@ -3874,6 +4113,9 @@ def run_backend(
             optimizer_overrides=gpu_optimizer_overrides,
             sig_digits=sig_digits,
             algorithm_contract=algorithm_contract,
+            proxy_evaluation_policy=(
+                halving_policy if halving_policy["enabled"] else None
+            ),
         ),
     )
     budget = int(config["optimize"]["iters"])
@@ -4227,14 +4469,57 @@ def run_backend(
                 else 0.0
             )
             proxy_started = time.perf_counter() if profile_enabled else 0.0
-            metric_rows = evaluate_proxy(proxy_candidates)
+            proxy_profile_records = []
+
+            def capture_halving_profile(rung, history_fraction, candidate_count):
+                if not profile_enabled:
+                    return
+                for item in profile_proxies:
+                    record = deepcopy(getattr(item, "last_profile", {}))
+                    record.update(
+                        successive_halving_rung=int(rung),
+                        history_fraction=float(history_fraction),
+                        rung_candidate_count=int(candidate_count),
+                    )
+                    proxy_profile_records.append(record)
+
+            if halving_policy["enabled"]:
+                (
+                    metric_rows,
+                    proxy_objectives,
+                    proxy_violations,
+                    full_rung_indices,
+                    halving_trace,
+                ) = _evaluate_successive_halving(
+                    proxy_candidates,
+                    policy=halving_policy,
+                    evaluate_proxy=evaluate_proxy,
+                    proxy_fitness=proxy_fitness,
+                    interrupt_check=interrupt_check,
+                    stage_callback=capture_halving_profile,
+                )
+            else:
+                metric_rows = evaluate_proxy(proxy_candidates)
+                proxy_objectives, proxy_violations = proxy_fitness(metric_rows)
+                full_rung_indices = np.arange(len(rows), dtype=np.int64)
+                halving_trace = []
             proxy_seconds = (
                 time.perf_counter() - proxy_started if profile_enabled else 0.0
             )
-            proxy_objectives, proxy_violations = proxy_fitness(metric_rows)
             proxy_evaluations += len(rows)
+            if halving_trace:
+                logging.info(
+                    "GPU successive halving | gen=%d rungs=%s full_history=%d/%d",
+                    generation + 1,
+                    ",".join(
+                        f"{item['history_fraction']:.0%}:{item['candidate_count']}"
+                        for item in halving_trace
+                    ),
+                    len(full_rung_indices),
+                    len(rows),
+                )
             if objective_scale.median is None:
-                objective_scale.fit(proxy_objectives)
+                objective_scale.fit(proxy_objectives[full_rung_indices])
             proxy_scores = objective_scale.score(proxy_objectives)
             population.set("F", proxy_objectives)
             population.set(
@@ -4263,13 +4548,17 @@ def run_backend(
                 int(options["validate_per_generation"]),
                 int(options["drift_probes"]),
             )
-            selections = _select_validation_indices(
-                proxy_objectives,
-                proxy_scores,
-                proxy_violations,
+            full_rung_selections = _select_validation_indices(
+                proxy_objectives[full_rung_indices],
+                proxy_scores[full_rung_indices],
+                proxy_violations[full_rung_indices],
                 total=validation_count,
                 probes=probe_count,
             )
+            selections = [
+                (int(full_rung_indices[index]), is_probe, is_proxy_front)
+                for index, is_probe, is_proxy_front in full_rung_selections
+            ]
             while True:
                 try:
                     exact_selections = _select_exact_validations(
@@ -4327,10 +4616,11 @@ def run_backend(
                 generation_wall_seconds = (
                     time.perf_counter() - generation_profile_started
                 )
-                proxy_profile_records = [
-                    deepcopy(getattr(item, "last_profile", {}))
-                    for item in profile_proxies
-                ]
+                if not halving_policy["enabled"]:
+                    proxy_profile_records = [
+                        deepcopy(getattr(item, "last_profile", {}))
+                        for item in profile_proxies
+                    ]
                 proxy_profile_wall = sum(
                     float(item.get("wall_seconds", 0.0))
                     for item in proxy_profile_records
@@ -4345,6 +4635,8 @@ def run_backend(
                     "generation",
                     generation=generation,
                     population_size=len(rows),
+                    successive_halving=halving_trace,
+                    full_history_candidate_count=len(full_rung_indices),
                     proxy_profiles=proxy_profile_records,
                     timings_seconds={
                         "nsga_ask": ask_seconds,

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -2143,10 +2143,17 @@ def _normalized_farthest_indices(values: np.ndarray, count: int) -> list[int]:
     span = np.nanmax(values, axis=0) - low
     normalized = (values - low) / np.where(span > 1.0e-12, span, 1.0)
     chosen = [int(np.argmin(np.nanmean(normalized, axis=1)))]
+    selected = np.zeros(len(values), dtype=bool)
+    selected[chosen[0]] = True
     distance = np.linalg.norm(normalized - normalized[chosen[0]], axis=1)
     for _ in range(count - 1):
-        index = int(np.argmax(distance))
+        available = np.flatnonzero(~selected)
+        available_distances = np.where(
+            np.isfinite(distance[available]), distance[available], -np.inf
+        )
+        index = int(available[int(np.argmax(available_distances))])
         chosen.append(index)
+        selected[index] = True
         distance = np.minimum(
             distance, np.linalg.norm(normalized - normalized[index], axis=1)
         )
@@ -4506,7 +4513,11 @@ def run_backend(
             proxy_seconds = (
                 time.perf_counter() - proxy_started if profile_enabled else 0.0
             )
-            proxy_evaluations += len(rows)
+            proxy_evaluations += (
+                sum(int(item["candidate_count"]) for item in halving_trace)
+                if halving_trace
+                else len(rows)
+            )
             if halving_trace:
                 logging.info(
                     "GPU successive halving | gen=%d rungs=%s full_history=%d/%d",

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -1421,7 +1421,7 @@ class MpsEmaAnchorRunner:
         self._rolling_buffers: dict[int, tuple[torch.Tensor, torch.Tensor]] = {}
         self._recovery_buffers: dict[int, torch.Tensor] = {}
         self._equity_balance_diff_buffers: dict[int, torch.Tensor] = {}
-        self._sizes: dict[tuple[int, int], torch.Tensor] = {}
+        self._sizes: dict[tuple[int, int, int], torch.Tensor] = {}
         self.last_profile: dict[str, float | int | bool] = {}
 
     def _shader_library_cache_call(self):
@@ -1550,11 +1550,21 @@ class MpsEmaAnchorRunner:
         return self._equity_balance_diff_buffers[batch_size]
 
     def _single_coin_size_values(
-        self, batch_size: int, parameter_count: int
+        self,
+        batch_size: int,
+        parameter_count: int,
+        *,
+        end_step: int | None = None,
     ) -> list[int]:
+        effective_end_step = self.n if end_step is None else int(end_step)
+        if not 3 <= effective_end_step <= self.n:
+            raise ValueError(
+                "single-coin MPS end_step must be between 3 and the full candle "
+                f"count {self.n}, got {effective_end_step}"
+            )
         values = [
             int(batch_size),
-            self.n,
+            effective_end_step,
             self.n_days,
             int(parameter_count),
             self.run_config.first_valid_idx,
@@ -1566,7 +1576,13 @@ class MpsEmaAnchorRunner:
             values.extend([self.recovery_stride, self.n_recovery_samples])
         return values
 
-    def run(self, params: np.ndarray, *, profile: bool = False) -> dict:
+    def run(
+        self,
+        params: np.ndarray,
+        *,
+        profile: bool = False,
+        end_step: int | None = None,
+    ) -> dict:
         started = time.perf_counter() if profile else 0.0
         matrix = self._pack_params(params)
         packed = time.perf_counter() if profile else 0.0
@@ -1582,10 +1598,13 @@ class MpsEmaAnchorRunner:
             else None
         )
         equity_balance_diff = self._equity_balance_diff_buffer(batch_size)
-        sizes_key = (batch_size, int(matrix.shape[1]))
+        effective_end_step = self.n if end_step is None else int(end_step)
+        sizes_key = (batch_size, int(matrix.shape[1]), effective_end_step)
         if sizes_key not in self._sizes:
             size_values = self._single_coin_size_values(
-                batch_size, int(matrix.shape[1])
+                batch_size,
+                int(matrix.shape[1]),
+                end_step=effective_end_step,
             )
             self._sizes[sizes_key] = torch.tensor(
                 size_values,
@@ -1640,6 +1659,7 @@ class MpsEmaAnchorRunner:
                 "batch_size": batch_size,
                 "dispatch_count": 1,
                 "cold": cold,
+                "effective_candle_count": effective_end_step,
             }
         else:
             self.last_profile = {}
@@ -2863,7 +2883,13 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
             scaled, TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS, sides=2
         )
 
-    def run(self, params: np.ndarray, *, profile: bool = False) -> dict:
+    def run(
+        self,
+        params: np.ndarray,
+        *,
+        profile: bool = False,
+        end_step: int | None = None,
+    ) -> dict:
         started = time.perf_counter() if profile else 0.0
         matrix = self._pack_params(params)
         dispatch_features = _tm_dispatch_specialization(
@@ -2889,10 +2915,13 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
         entry_interval_stats, entry_interval_counts = self._entry_interval_buffers(
             batch_size
         )
-        sizes_key = (batch_size, int(matrix.shape[1]))
+        effective_end_step = self.n if end_step is None else int(end_step)
+        sizes_key = (batch_size, int(matrix.shape[1]), effective_end_step)
         if sizes_key not in self._sizes:
             size_values = self._single_coin_size_values(
-                batch_size, int(matrix.shape[1])
+                batch_size,
+                int(matrix.shape[1]),
+                end_step=effective_end_step,
             )
             self._sizes[sizes_key] = torch.tensor(
                 size_values,
@@ -2949,6 +2978,7 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
                 "batch_size": batch_size,
                 "dispatch_count": 1,
                 "cold": cold,
+                "effective_candle_count": effective_end_step,
                 "dispatch_specialization": {
                     "trailing_entry_only": dispatch_features[0],
                     "trailing_close_only": dispatch_features[1],

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -230,13 +230,26 @@ def _gpu_profile_features(proxy, runners) -> dict[str, bool]:
     }
 
 
-def _new_gpu_proxy_profile(proxy, candidates, runners, *, coin_count, side_count):
-    candle_count = max(
-        (int(getattr(runner, "n", 0)) for runner in runners), default=0
-    )
-    dispatch_batch_size = int(
-        getattr(proxy, "dispatch_batch_size", getattr(proxy, "batch_size", 0))
-    )
+def _new_gpu_proxy_profile(
+    proxy,
+    candidates,
+    runners,
+    *,
+    coin_count,
+    side_count,
+    candle_count=None,
+    dispatch_batch_size=None,
+):
+    if candle_count is None:
+        candle_count = max(
+            (int(getattr(runner, "n", 0)) for runner in runners), default=0
+        )
+    candle_count = int(candle_count)
+    if dispatch_batch_size is None:
+        dispatch_batch_size = int(
+            getattr(proxy, "dispatch_batch_size", getattr(proxy, "batch_size", 0))
+        )
+    dispatch_batch_size = int(dispatch_batch_size)
     return {
         "schema_version": 1,
         "scope": "proxy_evaluation",
@@ -2014,9 +2027,61 @@ class MpsSingleCoinProxy:
             rows.append(row)
         return np.asarray(rows, dtype=np.float64)
 
-    def evaluate(self, candidates: list[dict]) -> list[dict]:
+    def end_step_for_history_fraction(self, history_fraction: float) -> int:
+        """Map a prefix fraction to a safe candle boundary after warmup."""
+
+        fraction = float(history_fraction)
+        if not np.isfinite(fraction) or not 0.0 < fraction <= 1.0:
+            raise ValueError("GPU history fraction must be finite and in (0, 1]")
+        candle_count = int(self.runner.n)
+        minimum = min(
+            candle_count,
+            max(
+                3,
+                int(self.run.trade_start_idx) + 2,
+                int(self.run.first_valid_idx) + 2,
+            ),
+        )
+        return min(
+            candle_count,
+            max(minimum, int(np.ceil(candle_count * fraction))),
+        )
+
+    def evaluate(
+        self, candidates: list[dict], *, end_step: int | None = None
+    ) -> list[dict]:
         results: list[dict] = []
         torch = self._torch
+        full_candle_count = max(
+            3,
+            int(
+                getattr(
+                    self.runner,
+                    "n",
+                    getattr(self, "metrics_data", {}).get("n", 3),
+                )
+            ),
+        )
+        effective_end_step = (
+            full_candle_count if end_step is None else int(end_step)
+        )
+        if not 3 <= effective_end_step <= full_candle_count:
+            raise ValueError(
+                "GPU single-coin end_step must be between 3 and the full candle "
+                f"count {full_candle_count}, got {effective_end_step}"
+            )
+        side_count = int(bool(getattr(self.runner, "long_enabled", True))) + int(
+            bool(getattr(self.runner, "short_enabled", False))
+        )
+        dispatch_batch_size = (
+            int(getattr(self, "dispatch_batch_size", self.batch_size))
+            if end_step is None
+            else _mps_dispatch_batch_size(
+                self.batch_size,
+                n_bars=effective_end_step,
+                n_sides=side_count,
+            )
+        )
         profile_started = time.perf_counter() if self.profile_enabled else 0.0
         profile = (
             _new_gpu_proxy_profile(
@@ -2024,16 +2089,14 @@ class MpsSingleCoinProxy:
                 candidates,
                 (self.runner,),
                 coin_count=1,
-                side_count=int(bool(getattr(self.runner, "long_enabled", True)))
-                + int(bool(getattr(self.runner, "short_enabled", False))),
+                side_count=side_count,
+                candle_count=effective_end_step,
+                dispatch_batch_size=dispatch_batch_size,
             )
             if self.profile_enabled
             else None
         )
         self.last_profile = {}
-        dispatch_batch_size = getattr(
-            self, "dispatch_batch_size", self.batch_size
-        )
         interrupt_check = getattr(self, "interrupt_check", lambda: None)
         progress = _new_gpu_dispatch_progress(
             len(candidates), dispatch_batch_size
@@ -2055,12 +2118,16 @@ class MpsSingleCoinProxy:
             output = self.runner.run(
                 parameter_matrix,
                 profile=self.profile_enabled,
+                end_step=effective_end_step,
             )
             if profile is not None:
                 _add_gpu_runner_profile(
                     profile,
                     self.runner,
                     side_count=profile["side_count"],
+                    effective_candidate_steps=np.full(
+                        len(chunk), effective_end_step, dtype=np.int64
+                    ),
                 )
             interrupt_check()
             stage_started = (
@@ -2121,7 +2188,7 @@ class MpsSingleCoinProxy:
             objectives = self._compute_objectives(
                 output,
                 self.run,
-                self.metrics_data,
+                {**self.metrics_data, "n": effective_end_step},
                 needed=self.needed_metrics,
             )
             if profile is not None:

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -2034,7 +2034,7 @@ class MpsSingleCoinProxy:
         if not np.isfinite(fraction) or not 0.0 < fraction <= 1.0:
             raise ValueError("GPU history fraction must be finite and in (0, 1]")
         candle_count = int(self.runner.n)
-        minimum = min(
+        effective_start = min(
             candle_count,
             max(
                 3,
@@ -2044,7 +2044,8 @@ class MpsSingleCoinProxy:
         )
         return min(
             candle_count,
-            max(minimum, int(np.ceil(candle_count * fraction))),
+            effective_start
+            + int(np.ceil((candle_count - effective_start) * fraction)),
         )
 
     def evaluate(

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -32,6 +32,7 @@ from optimization.backends.gpu_backend import (
     _constraint_diagnostics,
     _ema_multicoin_bound_map,
     _evaluate_gpu_suite_proxies,
+    _evaluate_successive_halving,
     _format_constraint_diagnostics,
     _gpu_fixed_bound_context,
     _gpu_candidate_search_sides,
@@ -66,6 +67,7 @@ from optimization.backends.gpu_backend import (
     _restore_gpu_result_run_contract,
     _gpu_unstuck_search_sides,
     _single_scenario_metric_surface,
+    _successive_halving_survivor_indices,
     _suite_limit_metric_value,
     _trailing_martingale_multicoin_bound_map,
     _ProxyFrontValidationPending,
@@ -350,6 +352,106 @@ def test_gpu_options_are_additive_and_validate_ranges():
     config["optimize"]["gpu"]["drift_halt"] = 0.0
     with pytest.raises(ValueError, match="greater than zero"):
         _resolve_options(config)
+
+
+def test_gpu_successive_halving_options_are_opt_in_and_fail_closed():
+    config = _long_only_ema_config()
+    options = _resolve_options(config)
+    assert options["successive_halving"] == {
+        "enabled": False,
+        "history_fractions": [0.25, 0.5, 1.0],
+        "survival_fraction": 0.5,
+        "min_survivors": 64,
+    }
+
+    config["optimize"]["gpu"]["successive_halving"] = {
+        "enabled": True,
+        "history_fractions": [0.5, 0.25, 1.0],
+    }
+    with pytest.raises(ValueError, match="strictly increasing"):
+        _resolve_options(config)
+
+    config["optimize"]["gpu"]["successive_halving"] = {
+        "enabled": True,
+        "min_survivors": 7,
+    }
+    with pytest.raises(ValueError, match="validate_per_generation"):
+        _resolve_options(config)
+
+
+def test_successive_halving_keeps_pareto_diversity_and_full_rung_evidence_only():
+    candidates = [{"id": index} for index in range(8)]
+    calls = []
+
+    def evaluate_proxy(stage_candidates, *, history_fraction):
+        ids = [candidate["id"] for candidate in stage_candidates]
+        calls.append((history_fraction, ids))
+        return [
+            {
+                "left": float(index),
+                "right": float(7 - index),
+                "violation": 0.0,
+            }
+            for index in ids
+        ]
+
+    def proxy_fitness(rows):
+        return (
+            np.asarray([[row["left"], row["right"]] for row in rows]),
+            np.asarray([row["violation"] for row in rows]),
+        )
+
+    metric_rows, objectives, violations, full_indices, trace = (
+        _evaluate_successive_halving(
+            candidates,
+            policy={
+                "history_fractions": [0.25, 0.5, 1.0],
+                "survival_fraction": 0.5,
+                "min_survivors": 2,
+            },
+            evaluate_proxy=evaluate_proxy,
+            proxy_fitness=proxy_fitness,
+            interrupt_check=lambda: None,
+        )
+    )
+
+    assert [len(ids) for _fraction, ids in calls] == [8, 4, 2]
+    assert trace == [
+        {
+            "rung": 1,
+            "history_fraction": 0.25,
+            "candidate_count": 8,
+            "survivor_count": 4,
+        },
+        {
+            "rung": 2,
+            "history_fraction": 0.5,
+            "candidate_count": 4,
+            "survivor_count": 2,
+        },
+        {
+            "rung": 3,
+            "history_fraction": 1.0,
+            "candidate_count": 2,
+            "survivor_count": 2,
+        },
+    ]
+    assert len(metric_rows) == len(objectives) == len(violations) == 8
+    assert len(full_indices) == 2
+    assert np.all(np.isfinite(violations[full_indices]))
+    assert np.all(np.isinf(np.delete(violations, full_indices)))
+
+
+def test_successive_halving_survivors_prioritize_feasibility_then_violation():
+    objectives = np.asarray([[0.0], [1.0], [2.0], [3.0]])
+    violations = np.asarray([0.0, 0.0, 0.2, 0.1])
+
+    survivors = _successive_halving_survivor_indices(
+        objectives, violations, count=3
+    )
+
+    assert set(survivors[:2]) == {0, 1}
+    assert survivors[2] == 3
 
 
 def test_fresh_run_accepts_partial_suffix_with_opportunistic_probes():
@@ -2004,6 +2106,26 @@ def test_gpu_preparation_preflight_explains_trailing_grid_cpu_fallback():
     ):
         validate_gpu_preparation_scope(
             config,
+            torch_module=_fake_torch_with_mps(),
+        )
+
+
+def test_gpu_preparation_preflight_rejects_halving_for_ema_or_suite():
+    config = _long_only_ema_config()
+    config["optimize"]["gpu"]["successive_halving"]["enabled"] = True
+
+    with pytest.raises(ValueError, match="single-coin trailing_martingale"):
+        validate_gpu_preparation_scope(
+            config,
+            torch_module=_fake_torch_with_mps(),
+        )
+
+    config = _directional_tm_config(long_enabled=True, short_enabled=False)
+    config["optimize"]["gpu"]["successive_halving"]["enabled"] = True
+    with pytest.raises(ValueError, match="non-suite"):
+        validate_gpu_preparation_scope(
+            config,
+            {"enabled": True, "scenarios": []},
             torch_module=_fake_torch_with_mps(),
         )
 
@@ -6295,7 +6417,25 @@ def test_gpu_checkpoint_signature_tracks_full_fixed_search_contract():
             "population_size": 64,
             "mutation": {"prob": 0.5},
         },
+        proxy_evaluation_policy={
+            "enabled": False,
+            "history_fractions": [0.25, 0.5, 1.0],
+        },
     )
+    assert contract["version"] == 2
+    assert contract["proxy_evaluation"]["enabled"] is False
+    ordinary_contract = _gpu_search_checkpoint_contract(
+        key_paths=key_paths,
+        bounds=bounds,
+        base_vector=base,
+        fixed_bound_values={"long_base_qty_pct": 0.02},
+        fixed_parameter_overrides={"long_base_qty_pct": 0.02},
+        optimizer_overrides=set(),
+        sig_digits=3,
+        algorithm_contract=contract["algorithm"],
+    )
+    assert ordinary_contract["version"] == 1
+    assert "proxy_evaluation" not in ordinary_contract
     active = [("long_offset", 0, bounds[0])]
     scoring = [{"goal": "max", "metric": "adg_strategy_eq"}]
     original = _checkpoint_signature(
@@ -6321,6 +6461,9 @@ def test_gpu_checkpoint_signature_tracks_full_fixed_search_contract():
     changed_mutation = copy.deepcopy(contract)
     changed_mutation["algorithm"]["mutation"]["prob"] = 0.25
     mutations.append(changed_mutation)
+    changed_proxy_policy = copy.deepcopy(contract)
+    changed_proxy_policy["proxy_evaluation"]["enabled"] = True
+    mutations.append(changed_proxy_policy)
 
     assert all(
         _checkpoint_signature(active, scoring, search_contract=changed)

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -438,8 +438,10 @@ def test_successive_halving_keeps_pareto_diversity_and_full_rung_evidence_only()
     ]
     assert len(metric_rows) == len(objectives) == len(violations) == 8
     assert len(full_indices) == 2
+    assert len(np.unique(full_indices)) == 2
     assert np.all(np.isfinite(violations[full_indices]))
     assert np.all(np.isinf(np.delete(violations, full_indices)))
+    assert sum(item["candidate_count"] for item in trace) == 14
 
 
 def test_successive_halving_survivors_prioritize_feasibility_then_violation():
@@ -452,6 +454,16 @@ def test_successive_halving_survivors_prioritize_feasibility_then_violation():
 
     assert set(survivors[:2]) == {0, 1}
     assert survivors[2] == 3
+
+
+def test_successive_halving_survivors_remain_unique_when_objectives_tie():
+    survivors = _successive_halving_survivor_indices(
+        np.zeros((8, 2), dtype=np.float64),
+        np.zeros(8, dtype=np.float64),
+        count=6,
+    )
+
+    assert survivors.tolist() == [0, 1, 2, 3, 4, 5]
 
 
 def test_fresh_run_accepts_partial_suffix_with_opportunistic_probes():

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -776,6 +776,58 @@ def test_mps_tm_hsl_diagnostic_opt_out_preserves_strategy_outputs():
     assert lean["hsl_triggers_long"].item() == 0.0
 
 
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+def test_mps_tm_end_step_preserves_full_run_and_truncates_only_the_horizon():
+    count = 120
+    steps = np.arange(count, dtype=np.float64)
+    close = 100.0 + np.sin(steps / 7.0)
+    high = close + 0.2
+    low = close - 0.2
+    timestamps = 1_700_000_000_000 + steps.astype(np.int64) * 60_000
+    market = ProxyMarket(0.001, 0.01, 0.001, 0.0, 1.0, 0.0)
+    run = ProxyRun(
+        1_000.0,
+        1,
+        1,
+        int(timestamps[0]),
+        int(timestamps[0]),
+        int(timestamps[0]),
+        60_000,
+        0.05,
+        0,
+        count - 1,
+    )
+    data = build_mps_data(high, low, close, timestamps, run, market)
+    row = _tm_single_row(initial_ema_dist=0.0)
+    matrix = np.asarray([row + row], dtype=np.float64)
+
+    def run_once(end_step=None):
+        runner = MpsTrailingMartingaleRunner(
+            market,
+            run,
+            data,
+            long_enabled=True,
+            short_enabled=False,
+            hsl_enabled=False,
+        )
+        return runner.run(matrix, end_step=end_step)
+
+    ordinary = run_once()
+    explicit_full = run_once(count)
+    truncated = run_once(60)
+    torch.mps.synchronize()
+
+    for key in ordinary:
+        if isinstance(ordinary[key], torch.Tensor):
+            torch.testing.assert_close(
+                ordinary[key], explicit_full[key], rtol=0.0, atol=0.0,
+                equal_nan=True,
+            )
+    assert truncated["last_eq_ts"].item() < ordinary["last_eq_ts"].item()
+
+
 @pytest.mark.parametrize("recovery_enabled", [False, True])
 @pytest.mark.parametrize("runner_name", ["ema_anchor", "trailing_martingale"])
 def test_single_coin_size_buffer_packs_last_valid_before_recovery_fields(
@@ -808,6 +860,14 @@ def test_single_coin_size_buffer_packs_last_valid_before_recovery_fields(
     assert actual == [5, 17, 2, 13, 3, 9, 7, 11] + (
         [60, 4] if recovery_enabled else []
     )
+
+    truncated = runner._single_coin_size_values(5, 13, end_step=12)
+    assert truncated == [5, 12, 2, 13, 3, 9, 7, 11] + (
+        [60, 4] if recovery_enabled else []
+    )
+
+    with pytest.raises(ValueError, match="end_step"):
+        runner._single_coin_size_values(5, 13, end_step=18)
 
 
 def test_trailing_martingale_runner_accepts_ordinary_market_execution(monkeypatch):

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -443,6 +443,33 @@ def test_single_coin_proxy_preserves_order_across_bounded_dispatches():
     assert calls == [[0.0, 1.0], [2.0, 3.0], [4.0]]
 
 
+def test_single_coin_proxy_partial_history_expands_safe_dispatch_and_routes_end_step():
+    proxy, calls = _minimal_single_coin_proxy()
+    proxy.batch_size = 4096
+    proxy.dispatch_batch_size = 258
+    proxy.runner.n = 1_931_815
+    proxy.run = SimpleNamespace(trade_start_idx=10, first_valid_idx=0)
+    original_run = proxy.runner.run
+    routed_end_steps = []
+
+    def routed_run(parameters, **kwargs):
+        routed_end_steps.append(kwargs["end_step"])
+        return original_run(parameters, **kwargs)
+
+    proxy.runner.run = routed_run
+
+    end_step = proxy.end_step_for_history_fraction(0.25)
+    results = proxy.evaluate(
+        [{"value": float(index)} for index in range(1024)],
+        end_step=end_step,
+    )
+
+    assert end_step == 482_954
+    assert len(results) == 1024
+    assert [len(call) for call in calls] == [1024]
+    assert routed_end_steps == [482_954]
+
+
 def test_single_coin_proxy_profile_records_dispatch_shape_and_timings(monkeypatch):
     torch = pytest.importorskip("torch")
     proxy, calls = _minimal_single_coin_proxy()

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -464,10 +464,14 @@ def test_single_coin_proxy_partial_history_expands_safe_dispatch_and_routes_end_
         end_step=end_step,
     )
 
-    assert end_step == 482_954
+    assert end_step == 482_963
     assert len(results) == 1024
     assert [len(call) for call in calls] == [1024]
-    assert routed_end_steps == [482_954]
+    assert routed_end_steps == [482_963]
+
+    proxy.runner.n = 1_250
+    proxy.run = SimpleNamespace(trade_start_idx=1_000, first_valid_idx=900)
+    assert proxy.end_step_for_history_fraction(0.25) == 1_064
 
 
 def test_single_coin_proxy_profile_records_dispatch_shape_and_timings(monkeypatch):


### PR DESCRIPTION
## Summary
- add disabled-by-default successive-halving proxy screening for single-coin Trailing Martingale on Apple MPS
- evaluate progressively longer history prefixes while preserving the 500M candidate-bars dispatch safety cap
- admit only full-history survivors to exact Rust validation, proxy-front selection, broad probes, and drift evidence
- keep ordinary GPU, CPU optimizer, backtest, and live paths unchanged

## Validation
- focused GPU backend and service suites
- CPU runtime import-boundary regression
- real-MPS full-horizon equality and partial-horizon truncation regression
- Python syntax compilation and diff checks
- fixed-seed one-year synthetic TM case, 1,024 candidates: 7.146s ordinary versus 4.807s for the 1,024@25%, 512@50%, 256@100% ladder (1.49x); all ladder rungs dispatched once

`mkdocs build --strict` completes rendering but remains nonzero on the pre-existing release-note links to `../CHANGELOG.md` outside the docs navigation.