### PR TITLE
Skip unused TM volatility state on Apple MPS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Apple MPS single-coin Trailing Martingale screening now compiles out the 1-minute and 1-hour
+  volatility EMA state, candle-range loads, and volatility-weight arithmetic when every active
+  candidate in a dispatch uses zero volatility weights for entry and close thresholds and
+  retracements. Mixed or nonzero-weight dispatches retain the full kernel. Opt-in GPU profiles now
+  also report terminated-candidate counts and estimated post-termination candidate-bars, making
+  future early-exit work measurable. Exact Rust validation, CPU optimization, backtests, and live
+  behavior are unchanged.
+
 - Apple MPS single-coin Trailing Martingale optimization now offers disabled-by-default
   successive-halving proxy screening. The default opt-in ladder evaluates 1024 candidates on 25%
   of history, 512 on 50%, and 256 on the complete history, while preserving the existing

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -750,7 +750,10 @@ cold compilation versus warm library lookup, kernel execution, device-to-host tr
 reduction, and remaining host overhead. Shape metadata includes requested and actual dispatch batch
 sizes, dispatch chunk and strategy-kernel counts, candidate-bars, candle/coin/side counts, requested
 optional metric features, dispatch-proven Trailing Martingale specializations, and cold/warm
-dispatch counts. Exact Rust evaluation remains
+dispatch counts. Single-coin profiles also report how many candidates terminated before the end of
+the evaluated history, estimated candidate-bars after termination, the corresponding fraction of
+total candidate-bars, and terminal-step p50/p90. These estimates make the ceiling for a future
+early-exit optimization visible without adding work to unprofiled runs. Exact Rust evaluation remains
 authoritative; profiling fields are diagnostic log output and are not added to retained optimization
 results. Chunked proxy generations that run for at least 30 seconds also emit rate-limited ordinary
 progress with completed chunks and candidates, elapsed time, and ETA. This progress remains
@@ -761,8 +764,12 @@ cached Metal library. When every enabled-side candidate has positive entry or cl
 the corresponding recursive grid path is compiled out. When every enabled-side candidate disables
 the position/total-exposure enforcers and auto-unstuck, those reducer paths are compiled out as a
 group. Fixed run settings similarly specialize ordinary market execution and the realized-loss
-gate. A mixed dispatch keeps each relevant full path, so this changes compiled work rather than
-proxy semantics. A run may record an additional cold compile if its dispatch feature shape changes.
+gate. When all eight entry/close threshold and retracement volatility weights are exactly zero for
+every active row, the selected kernel also omits the 1-minute and 1-hour volatility EMA state,
+candle-range loads, and volatility-weight arithmetic. Any nonzero, non-finite, or mixed row keeps
+the full volatility path. A mixed dispatch keeps each relevant full path, so this changes compiled
+work rather than proxy semantics. A run may record an additional cold compile if its dispatch
+feature shape changes.
 HSL topology likewise considers enabled sides only; an HSL setting left on an exposure-disabled
 side does not make the active side pay for an HSL controller.
 

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -1194,6 +1194,8 @@ mod tests {
         assert!(source.contains("#ifndef PASSIVBOT_TM_TRAILING_ENTRY_ONLY"));
         assert!(source.contains("#ifndef PASSIVBOT_TM_TRAILING_CLOSE_ONLY"));
         assert!(source.contains("#ifndef PASSIVBOT_TM_REDUCERS_DISABLED"));
+        assert!(source.contains("#ifndef PASSIVBOT_TM_VOLATILITY_DISABLED"));
+        assert!(source.contains("#if !PASSIVBOT_TM_VOLATILITY_DISABLED"));
         assert!(source
             .contains("const float market_order_near_touch_threshold = fmax(settings[20], 0.0f)"));
         assert!(source.contains("should_use_ordinary_market_execution("));

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -16,6 +16,9 @@ using namespace metal;
 #ifndef PASSIVBOT_TM_LOSS_GATE_DISABLED
 #define PASSIVBOT_TM_LOSS_GATE_DISABLED 0
 #endif
+#ifndef PASSIVBOT_TM_VOLATILITY_DISABLED
+#define PASSIVBOT_TM_VOLATILITY_DISABLED 0
+#endif
 
 #if PASSIVBOT_BTC_RISK_ENABLED
 constant int DAILY_COLS = 11;
@@ -278,15 +281,26 @@ inline void record_directional_gross_pnl(
 }
 
 struct TmSide {
-    float alpha0, alpha1, alpha2, alpha1m, alpha1h;
+    float alpha0, alpha1, alpha2;
+#if !PASSIVBOT_TM_VOLATILITY_DISABLED
+    float alpha1m, alpha1h;
+#endif
     float ddf, initial_ema_dist, initial_qty_pct;
     float entry_threshold_base, entry_threshold_we;
+#if !PASSIVBOT_TM_VOLATILITY_DISABLED
     float entry_threshold_v1h, entry_threshold_v1m;
+#endif
     float entry_retracement_base, entry_retracement_we;
+#if !PASSIVBOT_TM_VOLATILITY_DISABLED
     float entry_retracement_v1h, entry_retracement_v1m;
+#endif
     float close_qty_pct, close_threshold_base, close_threshold_we;
+#if !PASSIVBOT_TM_VOLATILITY_DISABLED
     float close_threshold_v1h, close_threshold_v1m;
     float close_retracement_base, close_retracement_v1h, close_retracement_v1m;
+#else
+    float close_retracement_base;
+#endif
     float cooldown_min, twel, allowed_wel, entry_cap;
     bool gate_initial, gate_reentry, twel_entry_gate_enabled;
     bool wel_enforcer_enabled;
@@ -307,7 +321,10 @@ struct TmSide {
     bool entry_market, close_market, secondary_close_market;
     bool market_orders_allowed;
     float market_order_near_touch_threshold;
-    float ema0, ema1, ema2, vol1m, vol1h;
+    float ema0, ema1, ema2;
+#if !PASSIVBOT_TM_VOLATILITY_DISABLED
+    float vol1m, vol1h;
+#endif
     float psize, pprice, last_inc_k, pos_open_k;
     int entry_ticks, close_ticks, secondary_close_ticks;
     float entry_price, close_price, entry_qty, entry_strategy_qty, close_qty;
@@ -421,27 +438,37 @@ inline TmSide load_side(constant float* p, int o, float seed) {
     s.alpha0 = clamp(2.0f / (lo + 1.0f), 0.0f, 1.0f);
     s.alpha1 = clamp(2.0f / (mid + 1.0f), 0.0f, 1.0f);
     s.alpha2 = clamp(2.0f / (hi + 1.0f), 0.0f, 1.0f);
+#if !PASSIVBOT_TM_VOLATILITY_DISABLED
     s.alpha1h = p[o + 2] > 0.0f ? 2.0f / (fmax(p[o + 2], 1.0f) + 1.0f) : 0.0f;
     s.alpha1m = p[o + 3] > 0.0f ? clamp(2.0f / (p[o + 3] + 1.0f), 0.0f, 1.0f) : 0.0f;
+#endif
     s.ddf = p[o + 4];
     s.initial_ema_dist = p[o + 5];
     s.initial_qty_pct = p[o + 6];
     s.entry_threshold_base = p[o + 7];
     s.entry_threshold_we = p[o + 8];
+#if !PASSIVBOT_TM_VOLATILITY_DISABLED
     s.entry_threshold_v1h = p[o + 9];
     s.entry_threshold_v1m = p[o + 10];
+#endif
     s.entry_retracement_base = p[o + 11];
     s.entry_retracement_we = p[o + 12];
+#if !PASSIVBOT_TM_VOLATILITY_DISABLED
     s.entry_retracement_v1h = p[o + 13];
     s.entry_retracement_v1m = p[o + 14];
+#endif
     s.close_qty_pct = p[o + 15];
     s.close_threshold_base = p[o + 16];
     s.close_threshold_we = p[o + 17];
+#if !PASSIVBOT_TM_VOLATILITY_DISABLED
     s.close_threshold_v1h = p[o + 18];
     s.close_threshold_v1m = p[o + 19];
+#endif
     s.close_retracement_base = p[o + 20];
+#if !PASSIVBOT_TM_VOLATILITY_DISABLED
     s.close_retracement_v1h = p[o + 21];
     s.close_retracement_v1m = p[o + 22];
+#endif
     s.cooldown_min = ceil(p[o + 23]);
     s.twel = p[o + 24];
     s.gate_initial = p[o + 25] > 0.5f;
@@ -491,7 +518,9 @@ inline TmSide load_side(constant float* p, int o, float seed) {
     s.market_orders_allowed = false;
     s.market_order_near_touch_threshold = 0.0f;
     s.ema0 = seed; s.ema1 = seed; s.ema2 = seed;
+#if !PASSIVBOT_TM_VOLATILITY_DISABLED
     s.vol1m = 0.0f; s.vol1h = 0.0f;
+#endif
     s.psize = 0.0f; s.pprice = 0.0f;
     s.last_inc_k = -1.0f; s.pos_open_k = -1.0f;
     s.entry_ticks = 0; s.entry_qty = 0.0f; s.entry_strategy_qty = 0.0f;
@@ -521,14 +550,18 @@ inline TmSide load_side(constant float* p, int o, float seed) {
 inline void update_indicators(
     thread TmSide& s, float close, float lr, float hour_lr, bool valid, bool hour_valid
 ) {
+#if !PASSIVBOT_TM_VOLATILITY_DISABLED
     if (hour_valid && s.alpha1h > 0.0f)
         s.vol1h = fma(s.alpha1h, hour_lr - s.vol1h, s.vol1h);
+#endif
     if (valid) {
         s.ema0 = fma(s.alpha0, close - s.ema0, s.ema0);
         s.ema1 = fma(s.alpha1, close - s.ema1, s.ema1);
         s.ema2 = fma(s.alpha2, close - s.ema2, s.ema2);
+#if !PASSIVBOT_TM_VOLATILITY_DISABLED
         if (s.alpha1m > 0.0f)
             s.vol1m = fma(s.alpha1m, lr - s.vol1m, s.vol1m);
+#endif
     }
 }
 
@@ -934,6 +967,10 @@ inline void generate_orders(
     float we = !flat && balance > 0.0f
         ? s.psize * s.pprice * c_mult / balance : 0.0f;
     float wer = we / fmax(s.allowed_wel, 1.0e-12f);
+#if PASSIVBOT_TM_VOLATILITY_DISABLED
+    float tm = fmax(1.0f + wer * s.entry_threshold_we, 1.0f);
+    float rm = fmax(1.0f + wer * s.entry_retracement_we, 1.0f);
+#else
     float tm = fmax(
         1.0f + s.vol1h * s.entry_threshold_v1h
             + s.vol1m * s.entry_threshold_v1m + wer * s.entry_threshold_we,
@@ -944,6 +981,7 @@ inline void generate_orders(
             + s.vol1m * s.entry_retracement_v1m + wer * s.entry_retracement_we,
         1.0f
     );
+#endif
     float threshold = fmax(s.entry_threshold_base, 0.0f) * tm;
     float retracement = fmax(s.entry_retracement_base, 0.0f) * rm;
     const bool trailing_entry = PASSIVBOT_TM_TRAILING_ENTRY_ONLY
@@ -1117,6 +1155,10 @@ inline void generate_orders(
     }
     float unstuck_exec_price = unstuck_market ? price_now : unstuck_price;
 
+#if PASSIVBOT_TM_VOLATILITY_DISABLED
+    float ct = s.close_threshold_base + wer * s.close_threshold_we;
+    float cr = fmax(s.close_retracement_base, 0.0f);
+#else
     float ct = s.close_threshold_base + wer * s.close_threshold_we
         + s.vol1h * s.close_threshold_v1h + s.vol1m * s.close_threshold_v1m;
     float cr = fmax(s.close_retracement_base, 0.0f) * fmax(
@@ -1124,6 +1166,7 @@ inline void generate_orders(
             + s.vol1m * s.close_retracement_v1m,
         1.0f
     );
+#endif
     const bool trailing_close = PASSIVBOT_TM_TRAILING_CLOSE_ONLY
         || s.close_retracement_base > 0.0f;
     bool retraced_close = is_long
@@ -1937,12 +1980,16 @@ inline void passivbot_single_coin_impl(
         const float high = bars[bo + 0];
         const float low = bars[bo + 1];
         const float close = bars[bo + 2];
+#if !PASSIVBOT_TM_VOLATILITY_DISABLED
         const float log_range = bars[bo + 3];
         const float hour_lr = bars[bo + 4];
+#endif
         const bool valid = flags[fo + 0] != 0;
         const bool can_gen = flags[fo + 1] != 0;
         const int di = flags[fo + 2];
+#if !PASSIVBOT_TM_VOLATILITY_DISABLED
         const bool hour_valid = flags[fo + 3] != 0;
+#endif
         const int high_fill_max_tick = flags[fo + 4];
         const int low_nonfill_max_tick = flags[fo + 5];
         const int touch_down_tick = flags[fo + 6];
@@ -2023,9 +2070,13 @@ inline void passivbot_single_coin_impl(
             // Positive WE weight makes later generated long closes nearer.
             // The zero-WE target is a conservative lower bound: reconstruct
             // the sorted grid only if this candle can reach that bound.
+#if PASSIVBOT_TM_VOLATILITY_DISABLED
+            float threshold_floor = long_side.close_threshold_base;
+#else
             float threshold_floor = long_side.close_threshold_base
                 + long_side.vol1h * long_side.close_threshold_v1h
                 + long_side.vol1m * long_side.close_threshold_v1m;
+#endif
             int target_ticks = directional_ticks(
                 long_side.close_gen_pprice * (1.0f + threshold_floor),
                 price_step, true
@@ -2781,9 +2832,13 @@ inline void passivbot_single_coin_impl(
             && short_side.close_threshold_we > 0.0f) {
             // Positive WE weight makes later generated short closes nearer.
             // The zero-WE target is a conservative upper bound.
+#if PASSIVBOT_TM_VOLATILITY_DISABLED
+            float threshold_floor = short_side.close_threshold_base;
+#else
             float threshold_floor = short_side.close_threshold_base
                 + short_side.vol1h * short_side.close_threshold_v1h
                 + short_side.vol1m * short_side.close_threshold_v1m;
+#endif
             int target_ticks = directional_ticks(
                 short_side.close_gen_pprice * (1.0f - threshold_floor),
                 price_step, false
@@ -3619,12 +3674,20 @@ inline void passivbot_single_coin_impl(
 
 #if !defined(PASSIVBOT_TRAILING_SHORT_ONLY)
         if (long_enabled) {
+#if PASSIVBOT_TM_VOLATILITY_DISABLED
+            update_indicators(long_side, close, 0.0f, 0.0f, valid, false);
+#else
             update_indicators(long_side, close, log_range, hour_lr, valid, hour_valid);
+#endif
         }
 #endif
 #if !defined(PASSIVBOT_TRAILING_LONG_ONLY)
         if (short_enabled) {
+#if PASSIVBOT_TM_VOLATILITY_DISABLED
+            update_indicators(short_side, close, 0.0f, 0.0f, valid, false);
+#else
             update_indicators(short_side, close, log_range, hour_lr, valid, hour_valid);
+#endif
         }
 #endif
 #if !defined(PASSIVBOT_TRAILING_SHORT_ONLY)

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -76,6 +76,9 @@ _TM_MARKET_ORDERS_DISABLED_DEFINE = (
     "#define PASSIVBOT_TM_MARKET_ORDERS_DISABLED 1\n"
 )
 _TM_LOSS_GATE_DISABLED_DEFINE = "#define PASSIVBOT_TM_LOSS_GATE_DISABLED 1\n"
+_TM_VOLATILITY_DISABLED_DEFINE = (
+    "#define PASSIVBOT_TM_VOLATILITY_DISABLED 1\n"
+)
 
 
 def _with_hsl_ema_tail(source: str, enabled: bool) -> str:
@@ -172,6 +175,7 @@ def _with_tm_dispatch_features(
     reducers_disabled: bool,
     market_orders_disabled: bool,
     loss_gate_disabled: bool,
+    volatility_disabled: bool,
 ) -> str:
     features = (
         (
@@ -198,6 +202,11 @@ def _with_tm_dispatch_features(
             loss_gate_disabled,
             "#ifndef PASSIVBOT_TM_LOSS_GATE_DISABLED",
             _TM_LOSS_GATE_DISABLED_DEFINE,
+        ),
+        (
+            volatility_disabled,
+            "#ifndef PASSIVBOT_TM_VOLATILITY_DISABLED",
+            _TM_VOLATILITY_DISABLED_DEFINE,
         ),
     )
     for enabled, marker, define in features:
@@ -271,7 +280,7 @@ def _tm_dispatch_specialization(
     short_enabled: bool,
     market_orders_allowed: bool,
     loss_gate_enabled: bool,
-) -> tuple[bool, bool, bool, bool, bool]:
+) -> tuple[bool, bool, bool, bool, bool, bool]:
     """Prove dispatch-wide TM features before compiling away inactive paths."""
 
     side_width = len(TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS)
@@ -308,12 +317,29 @@ def _tm_dispatch_specialization(
             "unstuck_enabled",
         )
     )
+    volatility_disabled = all(
+        all_active_rows(
+            lambda values: np.all(np.isfinite(values) & (values == 0.0)),
+            key,
+        )
+        for key in (
+            "entry_threshold_volatility_1h_weight",
+            "entry_threshold_volatility_1m_weight",
+            "entry_retracement_volatility_1h_weight",
+            "entry_retracement_volatility_1m_weight",
+            "close_threshold_volatility_1h_weight",
+            "close_threshold_volatility_1m_weight",
+            "close_retracement_volatility_1h_weight",
+            "close_retracement_volatility_1m_weight",
+        )
+    )
     return (
         trailing_entry_only,
         trailing_close_only,
         reducers_disabled,
         not market_orders_allowed,
         not loss_gate_enabled,
+        volatility_disabled,
     )
 
 
@@ -652,6 +678,7 @@ def _trailing_martingale_shader_library(
     reducers_disabled: bool = False,
     market_orders_disabled: bool = False,
     loss_gate_disabled: bool = False,
+    volatility_disabled: bool = False,
     hsl_ema_tail_enabled: bool = False,
     hsl_raw_drawdown_enabled: bool = False,
     hsl_raw_tail_enabled: bool = False,
@@ -672,6 +699,7 @@ def _trailing_martingale_shader_library(
         reducers_disabled=reducers_disabled,
         market_orders_disabled=market_orders_disabled,
         loss_gate_disabled=loss_gate_disabled,
+        volatility_disabled=volatility_disabled,
     )
     source = _with_hsl_features(
         source,
@@ -694,6 +722,7 @@ def _trailing_martingale_long_hsl_shader_library(
     reducers_disabled: bool = False,
     market_orders_disabled: bool = False,
     loss_gate_disabled: bool = False,
+    volatility_disabled: bool = False,
     hsl_ema_tail_enabled: bool = False,
     hsl_raw_drawdown_enabled: bool = False,
     hsl_raw_tail_enabled: bool = False,
@@ -714,6 +743,7 @@ def _trailing_martingale_long_hsl_shader_library(
         reducers_disabled=reducers_disabled,
         market_orders_disabled=market_orders_disabled,
         loss_gate_disabled=loss_gate_disabled,
+        volatility_disabled=volatility_disabled,
     )
     source = _with_hsl_features(
         source,
@@ -736,6 +766,7 @@ def _trailing_martingale_short_hsl_shader_library(
     reducers_disabled: bool = False,
     market_orders_disabled: bool = False,
     loss_gate_disabled: bool = False,
+    volatility_disabled: bool = False,
     hsl_ema_tail_enabled: bool = False,
     hsl_raw_drawdown_enabled: bool = False,
     hsl_raw_tail_enabled: bool = False,
@@ -756,6 +787,7 @@ def _trailing_martingale_short_hsl_shader_library(
         reducers_disabled=reducers_disabled,
         market_orders_disabled=market_orders_disabled,
         loss_gate_disabled=loss_gate_disabled,
+        volatility_disabled=volatility_disabled,
     )
     source = _with_hsl_features(
         source,
@@ -778,6 +810,7 @@ def _trailing_martingale_long_no_hsl_shader_library(
     reducers_disabled: bool = False,
     market_orders_disabled: bool = False,
     loss_gate_disabled: bool = False,
+    volatility_disabled: bool = False,
     recovery_distribution_enabled: bool = False,
     btc_risk_enabled: bool = False,
     equity_balance_diff_enabled: bool = False,
@@ -794,6 +827,7 @@ def _trailing_martingale_long_no_hsl_shader_library(
         reducers_disabled=reducers_disabled,
         market_orders_disabled=market_orders_disabled,
         loss_gate_disabled=loss_gate_disabled,
+        volatility_disabled=volatility_disabled,
     )
     source = _with_recovery_distribution(
         source,
@@ -812,6 +846,7 @@ def _trailing_martingale_short_no_hsl_shader_library(
     reducers_disabled: bool = False,
     market_orders_disabled: bool = False,
     loss_gate_disabled: bool = False,
+    volatility_disabled: bool = False,
     recovery_distribution_enabled: bool = False,
     btc_risk_enabled: bool = False,
     equity_balance_diff_enabled: bool = False,
@@ -828,6 +863,7 @@ def _trailing_martingale_short_no_hsl_shader_library(
         reducers_disabled=reducers_disabled,
         market_orders_disabled=market_orders_disabled,
         loss_gate_disabled=loss_gate_disabled,
+        volatility_disabled=volatility_disabled,
     )
     source = _with_recovery_distribution(
         source,
@@ -2773,7 +2809,7 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
 
     def _shader_library_cache_call(
         self,
-        dispatch_features: tuple[bool, bool, bool, bool, bool] | None = None,
+        dispatch_features: tuple[bool, bool, bool, bool, bool, bool] | None = None,
     ):
         if dispatch_features is None:
             dispatch_features = (
@@ -2782,6 +2818,7 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
                 False,
                 not getattr(self, "market_orders_allowed", False),
                 not getattr(self, "loss_gate_enabled", False),
+                False,
             )
         if self.shader_topology == "long_hsl":
             return _trailing_martingale_long_hsl_shader_library, (
@@ -2985,6 +3022,7 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
                     "reducers_disabled": dispatch_features[2],
                     "market_orders_disabled": dispatch_features[3],
                     "loss_gate_disabled": dispatch_features[4],
+                    "volatility_disabled": dispatch_features[5],
                 },
             }
         else:

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -272,6 +272,10 @@ def _new_gpu_proxy_profile(
             len(candidates) * candle_count * int(coin_count) * int(side_count)
         ),
         "kernel_candidate_bars": 0,
+        "terminal_candidate_count": 0,
+        "terminal_without_equity_count": 0,
+        "estimated_post_terminal_candidate_bars": 0,
+        "_terminal_step_fractions": [],
         "candle_count": candle_count,
         "coin_count": int(coin_count),
         "side_count": int(side_count),
@@ -365,6 +369,45 @@ def _add_gpu_runner_profile(
     )
 
 
+def _add_gpu_terminal_profile(
+    profile: dict,
+    output: dict,
+    *,
+    interval_ms: int,
+    effective_end_step: int,
+) -> None:
+    """Estimate work after irreversible single-coin candidate termination."""
+
+    alive = output.get("alive")
+    last_eq_ts = output.get("last_eq_ts")
+    if alive is None or last_eq_ts is None:
+        return
+    alive_values = alive.detach().cpu().numpy().astype(bool, copy=False)
+    terminal = ~alive_values
+    terminal_count = int(terminal.sum())
+    if terminal_count == 0:
+        return
+    last_eq_values = np.asarray(
+        last_eq_ts.detach().cpu().numpy(), dtype=np.float64
+    )
+    terminal_last_eq = last_eq_values[terminal]
+    finite = np.isfinite(terminal_last_eq)
+    estimated_steps = np.ones(terminal_count, dtype=np.int64)
+    if np.any(finite):
+        estimated_steps[finite] = np.rint(
+            terminal_last_eq[finite] / max(1, int(interval_ms))
+        ).astype(np.int64)
+    estimated_steps = np.clip(estimated_steps, 1, max(1, effective_end_step - 2))
+    profile["terminal_candidate_count"] += terminal_count
+    profile["terminal_without_equity_count"] += int((~finite).sum())
+    profile["estimated_post_terminal_candidate_bars"] += int(
+        np.maximum(effective_end_step - 2 - estimated_steps, 0).sum()
+    ) * int(profile.get("side_count", 1))
+    profile["_terminal_step_fractions"].extend(
+        (estimated_steps / max(1, effective_end_step - 2)).tolist()
+    )
+
+
 def _finish_gpu_proxy_profile(profile: dict, started: float) -> dict:
     profile["actual_dispatch_batch_sizes"] = list(
         profile["actual_dispatch_batch_sizes"]
@@ -374,6 +417,23 @@ def _finish_gpu_proxy_profile(profile: dict, started: float) -> dict:
     profile["timings_seconds"]["host_overhead"] = max(
         0.0,
         profile["wall_seconds"] - accounted,
+    )
+    terminal_fractions = np.asarray(
+        profile.pop("_terminal_step_fractions", ()), dtype=np.float64
+    )
+    avoidable = int(profile["estimated_post_terminal_candidate_bars"])
+    profile["estimated_post_terminal_candidate_bar_fraction"] = (
+        avoidable / max(1, int(profile["candidate_bars"]))
+    )
+    profile["terminal_step_fraction_p50"] = (
+        float(np.quantile(terminal_fractions, 0.50))
+        if len(terminal_fractions)
+        else None
+    )
+    profile["terminal_step_fraction_p90"] = (
+        float(np.quantile(terminal_fractions, 0.90))
+        if len(terminal_fractions)
+        else None
     )
     return profile
 
@@ -2143,10 +2203,13 @@ class MpsSingleCoinProxy:
                     time.perf_counter() - stage_started
                 )
                 stage_started = time.perf_counter()
+            host_output_keys = CORE_OUTPUT_KEYS | DIRECTIONAL_HSL_OUTPUT_KEYS
+            if profile is not None:
+                host_output_keys = host_output_keys | {"alive"}
             output = {
                 key: value.cpu()
                 for key, value in output.items()
-                if key in CORE_OUTPUT_KEYS | DIRECTIONAL_HSL_OUTPUT_KEYS
+                if key in host_output_keys
             }
             if recovery_distribution is not None:
                 output["strategy_eq_recovery_distribution"] = (
@@ -2157,6 +2220,12 @@ class MpsSingleCoinProxy:
                     time.perf_counter() - stage_started
                 )
                 stage_started = time.perf_counter()
+                _add_gpu_terminal_profile(
+                    profile,
+                    output,
+                    interval_ms=int(self.run.interval_ms),
+                    effective_end_step=effective_end_step,
+                )
             timestamp_origin = float(self.metrics_data["ts0"])
             for key in (
                 "first_fill_ts",

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -12583,7 +12583,7 @@ def test_tm_dispatch_specialization_requires_every_enabled_side_and_row():
         short_enabled=False,
         market_orders_allowed=False,
         loss_gate_enabled=False,
-    ) == (True, True, True, True, True)
+    ) == (True, True, True, True, True, True)
 
     entry_column = TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS.index(
         "entry_retracement_base_pct"
@@ -12595,7 +12595,20 @@ def test_tm_dispatch_specialization_requires_every_enabled_side_and_row():
         short_enabled=False,
         market_orders_allowed=True,
         loss_gate_enabled=True,
-    ) == (False, True, True, False, False)
+    ) == (False, True, True, False, False, True)
+
+    volatility_column = TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS.index(
+        "entry_threshold_volatility_1m_weight"
+    )
+    matrix[1, volatility_column] = 0.1
+    assert _tm_dispatch_specialization(
+        matrix,
+        long_enabled=True,
+        short_enabled=False,
+        market_orders_allowed=False,
+        loss_gate_enabled=False,
+    )[5] is False
+    matrix[1, volatility_column] = 0.0
 
     matrix[1, entry_column] = 0.001
     side_width = len(TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS)
@@ -12630,6 +12643,7 @@ def test_tm_dispatch_feature_defines_are_opt_in_and_guarded():
         reducers_disabled=True,
         market_orders_disabled=True,
         loss_gate_disabled=True,
+        volatility_disabled=True,
     )
 
     for name in (
@@ -12638,6 +12652,7 @@ def test_tm_dispatch_feature_defines_are_opt_in_and_guarded():
         "PASSIVBOT_TM_REDUCERS_DISABLED",
         "PASSIVBOT_TM_MARKET_ORDERS_DISABLED",
         "PASSIVBOT_TM_LOSS_GATE_DISABLED",
+        "PASSIVBOT_TM_VOLATILITY_DISABLED",
     ):
         assert f"#define {name} 1" in transformed
         assert f"#ifndef {name}" in transformed
@@ -12649,7 +12664,107 @@ def test_tm_dispatch_feature_defines_are_opt_in_and_guarded():
         reducers_disabled=False,
         market_orders_disabled=False,
         loss_gate_disabled=False,
+        volatility_disabled=False,
     ) == source
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize(
+    ("topology", "hsl_enabled"),
+    [
+        ("long", True),
+        ("short", True),
+        ("long", False),
+        ("short", False),
+        ("dual", True),
+    ],
+)
+def test_mps_tm_zero_volatility_specialization_matches_generic(
+    monkeypatch, topology, hsl_enabled
+):
+    import optimization.gpu.mps_kernel as mps_kernel
+
+    count = 512
+    steps = np.arange(count, dtype=np.float64)
+    close = 100.0 + np.sin(steps / 17.0) * 3.0
+    high = close + 0.5
+    low = close - 0.5
+    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    market = ProxyMarket(0.001, 0.01, 0.001, 5.0, 1.0, 0.0002)
+    run = ProxyRun(
+        1_000.0,
+        1,
+        1,
+        int(timestamps[0]),
+        int(timestamps[0]),
+        int(timestamps[0]),
+        60_000,
+        0.05,
+        0,
+        count - 1,
+    )
+    data = build_mps_data(high, low, close, timestamps, run, market)
+    rows = []
+    for initial_dist, threshold in ((0.005, 0.03), (0.01, 0.08)):
+        row = _tm_single_row(initial_ema_dist=initial_dist)
+        row[TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS.index("hsl_enabled")] = (
+            float(hsl_enabled)
+        )
+        row[
+            TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS.index("hsl_red_threshold")
+        ] = threshold
+        rows.append(row + row)
+    parameters = np.asarray(rows, dtype=np.float64)
+
+    specialized_runner = MpsTrailingMartingaleRunner(
+        market,
+        run,
+        data,
+        long_enabled=topology != "short",
+        short_enabled=topology != "long",
+        hsl_enabled=hsl_enabled,
+    )
+    specialized = specialized_runner.run(parameters, profile=True)
+    original_specialization = mps_kernel._tm_dispatch_specialization
+
+    def force_generic_volatility(*args, **kwargs):
+        features = original_specialization(*args, **kwargs)
+        return (*features[:5], False)
+
+    monkeypatch.setattr(
+        mps_kernel, "_tm_dispatch_specialization", force_generic_volatility
+    )
+    generic_runner = MpsTrailingMartingaleRunner(
+        market,
+        run,
+        data,
+        long_enabled=topology != "short",
+        short_enabled=topology != "long",
+        hsl_enabled=hsl_enabled,
+    )
+    generic = generic_runner.run(parameters, profile=True)
+    torch.mps.synchronize()
+
+    assert specialized_runner.last_profile["dispatch_specialization"][
+        "volatility_disabled"
+    ] is True
+    assert generic_runner.last_profile["dispatch_specialization"][
+        "volatility_disabled"
+    ] is False
+    assert specialized.keys() == generic.keys()
+    for key in specialized:
+        if isinstance(specialized[key], torch.Tensor):
+            torch.testing.assert_close(
+                specialized[key].cpu(),
+                generic[key].cpu(),
+                rtol=0.0,
+                atol=0.0,
+                equal_nan=True,
+            )
+        else:
+            assert specialized[key] == generic[key]
 
 
 @pytest.mark.skipif(

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -424,6 +424,7 @@ def _minimal_single_coin_proxy(*, interrupt_check=lambda: None):
             )
         }
         output["max_dd"] = torch.as_tensor(parameters[:, 0])
+        output["alive"] = torch.ones(batch, dtype=torch.bool)
         return output
 
     proxy.runner = SimpleNamespace(run=run)
@@ -481,11 +482,17 @@ def test_single_coin_proxy_profile_records_dispatch_shape_and_timings(monkeypatc
     proxy.strategy_kind = "ema_anchor"
     proxy.runner.n = 100
     proxy.runner.long_enabled = True
-    proxy.runner.short_enabled = False
+    proxy.runner.short_enabled = True
+    proxy.run = SimpleNamespace(interval_ms=60_000)
     original_run = proxy.runner.run
 
     def profiled_run(parameters, **kwargs):
         output = original_run(parameters, **kwargs)
+        candidate_ids = parameters[:, 0].astype(int)
+        output["alive"] = torch.as_tensor(candidate_ids % 2 == 0)
+        output["last_eq_ts"] = torch.as_tensor(
+            np.where(candidate_ids % 2 == 0, 99, candidate_ids + 9) * 60_000.0
+        )
         proxy.runner.last_profile = {
             "cpu_pack_seconds": 0.001,
             "upload_and_zero_seconds": 0.002,
@@ -502,6 +509,7 @@ def test_single_coin_proxy_profile_records_dispatch_shape_and_timings(monkeypatc
                 "reducers_disabled": True,
                 "market_orders_disabled": True,
                 "loss_gate_disabled": True,
+                "volatility_disabled": True,
             },
         }
         return output
@@ -523,6 +531,7 @@ def test_single_coin_proxy_profile_records_dispatch_shape_and_timings(monkeypatc
             "reducers_disabled": True,
             "market_orders_disabled": True,
             "loss_gate_disabled": True,
+            "volatility_disabled": True,
         }
     ] * 3
     assert profile["dispatch_count"] == 3
@@ -530,10 +539,18 @@ def test_single_coin_proxy_profile_records_dispatch_shape_and_timings(monkeypatc
     assert profile["warm_dispatch_count"] == 2
     assert len(profile["dispatch_chunk_wall_seconds"]) == 3
     assert all(value >= 0.0 for value in profile["dispatch_chunk_wall_seconds"])
-    assert profile["candidate_bars"] == 500
-    assert profile["kernel_candidate_bars"] == 500
+    assert profile["candidate_bars"] == 1_000
+    assert profile["kernel_candidate_bars"] == 1_000
+    assert profile["terminal_candidate_count"] == 2
+    assert profile["terminal_without_equity_count"] == 0
+    assert profile["estimated_post_terminal_candidate_bars"] == 348
+    assert profile["estimated_post_terminal_candidate_bar_fraction"] == pytest.approx(
+        0.348
+    )
+    assert profile["terminal_step_fraction_p50"] == pytest.approx(11.0 / 98.0)
+    assert profile["terminal_step_fraction_p90"] == pytest.approx(11.8 / 98.0)
     assert profile["coin_count"] == 1
-    assert profile["side_count"] == 1
+    assert profile["side_count"] == 2
     assert profile["timings_seconds"]["kernel_execution"] == pytest.approx(
         0.015
     )


### PR DESCRIPTION
## Summary

- prove dispatch-wide zero volatility weights before selecting a Trailing Martingale Metal library
- compile out 1-minute and 1-hour volatility EMA state, candle-range loads, and volatility-weight arithmetic only for all-zero active dispatches
- retain the full kernel for mixed, nonzero, or non-finite weights
- extend opt-in GPU profiles with terminated-candidate and estimated post-termination candidate-bar evidence

Exact Rust validation remains authoritative. CPU optimization, backtests, live behavior, and unprofiled host transfer behavior are unchanged.

## Performance

Deterministic in-memory tm-single-long-hsl fixture, seed 7, 512 candidates, 250,000 candles, one 128,000,000 candidate-bar dispatch:

- held-generic versus specialized alternating comparison: kernel p50 1.785 s to 1.698 s, 4.9% faster
- held-generic versus specialized wall p50: 1.821 s to 1.738 s, 4.6% faster
- immutable head 494778bff standard harness: 296.4 candidates/s warm p50, 1.676 s kernel p50, one dispatch

The fixture is public and reproducible with:

    python -m tools.gpu_proxy_benchmark --case tm-single-long-hsl --candidates 512 --dispatch-batch-size 512 --single-bars 250000 --warm-runs 5 --seed 7 --compact

## Validation

- 275 Rust tests with cargo test --no-default-features
- full GPU service tests plus focused dispatch-specialization tests
- physical Apple MPS bit-for-bit comparison against the generic volatility path for long/short HSL, long/short no-HSL, and dual-side kernels
- focused HSL lifecycle, market-entry, open-tail, and CPU import/preflight regressions
- repository-standard release extension rebuild and current-source verification for all five shader exports
- documentation build completed except for the two unchanged strict-mode CHANGELOG link warnings in existing release-note pages
- git diff --check