### PR TITLE
Fix Bitunix transient balance duplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
-- Bitunix now defers live exchange actions while confirming nonzero locked-fund balance state,
-  including after restart, when the account endpoint may transiently report unchanged locked funds
-  in both `available` and `used` balance components.
+- Bitunix now defers live exchange actions when a locked-fund balance does not reconcile with the
+  exchange-calculated maximum-transfer amount, including after restart, preventing a transient
+  account response from reporting unchanged locked funds in both `available` and `used` balance
+  components.
 
 - Apple MPS successive-halving optimization now evaluates its opt-in 25% and 50% rungs on the
   most recent portion of the configured date range, with the normal indicator warmup immediately

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Bitunix now defers live exchange actions when the account endpoint transiently reports unchanged
+  locked funds in both `available` and `used` balance components.
+
 - Apple MPS successive-halving optimization now evaluates its opt-in 25% and 50% rungs on the
   most recent portion of the configured date range, with the normal indicator warmup immediately
   preceding each scoring window. The final rung remains the full configured history. Checkpoint
@@ -17,7 +20,6 @@ All notable user-facing changes will be documented in this file.
   identity, so finite-lookback coin-HSL checkpoints from the old capacity cannot mix stale proxy
   evidence with new evaluations. Exact Rust validation, CPU optimization, backtests, and live
   behavior are unchanged.
-
 - Apple MPS single-coin Trailing Martingale screening now compiles out the 1-minute and 1-hour
   volatility EMA state, candle-range loads, and volatility-weight arithmetic when every active
   candidate in a dispatch uses zero volatility weights for entry and close thresholds and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
-- Bitunix now defers live exchange actions when the account endpoint transiently reports unchanged
-  locked funds in both `available` and `used` balance components.
+- Bitunix now defers live exchange actions while confirming nonzero locked-fund balance state,
+  including after restart, when the account endpoint may transiently report unchanged locked funds
+  in both `available` and `used` balance components.
 
 - Apple MPS successive-halving optimization now evaluates its opt-in 25% and 50% rungs on the
   most recent portion of the configured date range, with the normal indicator warmup immediately

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable user-facing changes will be documented in this file.
   exchange-calculated maximum-transfer amount, including after restart, preventing a transient
   account response from reporting unchanged locked funds in both `available` and `used` balance
   components.
+- Live `balance_override` values must now be positive finite numbers; booleans and other invalid
+  values fail during bot initialization instead of being coerced into a sizing balance.
 
 - Apple MPS successive-halving optimization now evaluates its opt-in 25% and 50% rungs on the
   most recent portion of the configured date range, with the normal indicator warmup immediately

--- a/src/exchanges/bitunix.py
+++ b/src/exchanges/bitunix.py
@@ -289,8 +289,9 @@ class BitunixClient:
         separately calculated maximum-transfer value. This covers both restart
         and a transition that changes frozen or margin components while the
         inconsistent response is active. Keep the last accepted components
-        unchanged until the response either returns to them or a new response
-        passes the transfer reconciliation.
+        unchanged until a response with locked funds passes the transfer
+        reconciliation, even when its visible components match the last
+        accepted tuple.
         """
         current = (available, frozen, margin)
         previous = self._accepted_balance_components
@@ -300,6 +301,17 @@ class BitunixClient:
             bonus=bonus,
             unrealized_pnl=unrealized_pnl,
         )
+        current_used = frozen + margin
+        if current_used > 0.0 and not transfer_reconciled:
+            self._defer_balance_candidate(
+                current,
+                defer_message=(
+                    "[balance] Bitunix locked-fund balance did not reconcile "
+                    "with maximum transfer; action=defer_authoritative_state"
+                ),
+            )
+            return
+
         if self._balance_components_close(previous, current):
             if self._pending_balance_components is not None:
                 logging.info(
@@ -307,17 +319,6 @@ class BitunixClient:
                     "action=resume_authoritative_state"
                 )
                 self._clear_pending_balance_transition()
-            return
-
-        current_used = frozen + margin
-        if current_used > 0.0 and not transfer_reconciled:
-            self._defer_balance_candidate(
-                current,
-                defer_message=(
-                    "[balance] Bitunix changed locked-fund balance did not reconcile "
-                    "with maximum transfer; action=defer_authoritative_state"
-                ),
-            )
             return
 
         if self._pending_balance_components is not None:

--- a/src/exchanges/bitunix.py
+++ b/src/exchanges/bitunix.py
@@ -28,6 +28,7 @@ from config.access import require_live_value
 from custom_endpoint_overrides import CustomEndpointConfigError
 from exchanges.ccxt_bot import CCXTBot, format_exchange_config_response
 from live.balance_composition import normalize_bitunix_balance_composition
+from live.state_refresh import AuthoritativeSurfaceUnavailable
 from passivbot import logging
 from utils import symbol_to_coin
 
@@ -170,6 +171,8 @@ class BitunixClient:
         "1w": 7 * 24 * 60 * 60_000,
         "1M": 30 * 24 * 60 * 60_000,
     }
+    BALANCE_TRANSITION_REASON = "balance_transition_confirmation"
+    BALANCE_TRANSITION_CONFIRMATION_SECONDS = 120.0
 
     def __init__(self, config: dict | None = None):
         config = config or {}
@@ -208,7 +211,105 @@ class BitunixClient:
         self._ticker_subscription_ids: tuple[str, ...] = ()
         self._ticker_ready = asyncio.Event()
         self._pending_status_warning_monotonic: dict[str, float] = {}
+        self._accepted_balance_components: tuple[float, float, float] | None = None
+        self._pending_balance_components: tuple[float, float, float] | None = None
+        self._pending_balance_started_monotonic: float | None = None
+        self._pending_balance_observation_count = 0
         self._closed = False
+
+    @staticmethod
+    def _balance_values_close(left: float, right: float) -> bool:
+        return math.isclose(float(left), float(right), rel_tol=1e-9, abs_tol=1e-9)
+
+    @classmethod
+    def _balance_components_close(
+        cls,
+        left: tuple[float, float, float] | None,
+        right: tuple[float, float, float],
+    ) -> bool:
+        return bool(
+            left is not None
+            and all(
+                cls._balance_values_close(left_value, right_value)
+                for left_value, right_value in zip(left, right)
+            )
+        )
+
+    def _validate_balance_transition(
+        self,
+        *,
+        available: float,
+        frozen: float,
+        margin: float,
+    ) -> None:
+        """Reject Bitunix's transient duplication of locked funds into available.
+
+        The known inconsistent response moves ``available`` by exactly the
+        unchanged locked amount while continuing to report that amount as locked.
+        Keep the last accepted components unchanged until the response either
+        reverts or remains stable across a bounded confirmation window.
+        """
+        current = (available, frozen, margin)
+        previous = self._accepted_balance_components
+        if previous is None:
+            self._accepted_balance_components = current
+            return
+
+        previous_available, previous_frozen, previous_margin = previous
+        previous_used = previous_frozen + previous_margin
+        available_delta = available - previous_available
+        duplicates_locked_funds = bool(
+            previous_used > 0.0
+            and self._balance_values_close(frozen, previous_frozen)
+            and self._balance_values_close(margin, previous_margin)
+            and self._balance_values_close(available_delta, previous_used)
+        )
+
+        if duplicates_locked_funds:
+            now = time.monotonic()
+            if not self._balance_components_close(
+                self._pending_balance_components, current
+            ):
+                self._pending_balance_components = current
+                self._pending_balance_started_monotonic = now
+                self._pending_balance_observation_count = 1
+                logging.warning(
+                    "[balance] Bitunix reported locked funds in both available and used; "
+                    "action=defer_authoritative_state"
+                )
+            else:
+                self._pending_balance_observation_count += 1
+            pending_started = self._pending_balance_started_monotonic
+            pending_seconds = max(
+                0.0,
+                now - float(now if pending_started is None else pending_started),
+            )
+            if (
+                self._pending_balance_observation_count >= 2
+                and pending_seconds >= self.BALANCE_TRANSITION_CONFIRMATION_SECONDS
+            ):
+                logging.warning(
+                    "[balance] Bitunix balance transition remained stable through "
+                    "confirmation; action=resume_authoritative_state"
+                )
+                self._accepted_balance_components = current
+                self._pending_balance_components = None
+                self._pending_balance_started_monotonic = None
+                self._pending_balance_observation_count = 0
+                return
+            raise AuthoritativeSurfaceUnavailable(
+                "balance", self.BALANCE_TRANSITION_REASON
+            )
+
+        if self._pending_balance_components is not None:
+            logging.info(
+                "[balance] Bitunix balance transition returned to a consistent state; "
+                "action=resume_authoritative_state"
+            )
+            self._pending_balance_components = None
+            self._pending_balance_started_monotonic = None
+            self._pending_balance_observation_count = 0
+        self._accepted_balance_components = current
 
     def milliseconds(self) -> int:
         return int(time.time() * 1000)
@@ -478,6 +579,11 @@ class BitunixClient:
         isolated_upnl = _float(
             raw.get("isolationUnrealizedPNL"),
             field="account.isolationUnrealizedPNL",
+        )
+        self._validate_balance_transition(
+            available=available,
+            frozen=frozen,
+            margin=margin,
         )
         # Bitunix documents these as disjoint available, order-locked, and
         # position-locked quantities. Unrealized PnL is mark-to-market state,

--- a/src/exchanges/bitunix.py
+++ b/src/exchanges/bitunix.py
@@ -235,6 +235,47 @@ class BitunixClient:
             )
         )
 
+    def _clear_pending_balance_confirmation(self) -> None:
+        self._pending_balance_components = None
+        self._pending_balance_started_monotonic = None
+        self._pending_balance_observation_count = 0
+
+    def _confirm_balance_candidate(
+        self,
+        current: tuple[float, float, float],
+        *,
+        defer_message: str,
+    ) -> None:
+        now = time.monotonic()
+        if not self._balance_components_close(
+            self._pending_balance_components, current
+        ):
+            self._pending_balance_components = current
+            self._pending_balance_started_monotonic = now
+            self._pending_balance_observation_count = 1
+            logging.warning(defer_message)
+        else:
+            self._pending_balance_observation_count += 1
+        pending_started = self._pending_balance_started_monotonic
+        pending_seconds = max(
+            0.0,
+            now - float(now if pending_started is None else pending_started),
+        )
+        if (
+            self._pending_balance_observation_count >= 2
+            and pending_seconds >= self.BALANCE_TRANSITION_CONFIRMATION_SECONDS
+        ):
+            logging.warning(
+                "[balance] Bitunix balance state remained stable through "
+                "confirmation; action=resume_authoritative_state"
+            )
+            self._accepted_balance_components = current
+            self._clear_pending_balance_confirmation()
+            return
+        raise AuthoritativeSurfaceUnavailable(
+            "balance", self.BALANCE_TRANSITION_REASON
+        )
+
     def _validate_balance_transition(
         self,
         *,
@@ -246,13 +287,46 @@ class BitunixClient:
 
         The known inconsistent response moves ``available`` by exactly the
         unchanged locked amount while continuing to report that amount as locked.
-        Keep the last accepted components unchanged until the response either
-        reverts or remains stable across a bounded confirmation window.
+        Confirm an initial nonzero locked-funds state as well, so a restart during
+        the inconsistency cannot establish the duplicated response as trusted
+        truth. Keep the last accepted components unchanged until the response
+        either reverts or remains stable across a bounded confirmation window.
         """
         current = (available, frozen, margin)
         previous = self._accepted_balance_components
         if previous is None:
-            self._accepted_balance_components = current
+            current_used = frozen + margin
+            if current_used <= 0.0:
+                self._accepted_balance_components = current
+                self._clear_pending_balance_confirmation()
+                return
+            pending = self._pending_balance_components
+            if pending is not None:
+                pending_available, pending_frozen, pending_margin = pending
+                pending_used = pending_frozen + pending_margin
+                recovered_from_initial_duplication = bool(
+                    pending_used > 0.0
+                    and self._balance_values_close(frozen, pending_frozen)
+                    and self._balance_values_close(margin, pending_margin)
+                    and self._balance_values_close(
+                        pending_available - available, pending_used
+                    )
+                )
+                if recovered_from_initial_duplication:
+                    logging.info(
+                        "[balance] Bitunix initial balance returned to a consistent "
+                        "state; action=resume_authoritative_state"
+                    )
+                    self._accepted_balance_components = current
+                    self._clear_pending_balance_confirmation()
+                    return
+            self._confirm_balance_candidate(
+                current,
+                defer_message=(
+                    "[balance] Bitunix initial balance has nonzero locked funds; "
+                    "action=defer_authoritative_state_until_confirmed"
+                ),
+            )
             return
 
         previous_available, previous_frozen, previous_margin = previous
@@ -266,49 +340,21 @@ class BitunixClient:
         )
 
         if duplicates_locked_funds:
-            now = time.monotonic()
-            if not self._balance_components_close(
-                self._pending_balance_components, current
-            ):
-                self._pending_balance_components = current
-                self._pending_balance_started_monotonic = now
-                self._pending_balance_observation_count = 1
-                logging.warning(
+            self._confirm_balance_candidate(
+                current,
+                defer_message=(
                     "[balance] Bitunix reported locked funds in both available and used; "
                     "action=defer_authoritative_state"
-                )
-            else:
-                self._pending_balance_observation_count += 1
-            pending_started = self._pending_balance_started_monotonic
-            pending_seconds = max(
-                0.0,
-                now - float(now if pending_started is None else pending_started),
+                ),
             )
-            if (
-                self._pending_balance_observation_count >= 2
-                and pending_seconds >= self.BALANCE_TRANSITION_CONFIRMATION_SECONDS
-            ):
-                logging.warning(
-                    "[balance] Bitunix balance transition remained stable through "
-                    "confirmation; action=resume_authoritative_state"
-                )
-                self._accepted_balance_components = current
-                self._pending_balance_components = None
-                self._pending_balance_started_monotonic = None
-                self._pending_balance_observation_count = 0
-                return
-            raise AuthoritativeSurfaceUnavailable(
-                "balance", self.BALANCE_TRANSITION_REASON
-            )
+            return
 
         if self._pending_balance_components is not None:
             logging.info(
                 "[balance] Bitunix balance transition returned to a consistent state; "
                 "action=resume_authoritative_state"
             )
-            self._pending_balance_components = None
-            self._pending_balance_started_monotonic = None
-            self._pending_balance_observation_count = 0
+            self._clear_pending_balance_confirmation()
         self._accepted_balance_components = current
 
     def milliseconds(self) -> int:

--- a/src/exchanges/bitunix.py
+++ b/src/exchanges/bitunix.py
@@ -268,7 +268,11 @@ class BitunixClient:
         account response changed ``available`` alone, so this remains false even
         if that response is repeated across a restart.
         """
-        if transfer is None:
+        # ``transfer`` is floored at zero. At that floor it only proves that
+        # ``available + min(cross_unrealized_pnl, 0) - bonus <= 0``; it cannot
+        # independently disambiguate a locked-fund duplication. Keep the sample
+        # unavailable until a positive transfer value restores an exact cross-check.
+        if transfer is None or transfer <= 0.0:
             return False
         expected_available = transfer + bonus - min(cross_unrealized_pnl, 0.0)
         return self._balance_values_close(available, expected_available)

--- a/src/exchanges/bitunix.py
+++ b/src/exchanges/bitunix.py
@@ -171,8 +171,7 @@ class BitunixClient:
         "1w": 7 * 24 * 60 * 60_000,
         "1M": 30 * 24 * 60 * 60_000,
     }
-    BALANCE_TRANSITION_REASON = "balance_transition_confirmation"
-    BALANCE_TRANSITION_CONFIRMATION_SECONDS = 120.0
+    BALANCE_TRANSITION_REASON = "balance_consistency_check"
 
     def __init__(self, config: dict | None = None):
         config = config or {}
@@ -213,8 +212,6 @@ class BitunixClient:
         self._pending_status_warning_monotonic: dict[str, float] = {}
         self._accepted_balance_components: tuple[float, float, float] | None = None
         self._pending_balance_components: tuple[float, float, float] | None = None
-        self._pending_balance_started_monotonic: float | None = None
-        self._pending_balance_observation_count = 0
         self._closed = False
 
     @staticmethod
@@ -235,46 +232,44 @@ class BitunixClient:
             )
         )
 
-    def _clear_pending_balance_confirmation(self) -> None:
+    def _clear_pending_balance_transition(self) -> None:
         self._pending_balance_components = None
-        self._pending_balance_started_monotonic = None
-        self._pending_balance_observation_count = 0
 
-    def _confirm_balance_candidate(
+    def _defer_balance_candidate(
         self,
         current: tuple[float, float, float],
         *,
         defer_message: str,
     ) -> None:
-        now = time.monotonic()
         if not self._balance_components_close(
             self._pending_balance_components, current
         ):
             self._pending_balance_components = current
-            self._pending_balance_started_monotonic = now
-            self._pending_balance_observation_count = 1
             logging.warning(defer_message)
-        else:
-            self._pending_balance_observation_count += 1
-        pending_started = self._pending_balance_started_monotonic
-        pending_seconds = max(
-            0.0,
-            now - float(now if pending_started is None else pending_started),
-        )
-        if (
-            self._pending_balance_observation_count >= 2
-            and pending_seconds >= self.BALANCE_TRANSITION_CONFIRMATION_SECONDS
-        ):
-            logging.warning(
-                "[balance] Bitunix balance state remained stable through "
-                "confirmation; action=resume_authoritative_state"
-            )
-            self._accepted_balance_components = current
-            self._clear_pending_balance_confirmation()
-            return
         raise AuthoritativeSurfaceUnavailable(
             "balance", self.BALANCE_TRANSITION_REASON
         )
+
+    def _available_is_transfer_reconciled(
+        self,
+        *,
+        available: float,
+        transfer: float | None,
+        bonus: float,
+        unrealized_pnl: float,
+    ) -> bool:
+        """Corroborate available funds with Bitunix's maximum-transfer metric.
+
+        Bitunix excludes non-transferable bonus funds and unrealized losses from
+        the amount transferable out of futures. Rearranging that relationship
+        gives an exchange-calculated cross-check for ``available``. The known
+        inconsistent account response changed ``available`` alone, so this
+        remains false even if that response is repeated across a restart.
+        """
+        if transfer is None:
+            return False
+        expected_available = transfer + bonus - min(unrealized_pnl, 0.0)
+        return self._balance_values_close(available, expected_available)
 
     def _validate_balance_transition(
         self,
@@ -282,49 +277,64 @@ class BitunixClient:
         available: float,
         frozen: float,
         margin: float,
+        transfer: float | None,
+        bonus: float,
+        unrealized_pnl: float,
     ) -> None:
         """Reject Bitunix's transient duplication of locked funds into available.
 
         The known inconsistent response moves ``available`` by exactly the
         unchanged locked amount while continuing to report that amount as locked.
-        Confirm an initial nonzero locked-funds state as well, so a restart during
-        the inconsistency cannot establish the duplicated response as trusted
-        truth. Keep the last accepted components unchanged until the response
-        either reverts or remains stable across a bounded confirmation window.
+        Reconcile an initial nonzero locked-funds state with Bitunix's separately
+        calculated maximum-transfer value, so a restart during the inconsistency
+        cannot establish the duplicated response as trusted truth. Keep the last
+        accepted components unchanged until the response either returns to it or
+        a new response passes the transfer reconciliation.
         """
         current = (available, frozen, margin)
         previous = self._accepted_balance_components
+        transfer_reconciled = self._available_is_transfer_reconciled(
+            available=available,
+            transfer=transfer,
+            bonus=bonus,
+            unrealized_pnl=unrealized_pnl,
+        )
         if previous is None:
             current_used = frozen + margin
-            if current_used <= 0.0:
+            if current_used <= 0.0 or transfer_reconciled:
                 self._accepted_balance_components = current
-                self._clear_pending_balance_confirmation()
+                self._clear_pending_balance_transition()
                 return
-            pending = self._pending_balance_components
-            if pending is not None:
-                pending_available, pending_frozen, pending_margin = pending
-                pending_used = pending_frozen + pending_margin
-                recovered_from_initial_duplication = bool(
-                    pending_used > 0.0
-                    and self._balance_values_close(frozen, pending_frozen)
-                    and self._balance_values_close(margin, pending_margin)
-                    and self._balance_values_close(
-                        pending_available - available, pending_used
-                    )
-                )
-                if recovered_from_initial_duplication:
-                    logging.info(
-                        "[balance] Bitunix initial balance returned to a consistent "
-                        "state; action=resume_authoritative_state"
-                    )
-                    self._accepted_balance_components = current
-                    self._clear_pending_balance_confirmation()
-                    return
-            self._confirm_balance_candidate(
+            self._defer_balance_candidate(
                 current,
                 defer_message=(
-                    "[balance] Bitunix initial balance has nonzero locked funds; "
-                    "action=defer_authoritative_state_until_confirmed"
+                    "[balance] Bitunix initial locked-fund balance did not reconcile "
+                    "with maximum transfer; action=defer_authoritative_state"
+                ),
+            )
+            return
+
+        if self._pending_balance_components is not None:
+            if self._balance_components_close(previous, current):
+                logging.info(
+                    "[balance] Bitunix balance returned to the last trusted state; "
+                    "action=resume_authoritative_state"
+                )
+                self._clear_pending_balance_transition()
+                return
+            if transfer_reconciled:
+                logging.info(
+                    "[balance] Bitunix balance passed maximum-transfer reconciliation; "
+                    "action=resume_authoritative_state"
+                )
+                self._accepted_balance_components = current
+                self._clear_pending_balance_transition()
+                return
+            self._defer_balance_candidate(
+                current,
+                defer_message=(
+                    "[balance] Bitunix balance remained inconsistent after a deferred "
+                    "transition; action=defer_authoritative_state"
                 ),
             )
             return
@@ -340,21 +350,16 @@ class BitunixClient:
         )
 
         if duplicates_locked_funds:
-            self._confirm_balance_candidate(
-                current,
-                defer_message=(
-                    "[balance] Bitunix reported locked funds in both available and used; "
-                    "action=defer_authoritative_state"
-                ),
-            )
-            return
-
-        if self._pending_balance_components is not None:
-            logging.info(
-                "[balance] Bitunix balance transition returned to a consistent state; "
-                "action=resume_authoritative_state"
-            )
-            self._clear_pending_balance_confirmation()
+            if not transfer_reconciled:
+                self._defer_balance_candidate(
+                    current,
+                    defer_message=(
+                        "[balance] Bitunix reported locked funds in both available and "
+                        "used without maximum-transfer reconciliation; "
+                        "action=defer_authoritative_state"
+                    ),
+                )
+                return
         self._accepted_balance_components = current
 
     def milliseconds(self) -> int:
@@ -626,10 +631,19 @@ class BitunixClient:
             raw.get("isolationUnrealizedPNL"),
             field="account.isolationUnrealizedPNL",
         )
+        transfer = (
+            None
+            if raw.get("transfer") in (None, "")
+            else _float(raw.get("transfer"), field="account.transfer")
+        )
+        bonus = _float(raw.get("bonus"), field="account.bonus", default=0.0)
         self._validate_balance_transition(
             available=available,
             frozen=frozen,
             margin=margin,
+            transfer=transfer,
+            bonus=bonus,
+            unrealized_pnl=cross_upnl + isolated_upnl,
         )
         # Bitunix documents these as disjoint available, order-locked, and
         # position-locked quantities. Unrealized PnL is mark-to-market state,
@@ -2275,6 +2289,19 @@ class BitunixBot(CCXTBot):
     def _normalize_balance_diagnostics(self, fetched: object) -> dict:
         """Expose only documented Bitunix account components for diagnostics."""
         return normalize_bitunix_balance_composition(fetched)
+
+    async def _exchange_config_write_ready(self) -> bool:
+        """Gate position-mode writes on an authoritative Bitunix balance sample."""
+        if getattr(self, "balance_override", None) is not None:
+            return True
+        try:
+            await self.cca.fetch_balance()
+        except AuthoritativeSurfaceUnavailable as exc:
+            if exc.surface != "balance":
+                raise
+            self._last_authoritative_block_reason = exc.reason
+            return False
+        return True
 
     async def update_exchange_config(self) -> None:
         current = await self.cca.fetch_position_mode()

--- a/src/exchanges/bitunix.py
+++ b/src/exchanges/bitunix.py
@@ -256,19 +256,21 @@ class BitunixClient:
         available: float,
         transfer: float | None,
         bonus: float,
-        unrealized_pnl: float,
+        cross_unrealized_pnl: float,
     ) -> bool:
         """Corroborate available funds with Bitunix's maximum-transfer metric.
 
-        Bitunix excludes non-transferable bonus funds and unrealized losses from
-        the amount transferable out of futures. Rearranging that relationship
-        gives an exchange-calculated cross-check for ``available``. The known
-        inconsistent account response changed ``available`` alone, so this
-        remains false even if that response is repeated across a restart.
+        Bitunix excludes non-transferable bonus funds and cross-margin unrealized
+        losses from the amount transferable out of futures. Isolated PnL remains
+        confined to its position margin and therefore must not offset a cross
+        loss in this equation. Rearranging that relationship gives an
+        exchange-calculated cross-check for ``available``. The known inconsistent
+        account response changed ``available`` alone, so this remains false even
+        if that response is repeated across a restart.
         """
         if transfer is None:
             return False
-        expected_available = transfer + bonus - min(unrealized_pnl, 0.0)
+        expected_available = transfer + bonus - min(cross_unrealized_pnl, 0.0)
         return self._balance_values_close(available, expected_available)
 
     def _validate_balance_transition(
@@ -279,7 +281,7 @@ class BitunixClient:
         margin: float,
         transfer: float | None,
         bonus: float,
-        unrealized_pnl: float,
+        cross_unrealized_pnl: float,
     ) -> None:
         """Reject Bitunix's transient duplication of locked funds into available.
 
@@ -299,7 +301,7 @@ class BitunixClient:
             available=available,
             transfer=transfer,
             bonus=bonus,
-            unrealized_pnl=unrealized_pnl,
+            cross_unrealized_pnl=cross_unrealized_pnl,
         )
         current_used = frozen + margin
         if current_used > 0.0 and not transfer_reconciled:
@@ -600,7 +602,7 @@ class BitunixClient:
             raw.get("crossUnrealizedPNL"),
             field="account.crossUnrealizedPNL",
         )
-        isolated_upnl = _float(
+        _isolated_upnl = _float(
             raw.get("isolationUnrealizedPNL"),
             field="account.isolationUnrealizedPNL",
         )
@@ -616,7 +618,7 @@ class BitunixClient:
             margin=margin,
             transfer=transfer,
             bonus=bonus,
-            unrealized_pnl=cross_upnl + isolated_upnl,
+            cross_unrealized_pnl=cross_upnl,
         )
         # Bitunix documents these as disjoint available, order-locked, and
         # position-locked quantities. Unrealized PnL is mark-to-market state,
@@ -2265,7 +2267,16 @@ class BitunixBot(CCXTBot):
 
     async def _exchange_config_write_ready(self) -> bool:
         """Gate position-mode writes on an authoritative Bitunix balance sample."""
-        if getattr(self, "balance_override", None) is not None:
+        balance_override = getattr(self, "balance_override", None)
+        if balance_override is not None:
+            try:
+                if isinstance(balance_override, bool):
+                    raise ValueError("boolean balance override")
+                parsed_override = float(balance_override)
+            except (TypeError, ValueError):
+                raise ValueError("balance_override must be a finite numeric value") from None
+            if not math.isfinite(parsed_override):
+                raise ValueError("balance_override must be a finite numeric value")
             return True
         try:
             await self.cca.fetch_balance()

--- a/src/exchanges/bitunix.py
+++ b/src/exchanges/bitunix.py
@@ -2278,9 +2278,13 @@ class BitunixBot(CCXTBot):
                     raise ValueError("boolean balance override")
                 parsed_override = float(balance_override)
             except (TypeError, ValueError):
-                raise ValueError("balance_override must be a finite numeric value") from None
-            if not math.isfinite(parsed_override):
-                raise ValueError("balance_override must be a finite numeric value")
+                raise ValueError(
+                    "balance_override must be a positive finite numeric value"
+                ) from None
+            if not math.isfinite(parsed_override) or parsed_override <= 0.0:
+                raise ValueError(
+                    "balance_override must be a positive finite numeric value"
+                )
             return True
         try:
             await self.cca.fetch_balance()

--- a/src/exchanges/bitunix.py
+++ b/src/exchanges/bitunix.py
@@ -285,11 +285,12 @@ class BitunixClient:
 
         The known inconsistent response moves ``available`` by exactly the
         unchanged locked amount while continuing to report that amount as locked.
-        Reconcile an initial nonzero locked-funds state with Bitunix's separately
-        calculated maximum-transfer value, so a restart during the inconsistency
-        cannot establish the duplicated response as trusted truth. Keep the last
-        accepted components unchanged until the response either returns to it or
-        a new response passes the transfer reconciliation.
+        Reconcile every new tuple with nonzero locked funds against Bitunix's
+        separately calculated maximum-transfer value. This covers both restart
+        and a transition that changes frozen or margin components while the
+        inconsistent response is active. Keep the last accepted components
+        unchanged until the response either returns to them or a new response
+        passes the transfer reconciliation.
         """
         current = (available, frozen, margin)
         previous = self._accepted_balance_components
@@ -299,67 +300,38 @@ class BitunixClient:
             bonus=bonus,
             unrealized_pnl=unrealized_pnl,
         )
-        if previous is None:
-            current_used = frozen + margin
-            if current_used <= 0.0 or transfer_reconciled:
-                self._accepted_balance_components = current
+        if self._balance_components_close(previous, current):
+            if self._pending_balance_components is not None:
+                logging.info(
+                    "[balance] Bitunix balance returned to the last trusted state; "
+                    "action=resume_authoritative_state"
+                )
                 self._clear_pending_balance_transition()
-                return
+            return
+
+        current_used = frozen + margin
+        if current_used > 0.0 and not transfer_reconciled:
             self._defer_balance_candidate(
                 current,
                 defer_message=(
-                    "[balance] Bitunix initial locked-fund balance did not reconcile "
+                    "[balance] Bitunix changed locked-fund balance did not reconcile "
                     "with maximum transfer; action=defer_authoritative_state"
                 ),
             )
             return
 
         if self._pending_balance_components is not None:
-            if self._balance_components_close(previous, current):
-                logging.info(
-                    "[balance] Bitunix balance returned to the last trusted state; "
-                    "action=resume_authoritative_state"
-                )
-                self._clear_pending_balance_transition()
-                return
             if transfer_reconciled:
                 logging.info(
                     "[balance] Bitunix balance passed maximum-transfer reconciliation; "
                     "action=resume_authoritative_state"
                 )
-                self._accepted_balance_components = current
-                self._clear_pending_balance_transition()
-                return
-            self._defer_balance_candidate(
-                current,
-                defer_message=(
-                    "[balance] Bitunix balance remained inconsistent after a deferred "
-                    "transition; action=defer_authoritative_state"
-                ),
-            )
-            return
-
-        previous_available, previous_frozen, previous_margin = previous
-        previous_used = previous_frozen + previous_margin
-        available_delta = available - previous_available
-        duplicates_locked_funds = bool(
-            previous_used > 0.0
-            and self._balance_values_close(frozen, previous_frozen)
-            and self._balance_values_close(margin, previous_margin)
-            and self._balance_values_close(available_delta, previous_used)
-        )
-
-        if duplicates_locked_funds:
-            if not transfer_reconciled:
-                self._defer_balance_candidate(
-                    current,
-                    defer_message=(
-                        "[balance] Bitunix reported locked funds in both available and "
-                        "used without maximum-transfer reconciliation; "
-                        "action=defer_authoritative_state"
-                    ),
+            else:
+                logging.info(
+                    "[balance] Bitunix balance cleared locked funds; "
+                    "action=resume_authoritative_state"
                 )
-                return
+            self._clear_pending_balance_transition()
         self._accepted_balance_components = current
 
     def milliseconds(self) -> int:

--- a/src/live/state_refresh.py
+++ b/src/live/state_refresh.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from dataclasses import dataclass
 import logging
 import sys
 
@@ -9,6 +10,23 @@ from live import event_emitters
 from live.balance_composition import malformed_balance_composition, unavailable_balance_composition
 from live.diagnostic_safety import bounded_exception_type
 from utils import ts_to_date, utc_ms
+
+
+@dataclass(frozen=True)
+class DeferredAuthoritativeSurface:
+    """Explicit fail-closed result for a temporarily untrustworthy surface."""
+
+    surface: str
+    reason: str
+
+
+class AuthoritativeSurfaceUnavailable(RuntimeError):
+    """Signal that a fetched surface must not be committed or used for trading."""
+
+    def __init__(self, surface: str, reason: str):
+        self.surface = str(surface)
+        self.reason = str(reason)
+        super().__init__(f"{self.surface} unavailable: {self.reason}")
 
 
 def _utc_ms() -> int:
@@ -51,6 +69,10 @@ async def refresh_protective_authoritative_state(bot) -> bool:
     balance_composition = snapshot.get("balance_composition")
     fetched_positions = snapshot.get("positions")
     fetched_open_orders = snapshot.get("open_orders")
+
+    if isinstance(fetched_balance, DeferredAuthoritativeSurface):
+        bot._last_authoritative_block_reason = fetched_balance.reason
+        return False
 
     prepared_balance_snapshot = bot._prepare_balance_snapshot(fetched_balance)
     if prepared_balance_snapshot is None:
@@ -122,6 +144,9 @@ async def refresh_authoritative_state_staged(bot) -> bool:
         return False
     prepared_balance_snapshot = None
     if "balance" in plan:
+        if isinstance(fetched_balance, DeferredAuthoritativeSurface):
+            bot._last_authoritative_block_reason = fetched_balance.reason
+            return False
         prepared_balance_snapshot = bot._prepare_balance_snapshot(fetched_balance)
         if prepared_balance_snapshot is None:
             return False
@@ -178,25 +203,38 @@ async def refresh_authoritative_state_staged(bot) -> bool:
     return True
 
 
-async def capture_balance_staged_snapshot(bot) -> tuple[object, dict, float]:
+async def capture_balance_staged_snapshot(
+    bot,
+) -> tuple[object, dict, float | DeferredAuthoritativeSurface]:
     """Fetch one raw balance response plus bounded diagnostics and normalized value."""
-    if hasattr(bot, "capture_balance_snapshot"):
-        raw_balance, balance = await bot.capture_balance_snapshot()
-        normalizer = getattr(bot, "_normalize_balance_diagnostics", None)
-        if not callable(normalizer):
-            return raw_balance, unavailable_balance_composition(), balance
-        try:
-            return raw_balance, normalizer(raw_balance), balance
-        except Exception:
-            return (
-                raw_balance,
-                malformed_balance_composition(
-                    source="normalizer", reason="normalizer_error"
-                ),
-                balance,
-            )
-    balance = await bot.fetch_balance()
-    return None, unavailable_balance_composition(), balance
+    try:
+        if hasattr(bot, "capture_balance_snapshot"):
+            raw_balance, balance = await bot.capture_balance_snapshot()
+            normalizer = getattr(bot, "_normalize_balance_diagnostics", None)
+            if not callable(normalizer):
+                return raw_balance, unavailable_balance_composition(), balance
+            try:
+                return raw_balance, normalizer(raw_balance), balance
+            except AuthoritativeSurfaceUnavailable:
+                raise
+            except Exception:
+                return (
+                    raw_balance,
+                    malformed_balance_composition(
+                        source="normalizer", reason="normalizer_error"
+                    ),
+                    balance,
+                )
+        balance = await bot.fetch_balance()
+        return None, unavailable_balance_composition(), balance
+    except AuthoritativeSurfaceUnavailable as exc:
+        if exc.surface != "balance":
+            raise
+        return (
+            None,
+            unavailable_balance_composition(reason=exc.reason),
+            DeferredAuthoritativeSurface(surface=exc.surface, reason=exc.reason),
+        )
 
 
 async def capture_positions_staged_snapshot(bot) -> tuple[object, list[dict]]:

--- a/src/live/state_refresh.py
+++ b/src/live/state_refresh.py
@@ -207,6 +207,12 @@ async def capture_balance_staged_snapshot(
     bot,
 ) -> tuple[object, dict, float | DeferredAuthoritativeSurface]:
     """Fetch one raw balance response plus bounded diagnostics and normalized value."""
+    if getattr(bot, "balance_override", None) is not None:
+        return (
+            None,
+            unavailable_balance_composition(reason="balance_override"),
+            bot.get_raw_balance(),
+        )
     try:
         if hasattr(bot, "capture_balance_snapshot"):
             raw_balance, balance = await bot.capture_balance_snapshot()

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -3824,7 +3824,20 @@ class Passivbot:
         self._assert_supported_live_state()
         # self.set_live_configs()
         self.set_wallet_exposure_limits()
-        await self.refresh_authoritative_state()
+        authoritative_ready = await self.refresh_authoritative_state()
+        while (
+            authoritative_ready is False
+            and getattr(self, "_last_authoritative_block_reason", None)
+            == "balance_transition_confirmation"
+            and not self.stop_signal_received
+        ):
+            await self._sleep_unless_shutdown(
+                5.0,
+                stage="initial_balance_transition_confirmation",
+            )
+            if self.stop_signal_received:
+                return
+            authoritative_ready = await self.refresh_authoritative_state()
         self._assert_supported_live_state()
         self.set_market_specific_settings()
         await self.update_effective_min_cost()

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -244,6 +244,23 @@ FILL_COVERAGE_AUTHORITATIVE_RETRY_BASE_SECONDS = 30.0
 FILL_COVERAGE_AUTHORITATIVE_RETRY_MAX_SECONDS = 300.0
 
 
+def _parse_balance_override(raw_value: Any) -> Optional[float]:
+    """Parse the live sizing override without accepting boolean numerics."""
+    if raw_value in (None, ""):
+        return None
+    if isinstance(raw_value, bool):
+        raise ValueError("balance_override must be a positive finite numeric value")
+    try:
+        parsed = float(raw_value)
+    except (TypeError, ValueError):
+        raise ValueError(
+            "balance_override must be a positive finite numeric value"
+        ) from None
+    if not math.isfinite(parsed) or parsed <= 0.0:
+        raise ValueError("balance_override must be a positive finite numeric value")
+    return parsed
+
+
 # Match "...0xABCD..." anywhere (case-insensitive)
 _TYPE_MARKER_RE = re.compile(r"0x([0-9a-fA-F]{4})", re.IGNORECASE)
 # Leading pure-hex fallback: optional 0x then 4 hex at the very start
@@ -1278,9 +1295,7 @@ class Passivbot:
         raw_balance_override = get_optional_live_value(
             self.config, "balance_override", None
         )
-        self.balance_override = (
-            None if raw_balance_override in (None, "") else float(raw_balance_override)
-        )
+        self.balance_override = _parse_balance_override(raw_balance_override)
         self._balance_override_logged = False
         self.balance = 1e-12
         self.balance_raw = 1e-12

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -6151,7 +6151,29 @@ class Passivbot:
                         "pending_pnl",
                         "degraded_pnl",
                         "fill_history_coverage",
+                        "balance_transition_confirmation",
                     }:
+                        if (
+                            authoritative_block_reason
+                            == "balance_transition_confirmation"
+                        ):
+                            authoritative_fill_retry_count = 0
+                            authoritative_fill_retry_reason = None
+                            failed_update_pos_oos_pnls_ohlcvs_count = 0
+                            self._emit_live_cycle_degraded(
+                                cycle_id=cycle_id,
+                                reason_code=authoritative_block_reason,
+                                data={
+                                    "retry_delay_seconds": 5.0,
+                                    "timings_ms": dict(loop_timings_ms),
+                                },
+                                level="warning",
+                            )
+                            await self._sleep_unless_shutdown(
+                                5.0,
+                                stage="balance_transition_confirmation",
+                            )
+                            continue
                         if authoritative_fill_retry_reason != authoritative_block_reason:
                             authoritative_fill_retry_count = 0
                             authoritative_fill_retry_reason = authoritative_block_reason
@@ -7456,7 +7478,7 @@ class Passivbot:
         """Refresh live account state through the staged authoritative cohort."""
         return await state_refresh.refresh_authoritative_state_staged(self)
 
-    async def _capture_balance_staged_snapshot(self) -> tuple[object, dict, float]:
+    async def _capture_balance_staged_snapshot(self) -> tuple[object, dict, object]:
         """Fetch raw balance, bounded diagnostics, and its normalized value."""
         return await state_refresh.capture_balance_staged_snapshot(self)
 
@@ -15861,7 +15883,13 @@ class Passivbot:
             if not hasattr(self, "fetch_balance"):
                 logging.debug("update_balance: no fetch_balance implemented")
                 return False
-            balance_raw = await self.fetch_balance()
+            try:
+                balance_raw = await self.fetch_balance()
+            except state_refresh.AuthoritativeSurfaceUnavailable as exc:
+                if exc.surface != "balance":
+                    raise
+                self._last_authoritative_block_reason = exc.reason
+                return False
         return self._apply_balance_snapshot(balance_raw)
 
     def _reconcile_balance_after_open_orders_refresh(self) -> bool:

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -3783,15 +3783,42 @@ class Passivbot:
         """Load exchange market metadata and refresh approval lists."""
         # called at bot startup and once an hour thereafter
         self.init_markets_last_update_ms = utc_ms()
-        exchange_config_ready = await self._exchange_config_write_ready()
-        while exchange_config_ready is False and not self.stop_signal_received:
+        readiness_network_attempt = 0
+        while True:
+            try:
+                exchange_config_ready = await self._exchange_config_write_ready()
+            except (RequestTimeout, NetworkError) as e:
+                if self.stop_signal_received:
+                    return
+                readiness_network_attempt += 1
+                if readiness_network_attempt == 3:
+                    raise
+                retry_delay_seconds = 5 * readiness_network_attempt
+                logging.warning(
+                    "[init_markets] exchange-config readiness error "
+                    "(attempt %d/3): error_type=%s – retrying in %ds",
+                    readiness_network_attempt,
+                    bounded_exception_type(e),
+                    retry_delay_seconds,
+                )
+                await self._sleep_unless_shutdown(
+                    retry_delay_seconds,
+                    stage="exchange_config_balance_readiness_retry",
+                )
+                if self.stop_signal_received:
+                    return
+                continue
+            if self.stop_signal_received:
+                return
+            readiness_network_attempt = 0
+            if exchange_config_ready:
+                break
             await self._sleep_unless_shutdown(
                 5.0,
                 stage="exchange_config_balance_readiness",
             )
             if self.stop_signal_received:
                 return
-            exchange_config_ready = await self._exchange_config_write_ready()
         # Retry on transient network errors (TCP + TLS handshake on a fresh
         # aiohttp session can time out; also called hourly so transient errors
         # should not abort the refresh cycle).
@@ -6110,6 +6137,8 @@ class Passivbot:
         failed_update_pos_oos_pnls_ohlcvs_count = 0
         authoritative_fill_retry_count = 0
         authoritative_fill_retry_reason = None
+        balance_consistency_retry_count = 0
+        balance_consistency_last_warning_ms = 0
         max_n_fails = 10
         if self._equity_hard_stop_enabled():
             if self._equity_hard_stop_signal_mode() == "coin":
@@ -6158,6 +6187,14 @@ class Passivbot:
                         break
                     raise
                 mark_phase("authoritative", phase_start_ms)
+                if authoritative_ok and balance_consistency_retry_count:
+                    logging.info(
+                        "[balance] authoritative balance consistency recovered "
+                        "after %d retries; action=resume_execution",
+                        balance_consistency_retry_count,
+                    )
+                    balance_consistency_retry_count = 0
+                    balance_consistency_last_warning_ms = 0
                 if not authoritative_ok:
                     if self._shutdown_requested():
                         self._emit_live_cycle_degraded(
@@ -6182,14 +6219,24 @@ class Passivbot:
                             authoritative_fill_retry_count = 0
                             authoritative_fill_retry_reason = None
                             failed_update_pos_oos_pnls_ohlcvs_count = 0
+                            balance_consistency_retry_count += 1
+                            now_ms = utc_ms()
+                            warning_due = (
+                                balance_consistency_last_warning_ms <= 0
+                                or now_ms - balance_consistency_last_warning_ms
+                                >= 15 * 60 * 1000
+                            )
+                            if warning_due:
+                                balance_consistency_last_warning_ms = now_ms
                             self._emit_live_cycle_degraded(
                                 cycle_id=cycle_id,
                                 reason_code=authoritative_block_reason,
                                 data={
+                                    "retry_count": balance_consistency_retry_count,
                                     "retry_delay_seconds": 5.0,
                                     "timings_ms": dict(loop_timings_ms),
                                 },
-                                level="warning",
+                                level="warning" if warning_due else "debug",
                             )
                             await self._sleep_unless_shutdown(
                                 5.0,

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -3783,6 +3783,15 @@ class Passivbot:
         """Load exchange market metadata and refresh approval lists."""
         # called at bot startup and once an hour thereafter
         self.init_markets_last_update_ms = utc_ms()
+        exchange_config_ready = await self._exchange_config_write_ready()
+        while exchange_config_ready is False and not self.stop_signal_received:
+            await self._sleep_unless_shutdown(
+                5.0,
+                stage="exchange_config_balance_readiness",
+            )
+            if self.stop_signal_received:
+                return
+            exchange_config_ready = await self._exchange_config_write_ready()
         # Retry on transient network errors (TCP + TLS handshake on a fresh
         # aiohttp session can time out; also called hourly so transient errors
         # should not abort the refresh cycle).
@@ -3828,12 +3837,12 @@ class Passivbot:
         while (
             authoritative_ready is False
             and getattr(self, "_last_authoritative_block_reason", None)
-            == "balance_transition_confirmation"
+            == "balance_consistency_check"
             and not self.stop_signal_received
         ):
             await self._sleep_unless_shutdown(
                 5.0,
-                stage="initial_balance_transition_confirmation",
+                stage="initial_balance_consistency_check",
             )
             if self.stop_signal_received:
                 return
@@ -6164,11 +6173,11 @@ class Passivbot:
                         "pending_pnl",
                         "degraded_pnl",
                         "fill_history_coverage",
-                        "balance_transition_confirmation",
+                        "balance_consistency_check",
                     }:
                         if (
                             authoritative_block_reason
-                            == "balance_transition_confirmation"
+                            == "balance_consistency_check"
                         ):
                             authoritative_fill_retry_count = 0
                             authoritative_fill_retry_reason = None
@@ -6184,7 +6193,7 @@ class Passivbot:
                             )
                             await self._sleep_unless_shutdown(
                                 5.0,
-                                stage="balance_transition_confirmation",
+                                stage="balance_consistency_check",
                             )
                             continue
                         if authoritative_fill_retry_reason != authoritative_block_reason:
@@ -10122,6 +10131,10 @@ class Passivbot:
         """Exchange-specific hook to refresh global config state."""
         # defined by each exchange child class
         pass
+
+    async def _exchange_config_write_ready(self) -> bool:
+        """Return whether startup may perform authenticated exchange config writes."""
+        return True
 
     def is_old_enough(self, pside, symbol):
         """Return True if the market age exceeds the configured minimum for forager mode."""

--- a/tests/exchanges/test_bitunix.py
+++ b/tests/exchanges/test_bitunix.py
@@ -374,6 +374,31 @@ async def test_balance_transfer_reconciliation_does_not_net_isolated_profit():
 
 
 @pytest.mark.asyncio
+async def test_balance_zero_transfer_floor_cannot_confirm_locked_funds():
+    client = _prepared_client()
+    client._request = AsyncMock(
+        return_value={
+            "marginCoin": "USDT",
+            "available": "10",
+            "frozen": "0",
+            "margin": "10",
+            "transfer": "0",
+            "bonus": "0",
+            "positionMode": "HEDGE",
+            "crossUnrealizedPNL": "-10",
+            "isolationUnrealizedPNL": "0",
+        }
+    )
+
+    with pytest.raises(AuthoritativeSurfaceUnavailable) as exc_info:
+        await client.fetch_balance()
+
+    assert exc_info.value.reason == "balance_consistency_check"
+    assert client._accepted_balance_components is None
+    assert client._pending_balance_components == (10.0, 0.0, 10.0)
+
+
+@pytest.mark.asyncio
 async def test_balance_wallet_is_invariant_to_unrealized_pnl():
     client = _prepared_client()
     client._accepted_balance_components = (90.0, 4.0, 6.0)

--- a/tests/exchanges/test_bitunix.py
+++ b/tests/exchanges/test_bitunix.py
@@ -760,7 +760,15 @@ async def test_bitunix_config_write_readiness_honors_balance_override():
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "balance_override",
-    [float("nan"), float("inf"), float("-inf"), True, "not-a-number"],
+    [
+        float("nan"),
+        float("inf"),
+        float("-inf"),
+        0.0,
+        -1.0,
+        True,
+        "not-a-number",
+    ],
 )
 async def test_bitunix_config_write_readiness_rejects_invalid_balance_override(
     balance_override,
@@ -773,7 +781,7 @@ async def test_bitunix_config_write_readiness_rejects_invalid_balance_override(
 
     with pytest.raises(
         ValueError,
-        match="balance_override must be a finite numeric value",
+        match="balance_override must be a positive finite numeric value",
     ):
         await bot._exchange_config_write_ready()
 

--- a/tests/exchanges/test_bitunix.py
+++ b/tests/exchanges/test_bitunix.py
@@ -324,25 +324,22 @@ async def test_load_markets_retries_observed_network_error(monkeypatch):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("as_list", [False, True])
-async def test_balance_sums_disjoint_components_after_initial_confirmation(as_list):
+async def test_balance_sums_disjoint_components_after_transfer_reconciliation(as_list):
     client = _prepared_client()
     raw = {
         "marginCoin": "USDT",
         "available": "1000",
         "frozen": "4",
         "margin": "10",
+        "transfer": "1000",
+        "bonus": "0",
         "positionMode": "HEDGE",
         "crossUnrealizedPNL": "2",
         "isolationUnrealizedPNL": "-1",
     }
     response = [raw] if as_list else raw
-    client._request = AsyncMock(side_effect=[response, response])
+    client._request = AsyncMock(return_value=response)
 
-    with pytest.raises(AuthoritativeSurfaceUnavailable):
-        await client.fetch_balance()
-    client._pending_balance_started_monotonic -= (
-        client.BALANCE_TRANSITION_CONFIRMATION_SECONDS + 1.0
-    )
     balance = await client.fetch_balance()
 
     assert balance["free"]["USDT"] == 1000.0
@@ -407,13 +404,13 @@ async def test_balance_defers_duplicated_locked_funds_until_response_recovers():
 
     assert initial["total"]["USDT"] == pytest.approx(86.9)
     assert first.value.surface == "balance"
-    assert first.value.reason == "balance_transition_confirmation"
+    assert first.value.reason == "balance_consistency_check"
     assert recovered["total"]["USDT"] == pytest.approx(86.9)
     assert client._pending_balance_components is None
 
 
 @pytest.mark.asyncio
-async def test_balance_accepts_stable_exact_increase_after_bounded_confirmation():
+async def test_balance_accepts_exact_increase_when_transfer_reconciles():
     client = _prepared_client()
     client._accepted_balance_components = (90.0, 4.0, 6.0)
     client._request = AsyncMock(
@@ -433,7 +430,7 @@ async def test_balance_accepts_stable_exact_increase_after_bounded_confirmation(
                 "available": "100",
                 "frozen": "4",
                 "margin": "6",
-                "transfer": "98",
+                "transfer": "100",
                 "positionMode": "HEDGE",
                 "crossUnrealizedPNL": "0",
                 "isolationUnrealizedPNL": "0",
@@ -443,7 +440,7 @@ async def test_balance_accepts_stable_exact_increase_after_bounded_confirmation(
                 "available": "100",
                 "frozen": "4",
                 "margin": "6",
-                "transfer": "98",
+                "transfer": "100",
                 "positionMode": "HEDGE",
                 "crossUnrealizedPNL": "0",
                 "isolationUnrealizedPNL": "0",
@@ -452,11 +449,6 @@ async def test_balance_accepts_stable_exact_increase_after_bounded_confirmation(
     )
 
     before = await client.fetch_balance()
-    with pytest.raises(AuthoritativeSurfaceUnavailable):
-        await client.fetch_balance()
-    client._pending_balance_started_monotonic -= (
-        client.BALANCE_TRANSITION_CONFIRMATION_SECONDS + 1.0
-    )
     after = await client.fetch_balance()
 
     assert before["total"]["USDT"] == 100.0
@@ -478,8 +470,17 @@ async def test_balance_restart_during_duplication_waits_for_consistent_recovery(
             "isolationUnrealizedPNL": "0",
         }
 
+    def account_with_transfer(available, transfer):
+        result = account(available)
+        result["transfer"] = str(transfer)
+        return result
+
     client._request = AsyncMock(
-        side_effect=[account(86.9), account(86.9), account(85.3)]
+        side_effect=[
+            account_with_transfer(86.9, 85.1),
+            account_with_transfer(86.9, 85.1),
+            account_with_transfer(85.3, 85.1),
+        ]
     )
 
     with pytest.raises(AuthoritativeSurfaceUnavailable):
@@ -496,28 +497,87 @@ async def test_balance_restart_during_duplication_waits_for_consistent_recovery(
 
 
 @pytest.mark.asyncio
-async def test_balance_initial_locked_funds_require_bounded_confirmation():
+async def test_balance_initial_locked_funds_require_transfer_reconciliation():
     client = _prepared_client()
     raw = {
         "marginCoin": "USDT",
         "available": "90",
         "frozen": "4",
         "margin": "6",
+        "transfer": "90",
+        "bonus": "0",
         "positionMode": "HEDGE",
         "crossUnrealizedPNL": "0",
         "isolationUnrealizedPNL": "0",
     }
-    client._request = AsyncMock(side_effect=[raw, raw])
+    client._request = AsyncMock(return_value=raw)
 
-    with pytest.raises(AuthoritativeSurfaceUnavailable):
-        await client.fetch_balance()
-    client._pending_balance_started_monotonic -= (
-        client.BALANCE_TRANSITION_CONFIRMATION_SECONDS + 1.0
-    )
     confirmed = await client.fetch_balance()
 
     assert confirmed["total"]["USDT"] == 100.0
     assert client._accepted_balance_components == (90.0, 4.0, 6.0)
+    assert client._pending_balance_components is None
+
+
+@pytest.mark.asyncio
+async def test_balance_ambiguous_state_never_ages_into_acceptance():
+    client = _prepared_client()
+    raw = {
+        "marginCoin": "USDT",
+        "available": "100",
+        "frozen": "4",
+        "margin": "6",
+        "transfer": "90",
+        "bonus": "0",
+        "positionMode": "HEDGE",
+        "crossUnrealizedPNL": "0",
+        "isolationUnrealizedPNL": "0",
+    }
+    client._request = AsyncMock(return_value=raw)
+
+    for _ in range(100):
+        with pytest.raises(AuthoritativeSurfaceUnavailable) as exc_info:
+            await client.fetch_balance()
+
+    assert exc_info.value.reason == "balance_consistency_check"
+    assert client._accepted_balance_components is None
+    assert client._pending_balance_components == (100.0, 4.0, 6.0)
+
+
+@pytest.mark.asyncio
+async def test_balance_changed_locks_remain_deferred_until_transfer_reconciles():
+    client = _prepared_client()
+    client._accepted_balance_components = (90.0, 4.0, 6.0)
+
+    def account(*, available, frozen, margin, transfer):
+        return {
+            "marginCoin": "USDT",
+            "available": str(available),
+            "frozen": str(frozen),
+            "margin": str(margin),
+            "transfer": str(transfer),
+            "bonus": "0",
+            "positionMode": "HEDGE",
+            "crossUnrealizedPNL": "0",
+            "isolationUnrealizedPNL": "0",
+        }
+
+    client._request = AsyncMock(
+        side_effect=[
+            account(available=100, frozen=4, margin=6, transfer=90),
+            account(available=101, frozen=3, margin=7, transfer=90),
+            account(available=91, frozen=3, margin=7, transfer=91),
+        ]
+    )
+
+    with pytest.raises(AuthoritativeSurfaceUnavailable):
+        await client.fetch_balance()
+    with pytest.raises(AuthoritativeSurfaceUnavailable):
+        await client.fetch_balance()
+    reconciled = await client.fetch_balance()
+
+    assert reconciled["total"]["USDT"] == 101.0
+    assert client._accepted_balance_components == (91.0, 3.0, 7.0)
     assert client._pending_balance_components is None
 
 
@@ -540,6 +600,39 @@ async def test_balance_initial_state_without_locked_funds_is_immediately_usable(
 
     assert balance["total"]["USDT"] == 100.0
     assert client._accepted_balance_components == (100.0, 0.0, 0.0)
+
+
+@pytest.mark.asyncio
+async def test_bitunix_config_write_readiness_defers_unavailable_balance():
+    bot = BitunixBot.__new__(BitunixBot)
+    bot.balance_override = None
+    bot.cca = SimpleNamespace(
+        fetch_balance=AsyncMock(
+            side_effect=AuthoritativeSurfaceUnavailable(
+                "balance", "balance_consistency_check"
+            )
+        )
+    )
+
+    ready = await bot._exchange_config_write_ready()
+
+    assert ready is False
+    assert bot._last_authoritative_block_reason == "balance_consistency_check"
+    bot.cca.fetch_balance.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_bitunix_config_write_readiness_honors_balance_override():
+    bot = BitunixBot.__new__(BitunixBot)
+    bot.balance_override = 100.0
+    bot.cca = SimpleNamespace(
+        fetch_balance=AsyncMock(side_effect=AssertionError("must not fetch"))
+    )
+
+    ready = await bot._exchange_config_write_ready()
+
+    assert ready is True
+    bot.cca.fetch_balance.assert_not_awaited()
 
 
 def test_hedge_order_normalization_preserves_position_and_action_side():

--- a/tests/exchanges/test_bitunix.py
+++ b/tests/exchanges/test_bitunix.py
@@ -324,7 +324,7 @@ async def test_load_markets_retries_observed_network_error(monkeypatch):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("as_list", [False, True])
-async def test_balance_sums_disjoint_components_and_accepts_both_account_shapes(as_list):
+async def test_balance_sums_disjoint_components_after_initial_confirmation(as_list):
     client = _prepared_client()
     raw = {
         "marginCoin": "USDT",
@@ -335,8 +335,14 @@ async def test_balance_sums_disjoint_components_and_accepts_both_account_shapes(
         "crossUnrealizedPNL": "2",
         "isolationUnrealizedPNL": "-1",
     }
-    client._request = AsyncMock(return_value=[raw] if as_list else raw)
+    response = [raw] if as_list else raw
+    client._request = AsyncMock(side_effect=[response, response])
 
+    with pytest.raises(AuthoritativeSurfaceUnavailable):
+        await client.fetch_balance()
+    client._pending_balance_started_monotonic -= (
+        client.BALANCE_TRANSITION_CONFIRMATION_SECONDS + 1.0
+    )
     balance = await client.fetch_balance()
 
     assert balance["free"]["USDT"] == 1000.0
@@ -348,6 +354,7 @@ async def test_balance_sums_disjoint_components_and_accepts_both_account_shapes(
 @pytest.mark.asyncio
 async def test_balance_wallet_is_invariant_to_unrealized_pnl():
     client = _prepared_client()
+    client._accepted_balance_components = (90.0, 4.0, 6.0)
     responses = []
     for upnl in ("-25", "0", "25"):
         raw = {
@@ -368,6 +375,7 @@ async def test_balance_wallet_is_invariant_to_unrealized_pnl():
 @pytest.mark.asyncio
 async def test_balance_defers_duplicated_locked_funds_until_response_recovers():
     client = _prepared_client()
+    client._accepted_balance_components = (85.3, 0.4, 1.2)
 
     def account(*, available, transfer):
         return {
@@ -407,6 +415,7 @@ async def test_balance_defers_duplicated_locked_funds_until_response_recovers():
 @pytest.mark.asyncio
 async def test_balance_accepts_stable_exact_increase_after_bounded_confirmation():
     client = _prepared_client()
+    client._accepted_balance_components = (90.0, 4.0, 6.0)
     client._request = AsyncMock(
         side_effect=[
             {
@@ -452,6 +461,85 @@ async def test_balance_accepts_stable_exact_increase_after_bounded_confirmation(
 
     assert before["total"]["USDT"] == 100.0
     assert after["total"]["USDT"] == 110.0
+
+
+@pytest.mark.asyncio
+async def test_balance_restart_during_duplication_waits_for_consistent_recovery():
+    client = _prepared_client()
+
+    def account(available):
+        return {
+            "marginCoin": "USDT",
+            "available": str(available),
+            "frozen": "0.4",
+            "margin": "1.2",
+            "positionMode": "HEDGE",
+            "crossUnrealizedPNL": "-0.2",
+            "isolationUnrealizedPNL": "0",
+        }
+
+    client._request = AsyncMock(
+        side_effect=[account(86.9), account(86.9), account(85.3)]
+    )
+
+    with pytest.raises(AuthoritativeSurfaceUnavailable):
+        await client.fetch_balance()
+    with pytest.raises(AuthoritativeSurfaceUnavailable):
+        await client.fetch_balance()
+    recovered = await client.fetch_balance()
+
+    assert recovered["free"]["USDT"] == pytest.approx(85.3)
+    assert recovered["used"]["USDT"] == pytest.approx(1.6)
+    assert recovered["total"]["USDT"] == pytest.approx(86.9)
+    assert client._accepted_balance_components == pytest.approx((85.3, 0.4, 1.2))
+    assert client._pending_balance_components is None
+
+
+@pytest.mark.asyncio
+async def test_balance_initial_locked_funds_require_bounded_confirmation():
+    client = _prepared_client()
+    raw = {
+        "marginCoin": "USDT",
+        "available": "90",
+        "frozen": "4",
+        "margin": "6",
+        "positionMode": "HEDGE",
+        "crossUnrealizedPNL": "0",
+        "isolationUnrealizedPNL": "0",
+    }
+    client._request = AsyncMock(side_effect=[raw, raw])
+
+    with pytest.raises(AuthoritativeSurfaceUnavailable):
+        await client.fetch_balance()
+    client._pending_balance_started_monotonic -= (
+        client.BALANCE_TRANSITION_CONFIRMATION_SECONDS + 1.0
+    )
+    confirmed = await client.fetch_balance()
+
+    assert confirmed["total"]["USDT"] == 100.0
+    assert client._accepted_balance_components == (90.0, 4.0, 6.0)
+    assert client._pending_balance_components is None
+
+
+@pytest.mark.asyncio
+async def test_balance_initial_state_without_locked_funds_is_immediately_usable():
+    client = _prepared_client()
+    client._request = AsyncMock(
+        return_value={
+            "marginCoin": "USDT",
+            "available": "100",
+            "frozen": "0",
+            "margin": "0",
+            "positionMode": "HEDGE",
+            "crossUnrealizedPNL": "0",
+            "isolationUnrealizedPNL": "0",
+        }
+    )
+
+    balance = await client.fetch_balance()
+
+    assert balance["total"]["USDT"] == 100.0
+    assert client._accepted_balance_components == (100.0, 0.0, 0.0)
 
 
 def test_hedge_order_normalization_preserves_position_and_action_side():

--- a/tests/exchanges/test_bitunix.py
+++ b/tests/exchanges/test_bitunix.py
@@ -582,6 +582,40 @@ async def test_balance_changed_locks_remain_deferred_until_transfer_reconciles()
 
 
 @pytest.mark.asyncio
+async def test_balance_new_locked_funds_require_transfer_reconciliation():
+    client = _prepared_client()
+    client._accepted_balance_components = (90.0, 0.0, 0.0)
+
+    def account(*, available, margin):
+        return {
+            "marginCoin": "USDT",
+            "available": str(available),
+            "frozen": "0",
+            "margin": str(margin),
+            "transfer": "90",
+            "bonus": "0",
+            "positionMode": "HEDGE",
+            "crossUnrealizedPNL": "0",
+            "isolationUnrealizedPNL": "0",
+        }
+
+    client._request = AsyncMock(
+        side_effect=[
+            account(available=100, margin=10),
+            account(available=90, margin=10),
+        ]
+    )
+
+    with pytest.raises(AuthoritativeSurfaceUnavailable):
+        await client.fetch_balance()
+    reconciled = await client.fetch_balance()
+
+    assert reconciled["total"]["USDT"] == 100.0
+    assert client._accepted_balance_components == (90.0, 0.0, 10.0)
+    assert client._pending_balance_components is None
+
+
+@pytest.mark.asyncio
 async def test_balance_initial_state_without_locked_funds_is_immediately_usable():
     client = _prepared_client()
     client._request = AsyncMock(

--- a/tests/exchanges/test_bitunix.py
+++ b/tests/exchanges/test_bitunix.py
@@ -353,12 +353,13 @@ async def test_balance_wallet_is_invariant_to_unrealized_pnl():
     client = _prepared_client()
     client._accepted_balance_components = (90.0, 4.0, 6.0)
     responses = []
-    for upnl in ("-25", "0", "25"):
+    for upnl, transfer in (("-25", "65"), ("0", "90"), ("25", "90")):
         raw = {
             "marginCoin": "USDT",
             "available": "90",
             "frozen": "4",
             "margin": "6",
+            "transfer": transfer,
             "positionMode": "HEDGE",
             "crossUnrealizedPNL": upnl,
             "isolationUnrealizedPNL": "0",
@@ -388,10 +389,10 @@ async def test_balance_defers_duplicated_locked_funds_until_response_recovers():
 
     client._request = AsyncMock(
         side_effect=[
-            account(available=85.3, transfer=85.0),
-            account(available=86.9, transfer=85.0),
-            account(available=86.9, transfer=85.0),
-            account(available=85.3, transfer=85.0),
+            account(available=85.3, transfer=85.1),
+            account(available=86.9, transfer=85.1),
+            account(available=86.9, transfer=85.1),
+            account(available=85.3, transfer=85.1),
         ]
     )
 
@@ -420,7 +421,7 @@ async def test_balance_accepts_exact_increase_when_transfer_reconciles():
                 "available": "90",
                 "frozen": "4",
                 "margin": "6",
-                "transfer": "88",
+                "transfer": "90",
                 "positionMode": "HEDGE",
                 "crossUnrealizedPNL": "0",
                 "isolationUnrealizedPNL": "0",
@@ -612,6 +613,43 @@ async def test_balance_new_locked_funds_require_transfer_reconciliation():
 
     assert reconciled["total"]["USDT"] == 100.0
     assert client._accepted_balance_components == (90.0, 0.0, 10.0)
+    assert client._pending_balance_components is None
+
+
+@pytest.mark.asyncio
+async def test_balance_matching_locked_funds_still_require_transfer_reconciliation():
+    client = _prepared_client()
+    client._accepted_balance_components = (90.0, 0.0, 10.0)
+
+    def account(*, available, transfer):
+        return {
+            "marginCoin": "USDT",
+            "available": str(available),
+            "frozen": "0",
+            "margin": "10",
+            "transfer": str(transfer),
+            "bonus": "0",
+            "positionMode": "HEDGE",
+            "crossUnrealizedPNL": "0",
+            "isolationUnrealizedPNL": "0",
+        }
+
+    client._request = AsyncMock(
+        side_effect=[
+            account(available=90, transfer=80),
+            account(available=80, transfer=80),
+        ]
+    )
+
+    with pytest.raises(AuthoritativeSurfaceUnavailable) as exc_info:
+        await client.fetch_balance()
+    reconciled = await client.fetch_balance()
+
+    assert exc_info.value.reason == "balance_consistency_check"
+    assert reconciled["free"]["USDT"] == 80.0
+    assert reconciled["used"]["USDT"] == 10.0
+    assert reconciled["total"]["USDT"] == 90.0
+    assert client._accepted_balance_components == (80.0, 0.0, 10.0)
     assert client._pending_balance_components is None
 
 

--- a/tests/exchanges/test_bitunix.py
+++ b/tests/exchanges/test_bitunix.py
@@ -24,6 +24,7 @@ from custom_endpoint_overrides import (
     ResolvedEndpointOverride,
 )
 from exchanges.bitunix import BitunixBot, BitunixClient, BitunixOrderStream
+from live.state_refresh import AuthoritativeSurfaceUnavailable
 from fill_events_manager import (
     BitunixFetcher,
     _build_fetcher_for_bot,
@@ -362,6 +363,95 @@ async def test_balance_wallet_is_invariant_to_unrealized_pnl():
         responses.append(await client.fetch_balance())
 
     assert [response["total"]["USDT"] for response in responses] == [100.0] * 3
+
+
+@pytest.mark.asyncio
+async def test_balance_defers_duplicated_locked_funds_until_response_recovers():
+    client = _prepared_client()
+
+    def account(*, available, transfer):
+        return {
+            "marginCoin": "USDT",
+            "available": str(available),
+            "frozen": "0.4",
+            "margin": "1.2",
+            "transfer": str(transfer),
+            "positionMode": "HEDGE",
+            "crossUnrealizedPNL": "-0.2",
+            "isolationUnrealizedPNL": "0",
+        }
+
+    client._request = AsyncMock(
+        side_effect=[
+            account(available=85.3, transfer=85.0),
+            account(available=86.9, transfer=85.0),
+            account(available=86.9, transfer=85.0),
+            account(available=85.3, transfer=85.0),
+        ]
+    )
+
+    initial = await client.fetch_balance()
+    with pytest.raises(AuthoritativeSurfaceUnavailable) as first:
+        await client.fetch_balance()
+    with pytest.raises(AuthoritativeSurfaceUnavailable):
+        await client.fetch_balance()
+    recovered = await client.fetch_balance()
+
+    assert initial["total"]["USDT"] == pytest.approx(86.9)
+    assert first.value.surface == "balance"
+    assert first.value.reason == "balance_transition_confirmation"
+    assert recovered["total"]["USDT"] == pytest.approx(86.9)
+    assert client._pending_balance_components is None
+
+
+@pytest.mark.asyncio
+async def test_balance_accepts_stable_exact_increase_after_bounded_confirmation():
+    client = _prepared_client()
+    client._request = AsyncMock(
+        side_effect=[
+            {
+                "marginCoin": "USDT",
+                "available": "90",
+                "frozen": "4",
+                "margin": "6",
+                "transfer": "88",
+                "positionMode": "HEDGE",
+                "crossUnrealizedPNL": "0",
+                "isolationUnrealizedPNL": "0",
+            },
+            {
+                "marginCoin": "USDT",
+                "available": "100",
+                "frozen": "4",
+                "margin": "6",
+                "transfer": "98",
+                "positionMode": "HEDGE",
+                "crossUnrealizedPNL": "0",
+                "isolationUnrealizedPNL": "0",
+            },
+            {
+                "marginCoin": "USDT",
+                "available": "100",
+                "frozen": "4",
+                "margin": "6",
+                "transfer": "98",
+                "positionMode": "HEDGE",
+                "crossUnrealizedPNL": "0",
+                "isolationUnrealizedPNL": "0",
+            },
+        ]
+    )
+
+    before = await client.fetch_balance()
+    with pytest.raises(AuthoritativeSurfaceUnavailable):
+        await client.fetch_balance()
+    client._pending_balance_started_monotonic -= (
+        client.BALANCE_TRANSITION_CONFIRMATION_SECONDS + 1.0
+    )
+    after = await client.fetch_balance()
+
+    assert before["total"]["USDT"] == 100.0
+    assert after["total"]["USDT"] == 110.0
 
 
 def test_hedge_order_normalization_preserves_position_and_action_side():

--- a/tests/exchanges/test_bitunix.py
+++ b/tests/exchanges/test_bitunix.py
@@ -349,6 +349,31 @@ async def test_balance_sums_disjoint_components_after_transfer_reconciliation(as
 
 
 @pytest.mark.asyncio
+async def test_balance_transfer_reconciliation_does_not_net_isolated_profit():
+    client = _prepared_client()
+    client._request = AsyncMock(
+        return_value={
+            "marginCoin": "USDT",
+            "available": "100",
+            "frozen": "0",
+            "margin": "10",
+            "transfer": "90",
+            "bonus": "0",
+            "positionMode": "HEDGE",
+            "crossUnrealizedPNL": "-10",
+            "isolationUnrealizedPNL": "10",
+        }
+    )
+
+    balance = await client.fetch_balance()
+
+    assert balance["free"]["USDT"] == 100.0
+    assert balance["used"]["USDT"] == 10.0
+    assert balance["total"]["USDT"] == 110.0
+    assert client._accepted_balance_components == (100.0, 0.0, 10.0)
+
+
+@pytest.mark.asyncio
 async def test_balance_wallet_is_invariant_to_unrealized_pnl():
     client = _prepared_client()
     client._accepted_balance_components = (90.0, 4.0, 6.0)
@@ -704,6 +729,29 @@ async def test_bitunix_config_write_readiness_honors_balance_override():
     ready = await bot._exchange_config_write_ready()
 
     assert ready is True
+    bot.cca.fetch_balance.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "balance_override",
+    [float("nan"), float("inf"), float("-inf"), True, "not-a-number"],
+)
+async def test_bitunix_config_write_readiness_rejects_invalid_balance_override(
+    balance_override,
+):
+    bot = BitunixBot.__new__(BitunixBot)
+    bot.balance_override = balance_override
+    bot.cca = SimpleNamespace(
+        fetch_balance=AsyncMock(side_effect=AssertionError("must not fetch"))
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="balance_override must be a finite numeric value",
+    ):
+        await bot._exchange_config_write_ready()
+
     bot.cca.fetch_balance.assert_not_awaited()
 
 

--- a/tests/test_balance_composition.py
+++ b/tests/test_balance_composition.py
@@ -655,17 +655,17 @@ async def test_staged_balance_unavailability_is_explicit_and_bounded():
     class Bot:
         async def capture_balance_snapshot(self):
             raise AuthoritativeSurfaceUnavailable(
-                "balance", "balance_transition_confirmation"
+                "balance", "balance_consistency_check"
             )
 
     raw, composition, balance = await state_refresh.capture_balance_staged_snapshot(Bot())
 
     assert raw is None
     assert composition == unavailable_balance_composition(
-        reason="balance_transition_confirmation"
+        reason="balance_consistency_check"
     )
     assert balance == DeferredAuthoritativeSurface(
-        surface="balance", reason="balance_transition_confirmation"
+        surface="balance", reason="balance_consistency_check"
     )
 
 
@@ -679,7 +679,7 @@ async def test_staged_refresh_does_not_prepare_or_commit_deferred_balance():
             return {
                 "balance": DeferredAuthoritativeSurface(
                     surface="balance",
-                    reason="balance_transition_confirmation",
+                    reason="balance_consistency_check",
                 )
             }
 
@@ -691,7 +691,7 @@ async def test_staged_refresh_does_not_prepare_or_commit_deferred_balance():
     assert await state_refresh.refresh_authoritative_state_staged(bot) is False
     assert (
         bot._last_authoritative_block_reason
-        == "balance_transition_confirmation"
+        == "balance_consistency_check"
     )
 
 

--- a/tests/test_balance_composition.py
+++ b/tests/test_balance_composition.py
@@ -26,6 +26,10 @@ from live.event_bus import (
     format_console_event,
 )
 from live import state_refresh
+from live.state_refresh import (
+    AuthoritativeSurfaceUnavailable,
+    DeferredAuthoritativeSurface,
+)
 
 
 def _okx_payload(details):
@@ -644,6 +648,51 @@ async def test_diagnostic_normalizer_failure_is_explicit_without_losing_scalar_b
         source="normalizer", reason="normalizer_error"
     )
     assert "secret" not in str(composition)
+
+
+@pytest.mark.asyncio
+async def test_staged_balance_unavailability_is_explicit_and_bounded():
+    class Bot:
+        async def capture_balance_snapshot(self):
+            raise AuthoritativeSurfaceUnavailable(
+                "balance", "balance_transition_confirmation"
+            )
+
+    raw, composition, balance = await state_refresh.capture_balance_staged_snapshot(Bot())
+
+    assert raw is None
+    assert composition == unavailable_balance_composition(
+        reason="balance_transition_confirmation"
+    )
+    assert balance == DeferredAuthoritativeSurface(
+        surface="balance", reason="balance_transition_confirmation"
+    )
+
+
+@pytest.mark.asyncio
+async def test_staged_refresh_does_not_prepare_or_commit_deferred_balance():
+    class Bot:
+        def _authoritative_staged_refresh_plan(self):
+            return {"balance"}
+
+        async def _fetch_authoritative_state_staged_snapshot(self, _plan):
+            return {
+                "balance": DeferredAuthoritativeSurface(
+                    surface="balance",
+                    reason="balance_transition_confirmation",
+                )
+            }
+
+        def _prepare_balance_snapshot(self, _balance):
+            raise AssertionError("deferred balance must not be prepared")
+
+    bot = Bot()
+
+    assert await state_refresh.refresh_authoritative_state_staged(bot) is False
+    assert (
+        bot._last_authoritative_block_reason
+        == "balance_transition_confirmation"
+    )
 
 
 def test_composition_only_balance_event_remains_durable_but_is_not_console_visible():

--- a/tests/test_init_markets_retry.py
+++ b/tests/test_init_markets_retry.py
@@ -371,3 +371,47 @@ async def test_init_markets_uses_staged_refresh_for_bybit(monkeypatch):
     assert bot.positions_balance_calls == 0
     assert bot.open_orders_calls == 0
     assert bot.min_cost_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_init_markets_waits_for_initial_balance_confirmation(monkeypatch):
+    import passivbot as pb_mod
+
+    async def _load_markets(*_args, **_kwargs):
+        return {"BTC/USDT:USDT": {"id": "BTCUSDT"}}
+
+    monkeypatch.setattr(pb_mod, "load_markets", _load_markets)
+    monkeypatch.setattr(
+        pb_mod,
+        "filter_markets",
+        lambda *_args, **_kwargs: (["BTC/USDT:USDT"], [], {}),
+    )
+
+    async def _update_exchange_config(_attempt):
+        return None
+
+    bot = _FakeBot(_update_exchange_config)
+    bot.exchange = "bitunix"
+    bot.stop_signal_received = False
+    bot._last_authoritative_block_reason = "balance_transition_confirmation"
+    refresh_results = iter([False, False, True])
+    sleeps = []
+
+    async def _refresh_authoritative_state():
+        bot.refresh_authoritative_state_calls += 1
+        return next(refresh_results)
+
+    async def _sleep_unless_shutdown(seconds, *, stage):
+        sleeps.append((seconds, stage))
+
+    bot.refresh_authoritative_state = _refresh_authoritative_state
+    bot._sleep_unless_shutdown = _sleep_unless_shutdown
+
+    await pb_mod.Passivbot.init_markets(bot, verbose=False)
+
+    assert bot.refresh_authoritative_state_calls == 3
+    assert sleeps == [
+        (5.0, "initial_balance_transition_confirmation"),
+        (5.0, "initial_balance_transition_confirmation"),
+    ]
+    assert bot.min_cost_calls == 1

--- a/tests/test_init_markets_retry.py
+++ b/tests/test_init_markets_retry.py
@@ -13,10 +13,13 @@ class _FakeBot:
         self,
         update_exchange_config_impl,
         assert_supported_live_state_impl=None,
+        exchange_config_ready_impl=None,
     ):
         self._update_exchange_config_impl = update_exchange_config_impl
         self._assert_supported_live_state_impl = assert_supported_live_state_impl
+        self._exchange_config_ready_impl = exchange_config_ready_impl
         self.update_exchange_config_calls = 0
+        self.exchange_config_ready_calls = 0
         self.determine_utc_offset_calls = 0
         self.market_specific_settings_calls = 0
         self.positions_balance_calls = 0
@@ -25,10 +28,23 @@ class _FakeBot:
         self.min_cost_calls = 0
         self.abstraction_refresh_calls = 0
         self.assert_supported_live_state_calls = 0
+        self.stop_signal_received = False
+        self.shutdown_sleeps = []
 
     async def update_exchange_config(self):
         self.update_exchange_config_calls += 1
         return await self._update_exchange_config_impl(self.update_exchange_config_calls)
+
+    async def _exchange_config_write_ready(self):
+        self.exchange_config_ready_calls += 1
+        if self._exchange_config_ready_impl is None:
+            return True
+        return await self._exchange_config_ready_impl(
+            self.exchange_config_ready_calls
+        )
+
+    async def _sleep_unless_shutdown(self, seconds, *, stage):
+        self.shutdown_sleeps.append((seconds, stage))
 
     async def determine_utc_offset(self, verbose=True):
         self.determine_utc_offset_calls += 1
@@ -96,6 +112,10 @@ class _InitMarketsSizingBot(CCXTBot):
         self.approved_coins_minus_ignored_coins = {"long": set(), "short": set()}
         self.positions = {}
         self.open_orders = {}
+        self.stop_signal_received = False
+
+    async def _exchange_config_write_ready(self):
+        return True
 
     async def update_exchange_config(self):
         self.update_exchange_config_calls += 1
@@ -184,6 +204,49 @@ async def test_init_markets_retries_request_timeout_then_succeeds(monkeypatch):
     assert bot.positions_balance_calls == 0
     assert bot.open_orders_calls == 0
     assert bot.min_cost_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_init_markets_gates_exchange_config_write_on_balance_readiness(monkeypatch):
+    import passivbot as pb_mod
+
+    events = []
+
+    async def _load_markets(*_args, **_kwargs):
+        events.append("load_markets")
+        return {"BTC/USDT:USDT": {"id": "BTCUSDT"}}
+
+    async def _exchange_config_ready(attempt):
+        events.append(f"readiness:{attempt}")
+        return attempt >= 3
+
+    async def _update_exchange_config(_attempt):
+        events.append("update_exchange_config")
+
+    monkeypatch.setattr(pb_mod, "load_markets", _load_markets)
+    monkeypatch.setattr(
+        pb_mod,
+        "filter_markets",
+        lambda *_args, **_kwargs: (["BTC/USDT:USDT"], [], {}),
+    )
+
+    bot = _FakeBot(
+        _update_exchange_config,
+        exchange_config_ready_impl=_exchange_config_ready,
+    )
+
+    await pb_mod.Passivbot.init_markets(bot, verbose=False)
+
+    assert events[:4] == [
+        "readiness:1",
+        "readiness:2",
+        "readiness:3",
+        "update_exchange_config",
+    ]
+    assert bot.shutdown_sleeps == [
+        (5.0, "exchange_config_balance_readiness"),
+        (5.0, "exchange_config_balance_readiness"),
+    ]
 
 
 @pytest.mark.asyncio
@@ -374,7 +437,7 @@ async def test_init_markets_uses_staged_refresh_for_bybit(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_init_markets_waits_for_initial_balance_confirmation(monkeypatch):
+async def test_init_markets_waits_for_initial_balance_consistency(monkeypatch):
     import passivbot as pb_mod
 
     async def _load_markets(*_args, **_kwargs):
@@ -393,7 +456,7 @@ async def test_init_markets_waits_for_initial_balance_confirmation(monkeypatch):
     bot = _FakeBot(_update_exchange_config)
     bot.exchange = "bitunix"
     bot.stop_signal_received = False
-    bot._last_authoritative_block_reason = "balance_transition_confirmation"
+    bot._last_authoritative_block_reason = "balance_consistency_check"
     refresh_results = iter([False, False, True])
     sleeps = []
 
@@ -411,7 +474,7 @@ async def test_init_markets_waits_for_initial_balance_confirmation(monkeypatch):
 
     assert bot.refresh_authoritative_state_calls == 3
     assert sleeps == [
-        (5.0, "initial_balance_transition_confirmation"),
-        (5.0, "initial_balance_transition_confirmation"),
+        (5.0, "initial_balance_consistency_check"),
+        (5.0, "initial_balance_consistency_check"),
     ]
     assert bot.min_cost_calls == 1

--- a/tests/test_init_markets_retry.py
+++ b/tests/test_init_markets_retry.py
@@ -250,6 +250,93 @@ async def test_init_markets_gates_exchange_config_write_on_balance_readiness(mon
 
 
 @pytest.mark.asyncio
+async def test_init_markets_stops_after_balance_readiness_check(monkeypatch):
+    import passivbot as pb_mod
+
+    async def _load_markets(*_args, **_kwargs):
+        raise AssertionError("load_markets should not run after shutdown")
+
+    async def _update_exchange_config(_attempt):
+        raise AssertionError("exchange config should not be written after shutdown")
+
+    bot = _FakeBot(_update_exchange_config)
+
+    async def _exchange_config_ready(_attempt):
+        bot.stop_signal_received = True
+        return True
+
+    bot._exchange_config_ready_impl = _exchange_config_ready
+    monkeypatch.setattr(pb_mod, "load_markets", _load_markets)
+
+    await pb_mod.Passivbot.init_markets(bot, verbose=False)
+
+    assert bot.exchange_config_ready_calls == 1
+    assert bot.update_exchange_config_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_init_markets_retries_transient_balance_readiness_errors(monkeypatch):
+    import passivbot as pb_mod
+
+    async def _load_markets(*_args, **_kwargs):
+        return {"BTC/USDT:USDT": {"id": "BTCUSDT"}}
+
+    async def _exchange_config_ready(attempt):
+        if attempt < 3:
+            raise pb_mod.RequestTimeout("timed out")
+        return True
+
+    async def _update_exchange_config(_attempt):
+        return None
+
+    monkeypatch.setattr(pb_mod, "load_markets", _load_markets)
+    monkeypatch.setattr(
+        pb_mod,
+        "filter_markets",
+        lambda *_args, **_kwargs: (["BTC/USDT:USDT"], [], {}),
+    )
+    bot = _FakeBot(
+        _update_exchange_config,
+        exchange_config_ready_impl=_exchange_config_ready,
+    )
+
+    await pb_mod.Passivbot.init_markets(bot, verbose=False)
+
+    assert bot.exchange_config_ready_calls == 3
+    assert bot.update_exchange_config_calls == 1
+    assert bot.shutdown_sleeps == [
+        (5, "exchange_config_balance_readiness_retry"),
+        (10, "exchange_config_balance_readiness_retry"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_init_markets_reraises_after_max_balance_readiness_retries(monkeypatch):
+    import passivbot as pb_mod
+
+    async def _exchange_config_ready(_attempt):
+        raise pb_mod.NetworkError("unavailable")
+
+    async def _update_exchange_config(_attempt):
+        raise AssertionError("exchange config should not run without readiness")
+
+    bot = _FakeBot(
+        _update_exchange_config,
+        exchange_config_ready_impl=_exchange_config_ready,
+    )
+
+    with pytest.raises(pb_mod.NetworkError, match="unavailable"):
+        await pb_mod.Passivbot.init_markets(bot, verbose=False)
+
+    assert bot.exchange_config_ready_calls == 3
+    assert bot.update_exchange_config_calls == 0
+    assert bot.shutdown_sleeps == [
+        (5, "exchange_config_balance_readiness_retry"),
+        (10, "exchange_config_balance_readiness_retry"),
+    ]
+
+
+@pytest.mark.asyncio
 async def test_init_markets_validates_coin_overrides_before_sizing(monkeypatch):
     import passivbot as pb_mod
 

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -11277,6 +11277,11 @@ async def test_run_execution_loop_waits_on_bitunix_balance_confirmation_without_
         == "balance_consistency_check"
     ]
     assert len(balance_events) == 12
+    assert balance_events[0]["level"] == "warning"
+    assert all(event["level"] == "debug" for event in balance_events[1:])
+    assert [event["data"]["retry_count"] for event in balance_events] == list(
+        range(1, 13)
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -72,6 +72,30 @@ TEST_RUNTIME_IDENTITY = RuntimeIdentity(
 )
 
 
+@pytest.mark.asyncio
+async def test_staged_balance_override_bypasses_exchange_fetch_and_deferred_state():
+    from live import state_refresh
+
+    bot = SimpleNamespace(
+        balance_override=123.0,
+        get_raw_balance=lambda: 7.0,
+        fetch_balance=AsyncMock(
+            side_effect=AuthoritativeSurfaceUnavailable(
+                "balance", "balance_consistency_check"
+            )
+        ),
+    )
+
+    raw, composition, balance = await state_refresh.capture_balance_staged_snapshot(
+        bot
+    )
+
+    assert raw is None
+    assert balance == 7.0
+    assert composition["reason"] == "balance_override"
+    bot.fetch_balance.assert_not_awaited()
+
+
 def _empty_orchestrator_output(payload: dict, diagnostics: dict | None = None) -> str:
     global_bot_params = payload.get("global", {}).get("global_bot_params", {})
     symbol_states = []
@@ -8002,7 +8026,7 @@ async def test_update_balance_defers_explicitly_unavailable_surface_without_muta
 
     async def fake_fetch_balance():
         raise AuthoritativeSurfaceUnavailable(
-            "balance", "balance_transition_confirmation"
+            "balance", "balance_consistency_check"
         )
 
     bot.fetch_balance = fake_fetch_balance
@@ -8012,7 +8036,7 @@ async def test_update_balance_defers_explicitly_unavailable_surface_without_muta
     assert bot.balance_raw == 50.0
     assert (
         bot._last_authoritative_block_reason
-        == "balance_transition_confirmation"
+        == "balance_consistency_check"
     )
 
 
@@ -11222,7 +11246,7 @@ async def test_run_execution_loop_waits_on_bitunix_balance_confirmation_without_
         cycle["n"] += 1
         if cycle["n"] <= 12:
             bot._last_authoritative_block_reason = (
-                "balance_transition_confirmation"
+                "balance_consistency_check"
             )
             return False
         bot._begin_authoritative_refresh_epoch()
@@ -11244,13 +11268,13 @@ async def test_run_execution_loop_waits_on_bitunix_balance_confirmation_without_
     assert await bot.run_execution_loop() == {"executed_cycle": 13}
     bot.restart_bot_on_too_many_errors.assert_not_awaited()
     assert sleeps == [
-        (5.0, "balance_transition_confirmation")
+        (5.0, "balance_consistency_check")
     ] * 12
     balance_events = [
         call.kwargs
         for call in bot._emit_live_cycle_degraded.call_args_list
         if call.kwargs["reason_code"]
-        == "balance_transition_confirmation"
+        == "balance_consistency_check"
     ]
     assert len(balance_events) == 12
 

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -55,6 +55,7 @@ from live.balance_composition import (
     normalize_okx_balance_composition,
 )
 from live.data_packets import stable_hash
+from live.state_refresh import AuthoritativeSurfaceUnavailable
 
 
 TEST_RUNTIME_IDENTITY = RuntimeIdentity(
@@ -7991,6 +7992,31 @@ async def test_update_balance_failure_keeps_previous():
 
 
 @pytest.mark.asyncio
+async def test_update_balance_defers_explicitly_unavailable_surface_without_mutation():
+    bot = Passivbot.__new__(Passivbot)
+    bot.quote = "USDT"
+    bot.balance = 50.0
+    bot.balance_raw = 50.0
+    bot.balance_override = None
+    bot.previous_hysteresis_balance = 50.0
+
+    async def fake_fetch_balance():
+        raise AuthoritativeSurfaceUnavailable(
+            "balance", "balance_transition_confirmation"
+        )
+
+    bot.fetch_balance = fake_fetch_balance
+
+    assert await bot.update_balance() is False
+    assert bot.balance == 50.0
+    assert bot.balance_raw == 50.0
+    assert (
+        bot._last_authoritative_block_reason
+        == "balance_transition_confirmation"
+    )
+
+
+@pytest.mark.asyncio
 async def test_update_balance_override_does_not_reset_hysteresis_anchor():
     bot = Passivbot.__new__(Passivbot)
     bot.quote = "USDT"
@@ -11167,6 +11193,66 @@ async def test_run_execution_loop_waits_on_pending_pnl_without_restart(monkeypat
     assert sleep_seconds[:7] == [1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 60.0]
     assert sleep_seconds[7:12] == [60.0] * 5
     assert {stage for _seconds, stage in sleeps} == {"pending_pnl_authoritative_retry"}
+
+
+@pytest.mark.asyncio
+async def test_run_execution_loop_waits_on_bitunix_balance_confirmation_without_restart():
+    bot = Passivbot.__new__(Passivbot)
+    cycle = {"n": 0}
+    sleeps = []
+
+    async def fake_sleep_unless_shutdown(seconds, *, stage):
+        sleeps.append((seconds, stage))
+
+    bot.stop_signal_received = False
+    bot.execution_scheduled = False
+    bot.state_change_detected_by_symbol = set()
+    bot.debug_mode = True
+    bot._equity_hard_stop_enabled = lambda *args, **kwargs: False
+    bot._set_log_silence_watchdog_context = lambda *args, **kwargs: None
+    bot._maybe_log_health_summary = lambda: None
+    bot._maybe_log_unstuck_status = lambda: None
+    bot._monitor_flush_snapshot = AsyncMock()
+    bot.restart_bot_on_too_many_errors = AsyncMock()
+    bot._sleep_unless_shutdown = fake_sleep_unless_shutdown
+    bot._emit_live_cycle_degraded = MagicMock()
+    bot.live_value = lambda key: 0.0 if key == "execution_delay_seconds" else False
+
+    async def fake_refresh_authoritative_state():
+        cycle["n"] += 1
+        if cycle["n"] <= 12:
+            bot._last_authoritative_block_reason = (
+                "balance_transition_confirmation"
+            )
+            return False
+        bot._begin_authoritative_refresh_epoch()
+        for surface, sig in (
+            ("balance", ("b", 1)),
+            ("positions", ("p", 1)),
+            ("open_orders", ("o", 1)),
+            ("fills", ("f", 1)),
+            ("completed_candles", tuple()),
+        ):
+            bot._record_authoritative_surface(surface, sig)
+        return True
+
+    bot.refresh_authoritative_state = fake_refresh_authoritative_state
+    bot.prepare_planning_universe = AsyncMock()
+    bot.refresh_market_state_if_needed = AsyncMock(return_value=True)
+    bot.execute_to_exchange = AsyncMock(return_value={"executed_cycle": 13})
+
+    assert await bot.run_execution_loop() == {"executed_cycle": 13}
+    bot.restart_bot_on_too_many_errors.assert_not_awaited()
+    assert sleeps == [
+        (5.0, "balance_transition_confirmation")
+    ] * 12
+    balance_events = [
+        call.kwargs
+        for call in bot._emit_live_cycle_degraded.call_args_list
+        if call.kwargs["reason_code"]
+        == "balance_transition_confirmation"
+    ]
+    assert len(balance_events) == 12
 
 
 @pytest.mark.asyncio

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -36,7 +36,7 @@ sys.modules.setdefault(
     ),
 )
 
-from passivbot import Passivbot
+from passivbot import Passivbot, _parse_balance_override
 import passivbot as passivbot_module
 import fill_events_manager as fem
 from config import get_template_config, prepare_config
@@ -70,6 +70,49 @@ TEST_RUNTIME_IDENTITY = RuntimeIdentity(
     rust_source_sha256="d" * 64,
     rust_artifact_sha256="e" * 64,
 )
+
+
+@pytest.mark.parametrize(
+    "raw_value",
+    [True, False, 0.0, -1.0, float("nan"), float("inf"), "not-a-number"],
+)
+def test_parse_balance_override_rejects_invalid_raw_values(raw_value):
+    with pytest.raises(
+        ValueError,
+        match="balance_override must be a positive finite numeric value",
+    ):
+        _parse_balance_override(raw_value)
+
+
+@pytest.mark.parametrize(
+    ("raw_value", "expected"),
+    [(None, None), ("", None), ("100.5", 100.5), (100.5, 100.5)],
+)
+def test_parse_balance_override_accepts_disabled_and_positive_values(raw_value, expected):
+    assert _parse_balance_override(raw_value) == expected
+
+
+def test_passivbot_init_rejects_boolean_balance_override_before_coercion(monkeypatch):
+    config = get_template_config()
+    config["live"]["user"] = "test_user"
+    config["live"]["balance_override"] = True
+    monkeypatch.setattr(
+        passivbot_module,
+        "load_user_info",
+        lambda _user: {"exchange": "bitunix"},
+    )
+    monkeypatch.setattr(passivbot_module, "load_broker_code", lambda _exchange: "")
+    monkeypatch.setattr(
+        passivbot_module,
+        "resolve_custom_endpoint_override",
+        lambda _exchange: None,
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="balance_override must be a positive finite numeric value",
+    ):
+        Passivbot(config)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- detect the Bitunix account-response transition that reports unchanged locked funds in both available and used balance components
- reconcile nonzero locked-fund startup and suspicious transitions against the exchange-calculated maximum-transfer amount, bonus, and unrealized PnL
- keep ambiguous balance state unavailable indefinitely; resume only on an exact return to trusted components or a transfer-reconciled new tuple
- bypass exchange balance fetching when live.balance_override is configured
- gate startup exchange-configuration writes on Bitunix balance readiness
- add regression coverage for restart safety, persistent ambiguity, changed locked components, staged overrides, startup write gating, and execution-loop deferral

## Validation

- PYTHONPATH=src python -m pytest -q tests/exchanges/test_bitunix.py tests/test_init_markets_retry.py tests/test_balance_composition.py tests/test_passivbot_balance_split.py
- PYTHONPATH=src python -m pytest -q
- PYTHONPATH=src python -m compileall -q src tests
- git diff --check