### PR TITLE
Fix dense coin-HSL GPU screening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ All notable user-facing changes will be documented in this file.
 - Apple MPS single-coin `coin`-mode HSL screening now retains up to 4,096 realized-PnL events in
   the finite lookback window. High-cadence candidates with more than 2,048 valid close events no
   longer receive an artificial early-stop penalty that can poison proxy/exact drift evidence;
-  overflow remains bounded and fail closed. Exact Rust validation, CPU optimization, backtests,
-  and live behavior are unchanged.
+  overflow remains bounded and fail closed. The effective ring capacity is part of checkpoint
+  identity, so finite-lookback coin-HSL checkpoints from the old capacity cannot mix stale proxy
+  evidence with new evaluations. Exact Rust validation, CPU optimization, backtests, and live
+  behavior are unchanged.
 
 - Apple MPS single-coin Trailing Martingale screening now compiles out the 1-minute and 1-hour
   volatility EMA state, candle-range loads, and volatility-weight arithmetic when every active

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
-- Apple MPS single-coin `coin`-mode HSL screening now retains up to 8,192 realized-PnL events in
-  the finite lookback window. High-cadence candidates with more than 2,048 valid close events no
-  longer receive an artificial early-stop penalty after their separate entry-fee and close-PnL
-  records cross the old capacity, which could poison proxy/exact drift evidence;
+- Apple MPS single-coin `coin`-mode HSL screening now retains up to 8,192 realized-PnL event
+  candles in the finite lookback window and coalesces all same-candle entry fees and close PnL.
+  High-cadence candidates with more than 2,048 valid close events no longer receive an artificial
+  early-stop penalty from fill multiplicity crossing the old capacity, which could poison
+  proxy/exact drift evidence;
   overflow remains bounded and fail closed. The effective ring capacity is part of checkpoint
   identity, so finite-lookback coin-HSL checkpoints from the old capacity cannot mix stale proxy
   evidence with new evaluations. Exact Rust validation, CPU optimization, backtests, and live

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
-- Apple MPS single-coin `coin`-mode HSL screening now retains up to 4,096 realized-PnL events in
+- Apple MPS single-coin `coin`-mode HSL screening now retains up to 8,192 realized-PnL events in
   the finite lookback window. High-cadence candidates with more than 2,048 valid close events no
-  longer receive an artificial early-stop penalty that can poison proxy/exact drift evidence;
+  longer receive an artificial early-stop penalty after their separate entry-fee and close-PnL
+  records cross the old capacity, which could poison proxy/exact drift evidence;
   overflow remains bounded and fail closed. The effective ring capacity is part of checkpoint
   identity, so finite-lookback coin-HSL checkpoints from the old capacity cannot mix stale proxy
   evidence with new evaluations. Exact Rust validation, CPU optimization, backtests, and live

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Apple MPS single-coin `coin`-mode HSL screening now retains up to 4,096 realized-PnL events in
+  the finite lookback window. High-cadence candidates with more than 2,048 valid close events no
+  longer receive an artificial early-stop penalty that can poison proxy/exact drift evidence;
+  overflow remains bounded and fail closed. Exact Rust validation, CPU optimization, backtests,
+  and live behavior are unchanged.
+
 - Apple MPS single-coin Trailing Martingale screening now compiles out the 1-minute and 1-hour
   volatility EMA state, candle-range loads, and volatility-weight arithmetic when every active
   candidate in a dispatch uses zero volatility weights for entry and close thresholds and

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -217,9 +217,10 @@ The supported slice is intentionally narrow:
   candle interval. Pending directional orders are cleared at a gap before the next valid candle.
   Normal CPU input validation stays strict.
   Finite non-positive, partially invalid, or float32-unrepresentable prices remain fail-closed
-  for GPU screening. The single-coin coin-HSL ring retains up to 8,192 realized-PnL events in the
-  configured finite lookback; an overflow beyond that bounded capacity still fails closed with a
-  conservative full-horizon recovery penalty. Independent dual-side multi-coin summaries remain
+  for GPU screening. The single-coin coin-HSL ring coalesces realized-PnL components from the same
+  candle and retains up to 8,192 event candles in the configured finite lookback; an overflow
+  beyond that bounded capacity still fails closed with a conservative full-horizon recovery
+  penalty. Independent dual-side multi-coin summaries remain
   fail closed for these metrics because they cannot reconstruct one shared portfolio-equity curve.
   Compatible suites may use the supported topologies.
 - single-coin EMA Anchor and Trailing Martingale support auto-unstuck for long-only,

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -721,9 +721,10 @@ duplicate-elimination controls as the ordinary pymoo optimizer.
    successful completion. Checkpoint identity includes the complete optimizer shape (including
    fixed and dormant dimensions, quantization, runtime optimizer overrides, and effective NSGA-II
    population/variation policy) plus every prepared proxy's effective execution contract:
-   strategy and side topology, ordered coins, hashes of prepared candle values and timestamps,
-   starting balance, valid/trade windows, fully resolved fixed proxy parameters, liquidation and
-   exposure policy, resolved maker/taker fees and market settings, and other modeled execution settings.
+  strategy and side topology, ordered coins, hashes of prepared candle values and timestamps,
+  starting balance, valid/trade windows, fully resolved fixed proxy parameters, liquidation and
+  exposure policy, finite coin-HSL rolling capacity where applicable, resolved maker/taker fees and
+  market settings, and other modeled execution settings.
    Suite checkpoints record that contract independently for every scenario. Changing any of these
    inputs makes resume fail closed instead of mixing evolutionary state from incompatible runs.
    Checkpoints written before this expanded identity contract are intentionally incompatible.

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -217,7 +217,8 @@ The supported slice is intentionally narrow:
   candle interval. Pending directional orders are cleared at a gap before the next valid candle.
   Normal CPU input validation stays strict.
   Finite non-positive, partially invalid, or float32-unrepresentable prices remain fail-closed
-  for GPU screening. A bounded coin-HSL rolling-PnL overflow still fails closed with a
+  for GPU screening. The single-coin coin-HSL ring retains up to 4,096 realized-PnL events in the
+  configured finite lookback; an overflow beyond that bounded capacity still fails closed with a
   conservative full-horizon recovery penalty. Independent dual-side multi-coin summaries remain
   fail closed for these metrics because they cannot reconstruct one shared portfolio-equity curve.
   Compatible suites may use the supported topologies.

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -217,7 +217,7 @@ The supported slice is intentionally narrow:
   candle interval. Pending directional orders are cleared at a gap before the next valid candle.
   Normal CPU input validation stays strict.
   Finite non-positive, partially invalid, or float32-unrepresentable prices remain fail-closed
-  for GPU screening. The single-coin coin-HSL ring retains up to 4,096 realized-PnL events in the
+  for GPU screening. The single-coin coin-HSL ring retains up to 8,192 realized-PnL events in the
   configured finite lookback; an overflow beyond that bounded capacity still fails closed with a
   conservative full-horizon recovery penalty. Independent dual-side multi-coin summaries remain
   fail closed for these metrics because they cannot reconstruct one shared portfolio-equity curve.

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -423,6 +423,8 @@ mod tests {
         assert!(source.contains("short_coin_hsl_rolling && short_rolling_pnl.overflowed"));
         assert!(source.contains("prepare_coin_hsl_rolling_signal("));
         assert!(source.contains("reset_hsl_rolling_pnl_window("));
+        assert!(source.contains("indices[base + slot].x == k"));
+        assert!(source.contains("values[base + slot].y = fmax("));
         assert!(source.contains("const int pnl_lookback_bars"));
         assert!(source.contains("device float2* rolling_pnl_values"));
         assert!(source.contains("device int2* rolling_pnl_indices"));

--- a/passivbot-rust/src/gpu/mps_hsl_common.metal
+++ b/passivbot-rust/src/gpu/mps_hsl_common.metal
@@ -28,7 +28,10 @@ constant int HSL_SIGNAL_COIN = 2;
 // Finite coin-HSL PnL windows are candidate-local.  Their fill events live in
 // device buffers owned by the directional runner; this small thread-local
 // structure keeps only ring/deque cursors and the absolute realized cumsum.
-// The two packed buffers use float2(base_before, cumulative_after) and
+// Multiple realized-PnL components may occur on one candle (for example,
+// several martingale entry fees followed by a close).  They are coalesced into
+// one event-candle without changing the rolling current or peak.  The two
+// packed buffers use float2(base_before_candle, peak_during_candle) and
 // int2(event_k, monotonic_peak_slot) respectively.
 struct HslRollingPnlWindow {
     int event_head;
@@ -103,6 +106,37 @@ inline void record_hsl_rolling_pnl(
     prune_hsl_rolling_pnl_window(
         window, values, indices, base, capacity, k, lookback_bars
     );
+    if (window.event_count > 0) {
+        int slot = (window.event_head + window.event_count - 1) % capacity;
+        if (indices[base + slot].x == k) {
+            values[base + slot].y = fmax(
+                values[base + slot].y, window.absolute_cumulative
+            );
+            if (window.peak_count > 0) {
+                int peak_tail = (
+                    window.peak_head + window.peak_count - 1
+                ) % capacity;
+                if (indices[base + peak_tail].y == slot) {
+                    window.peak_count -= 1;
+                }
+            }
+            while (window.peak_count > 0) {
+                int back = (
+                    window.peak_head + window.peak_count - 1
+                ) % capacity;
+                int peak_slot = indices[base + back].y;
+                if (values[base + peak_slot].y
+                    > values[base + slot].y) break;
+                window.peak_count -= 1;
+            }
+            int peak_tail = (
+                window.peak_head + window.peak_count
+            ) % capacity;
+            indices[base + peak_tail].y = slot;
+            window.peak_count += 1;
+            return;
+        }
+    }
     if (window.event_count >= capacity || window.peak_count >= capacity) {
         window.overflowed = true;
         return;

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -43,10 +43,10 @@ MPS_MULTICOIN_FUSED_EMA_TAIL_SCALAR_COLS = 68
 MPS_MULTICOIN_FUSED_RAW_DRAWDOWN_SCALAR_COLS = 70
 MPS_MULTICOIN_FUSED_SCALAR_COLS = 72
 # A 30-day coin-HSL lookback can legitimately contain slightly more than
-# 2,048 completed round trips for high-cadence single-coin candidates. Each
-# trip records its entry fee and close PnL separately. Keep this bounded, but
-# leave enough headroom that ordinary dense strategies do not fail closed
-# solely because their valid rolling window crossed the old capacity.
+# 2,048 completed round trips for high-cadence single-coin candidates. Metal
+# coalesces every realized-PnL component from one candle into one ring event,
+# so ladder fill multiplicity does not consume extra slots. Keep this bounded,
+# but leave enough headroom for dense valid event-candle windows.
 MPS_DIRECTIONAL_HSL_ROLLING_CAPACITY = 8192
 MPS_STRATEGY_EQ_RECOVERY_METRIC_COLS = 7
 MPS_EQUITY_BALANCE_DIFF_COLS = 12

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -43,11 +43,11 @@ MPS_MULTICOIN_FUSED_EMA_TAIL_SCALAR_COLS = 68
 MPS_MULTICOIN_FUSED_RAW_DRAWDOWN_SCALAR_COLS = 70
 MPS_MULTICOIN_FUSED_SCALAR_COLS = 72
 # A 30-day coin-HSL lookback can legitimately contain slightly more than
-# 2,048 realized close events for high-cadence single-coin candidates. Keep
-# this bounded, but leave enough headroom that ordinary dense strategies do
-# not fail closed solely because their valid rolling window crossed the old
-# capacity.
-MPS_DIRECTIONAL_HSL_ROLLING_CAPACITY = 4096
+# 2,048 completed round trips for high-cadence single-coin candidates. Each
+# trip records its entry fee and close PnL separately. Keep this bounded, but
+# leave enough headroom that ordinary dense strategies do not fail closed
+# solely because their valid rolling window crossed the old capacity.
+MPS_DIRECTIONAL_HSL_ROLLING_CAPACITY = 8192
 MPS_STRATEGY_EQ_RECOVERY_METRIC_COLS = 7
 MPS_EQUITY_BALANCE_DIFF_COLS = 12
 MPS_ENTRY_INTERVAL_STAT_COLS = 2

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -42,7 +42,12 @@ MPS_MULTICOIN_FUSED_BASE_SCALAR_COLS = 66
 MPS_MULTICOIN_FUSED_EMA_TAIL_SCALAR_COLS = 68
 MPS_MULTICOIN_FUSED_RAW_DRAWDOWN_SCALAR_COLS = 70
 MPS_MULTICOIN_FUSED_SCALAR_COLS = 72
-MPS_DIRECTIONAL_HSL_ROLLING_CAPACITY = 2048
+# A 30-day coin-HSL lookback can legitimately contain slightly more than
+# 2,048 realized close events for high-cadence single-coin candidates. Keep
+# this bounded, but leave enough headroom that ordinary dense strategies do
+# not fail closed solely because their valid rolling window crossed the old
+# capacity.
+MPS_DIRECTIONAL_HSL_ROLLING_CAPACITY = 4096
 MPS_STRATEGY_EQ_RECOVERY_METRIC_COLS = 7
 MPS_EQUITY_BALANCE_DIFF_COLS = 12
 MPS_ENTRY_INTERVAL_STAT_COLS = 2

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -1913,6 +1913,11 @@ class MpsSingleCoinProxy:
             },
             "proxy_mode": "single-coin-exact-last-v1",
         }
+        pnl_lookback_bars = _directional_coin_hsl_lookback_bars(
+            backtest_params,
+            signal_mode=signal_mode,
+            hsl_enabled=bool(hsl_enabled_sides),
+        )
 
         self.checkpoint_contract = _gpu_proxy_execution_checkpoint_contract(
             strategy_kind=self.strategy_kind,
@@ -1950,11 +1955,6 @@ class MpsSingleCoinProxy:
             taker_fee=float(market_params["taker_fee"]),
         )
         interval_ms = candle_interval_minutes * 60_000
-        pnl_lookback_bars = _directional_coin_hsl_lookback_bars(
-            backtest_params,
-            signal_mode=signal_mode,
-            hsl_enabled=bool(hsl_enabled_sides),
-        )
         self.run = ProxyRun(
             starting_balance=float(backtest_params["starting_balance"]),
             warmup_bars=max(1, int(backtest_params.get("global_warmup_bars", 0) or 1)),

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -535,6 +535,7 @@ def _gpu_proxy_execution_checkpoint_contract(
     exchange_params,
     base_params,
     btc_prices=None,
+    directional_hsl_rolling_capacity: int | None = None,
 ) -> dict:
     """Return the prepared execution inputs which make proxy state reusable."""
 
@@ -610,6 +611,10 @@ def _gpu_proxy_execution_checkpoint_contract(
             for side, params in sorted((base_params or {}).items())
         },
     }
+    if directional_hsl_rolling_capacity is not None:
+        contract["directional_hsl_rolling_capacity"] = int(
+            directional_hsl_rolling_capacity
+        )
     if btc_prices is not None:
         btc_values = np.ascontiguousarray(
             np.asarray(btc_prices, dtype=np.float64).reshape(-1)
@@ -1722,6 +1727,7 @@ class MpsSingleCoinProxy:
 
         from backtest import build_backtest_payload
         from optimization.gpu.mps_kernel import (
+            MPS_DIRECTIONAL_HSL_ROLLING_CAPACITY,
             MpsEmaAnchorRunner,
             MpsTrailingMartingaleRunner,
         )
@@ -1918,6 +1924,11 @@ class MpsSingleCoinProxy:
             exchange_params=payload.exchange_params,
             base_params=self.base_params,
             btc_prices=btc_values if self.btc_analysis_enabled else None,
+            directional_hsl_rolling_capacity=(
+                MPS_DIRECTIONAL_HSL_ROLLING_CAPACITY
+                if pnl_lookback_bars > 0
+                else None
+            ),
         )
 
         self.base_total_wallet_exposure_limits = {

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -897,7 +897,8 @@ def test_trailing_martingale_runner_accepts_ordinary_market_execution(monkeypatc
 def test_mps_coin_hsl_rolling_pnl_window_expires_and_resets_fill_events():
     import passivbot_rust
 
-    dense_event_count = 2_096
+    dense_round_trip_count = 2_096
+    dense_event_count = dense_round_trip_count * 2
     assert MPS_DIRECTIONAL_HSL_ROLLING_CAPACITY >= dense_event_count
     probe_kernel = r"""
 kernel void passivbot_hsl_rolling_pnl_probe(
@@ -972,15 +973,21 @@ kernel void passivbot_hsl_rolling_pnl_probe(
     output[11] = overflow.overflowed ? 1.0f : 0.0f;
 
     HslRollingPnlWindow dense = init_hsl_rolling_pnl_window();
-    for (int k = 0; k < __DENSE_EVENT_COUNT__; ++k) {
+    for (int k = 0; k < __DENSE_ROUND_TRIP_COUNT__; ++k) {
         record_hsl_rolling_pnl(
             dense, values, indices, 6, __DENSE_CAPACITY__, k,
             __DENSE_EVENT_COUNT__ + 1, true, 1.0f
         );
+        record_hsl_rolling_pnl(
+            dense, values, indices, 6, __DENSE_CAPACITY__, k,
+            __DENSE_EVENT_COUNT__ + 1, true, -0.1f
+        );
     }
     output[12] = dense.overflowed ? 1.0f : 0.0f;
 }
-""".replace("__DENSE_EVENT_COUNT__", str(dense_event_count)).replace(
+""".replace(
+        "__DENSE_ROUND_TRIP_COUNT__", str(dense_round_trip_count)
+    ).replace("__DENSE_EVENT_COUNT__", str(dense_event_count)).replace(
         "__DENSE_CAPACITY__", str(MPS_DIRECTIONAL_HSL_ROLLING_CAPACITY)
     )
     buffer_size = 6 + MPS_DIRECTIONAL_HSL_ROLLING_CAPACITY

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -898,8 +898,8 @@ def test_mps_coin_hsl_rolling_pnl_window_expires_and_resets_fill_events():
     import passivbot_rust
 
     dense_round_trip_count = 2_096
-    dense_event_count = dense_round_trip_count * 2
-    assert MPS_DIRECTIONAL_HSL_ROLLING_CAPACITY >= dense_event_count
+    fills_per_round_trip = 4
+    assert MPS_DIRECTIONAL_HSL_ROLLING_CAPACITY >= dense_round_trip_count
     probe_kernel = r"""
 kernel void passivbot_hsl_rolling_pnl_probe(
     device float2* values,
@@ -974,26 +974,43 @@ kernel void passivbot_hsl_rolling_pnl_probe(
 
     HslRollingPnlWindow dense = init_hsl_rolling_pnl_window();
     for (int k = 0; k < __DENSE_ROUND_TRIP_COUNT__; ++k) {
+        for (int fill = 0; fill < __FILLS_PER_ROUND_TRIP__; ++fill) {
+            record_hsl_rolling_pnl(
+                dense, values, indices, 6, __DENSE_CAPACITY__, k,
+                __DENSE_ROUND_TRIP_COUNT__ + 1, true, -0.1f
+            );
+        }
         record_hsl_rolling_pnl(
             dense, values, indices, 6, __DENSE_CAPACITY__, k,
-            __DENSE_EVENT_COUNT__ + 1, true, 1.0f
-        );
-        record_hsl_rolling_pnl(
-            dense, values, indices, 6, __DENSE_CAPACITY__, k,
-            __DENSE_EVENT_COUNT__ + 1, true, -0.1f
+            __DENSE_ROUND_TRIP_COUNT__ + 1, true, 1.0f
         );
     }
     output[12] = dense.overflowed ? 1.0f : 0.0f;
+    output[13] = float(dense.event_count);
+
+    HslRollingPnlWindow coalesced = init_hsl_rolling_pnl_window();
+    record_hsl_rolling_pnl(
+        coalesced, values, indices, 6, __DENSE_CAPACITY__, 0, 2, true, 50.0f
+    );
+    record_hsl_rolling_pnl(
+        coalesced, values, indices, 6, __DENSE_CAPACITY__, 0, 2, true, -80.0f
+    );
+    HslRollingPnlSignal coalesced_signal = effective_hsl_rolling_pnl(
+        coalesced, values, indices, 6, __DENSE_CAPACITY__, 0, 2
+    );
+    output[14] = coalesced_signal.peak;
+    output[15] = coalesced_signal.current;
+    output[16] = float(coalesced.event_count);
 }
 """.replace(
         "__DENSE_ROUND_TRIP_COUNT__", str(dense_round_trip_count)
-    ).replace("__DENSE_EVENT_COUNT__", str(dense_event_count)).replace(
+    ).replace("__FILLS_PER_ROUND_TRIP__", str(fills_per_round_trip)).replace(
         "__DENSE_CAPACITY__", str(MPS_DIRECTIONAL_HSL_ROLLING_CAPACITY)
     )
     buffer_size = 6 + MPS_DIRECTIONAL_HSL_ROLLING_CAPACITY
     values = torch.empty((buffer_size, 2), dtype=torch.float32, device="mps")
     indices = torch.empty((buffer_size, 2), dtype=torch.int32, device="mps")
-    output = torch.zeros(13, dtype=torch.float32, device="mps")
+    output = torch.zeros(17, dtype=torch.float32, device="mps")
     library = torch.mps.compile_shader(
         passivbot_rust.mps_ema_anchor_source_py() + probe_kernel
     )
@@ -1017,6 +1034,10 @@ kernel void passivbot_hsl_rolling_pnl_probe(
         0.0,
         1.0,
         0.0,
+        float(dense_round_trip_count),
+        50.0,
+        -30.0,
+        1.0,
     ]
 
 
@@ -13226,6 +13247,76 @@ def test_mps_tm_recursive_market_entry_retains_exact_twel_prefix(
     # snapshot, before backtest-only adverse slippage is applied to the fill.
     assert promoted[size_key].item() * 100.0 / 1_000.0 < threshold
     assert promoted["balance"].item() < 1_000.0
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_tm_coin_hsl_coalesces_recursive_same_candle_entry_fees(side):
+    count = 5
+    close = np.full(count, 100.0)
+    high = np.full(count, 100.0)
+    low = np.full(count, 100.0)
+    low[3] = 99.89
+    high[3] = 100.11
+    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    market = ProxyMarket(0.001, 0.01, 0.001, 0.0, 1.0, 0.0002)
+    run = ProxyRun(
+        1_000.0,
+        1,
+        1,
+        int(timestamps[0]),
+        int(timestamps[0]),
+        int(timestamps[0]),
+        60_000,
+        0.05,
+        0,
+        count - 1,
+    )
+    data = build_mps_data(high, low, close, timestamps, run, market)
+    row = _tm_single_row(
+        initial_ema_dist=0.001,
+        gate_initial=False,
+        gate_reentry=False,
+        entry_gate=True,
+        threshold=0.15,
+    )
+    for key, value in {
+        "entry_double_down_factor": 1.0,
+        "entry_initial_qty_pct": 0.05,
+        "entry_threshold_base_pct": 0.001,
+        "entry_retracement_base_pct": 0.0,
+        "close_threshold_base_pct": 10.0,
+        "close_retracement_base_pct": 0.001,
+        "hsl_enabled": 1.0,
+        "hsl_red_threshold": 1.0,
+        "hsl_signal_mode": 2.0,
+    }.items():
+        row[TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS.index(key)] = value
+    params = np.asarray([row + row], dtype=np.float64)
+    runner = MpsTrailingMartingaleRunner(
+        market,
+        run,
+        data,
+        long_enabled=side == "long",
+        short_enabled=side == "short",
+        pnl_lookback_bars=count,
+        taker_fee=0.01,
+        market_order_slippage_pct=0.01,
+        market_orders_allowed=True,
+        market_order_near_touch_threshold=0.003,
+    )
+    # Three production ladder fills land on one candle. A one-slot ring proves
+    # their fees are coalesced rather than overflowing per fill.
+    runner.rolling_capacity = 1
+
+    output = runner.run(params)
+    torch.mps.synchronize()
+
+    assert output["fill_count_entry"].item() == 3.0
+    assert output["alive"].item()
+    assert output["balance"].item() > 0.0
 
 
 @pytest.mark.skipif(

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -39,6 +39,7 @@ from optimization.gpu.model import (
     build_mps_multicoin_data,
 )
 from optimization.gpu.mps_kernel import (
+    MPS_DIRECTIONAL_HSL_ROLLING_CAPACITY,
     MpsEmaAnchorMulticoinRunner,
     MpsEmaAnchorRunner,
     MpsEmaAnchorMulticoinFusedRunner,
@@ -896,6 +897,8 @@ def test_trailing_martingale_runner_accepts_ordinary_market_execution(monkeypatc
 def test_mps_coin_hsl_rolling_pnl_window_expires_and_resets_fill_events():
     import passivbot_rust
 
+    dense_event_count = 2_096
+    assert MPS_DIRECTIONAL_HSL_ROLLING_CAPACITY >= dense_event_count
     probe_kernel = r"""
 kernel void passivbot_hsl_rolling_pnl_probe(
     device float2* values,
@@ -967,11 +970,23 @@ kernel void passivbot_hsl_rolling_pnl_probe(
         overflow, values, indices, 4, 2, 2, 10, true, 1.0f
     );
     output[11] = overflow.overflowed ? 1.0f : 0.0f;
+
+    HslRollingPnlWindow dense = init_hsl_rolling_pnl_window();
+    for (int k = 0; k < __DENSE_EVENT_COUNT__; ++k) {
+        record_hsl_rolling_pnl(
+            dense, values, indices, 6, __DENSE_CAPACITY__, k,
+            __DENSE_EVENT_COUNT__ + 1, true, 1.0f
+        );
+    }
+    output[12] = dense.overflowed ? 1.0f : 0.0f;
 }
-"""
-    values = torch.empty((6, 2), dtype=torch.float32, device="mps")
-    indices = torch.empty((6, 2), dtype=torch.int32, device="mps")
-    output = torch.zeros(12, dtype=torch.float32, device="mps")
+""".replace("__DENSE_EVENT_COUNT__", str(dense_event_count)).replace(
+        "__DENSE_CAPACITY__", str(MPS_DIRECTIONAL_HSL_ROLLING_CAPACITY)
+    )
+    buffer_size = 6 + MPS_DIRECTIONAL_HSL_ROLLING_CAPACITY
+    values = torch.empty((buffer_size, 2), dtype=torch.float32, device="mps")
+    indices = torch.empty((buffer_size, 2), dtype=torch.int32, device="mps")
+    output = torch.zeros(13, dtype=torch.float32, device="mps")
     library = torch.mps.compile_shader(
         passivbot_rust.mps_ema_anchor_source_py() + probe_kernel
     )
@@ -994,6 +1009,7 @@ kernel void passivbot_hsl_rolling_pnl_probe(
         0.0,
         0.0,
         1.0,
+        0.0,
     ]
 
 

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -147,6 +147,28 @@ def test_gpu_proxy_execution_checkpoint_contract_tracks_effective_inputs():
         exchange_params=[market],
         base_params={"long": {"offset": 0.01}},
     )
+    with_hsl_ring = _gpu_proxy_execution_checkpoint_contract(
+        strategy_kind="ema_anchor",
+        exchange="bybit",
+        enabled_sides=["long"],
+        hlcvs=np.arange(12, dtype=np.float64).reshape(3, 1, 4),
+        timestamps=np.array([1_000, 2_000, 3_000], dtype=np.int64),
+        backtest_params=backtest_params,
+        exchange_params=[market],
+        base_params={"long": {"offset": 0.01}},
+        directional_hsl_rolling_capacity=4_096,
+    )
+    changed_hsl_ring = _gpu_proxy_execution_checkpoint_contract(
+        strategy_kind="ema_anchor",
+        exchange="bybit",
+        enabled_sides=["long"],
+        hlcvs=np.arange(12, dtype=np.float64).reshape(3, 1, 4),
+        timestamps=np.array([1_000, 2_000, 3_000], dtype=np.int64),
+        backtest_params=backtest_params,
+        exchange_params=[market],
+        base_params={"long": {"offset": 0.01}},
+        directional_hsl_rolling_capacity=2_048,
+    )
     changed_fee = dict(market, maker_fee=0.0005)
     changed = _gpu_proxy_execution_checkpoint_contract(
         strategy_kind="ema_anchor",
@@ -218,6 +240,9 @@ def test_gpu_proxy_execution_checkpoint_contract_tracks_effective_inputs():
     assert changed_timestamps != original
     assert changed_hlcvs != original
     assert changed_base_params != original
+    assert "directional_hsl_rolling_capacity" not in original
+    assert with_hsl_ring["directional_hsl_rolling_capacity"] == 4_096
+    assert changed_hsl_ring != with_hsl_ring
     assert "btc_analysis" not in original
     assert changed_btc != with_btc
     assert original["timestamps"]["count"] == 3

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -156,7 +156,7 @@ def test_gpu_proxy_execution_checkpoint_contract_tracks_effective_inputs():
         backtest_params=backtest_params,
         exchange_params=[market],
         base_params={"long": {"offset": 0.01}},
-        directional_hsl_rolling_capacity=4_096,
+        directional_hsl_rolling_capacity=8_192,
     )
     changed_hsl_ring = _gpu_proxy_execution_checkpoint_contract(
         strategy_kind="ema_anchor",
@@ -167,7 +167,7 @@ def test_gpu_proxy_execution_checkpoint_contract_tracks_effective_inputs():
         backtest_params=backtest_params,
         exchange_params=[market],
         base_params={"long": {"offset": 0.01}},
-        directional_hsl_rolling_capacity=2_048,
+        directional_hsl_rolling_capacity=4_096,
     )
     changed_fee = dict(market, maker_fee=0.0005)
     changed = _gpu_proxy_execution_checkpoint_contract(
@@ -241,7 +241,7 @@ def test_gpu_proxy_execution_checkpoint_contract_tracks_effective_inputs():
     assert changed_hlcvs != original
     assert changed_base_params != original
     assert "directional_hsl_rolling_capacity" not in original
-    assert with_hsl_ring["directional_hsl_rolling_capacity"] == 4_096
+    assert with_hsl_ring["directional_hsl_rolling_capacity"] == 8_192
     assert changed_hsl_ring != with_hsl_ring
     assert "btc_analysis" not in original
     assert changed_btc != with_btc


### PR DESCRIPTION
## Summary

- raise the bounded single-coin coin-HSL rolling realized-PnL ring from 2,048 to 4,096 events
- keep overflow fail-closed while avoiding artificial early termination for valid high-cadence windows
- document the capacity and add a Metal regression above the previous boundary

## Validation

- `pytest -q tests/optimization/test_gpu_mps.py::test_mps_coin_hsl_rolling_pnl_window_expires_and_resets_fill_events tests/optimization/test_gpu_mps.py::test_mps_recovery_fails_closed_on_coin_hsl_rolling_overflow tests/optimization/test_gpu_service.py::test_single_coin_proxy_preserves_order_across_bounded_dispatches`
- `pytest -q tests/optimization/test_gpu_service.py tests/optimization/test_gpu_backend.py`
- focused cache-only Apple MPS replay confirmed the artificial ring-overflow endpoint is removed and proxy/exact feasibility classification remains aligned

Exact Rust validation, CPU optimization, backtests, and live behavior are unchanged.