### PR TITLE
Evaluate GPU halving on recent history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Apple MPS successive-halving optimization now evaluates its opt-in 25% and 50% rungs on the
+  most recent portion of the configured date range, with the normal indicator warmup immediately
+  preceding each scoring window. The final rung remains the full configured history. Checkpoint
+  identity distinguishes these recent-suffix semantics from the former historical-prefix behavior.
 - Apple MPS single-coin `coin`-mode HSL screening now retains up to 8,192 realized-PnL event
   candles in the finite lookback window and coalesces all same-candle entry fees and close PnL.
   High-cadence candidates with more than 2,048 valid close events no longer receive an artificial

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -668,17 +668,20 @@ duplicate-elimination controls as the ordinary pymoo optimizer.
   A topology whose single candidate already exceeds the safety envelope fails closed with guidance
   to shorten the date range or reduce its coin count.
 - `successive_halving.enabled` opts a non-suite, single-coin Trailing Martingale run into
-  progressively longer history prefixes. The default `history_fractions` are 25%, 50%, and 100%;
-  after each partial rung, constraint-aware Pareto selection retains `survival_fraction` (50% by
-  default), subject to `min_survivors` (64 by default). With the default 1024 population this means
-  1024 candidates at 25%, 512 at 50%, and 256 at full history. Shorter rungs use the same 500
-  million candidate-bars safety envelope, so they can safely dispatch more candidates together;
-  the cap itself is not raised. Partial-rung rows are marked ineligible in NSGA-II, and only the
-  full-history survivors may enter exact Rust validation, proxy-front selection, broad probes, or
-  drift evidence. The ladder is disabled by default because progressive prefixes trade some
-  search breadth for throughput and emphasize the earlier part of the configured period. Its
-  policy is included in checkpoint identity. EMA Anchor, multicoin, and suite runs fail closed if
-  this opt-in is requested.
+  progressively longer recent-history suffixes. The default `history_fractions` are 25%, 50%, and
+  100%, measured backwards from the configured end date; each partial suffix receives the normal
+  indicator warmup immediately before its scoring boundary. After each partial rung,
+  constraint-aware Pareto selection retains `survival_fraction` (50% by default), subject to
+  `min_survivors` (64 by default). With the default 1024 population this means 1024 candidates on
+  the most recent 25%, 512 on the most recent 50%, and 256 on full history. Shorter rungs use the
+  same 500 million candidate-bars safety envelope, so they can safely dispatch more candidates
+  together; the cap itself is not raised. Partial-rung rows are marked ineligible in NSGA-II, and
+  only the full-history survivors may enter exact Rust validation, proxy-front selection, broad
+  probes, or drift evidence. The ladder remains disabled by default because it trades some search
+  breadth for throughput and deliberately biases early filtering toward recent market behavior.
+  The suffix-window semantics are included in checkpoint identity, so checkpoints made with the
+  former prefix behavior do not resume. EMA Anchor, multicoin, and suite runs fail closed if this
+  opt-in is requested.
 - `validate_per_generation` caps exact candidates selected from each proxy generation.
 - `drift_probes` reserves at least part of that validation budget for candidates away from the
   proxy front.

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -1043,8 +1043,21 @@ mod tests {
         assert!(source.contains("k >= bounded_trade_start"));
         assert!(source.contains("const int recovery_sample_capacity = sizes[9]"));
         assert!(source.contains("const int recovery_sample_count = sizes[12]"));
+        assert!(source.contains(
+            "const int bounded_first_hour_step = sizes[13]"
+        ));
+        assert!(source.contains(
+            "const bool bounded_first_hour_ready = sizes[14] != 0"
+        ));
+        assert!(source.contains(
+            "const int bounded_first_next_window_start = sizes[15]"
+        ));
         assert!(source.contains("const bool hour_boundary = (hour_flags & 2)"));
+        assert!(source.contains("(hour_flags & 4) != 0"));
+        assert!(source.contains("(hour_flags & 8) != 0"));
         assert!(source.contains("bounded_hour_latest_valid"));
+        assert!(source.contains("bounded_hour_synced"));
+        assert!(!source.contains("k > bounded_hour_start_k + 1"));
         assert_eq!(source.matches("record_initial_entry_interval(").count(), 3);
         assert!(source.contains("long_last_initial_entry_k"));
         assert!(source.contains("short_last_initial_entry_k"));

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -301,16 +301,25 @@ mod tests {
         assert!(source.contains("device int* counts"));
     }
 
-    fn assert_directional_recovery_sampling_contract(source: &str) {
+    fn assert_directional_recovery_sampling_contract(
+        source: &str,
+        separate_sample_capacity: bool,
+    ) {
         assert_eq!(source.matches("device float* recovery_samples").count(), 2);
         assert!(source.contains("#ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED"));
         assert!(source.contains("const int last_valid = sizes[7]"));
         assert!(source.contains("const int recovery_stride = sizes[8]"));
-        assert!(source.contains("const int recovery_sample_count = sizes[9]"));
+        if separate_sample_capacity {
+            assert!(source.contains("const int recovery_sample_capacity = sizes[9]"));
+            assert!(source.contains("const int recovery_sample_count = sizes[12]"));
+            assert!(source.contains("int(b) * recovery_sample_capacity + sample_index"));
+        } else {
+            assert!(source.contains("const int recovery_sample_count = sizes[9]"));
+            assert!(source.contains("int(b) * recovery_sample_count + sample_index"));
+        }
         assert!(source.contains("int recovery_start_k = -1"));
         assert!(source.contains("const bool recovery_terminal = liq || k == T - 2"));
         assert!(source.contains("(recovery_elapsed + recovery_stride - 1) / recovery_stride"));
-        assert!(source.contains("int(b) * recovery_sample_count + sample_index"));
         assert!(source.contains("const bool rolling_pnl_overflowed ="));
         assert!(source.contains("= RECOVERY_FAIL_CLOSED_SENTINEL;"));
         assert!(source.contains("const bool after_valid_tail = k > last_valid"));
@@ -682,7 +691,7 @@ mod tests {
     fn ema_anchor_mps_source_exposes_expected_kernel_contract() {
         let source = mps_ema_anchor_source();
         assert_shared_hsl_contract(source);
-        assert_directional_recovery_sampling_contract(source);
+        assert_directional_recovery_sampling_contract(source, false);
         assert_directional_hsl_accounting_contract(source);
         assert!(source.contains("kernel void passivbot_ema_anchor"));
         assert!(source.contains("constant int DAILY_COLS = 8"));
@@ -1024,7 +1033,7 @@ mod tests {
         let source = mps_trailing_martingale_source();
         assert_shared_hsl_contract(source);
         assert_shared_entry_interval_contract(source);
-        assert_directional_recovery_sampling_contract(source);
+        assert_directional_recovery_sampling_contract(source, true);
         assert_directional_hsl_accounting_contract(source);
         assert!(source.contains("kernel void passivbot_trailing_martingale"));
         assert!(source.contains("const int bounded_history_start = sizes[10]"));
@@ -1032,6 +1041,10 @@ mod tests {
         assert!(source.contains("const bool recent_history_window"));
         assert!(source.contains("const int loop_start = recent_history_window"));
         assert!(source.contains("k >= bounded_trade_start"));
+        assert!(source.contains("const int recovery_sample_capacity = sizes[9]"));
+        assert!(source.contains("const int recovery_sample_count = sizes[12]"));
+        assert!(source.contains("const bool hour_boundary = (hour_flags & 2)"));
+        assert!(source.contains("bounded_hour_latest_valid"));
         assert_eq!(source.matches("record_initial_entry_interval(").count(), 3);
         assert!(source.contains("long_last_initial_entry_k"));
         assert!(source.contains("short_last_initial_entry_k"));

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -1027,6 +1027,11 @@ mod tests {
         assert_directional_recovery_sampling_contract(source);
         assert_directional_hsl_accounting_contract(source);
         assert!(source.contains("kernel void passivbot_trailing_martingale"));
+        assert!(source.contains("const int bounded_history_start = sizes[10]"));
+        assert!(source.contains("const int bounded_trade_start = sizes[11]"));
+        assert!(source.contains("const bool recent_history_window"));
+        assert!(source.contains("const int loop_start = recent_history_window"));
+        assert!(source.contains("k >= bounded_trade_start"));
         assert_eq!(source.matches("record_initial_entry_interval(").count(), 3);
         assert!(source.contains("long_last_initial_entry_k"));
         assert!(source.contains("short_last_initial_entry_k"));

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -1818,6 +1818,11 @@ inline void passivbot_single_coin_impl(
     const int bounded_history_start = sizes[10];
     const int bounded_trade_start = sizes[11];
     const bool recent_history_window = bounded_history_start >= 0;
+#if !PASSIVBOT_TM_VOLATILITY_DISABLED
+    const int bounded_first_hour_step = sizes[13];
+    const bool bounded_first_hour_ready = sizes[14] != 0;
+    const int bounded_first_next_window_start = sizes[15];
+#endif
 #ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
     const int recovery_stride = sizes[8];
     const int recovery_sample_capacity = sizes[9];
@@ -1986,7 +1991,7 @@ inline void passivbot_single_coin_impl(
     float bounded_hour_latest = 0.0f;
     bool bounded_hour_has_price = false;
     bool bounded_hour_latest_valid = false;
-    int bounded_hour_start_k = seed_k;
+    bool bounded_hour_synced = false;
     if (recent_history_window && seed_k <= last_valid) {
         const float seed_high = bars[seed_k * 5 + 0];
         const float seed_low = bars[seed_k * 5 + 1];
@@ -2017,30 +2022,53 @@ inline void passivbot_single_coin_impl(
 #if !PASSIVBOT_TM_VOLATILITY_DISABLED
         const int hour_flags = flags[fo + 3];
         bool hour_valid = (hour_flags & 1) != 0;
-        if (recent_history_window) {
+        if (recent_history_window && !bounded_hour_synced) {
             const bool hour_boundary = (hour_flags & 2) != 0;
             if (hour_boundary) {
-                if (k > bounded_hour_start_k + 1 && bounded_hour_has_price
+                const bool bounded_window_ready = k == bounded_first_hour_step
+                    ? bounded_first_hour_ready
+                    : (hour_flags & 4) != 0;
+                if (bounded_window_ready && bounded_hour_has_price
                         && bounded_hour_high > 0.0f && bounded_hour_low > 0.0f) {
                     bounded_hour_latest = log(
                         bounded_hour_high / bounded_hour_low
                     );
                     bounded_hour_latest_valid = isfinite(bounded_hour_latest);
+                    bounded_hour_synced = bounded_hour_latest_valid;
                 }
                 hour_lr = bounded_hour_latest;
                 hour_valid = bounded_hour_latest_valid;
-                bounded_hour_start_k = k;
-                bounded_hour_high = -INFINITY;
-                bounded_hour_low = INFINITY;
-                bounded_hour_has_price = false;
+                if (!bounded_hour_synced) {
+                    const int next_window_start = k == bounded_first_hour_step
+                        ? bounded_first_next_window_start
+                        : ((hour_flags & 8) != 0 ? k - 1 : k);
+                    bounded_hour_high = -INFINITY;
+                    bounded_hour_low = INFINITY;
+                    bounded_hour_has_price = false;
+                    for (int hour_k = max(seed_k, next_window_start);
+                            hour_k <= k && hour_k <= last_valid; ++hour_k) {
+                        const float hour_high = bars[hour_k * 5 + 0];
+                        const float hour_low = bars[hour_k * 5 + 1];
+                        if (isfinite(hour_high) && isfinite(hour_low)
+                                && hour_high > 0.0f && hour_low > 0.0f) {
+                            bounded_hour_high = fmax(
+                                bounded_hour_high, hour_high
+                            );
+                            bounded_hour_low = fmin(
+                                bounded_hour_low, hour_low
+                            );
+                            bounded_hour_has_price = true;
+                        }
+                    }
+                }
             } else {
                 hour_valid = false;
-            }
-            if (k <= last_valid && isfinite(high) && isfinite(low)
-                    && high > 0.0f && low > 0.0f) {
-                bounded_hour_high = fmax(bounded_hour_high, high);
-                bounded_hour_low = fmin(bounded_hour_low, low);
-                bounded_hour_has_price = true;
+                if (k <= last_valid && isfinite(high) && isfinite(low)
+                        && high > 0.0f && low > 0.0f) {
+                    bounded_hour_high = fmax(bounded_hour_high, high);
+                    bounded_hour_low = fmin(bounded_hour_low, low);
+                    bounded_hour_has_price = true;
+                }
             }
         }
 #endif

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -1815,6 +1815,9 @@ inline void passivbot_single_coin_impl(
     const int P = sizes[3];
     const int first_valid = sizes[4];
     const int last_valid = sizes[7];
+    const int bounded_history_start = sizes[10];
+    const int bounded_trade_start = sizes[11];
+    const bool recent_history_window = bounded_history_start >= 0;
 #ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
     const int recovery_stride = sizes[8];
     const int recovery_sample_count = sizes[9];
@@ -1858,7 +1861,9 @@ inline void passivbot_single_coin_impl(
     const float log_bin_scale = 127.0f / log(4000001.0f);
 
     const int po = int(b) * P;
-    const int seed_k = clamp(first_valid, 0, T - 1);
+    const int seed_k = recent_history_window
+        ? clamp(bounded_history_start, 0, T - 1)
+        : clamp(first_valid, 0, T - 1);
     const float seed_close = bars[seed_k * 5 + 2];
     TmSide long_side = load_side(params, po, seed_close);
     TmSide short_side = load_side(params, po + SIDE_PARAMS, seed_close);
@@ -1955,7 +1960,7 @@ inline void passivbot_single_coin_impl(
     float hsl_tier_samples_red = 0.0f;
 #endif
 
-    int cur_day = flags[2];
+    int cur_day = flags[seed_k * 11 + 2];
     bool day_touched = false;
     float day_end = 0.0f;
     float day_min = INFINITY;
@@ -1974,7 +1979,8 @@ inline void passivbot_single_coin_impl(
     );
 #endif
 
-    for (int k = 1; k < T - 1; ++k) {
+    const int loop_start = recent_history_window ? max(seed_k + 1, 1) : 1;
+    for (int k = loop_start; k < T - 1; ++k) {
         const int bo = k * 5;
         const int fo = k * 11;
         const float high = bars[bo + 0];
@@ -1985,7 +1991,8 @@ inline void passivbot_single_coin_impl(
         const float hour_lr = bars[bo + 4];
 #endif
         const bool valid = flags[fo + 0] != 0;
-        const bool can_gen = flags[fo + 1] != 0;
+        const bool can_gen = flags[fo + 1] != 0
+            && (!recent_history_window || k >= bounded_trade_start);
         const int di = flags[fo + 2];
 #if !PASSIVBOT_TM_VOLATILITY_DISABLED
         const bool hour_valid = flags[fo + 3] != 0;

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -1820,7 +1820,8 @@ inline void passivbot_single_coin_impl(
     const bool recent_history_window = bounded_history_start >= 0;
 #ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
     const int recovery_stride = sizes[8];
-    const int recovery_sample_count = sizes[9];
+    const int recovery_sample_capacity = sizes[9];
+    const int recovery_sample_count = sizes[12];
 #endif
     if (b >= uint(B)) return;
 
@@ -1979,6 +1980,25 @@ inline void passivbot_single_coin_impl(
     );
 #endif
 
+#if !PASSIVBOT_TM_VOLATILITY_DISABLED
+    float bounded_hour_high = -INFINITY;
+    float bounded_hour_low = INFINITY;
+    float bounded_hour_latest = 0.0f;
+    bool bounded_hour_has_price = false;
+    bool bounded_hour_latest_valid = false;
+    int bounded_hour_start_k = seed_k;
+    if (recent_history_window && seed_k <= last_valid) {
+        const float seed_high = bars[seed_k * 5 + 0];
+        const float seed_low = bars[seed_k * 5 + 1];
+        if (isfinite(seed_high) && isfinite(seed_low)
+                && seed_high > 0.0f && seed_low > 0.0f) {
+            bounded_hour_high = seed_high;
+            bounded_hour_low = seed_low;
+            bounded_hour_has_price = true;
+        }
+    }
+#endif
+
     const int loop_start = recent_history_window ? max(seed_k + 1, 1) : 1;
     for (int k = loop_start; k < T - 1; ++k) {
         const int bo = k * 5;
@@ -1988,14 +2008,41 @@ inline void passivbot_single_coin_impl(
         const float close = bars[bo + 2];
 #if !PASSIVBOT_TM_VOLATILITY_DISABLED
         const float log_range = bars[bo + 3];
-        const float hour_lr = bars[bo + 4];
+        float hour_lr = bars[bo + 4];
 #endif
         const bool valid = flags[fo + 0] != 0;
         const bool can_gen = flags[fo + 1] != 0
             && (!recent_history_window || k >= bounded_trade_start);
         const int di = flags[fo + 2];
 #if !PASSIVBOT_TM_VOLATILITY_DISABLED
-        const bool hour_valid = flags[fo + 3] != 0;
+        const int hour_flags = flags[fo + 3];
+        bool hour_valid = (hour_flags & 1) != 0;
+        if (recent_history_window) {
+            const bool hour_boundary = (hour_flags & 2) != 0;
+            if (hour_boundary) {
+                if (k > bounded_hour_start_k + 1 && bounded_hour_has_price
+                        && bounded_hour_high > 0.0f && bounded_hour_low > 0.0f) {
+                    bounded_hour_latest = log(
+                        bounded_hour_high / bounded_hour_low
+                    );
+                    bounded_hour_latest_valid = isfinite(bounded_hour_latest);
+                }
+                hour_lr = bounded_hour_latest;
+                hour_valid = bounded_hour_latest_valid;
+                bounded_hour_start_k = k;
+                bounded_hour_high = -INFINITY;
+                bounded_hour_low = INFINITY;
+                bounded_hour_has_price = false;
+            } else {
+                hour_valid = false;
+            }
+            if (k <= last_valid && isfinite(high) && isfinite(low)
+                    && high > 0.0f && low > 0.0f) {
+                bounded_hour_high = fmax(bounded_hour_high, high);
+                bounded_hour_low = fmin(bounded_hour_low, low);
+                bounded_hour_has_price = true;
+            }
+        }
 #endif
         const int high_fill_max_tick = flags[fo + 4];
         const int low_nonfill_max_tick = flags[fo + 5];
@@ -3967,7 +4014,7 @@ inline void passivbot_single_coin_impl(
             // A bounded rolling-PnL overflow invalidates the proxy candidate.
             // The postprocessor maps this impossible equity to the maximum
             // bounded duration for every minimized recovery statistic.
-            recovery_samples[int(b) * recovery_sample_count]
+            recovery_samples[int(b) * recovery_sample_capacity]
                 = RECOVERY_FAIL_CLOSED_SENTINEL;
 #endif
             balance = 0.0f;
@@ -4192,7 +4239,7 @@ inline void passivbot_single_coin_impl(
 #ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
             if (recovery_stride > 0 && recovery_start_k < 0) {
                 recovery_start_k = k;
-                recovery_samples[int(b) * recovery_sample_count] = eqf;
+                recovery_samples[int(b) * recovery_sample_capacity] = eqf;
             } else if (recovery_stride > 0) {
                 const int recovery_elapsed = k - recovery_start_k;
                 const bool recovery_terminal = liq || k == T - 2;
@@ -4203,7 +4250,7 @@ inline void passivbot_single_coin_impl(
                         : recovery_elapsed / recovery_stride;
                     if (sample_index < recovery_sample_count) {
                         recovery_samples[
-                            int(b) * recovery_sample_count + sample_index
+                            int(b) * recovery_sample_capacity + sample_index
                         ] = eqf;
                     }
                 }

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -1039,6 +1039,7 @@ def _resolve_options(config: dict) -> dict:
             "optimize.gpu.successive_halving.history_fractions must be strictly "
             "increasing finite values in (0, 1] ending at 1.0"
         )
+    fractions[-1] = 1.0
     survival_fraction = float(halving["survival_fraction"])
     if not math.isfinite(survival_fraction) or not 0.0 < survival_fraction <= 1.0:
         raise ValueError(

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -2223,7 +2223,7 @@ def _evaluate_successive_halving(
     interrupt_check: InterruptCheck,
     stage_callback=None,
 ) -> tuple[list[dict], np.ndarray, np.ndarray, np.ndarray, list[dict]]:
-    """Evaluate progressively longer prefixes and return full-rung eligibility."""
+    """Evaluate progressively longer history windows and return full-rung eligibility."""
 
     active = np.arange(len(candidates), dtype=np.int64)
     metric_rows: list[dict | None] = [None] * len(candidates)
@@ -3979,12 +3979,16 @@ def run_backend(
         profile_proxies = [proxy]
 
         def evaluate_proxy(candidates, *, history_fraction=1.0):
-            end_step = (
-                proxy.end_step_for_history_fraction(history_fraction)
-                if float(history_fraction) < 1.0
-                else None
-            )
-            return proxy.evaluate(candidates, end_step=end_step)
+            if float(history_fraction) < 1.0:
+                history_start, trade_start = (
+                    proxy.recent_window_for_history_fraction(history_fraction)
+                )
+                return proxy.evaluate(
+                    candidates,
+                    history_start_step=history_start,
+                    trade_start_step=trade_start,
+                )
+            return proxy.evaluate(candidates)
 
     active_low = np.asarray(
         [bound.low for _name, _index, bound in active], dtype=np.float64
@@ -4121,7 +4125,12 @@ def run_backend(
             sig_digits=sig_digits,
             algorithm_contract=algorithm_contract,
             proxy_evaluation_policy=(
-                halving_policy if halving_policy["enabled"] else None
+                {
+                    **halving_policy,
+                    "history_window": "recent_suffix_v1",
+                }
+                if halving_policy["enabled"]
+                else None
             ),
         ),
     )

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -2810,16 +2810,36 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
             self.hsl_raw_tail_enabled = False
 
     def _encode_hour_boundary_flags(self) -> None:
+        first_ts_ms = int(self.run_config.first_ts_ms)
+        interval_ms = int(self.run_config.interval_ms)
         derived_timestamps = (
-            int(self.run_config.first_ts_ms)
-            + np.arange(self.n, dtype=np.int64)
-            * int(self.run_config.interval_ms)
+            first_ts_ms + np.arange(self.n, dtype=np.int64) * interval_ms
         )
         hour_indices = derived_timestamps // 3_600_000
-        hour_boundaries = np.zeros(self.n, dtype=np.int32)
-        hour_boundaries[1:] = hour_indices[1:] > hour_indices[:-1]
+        boundary_indices = np.flatnonzero(
+            np.r_[False, hour_indices[1:] > hour_indices[:-1]]
+        )
+        hour_boundary_bits = np.zeros(self.n, dtype=np.int32)
+        last_hour_boundary_ms = (first_ts_ms // 3_600_000) * 3_600_000
+        for step in boundary_indices:
+            current_ts_ms = int(derived_timestamps[step])
+            window_start_ms = max(first_ts_ms, last_hour_boundary_ms)
+            window_ready = current_ts_ms > window_start_ms + interval_ms
+            current_hour_boundary_ms = (
+                current_ts_ms // 3_600_000
+            ) * 3_600_000
+            next_window_start = max(
+                0,
+                (current_hour_boundary_ms - first_ts_ms) // interval_ms,
+            )
+            hour_boundary_bits[step] = (
+                2
+                | (4 if window_ready else 0)
+                | (8 if next_window_start < step else 0)
+            )
+            last_hour_boundary_ms = current_hour_boundary_ms
         boundary_bits = torch.as_tensor(
-            hour_boundaries * 2, dtype=torch.int32, device="mps"
+            hour_boundary_bits, dtype=torch.int32, device="mps"
         )
         self.flags[:, 3].bitwise_or_(boundary_bits)
 
@@ -2967,6 +2987,27 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
                     "recent-history MPS steps must satisfy 0 <= history start < "
                     "trade start < end_step - 1"
                 )
+            interval_ms = int(self.run_config.interval_ms)
+            first_ts_ms = int(self.run_config.first_ts_ms)
+            seed_ts_ms = first_ts_ms + history_start_step * interval_ms
+            next_hour_ms = (seed_ts_ms // 3_600_000 + 1) * 3_600_000
+            first_hour_step = min(
+                effective_end_step,
+                int(np.ceil((next_hour_ms - first_ts_ms) / interval_ms)),
+            )
+            first_hour_ts_ms = first_ts_ms + first_hour_step * interval_ms
+            first_hour_ready = int(
+                first_hour_step < effective_end_step
+                and first_hour_ts_ms > seed_ts_ms + interval_ms
+            )
+            first_hour_boundary_ms = (
+                first_hour_ts_ms // 3_600_000
+            ) * 3_600_000
+            first_next_window_start = max(
+                history_start_step,
+                history_start_step
+                + (first_hour_boundary_ms - seed_ts_ms) // interval_ms,
+            )
             recovery_sample_count = (
                 min(
                     self.n_recovery_samples,
@@ -2987,6 +3028,9 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
         else:
             history_start_step = -1
             trade_start_step = -1
+            first_hour_step = -1
+            first_hour_ready = 0
+            first_next_window_start = -1
             recovery_sample_count = (
                 self.n_recovery_samples
                 if self.recovery_distribution_enabled
@@ -3001,6 +3045,9 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
                 history_start_step,
                 trade_start_step,
                 recovery_sample_count,
+                first_hour_step,
+                first_hour_ready,
+                first_next_window_start,
             ]
         )
         return values

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -2784,6 +2784,7 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
+        self._encode_hour_boundary_flags()
         self.hsl_diagnostics_enabled = bool(hsl_diagnostics_enabled)
         if not self.hsl_diagnostics_enabled and (
             self.hsl_ema_tail_enabled
@@ -2807,6 +2808,20 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
             self.hsl_ema_tail_enabled = False
             self.hsl_raw_drawdown_enabled = False
             self.hsl_raw_tail_enabled = False
+
+    def _encode_hour_boundary_flags(self) -> None:
+        derived_timestamps = (
+            int(self.run_config.first_ts_ms)
+            + np.arange(self.n, dtype=np.int64)
+            * int(self.run_config.interval_ms)
+        )
+        hour_indices = derived_timestamps // 3_600_000
+        hour_boundaries = np.zeros(self.n, dtype=np.int32)
+        hour_boundaries[1:] = hour_indices[1:] > hour_indices[:-1]
+        boundary_bits = torch.as_tensor(
+            hour_boundaries * 2, dtype=torch.int32, device="mps"
+        )
+        self.flags[:, 3].bitwise_or_(boundary_bits)
 
     def _shader_library(self):
         loader, args = self._shader_library_cache_call()
@@ -2952,25 +2967,42 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
                     "recent-history MPS steps must satisfy 0 <= history start < "
                     "trade start < end_step - 1"
                 )
-            if self.recovery_distribution_enabled:
-                values[9] = max(
-                    1,
-                    int(
-                        np.ceil(
-                            (effective_end_step - trade_start_step)
-                            / self.recovery_stride
+            recovery_sample_count = (
+                min(
+                    self.n_recovery_samples,
+                    max(
+                        1,
+                        int(
+                            np.ceil(
+                                (effective_end_step - trade_start_step)
+                                / self.recovery_stride
+                            )
                         )
-                    )
-                    + 1,
+                        + 1,
+                    ),
                 )
+                if self.recovery_distribution_enabled
+                else 0
+            )
         else:
             history_start_step = -1
             trade_start_step = -1
+            recovery_sample_count = (
+                self.n_recovery_samples
+                if self.recovery_distribution_enabled
+                else 0
+            )
         # Reserve the existing recovery ABI slots even when that feature is
         # compiled out, then append the recent-window fields at fixed indices.
         if not self.recovery_distribution_enabled:
             values.extend([0, 0])
-        values.extend([history_start_step, trade_start_step])
+        values.extend(
+            [
+                history_start_step,
+                trade_start_step,
+                recovery_sample_count,
+            ]
+        )
         return values
 
     def run(
@@ -3016,15 +3048,18 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
         )
         effective_recovery_sample_count = self.n_recovery_samples
         if self.recovery_distribution_enabled and effective_trade_start >= 0:
-            effective_recovery_sample_count = max(
-                1,
-                int(
-                    np.ceil(
-                        (effective_end_step - effective_trade_start)
-                        / self.recovery_stride
+            effective_recovery_sample_count = min(
+                self.n_recovery_samples,
+                max(
+                    1,
+                    int(
+                        np.ceil(
+                            (effective_end_step - effective_trade_start)
+                            / self.recovery_stride
+                        )
                     )
-                )
-                + 1,
+                    + 1,
+                ),
             )
         sizes_key = (
             batch_size,

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -2925,12 +2925,62 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
             scaled, TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS, sides=2
         )
 
+    def _trailing_single_coin_size_values(
+        self,
+        batch_size: int,
+        parameter_count: int,
+        *,
+        end_step: int | None = None,
+        history_start_step: int | None = None,
+        trade_start_step: int | None = None,
+    ) -> list[int]:
+        values = self._single_coin_size_values(
+            batch_size, parameter_count, end_step=end_step
+        )
+        effective_end_step = self.n if end_step is None else int(end_step)
+        bounded = history_start_step is not None or trade_start_step is not None
+        if bounded and (history_start_step is None or trade_start_step is None):
+            raise ValueError(
+                "recent-history MPS dispatch requires both history_start_step "
+                "and trade_start_step"
+            )
+        if bounded:
+            history_start_step = int(history_start_step)
+            trade_start_step = int(trade_start_step)
+            if not 0 <= history_start_step < trade_start_step < effective_end_step - 1:
+                raise ValueError(
+                    "recent-history MPS steps must satisfy 0 <= history start < "
+                    "trade start < end_step - 1"
+                )
+            if self.recovery_distribution_enabled:
+                values[9] = max(
+                    1,
+                    int(
+                        np.ceil(
+                            (effective_end_step - trade_start_step)
+                            / self.recovery_stride
+                        )
+                    )
+                    + 1,
+                )
+        else:
+            history_start_step = -1
+            trade_start_step = -1
+        # Reserve the existing recovery ABI slots even when that feature is
+        # compiled out, then append the recent-window fields at fixed indices.
+        if not self.recovery_distribution_enabled:
+            values.extend([0, 0])
+        values.extend([history_start_step, trade_start_step])
+        return values
+
     def run(
         self,
         params: np.ndarray,
         *,
         profile: bool = False,
         end_step: int | None = None,
+        history_start_step: int | None = None,
+        trade_start_step: int | None = None,
     ) -> dict:
         started = time.perf_counter() if profile else 0.0
         matrix = self._pack_params(params)
@@ -2958,12 +3008,38 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
             batch_size
         )
         effective_end_step = self.n if end_step is None else int(end_step)
-        sizes_key = (batch_size, int(matrix.shape[1]), effective_end_step)
+        effective_history_start = (
+            -1 if history_start_step is None else int(history_start_step)
+        )
+        effective_trade_start = (
+            -1 if trade_start_step is None else int(trade_start_step)
+        )
+        effective_recovery_sample_count = self.n_recovery_samples
+        if self.recovery_distribution_enabled and effective_trade_start >= 0:
+            effective_recovery_sample_count = max(
+                1,
+                int(
+                    np.ceil(
+                        (effective_end_step - effective_trade_start)
+                        / self.recovery_stride
+                    )
+                )
+                + 1,
+            )
+        sizes_key = (
+            batch_size,
+            int(matrix.shape[1]),
+            effective_end_step,
+            effective_history_start,
+            effective_trade_start,
+        )
         if sizes_key not in self._sizes:
-            size_values = self._single_coin_size_values(
+            size_values = self._trailing_single_coin_size_values(
                 batch_size,
                 int(matrix.shape[1]),
                 end_step=effective_end_step,
+                history_start_step=history_start_step,
+                trade_start_step=trade_start_step,
             )
             self._sizes[sizes_key] = torch.tensor(
                 size_values,
@@ -3020,7 +3096,8 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
                 "batch_size": batch_size,
                 "dispatch_count": 1,
                 "cold": cold,
-                "effective_candle_count": effective_end_step,
+                "effective_candle_count": effective_end_step
+                - max(0, effective_history_start),
                 "dispatch_specialization": {
                     "trailing_entry_only": dispatch_features[0],
                     "trailing_close_only": dispatch_features[1],
@@ -3040,7 +3117,9 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
             )
         )
         if self.recovery_distribution_enabled:
-            output["strategy_eq_recovery_samples"] = recovery_samples
+            output["strategy_eq_recovery_samples"] = recovery_samples[
+                :, :effective_recovery_sample_count
+            ]
             output["strategy_eq_recovery_sample_interval_days"] = (
                 self.recovery_stride * self.run_config.interval_ms / 86_400_000.0
             )

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -1976,6 +1976,13 @@ class MpsSingleCoinProxy:
             first_valid_idx=int(backtest_params["first_valid_indices"][0]),
             last_valid_idx=int(backtest_params["last_valid_indices"][0]),
         )
+        coin_warmup_minutes = int(
+            (backtest_params.get("warmup_minutes") or [0])[0]
+        )
+        self.history_warmup_bars = max(
+            int(self.run.warmup_bars),
+            int(np.ceil(coin_warmup_minutes / candle_interval_minutes)),
+        )
 
         high = hlcvs[:, 0, 0].astype(np.float64)
         low = hlcvs[:, 0, 1].astype(np.float64)
@@ -2098,29 +2105,46 @@ class MpsSingleCoinProxy:
             rows.append(row)
         return np.asarray(rows, dtype=np.float64)
 
-    def end_step_for_history_fraction(self, history_fraction: float) -> int:
-        """Map a prefix fraction to a safe candle boundary after warmup."""
+    def recent_window_for_history_fraction(
+        self, history_fraction: float
+    ) -> tuple[int, int]:
+        """Map a history fraction to warmup and trade starts for a recent suffix."""
 
         fraction = float(history_fraction)
         if not np.isfinite(fraction) or not 0.0 < fraction <= 1.0:
             raise ValueError("GPU history fraction must be finite and in (0, 1]")
         candle_count = int(self.runner.n)
-        effective_start = min(
-            candle_count,
-            max(
-                3,
-                int(self.run.trade_start_idx) + 2,
-                int(self.run.first_valid_idx) + 2,
+        full_trade_start = min(
+            candle_count - 3,
+            max(2, int(self.run.trade_start_idx), int(self.run.first_valid_idx) + 1),
+        )
+        suffix_candles = max(
+            2,
+            int(np.ceil((candle_count - full_trade_start) * fraction)),
+        )
+        trade_start = max(full_trade_start, candle_count - suffix_candles)
+        history_start = max(
+            int(self.run.first_valid_idx),
+            trade_start
+            - max(
+                1,
+                int(
+                    getattr(
+                        self, "history_warmup_bars", self.run.warmup_bars
+                    )
+                ),
             ),
         )
-        return min(
-            candle_count,
-            effective_start
-            + int(np.ceil((candle_count - effective_start) * fraction)),
-        )
+        history_start = min(history_start, trade_start - 1)
+        return history_start, trade_start
 
     def evaluate(
-        self, candidates: list[dict], *, end_step: int | None = None
+        self,
+        candidates: list[dict],
+        *,
+        end_step: int | None = None,
+        history_start_step: int | None = None,
+        trade_start_step: int | None = None,
     ) -> list[dict]:
         results: list[dict] = []
         torch = self._torch
@@ -2142,15 +2166,37 @@ class MpsSingleCoinProxy:
                 "GPU single-coin end_step must be between 3 and the full candle "
                 f"count {full_candle_count}, got {effective_end_step}"
             )
+        bounded_history = (
+            history_start_step is not None or trade_start_step is not None
+        )
+        if bounded_history and (
+            history_start_step is None or trade_start_step is None
+        ):
+            raise ValueError(
+                "GPU recent-history evaluation requires both history and trade starts"
+            )
+        if bounded_history and self.strategy_kind != "trailing_martingale":
+            raise ValueError(
+                "GPU recent-history evaluation currently requires trailing_martingale"
+            )
+        effective_history_start = (
+            0 if history_start_step is None else int(history_start_step)
+        )
+        effective_trade_start = (
+            int(trade_start_step) if bounded_history else 0
+        )
+        effective_candle_count = effective_end_step - effective_history_start
+        if effective_candle_count < 3:
+            raise ValueError("GPU recent-history evaluation requires at least 3 candles")
         side_count = int(bool(getattr(self.runner, "long_enabled", True))) + int(
             bool(getattr(self.runner, "short_enabled", False))
         )
         dispatch_batch_size = (
             int(getattr(self, "dispatch_batch_size", self.batch_size))
-            if end_step is None
+            if end_step is None and not bounded_history
             else _mps_dispatch_batch_size(
                 self.batch_size,
-                n_bars=effective_end_step,
+                n_bars=effective_candle_count,
                 n_sides=side_count,
             )
         )
@@ -2162,7 +2208,7 @@ class MpsSingleCoinProxy:
                 (self.runner,),
                 coin_count=1,
                 side_count=side_count,
-                candle_count=effective_end_step,
+                candle_count=effective_candle_count,
                 dispatch_batch_size=dispatch_batch_size,
             )
             if self.profile_enabled
@@ -2187,18 +2233,23 @@ class MpsSingleCoinProxy:
                 profile["timings_seconds"]["candidate_materialization"] += (
                     time.perf_counter() - stage_started
                 )
-            output = self.runner.run(
-                parameter_matrix,
-                profile=self.profile_enabled,
-                end_step=effective_end_step,
-            )
+            runner_kwargs = {
+                "profile": self.profile_enabled,
+                "end_step": effective_end_step,
+            }
+            if bounded_history:
+                runner_kwargs.update(
+                    history_start_step=effective_history_start,
+                    trade_start_step=effective_trade_start,
+                )
+            output = self.runner.run(parameter_matrix, **runner_kwargs)
             if profile is not None:
                 _add_gpu_runner_profile(
                     profile,
                     self.runner,
                     side_count=profile["side_count"],
                     effective_candidate_steps=np.full(
-                        len(chunk), effective_end_step, dtype=np.int64
+                        len(chunk), effective_candle_count, dtype=np.int64
                     ),
                 )
             interrupt_check()
@@ -2266,9 +2317,21 @@ class MpsSingleCoinProxy:
                         torch=torch,
                     )
                 )
+            metrics_run = self.run
+            if bounded_history:
+                requested_start_ts_ms = int(
+                    self.metrics_data["ts0"]
+                    + effective_trade_start * self.run.interval_ms
+                )
+                metrics_run = replace(
+                    self.run,
+                    trade_start_idx=effective_trade_start,
+                    requested_start_ts_ms=requested_start_ts_ms,
+                    guard_ts_ms=requested_start_ts_ms,
+                )
             objectives = self._compute_objectives(
                 output,
-                self.run,
+                metrics_run,
                 {**self.metrics_data, "n": effective_end_step},
                 needed=self.needed_metrics,
             )

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -2128,11 +2128,7 @@ class MpsSingleCoinProxy:
         )
         full_trade_start = min(
             candle_count - 3,
-            max(
-                2,
-                int(self.run.trade_start_idx),
-                int(self.run.first_valid_idx) + warmup_readiness_bars + 1,
-            ),
+            max(2, int(self.run.trade_start_idx), int(self.run.first_valid_idx) + 1),
         )
         suffix_candles = max(
             2,

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -2114,9 +2114,19 @@ class MpsSingleCoinProxy:
         if not np.isfinite(fraction) or not 0.0 < fraction <= 1.0:
             raise ValueError("GPU history fraction must be finite and in (0, 1]")
         candle_count = int(self.runner.n)
+        warmup_readiness_bars = max(
+            1,
+            int(
+                getattr(self, "history_warmup_bars", self.run.warmup_bars)
+            ),
+        )
         full_trade_start = min(
             candle_count - 3,
-            max(2, int(self.run.trade_start_idx), int(self.run.first_valid_idx) + 1),
+            max(
+                2,
+                int(self.run.trade_start_idx),
+                int(self.run.first_valid_idx) + warmup_readiness_bars + 1,
+            ),
         )
         suffix_candles = max(
             2,
@@ -2125,15 +2135,7 @@ class MpsSingleCoinProxy:
         trade_start = max(full_trade_start, candle_count - suffix_candles)
         history_start = max(
             int(self.run.first_valid_idx),
-            trade_start
-            - max(
-                1,
-                int(
-                    getattr(
-                        self, "history_warmup_bars", self.run.warmup_bars
-                    )
-                ),
-            ),
+            trade_start - warmup_readiness_bars - 1,
         )
         history_start = min(history_start, trade_start - 1)
         return history_start, trade_start

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -374,6 +374,7 @@ def _add_gpu_terminal_profile(
     output: dict,
     *,
     interval_ms: int,
+    effective_start_step: int = 0,
     effective_end_step: int,
 ) -> None:
     """Estimate work after irreversible single-coin candidate termination."""
@@ -396,15 +397,20 @@ def _add_gpu_terminal_profile(
     if np.any(finite):
         estimated_steps[finite] = np.rint(
             terminal_last_eq[finite] / max(1, int(interval_ms))
-        ).astype(np.int64)
-    estimated_steps = np.clip(estimated_steps, 1, max(1, effective_end_step - 2))
+        ).astype(np.int64) - int(effective_start_step)
+    effective_step_count = max(
+        1, int(effective_end_step) - int(effective_start_step)
+    )
+    estimated_steps = np.clip(
+        estimated_steps, 1, max(1, effective_step_count - 2)
+    )
     profile["terminal_candidate_count"] += terminal_count
     profile["terminal_without_equity_count"] += int((~finite).sum())
     profile["estimated_post_terminal_candidate_bars"] += int(
-        np.maximum(effective_end_step - 2 - estimated_steps, 0).sum()
+        np.maximum(effective_step_count - 2 - estimated_steps, 0).sum()
     ) * int(profile.get("side_count", 1))
     profile["_terminal_step_fractions"].extend(
-        (estimated_steps / max(1, effective_end_step - 2)).tolist()
+        (estimated_steps / max(1, effective_step_count - 2)).tolist()
     )
 
 
@@ -2288,6 +2294,7 @@ class MpsSingleCoinProxy:
                     profile,
                     output,
                     interval_ms=int(self.run.interval_ms),
+                    effective_start_step=effective_history_start,
                     effective_end_step=effective_end_step,
                 )
             timestamp_origin = float(self.metrics_data["ts0"])

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -371,6 +371,16 @@ def test_gpu_successive_halving_options_are_opt_in_and_fail_closed():
     with pytest.raises(ValueError, match="strictly increasing"):
         _resolve_options(config)
 
+    config = _long_only_ema_config()
+    config["optimize"]["gpu"]["successive_halving"] = {
+        "enabled": True,
+        "history_fractions": [0.25, 0.5, 0.999_999_999_999_5],
+    }
+    assert _resolve_options(config)["successive_halving"][
+        "history_fractions"
+    ] == [0.25, 0.5, 1.0]
+
+    config = _long_only_ema_config()
     config["optimize"]["gpu"]["successive_halving"] = {
         "enabled": True,
         "min_survivors": 7,

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -6432,10 +6432,12 @@ def test_gpu_checkpoint_signature_tracks_full_fixed_search_contract():
         proxy_evaluation_policy={
             "enabled": False,
             "history_fractions": [0.25, 0.5, 1.0],
+            "history_window": "recent_suffix_v1",
         },
     )
     assert contract["version"] == 2
     assert contract["proxy_evaluation"]["enabled"] is False
+    assert contract["proxy_evaluation"]["history_window"] == "recent_suffix_v1"
     ordinary_contract = _gpu_search_checkpoint_contract(
         key_paths=key_paths,
         bounds=bounds,
@@ -6476,6 +6478,11 @@ def test_gpu_checkpoint_signature_tracks_full_fixed_search_contract():
     changed_proxy_policy = copy.deepcopy(contract)
     changed_proxy_policy["proxy_evaluation"]["enabled"] = True
     mutations.append(changed_proxy_policy)
+    changed_history_window = copy.deepcopy(contract)
+    changed_history_window["proxy_evaluation"]["history_window"] = (
+        "historical_prefix_v1"
+    )
+    mutations.append(changed_history_window)
 
     assert all(
         _checkpoint_signature(active, scoring, search_contract=changed)

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -795,13 +795,23 @@ def test_mps_tm_hsl_diagnostic_opt_out_preserves_strategy_outputs():
 @pytest.mark.skipif(
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
-def test_mps_tm_history_window_preserves_full_run_and_selects_recent_suffix():
+@pytest.mark.parametrize(
+    ("interval_ms", "history_start_step", "trade_start_step"),
+    [
+        (60_000, 59, 80),
+        (45 * 60_000, 1, 4),
+    ],
+)
+def test_mps_tm_history_window_preserves_full_run_and_selects_recent_suffix(
+    interval_ms, history_start_step, trade_start_step
+):
     count = 120
     steps = np.arange(count, dtype=np.float64)
     close = 100.0 + np.sin(steps / 7.0)
     high = close + 0.2
     low = close - 0.2
-    timestamps = 1_700_000_000_000 + steps.astype(np.int64) * 60_000
+    first_ts_ms = (1_700_000_000_000 // 3_600_000) * 3_600_000
+    timestamps = first_ts_ms + steps.astype(np.int64) * interval_ms
     market = ProxyMarket(0.001, 0.01, 0.001, 0.0, 1.0, 0.0)
     run = ProxyRun(
         1_000.0,
@@ -810,7 +820,7 @@ def test_mps_tm_history_window_preserves_full_run_and_selects_recent_suffix():
         int(timestamps[0]),
         int(timestamps[0]),
         int(timestamps[0]),
-        60_000,
+        interval_ms,
         0.05,
         0,
         count - 1,
@@ -845,23 +855,28 @@ def test_mps_tm_history_window_preserves_full_run_and_selects_recent_suffix():
     explicit_full = run_once(count)
     truncated = run_once(60)
     recent = run_once(
-        history_start_step=59,
-        trade_start_step=80,
+        history_start_step=history_start_step,
+        trade_start_step=trade_start_step,
     )
     sliced_run = ProxyRun(
         1_000.0,
-        20,
-        21,
-        int(timestamps[80]),
-        int(timestamps[80]),
-        int(timestamps[59]),
-        60_000,
+        trade_start_step - history_start_step - 1,
+        trade_start_step - history_start_step,
+        int(timestamps[trade_start_step]),
+        int(timestamps[trade_start_step]),
+        int(timestamps[history_start_step]),
+        interval_ms,
         0.05,
         0,
-        count - 60,
+        count - history_start_step - 1,
     )
     sliced_data = build_mps_data(
-        high[59:], low[59:], close[59:], timestamps[59:], sliced_run, market
+        high[history_start_step:],
+        low[history_start_step:],
+        close[history_start_step:],
+        timestamps[history_start_step:],
+        sliced_run,
+        market,
     )
     sliced = MpsTrailingMartingaleRunner(
         market,
@@ -881,7 +896,7 @@ def test_mps_tm_history_window_preserves_full_run_and_selects_recent_suffix():
                 equal_nan=True,
             )
     assert truncated["last_eq_ts"][0].item() < ordinary["last_eq_ts"][0].item()
-    assert recent["first_eq_ts"][0].item() == 80 * 60_000
+    assert recent["first_eq_ts"][0].item() == trade_start_step * interval_ms
     assert recent["last_eq_ts"][0].item() == ordinary["last_eq_ts"][0].item()
     for key in (
         "balance",
@@ -904,10 +919,10 @@ def test_mps_tm_history_window_preserves_full_run_and_selects_recent_suffix():
         equal_nan=True,
     )
     assert recent["first_eq_ts"][0].item() == (
-        sliced["first_eq_ts"][0].item() + 59 * 60_000
+        sliced["first_eq_ts"][0].item() + history_start_step * interval_ms
     )
     assert recent["last_eq_ts"][0].item() == (
-        sliced["last_eq_ts"][0].item() + 59 * 60_000
+        sliced["last_eq_ts"][0].item() + history_start_step * interval_ms
     )
 
 
@@ -982,11 +997,17 @@ def test_tm_size_buffer_appends_recent_window_after_recovery_fields(
         -1,
         -1,
         10 if recovery_enabled else 0,
+        -1,
+        0,
+        -1,
     ]
     assert recent == [5, 17, 2, 13, 3, 9, 7, 11] + recovery + [
         5,
         10,
         5 if recovery_enabled else 0,
+        17,
+        0,
+        5,
     ]
     with pytest.raises(ValueError, match="requires both"):
         runner._trailing_single_coin_size_values(

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -617,6 +617,11 @@ def test_trailing_martingale_no_hsl_specialization_keeps_base_scalar_abi(
         self.hsl_raw_tail_enabled = bool(kwargs["hsl_raw_tail_enabled"])
 
     monkeypatch.setattr(MpsEmaAnchorRunner, "__init__", fake_base_init)
+    monkeypatch.setattr(
+        MpsTrailingMartingaleRunner,
+        "_encode_hour_boundary_flags",
+        lambda self: None,
+    )
     runner = MpsTrailingMartingaleRunner(
         None,
         None,
@@ -651,6 +656,11 @@ def test_trailing_martingale_hsl_specialization_keeps_requested_features(
         self.hsl_raw_tail_enabled = bool(kwargs["hsl_raw_tail_enabled"])
 
     monkeypatch.setattr(MpsEmaAnchorRunner, "__init__", fake_base_init)
+    monkeypatch.setattr(
+        MpsTrailingMartingaleRunner,
+        "_encode_hour_boundary_flags",
+        lambda self: None,
+    )
     runner = MpsTrailingMartingaleRunner(
         None,
         None,
@@ -686,6 +696,11 @@ def test_trailing_martingale_hsl_specialization_disables_unrequested_diagnostics
         self.equity_balance_diff_enabled = False
 
     monkeypatch.setattr(MpsEmaAnchorRunner, "__init__", fake_base_init)
+    monkeypatch.setattr(
+        MpsTrailingMartingaleRunner,
+        "_encode_hour_boundary_flags",
+        lambda self: None,
+    )
     runner = MpsTrailingMartingaleRunner(
         None,
         None,
@@ -802,7 +817,12 @@ def test_mps_tm_history_window_preserves_full_run_and_selects_recent_suffix():
     )
     data = build_mps_data(high, low, close, timestamps, run, market)
     row = _tm_single_row(initial_ema_dist=0.0)
-    matrix = np.asarray([row + row], dtype=np.float64)
+    row_two = _tm_single_row(initial_ema_dist=0.002)
+    matrix = np.asarray([row + row, row_two + row_two], dtype=np.float64)
+    volatility_column = TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS.index(
+        "entry_threshold_volatility_1h_weight"
+    )
+    matrix[:, volatility_column] = [0.25, 0.5]
 
     def run_once(end_step=None, history_start_step=None, trade_start_step=None):
         runner = MpsTrailingMartingaleRunner(
@@ -812,6 +832,7 @@ def test_mps_tm_history_window_preserves_full_run_and_selects_recent_suffix():
             long_enabled=True,
             short_enabled=False,
             hsl_enabled=False,
+            recovery_distribution_enabled=True,
         )
         return runner.run(
             matrix,
@@ -849,6 +870,7 @@ def test_mps_tm_history_window_preserves_full_run_and_selects_recent_suffix():
         long_enabled=True,
         short_enabled=False,
         hsl_enabled=False,
+        recovery_distribution_enabled=True,
     ).run(matrix)
     torch.mps.synchronize()
 
@@ -858,9 +880,9 @@ def test_mps_tm_history_window_preserves_full_run_and_selects_recent_suffix():
                 ordinary[key], explicit_full[key], rtol=0.0, atol=0.0,
                 equal_nan=True,
             )
-    assert truncated["last_eq_ts"].item() < ordinary["last_eq_ts"].item()
-    assert recent["first_eq_ts"].item() == 80 * 60_000
-    assert recent["last_eq_ts"].item() == ordinary["last_eq_ts"].item()
+    assert truncated["last_eq_ts"][0].item() < ordinary["last_eq_ts"][0].item()
+    assert recent["first_eq_ts"][0].item() == 80 * 60_000
+    assert recent["last_eq_ts"][0].item() == ordinary["last_eq_ts"][0].item()
     for key in (
         "balance",
         "psize",
@@ -872,11 +894,20 @@ def test_mps_tm_history_window_preserves_full_run_and_selects_recent_suffix():
         "held_sum_ms",
     ):
         torch.testing.assert_close(recent[key], sliced[key], rtol=0.0, atol=0.0)
-    assert recent["first_eq_ts"].item() == (
-        sliced["first_eq_ts"].item() + 59 * 60_000
+    torch.testing.assert_close(
+        recent["strategy_eq_recovery_samples"],
+        sliced["strategy_eq_recovery_samples"][
+            :, : recent["strategy_eq_recovery_samples"].shape[1]
+        ],
+        rtol=0.0,
+        atol=0.0,
+        equal_nan=True,
     )
-    assert recent["last_eq_ts"].item() == (
-        sliced["last_eq_ts"].item() + 59 * 60_000
+    assert recent["first_eq_ts"][0].item() == (
+        sliced["first_eq_ts"][0].item() + 59 * 60_000
+    )
+    assert recent["last_eq_ts"][0].item() == (
+        sliced["last_eq_ts"][0].item() + 59 * 60_000
     )
 
 
@@ -936,7 +967,7 @@ def test_tm_size_buffer_appends_recent_window_after_recovery_fields(
     runner.pnl_lookback_bars = 7
     runner.recovery_distribution_enabled = recovery_enabled
     runner.recovery_stride = 2
-    runner.n_recovery_samples = 4
+    runner.n_recovery_samples = 10
 
     ordinary = runner._trailing_single_coin_size_values(5, 13)
     recent = runner._trailing_single_coin_size_values(
@@ -946,10 +977,17 @@ def test_tm_size_buffer_appends_recent_window_after_recovery_fields(
         trade_start_step=10,
     )
 
-    recovery = [2, 4] if recovery_enabled else [0, 0]
-    assert ordinary == [5, 17, 2, 13, 3, 9, 7, 11] + recovery + [-1, -1]
-    recent_recovery = [2, 5] if recovery_enabled else [0, 0]
-    assert recent == [5, 17, 2, 13, 3, 9, 7, 11] + recent_recovery + [5, 10]
+    recovery = [2, 10] if recovery_enabled else [0, 0]
+    assert ordinary == [5, 17, 2, 13, 3, 9, 7, 11] + recovery + [
+        -1,
+        -1,
+        10 if recovery_enabled else 0,
+    ]
+    assert recent == [5, 17, 2, 13, 3, 9, 7, 11] + recovery + [
+        5,
+        10,
+        5 if recovery_enabled else 0,
+    ]
     with pytest.raises(ValueError, match="requires both"):
         runner._trailing_single_coin_size_values(
             5, 13, history_start_step=5
@@ -969,6 +1007,11 @@ def test_trailing_martingale_runner_accepts_ordinary_market_execution(monkeypatc
         self.recovery_distribution_enabled = False
 
     monkeypatch.setattr(MpsEmaAnchorRunner, "__init__", fake_base_init)
+    monkeypatch.setattr(
+        MpsTrailingMartingaleRunner,
+        "_encode_hour_boundary_flags",
+        lambda self: None,
+    )
     runner = MpsTrailingMartingaleRunner(
         None, None, None, market_orders_allowed=True, hsl_enabled=False
     )

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -850,7 +850,7 @@ def test_mps_tm_history_window_preserves_full_run_and_selects_recent_suffix():
     )
     sliced_run = ProxyRun(
         1_000.0,
-        1,
+        20,
         21,
         int(timestamps[80]),
         int(timestamps[80]),

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -780,7 +780,7 @@ def test_mps_tm_hsl_diagnostic_opt_out_preserves_strategy_outputs():
 @pytest.mark.skipif(
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
-def test_mps_tm_end_step_preserves_full_run_and_truncates_only_the_horizon():
+def test_mps_tm_history_window_preserves_full_run_and_selects_recent_suffix():
     count = 120
     steps = np.arange(count, dtype=np.float64)
     close = 100.0 + np.sin(steps / 7.0)
@@ -804,7 +804,7 @@ def test_mps_tm_end_step_preserves_full_run_and_truncates_only_the_horizon():
     row = _tm_single_row(initial_ema_dist=0.0)
     matrix = np.asarray([row + row], dtype=np.float64)
 
-    def run_once(end_step=None):
+    def run_once(end_step=None, history_start_step=None, trade_start_step=None):
         runner = MpsTrailingMartingaleRunner(
             market,
             run,
@@ -813,11 +813,43 @@ def test_mps_tm_end_step_preserves_full_run_and_truncates_only_the_horizon():
             short_enabled=False,
             hsl_enabled=False,
         )
-        return runner.run(matrix, end_step=end_step)
+        return runner.run(
+            matrix,
+            end_step=end_step,
+            history_start_step=history_start_step,
+            trade_start_step=trade_start_step,
+        )
 
     ordinary = run_once()
     explicit_full = run_once(count)
     truncated = run_once(60)
+    recent = run_once(
+        history_start_step=59,
+        trade_start_step=80,
+    )
+    sliced_run = ProxyRun(
+        1_000.0,
+        1,
+        21,
+        int(timestamps[80]),
+        int(timestamps[80]),
+        int(timestamps[59]),
+        60_000,
+        0.05,
+        0,
+        count - 60,
+    )
+    sliced_data = build_mps_data(
+        high[59:], low[59:], close[59:], timestamps[59:], sliced_run, market
+    )
+    sliced = MpsTrailingMartingaleRunner(
+        market,
+        sliced_run,
+        sliced_data,
+        long_enabled=True,
+        short_enabled=False,
+        hsl_enabled=False,
+    ).run(matrix)
     torch.mps.synchronize()
 
     for key in ordinary:
@@ -827,6 +859,25 @@ def test_mps_tm_end_step_preserves_full_run_and_truncates_only_the_horizon():
                 equal_nan=True,
             )
     assert truncated["last_eq_ts"].item() < ordinary["last_eq_ts"].item()
+    assert recent["first_eq_ts"].item() == 80 * 60_000
+    assert recent["last_eq_ts"].item() == ordinary["last_eq_ts"].item()
+    for key in (
+        "balance",
+        "psize",
+        "pprice",
+        "fill_count",
+        "fill_count_entry",
+        "max_dd",
+        "held_max_ms",
+        "held_sum_ms",
+    ):
+        torch.testing.assert_close(recent[key], sliced[key], rtol=0.0, atol=0.0)
+    assert recent["first_eq_ts"].item() == (
+        sliced["first_eq_ts"].item() + 59 * 60_000
+    )
+    assert recent["last_eq_ts"].item() == (
+        sliced["last_eq_ts"].item() + 59 * 60_000
+    )
 
 
 @pytest.mark.parametrize("recovery_enabled", [False, True])
@@ -869,6 +920,40 @@ def test_single_coin_size_buffer_packs_last_valid_before_recovery_fields(
 
     with pytest.raises(ValueError, match="end_step"):
         runner._single_coin_size_values(5, 13, end_step=18)
+
+
+@pytest.mark.parametrize("recovery_enabled", [False, True])
+def test_tm_size_buffer_appends_recent_window_after_recovery_fields(
+    recovery_enabled,
+):
+    runner = object.__new__(MpsTrailingMartingaleRunner)
+    runner.n = 17
+    runner.n_days = 2
+    runner.run_config = ProxyRun(
+        1_000.0, 1, 1, 0, 0, 0, 60_000, 0.05, 3, 11
+    )
+    runner.rolling_capacity = 9
+    runner.pnl_lookback_bars = 7
+    runner.recovery_distribution_enabled = recovery_enabled
+    runner.recovery_stride = 2
+    runner.n_recovery_samples = 4
+
+    ordinary = runner._trailing_single_coin_size_values(5, 13)
+    recent = runner._trailing_single_coin_size_values(
+        5,
+        13,
+        history_start_step=5,
+        trade_start_step=10,
+    )
+
+    recovery = [2, 4] if recovery_enabled else [0, 0]
+    assert ordinary == [5, 17, 2, 13, 3, 9, 7, 11] + recovery + [-1, -1]
+    recent_recovery = [2, 5] if recovery_enabled else [0, 0]
+    assert recent == [5, 17, 2, 13, 3, 9, 7, 11] + recent_recovery + [5, 10]
+    with pytest.raises(ValueError, match="requires both"):
+        runner._trailing_single_coin_size_values(
+            5, 13, history_start_step=5
+        )
 
 
 def test_trailing_martingale_runner_accepts_ordinary_market_execution(monkeypatch):

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -513,20 +513,20 @@ def test_single_coin_proxy_recent_history_expands_safe_dispatch_and_routes_windo
         trade_start_step=trade_start,
     )
 
-    assert (history_start, trade_start) == (1_448_763, 1_448_863)
+    assert (history_start, trade_start) == (1_448_785, 1_448_886)
     assert len(results) == 1024
     assert [len(call) for call in calls] == [1024]
     assert routed_windows == [
         {
             "profile": False,
             "end_step": 1_931_815,
-            "history_start_step": 1_448_763,
-            "trade_start_step": 1_448_863,
+            "history_start_step": 1_448_785,
+            "trade_start_step": 1_448_886,
         }
     ]
     assert len(metric_runs) == 1
-    assert metric_runs[0].trade_start_idx == 1_448_863
-    assert metric_runs[0].requested_start_ts_ms == 1_448_863 * 60_000
+    assert metric_runs[0].trade_start_idx == 1_448_886
+    assert metric_runs[0].requested_start_ts_ms == 1_448_886 * 60_000
 
     proxy.runner.n = 1_250
     proxy.run = ProxyRun(
@@ -541,7 +541,7 @@ def test_single_coin_proxy_recent_history_expands_safe_dispatch_and_routes_windo
         900,
         1_249,
     )
-    assert proxy.recent_window_for_history_fraction(0.25) == (1_087, 1_187)
+    assert proxy.recent_window_for_history_fraction(0.25) == (1_086, 1_187)
 
 
 def test_single_coin_proxy_profile_records_dispatch_shape_and_timings(monkeypatch):

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -514,20 +514,20 @@ def test_single_coin_proxy_recent_history_expands_safe_dispatch_and_routes_windo
         trade_start_step=trade_start,
     )
 
-    assert (history_start, trade_start) == (1_448_785, 1_448_886)
+    assert (history_start, trade_start) == (1_448_762, 1_448_863)
     assert len(results) == 1024
     assert [len(call) for call in calls] == [1024]
     assert routed_windows == [
         {
             "profile": False,
             "end_step": 1_931_815,
-            "history_start_step": 1_448_785,
-            "trade_start_step": 1_448_886,
+            "history_start_step": 1_448_762,
+            "trade_start_step": 1_448_863,
         }
     ]
     assert len(metric_runs) == 1
-    assert metric_runs[0].trade_start_idx == 1_448_886
-    assert metric_runs[0].requested_start_ts_ms == 1_448_886 * 60_000
+    assert metric_runs[0].trade_start_idx == 1_448_863
+    assert metric_runs[0].requested_start_ts_ms == 1_448_863 * 60_000
 
     proxy.runner.n = 1_250
     proxy.run = ProxyRun(
@@ -542,6 +542,7 @@ def test_single_coin_proxy_recent_history_expands_safe_dispatch_and_routes_windo
         900,
         1_249,
     )
+    assert proxy.recent_window_for_history_fraction(1.0) == (900, 1_000)
     assert proxy.recent_window_for_history_fraction(0.25) == (1_086, 1_187)
 
 

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -11,6 +11,7 @@ from optimization.gpu.model import (
     EMA_ANCHOR_COIN_OVERRIDE_FORCED_ACTIVE_COLUMN,
     EMA_ANCHOR_MULTICOIN_PARAM_KEYS,
     EMA_ANCHOR_PARAM_KEYS,
+    ProxyRun,
     TRAILING_MARTINGALE_COIN_OVERRIDE_COLS,
     TRAILING_MARTINGALE_COIN_OVERRIDE_FORCED_ACTIVE_COLUMN,
     TRAILING_MARTINGALE_COIN_OVERRIDE_GATE_INITIAL_COLUMN,
@@ -469,35 +470,78 @@ def test_single_coin_proxy_preserves_order_across_bounded_dispatches():
     assert calls == [[0.0, 1.0], [2.0, 3.0], [4.0]]
 
 
-def test_single_coin_proxy_partial_history_expands_safe_dispatch_and_routes_end_step():
+def test_single_coin_proxy_recent_history_expands_safe_dispatch_and_routes_window():
     proxy, calls = _minimal_single_coin_proxy()
     proxy.batch_size = 4096
     proxy.dispatch_batch_size = 258
+    proxy.strategy_kind = "trailing_martingale"
     proxy.runner.n = 1_931_815
-    proxy.run = SimpleNamespace(trade_start_idx=10, first_valid_idx=0)
+    proxy.run = ProxyRun(
+        1_000.0,
+        100,
+        10,
+        0,
+        0,
+        0,
+        60_000,
+        0.05,
+        0,
+        1_931_814,
+    )
+    proxy.history_warmup_bars = 100
     original_run = proxy.runner.run
-    routed_end_steps = []
+    routed_windows = []
+    metric_runs = []
 
     def routed_run(parameters, **kwargs):
-        routed_end_steps.append(kwargs["end_step"])
+        routed_windows.append(dict(kwargs))
         return original_run(parameters, **kwargs)
 
     proxy.runner.run = routed_run
+    original_compute = proxy._compute_objectives
 
-    end_step = proxy.end_step_for_history_fraction(0.25)
+    def capture_compute(output, run, *args, **kwargs):
+        metric_runs.append(run)
+        return original_compute(output, run, *args, **kwargs)
+
+    proxy._compute_objectives = capture_compute
+
+    history_start, trade_start = proxy.recent_window_for_history_fraction(0.25)
     results = proxy.evaluate(
         [{"value": float(index)} for index in range(1024)],
-        end_step=end_step,
+        history_start_step=history_start,
+        trade_start_step=trade_start,
     )
 
-    assert end_step == 482_963
+    assert (history_start, trade_start) == (1_448_763, 1_448_863)
     assert len(results) == 1024
     assert [len(call) for call in calls] == [1024]
-    assert routed_end_steps == [482_963]
+    assert routed_windows == [
+        {
+            "profile": False,
+            "end_step": 1_931_815,
+            "history_start_step": 1_448_763,
+            "trade_start_step": 1_448_863,
+        }
+    ]
+    assert len(metric_runs) == 1
+    assert metric_runs[0].trade_start_idx == 1_448_863
+    assert metric_runs[0].requested_start_ts_ms == 1_448_863 * 60_000
 
     proxy.runner.n = 1_250
-    proxy.run = SimpleNamespace(trade_start_idx=1_000, first_valid_idx=900)
-    assert proxy.end_step_for_history_fraction(0.25) == 1_064
+    proxy.run = ProxyRun(
+        1_000.0,
+        100,
+        1_000,
+        0,
+        0,
+        0,
+        60_000,
+        0.05,
+        900,
+        1_249,
+    )
+    assert proxy.recent_window_for_history_fraction(0.25) == (1_087, 1_187)
 
 
 def test_single_coin_proxy_profile_records_dispatch_shape_and_timings(monkeypatch):

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -44,6 +44,7 @@ from optimization.gpu.service import (
     _directional_gross_pnl_outputs,
     _gpu_proxy_execution_checkpoint_contract,
     _gpu_profile_unattributed_seconds,
+    _add_gpu_terminal_profile,
     _hsl_params,
     _hsl_diagnostics_needed,
     _mps_dispatch_batch_size,
@@ -630,6 +631,32 @@ def test_single_coin_proxy_profile_records_dispatch_shape_and_timings(monkeypatc
         0.006
     )
     assert profile["wall_seconds"] >= 0.0
+
+
+def test_gpu_terminal_profile_rebases_recent_window_steps():
+    torch = pytest.importorskip("torch")
+    profile = {
+        "terminal_candidate_count": 0,
+        "terminal_without_equity_count": 0,
+        "estimated_post_terminal_candidate_bars": 0,
+        "_terminal_step_fractions": [],
+        "side_count": 1,
+    }
+
+    _add_gpu_terminal_profile(
+        profile,
+        {
+            "alive": torch.as_tensor([False]),
+            "last_eq_ts": torch.as_tensor([75 * 60_000.0]),
+        },
+        interval_ms=60_000,
+        effective_start_step=50,
+        effective_end_step=100,
+    )
+
+    assert profile["terminal_candidate_count"] == 1
+    assert profile["estimated_post_terminal_candidate_bars"] == 23
+    assert profile["_terminal_step_fractions"] == [pytest.approx(25.0 / 48.0)]
 
 
 def test_gpu_dispatch_progress_is_rate_limited_and_reports_eta(


### PR DESCRIPTION
## Summary
- change opt-in single-coin Trailing Martingale successive halving from historical prefixes to recent-history suffixes
- give each partial scoring window the normal indicator warmup immediately before its trade boundary
- keep the full-history rung unchanged and version the checkpoint contract so prefix-era checkpoints fail closed

## Validation
- `PYO3_PYTHON=venv/bin/python cargo test --manifest-path passivbot-rust/Cargo.toml --no-default-features gpu::tests --lib` (14 passed)
- `pytest tests/optimization/test_gpu_mps.py` on Apple MPS
- `pytest tests/optimization/test_gpu_service.py tests/optimization/test_gpu_backend.py`
- CPU import isolation check confirms ordinary CPU startup does not import torch or the MPS kernel
- bounded opt-in GPU optimize smoke completed one 1024-candidate generation across recent 25%, recent 50%, and full-history rungs, then shut down cleanly via SIGINT

## Contract
- exact Rust validation remains authoritative
- the feature remains disabled by default
- EMA Anchor, multicoin, suite, CPU optimization, backtest, and bot paths are unchanged