### PR TITLE
Increase Apple MPS dispatch parallelism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Apple MPS optimization now defaults to a 1-billion candidate-bar dispatch envelope instead of
+  500 million, approximately doubling per-dispatch parallelism on long one-sided histories.
+  `optimize.gpu.max_dispatch_candidate_bars` may restore the former `500000000` conservative
+  setting; larger envelopes increase interrupt latency and may temporarily reduce desktop
+  responsiveness while a Metal dispatch is running.
+
 - Bitunix now defers live exchange actions when a locked-fund balance does not reconcile with the
   exchange-calculated maximum-transfer amount, including after restart, preventing a transient
   account response from reporting unchanged locked funds in both `available` and `used` balance

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -632,6 +632,7 @@ GPU-specific settings live under `optimize.gpu`:
     "backend": "gpu",
     "gpu": {
       "batch_size": 4096,
+      "max_dispatch_candidate_bars": 1000000000,
       "checkpoint_interval_seconds": 5.0,
       "drift_halt": 0.6,
       "drift_min_samples": 32,
@@ -667,6 +668,12 @@ duplicate-elimination controls as the ordinary pymoo optimizer.
   that incomplete ask/tell transaction is discarded and the last complete checkpoint is retained.
   A topology whose single candidate already exceeds the safety envelope fails closed with guidance
   to shorten the date range or reduce its coin count.
+- `max_dispatch_candidate_bars` sets that MPS work envelope. The default is 1 billion, allowing
+  roughly 512 candidates per dispatch across 1.95 million one-sided candle bars on a dedicated
+  optimization Mac. Set it to `500000000` for the former conservative behavior when desktop
+  responsiveness is more important than GPU throughput. Larger values increase the time before
+  Ctrl+C can be observed and may make the shared display GPU temporarily unresponsive;
+  `batch_size` remains an independent upper bound.
 - `successive_halving.enabled` opts a non-suite, single-coin Trailing Martingale run into
   progressively longer recent-history suffixes. The default `history_fractions` are 25%, 50%, and
   100%, measured backwards from the configured end date; each partial suffix receives the normal

--- a/src/config/schema.py
+++ b/src/config/schema.py
@@ -502,6 +502,7 @@ def get_template_config():
                     "seed": None,
                     "gpu": {
                         "batch_size": 4096,
+                        "max_dispatch_candidate_bars": 1000000000,
                         "checkpoint_interval_seconds": 5.0,
                         "drift_halt": 0.6,
                         "drift_min_samples": 32,

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -54,6 +54,7 @@ from utils import to_standard_exchange_name
 GPU_DEFAULTS = {
     "population_size": 1024,
     "batch_size": 4096,
+    "max_dispatch_candidate_bars": 1_000_000_000,
     "checkpoint_interval_seconds": 5.0,
     "validate_per_generation": 8,
     "drift_probes": 4,
@@ -1060,6 +1061,7 @@ def _resolve_options(config: dict) -> dict:
     for key in (
         "population_size",
         "batch_size",
+        "max_dispatch_candidate_bars",
         "validate_per_generation",
         "drift_window",
         "drift_min_samples",
@@ -3922,6 +3924,9 @@ def run_backend(
                 timestamps=item["timestamps"],
                 exchange=item["exchange"],
                 batch_size=int(options["batch_size"]),
+                max_dispatch_candidate_bars=int(
+                    options["max_dispatch_candidate_bars"]
+                ),
                 needed_metrics=needed_metrics,
                 interrupt_check=interrupt_check,
             )
@@ -3974,6 +3979,9 @@ def run_backend(
             timestamps=evaluator.timestamps.get(exchange),
             exchange=exchange,
             batch_size=int(options["batch_size"]),
+            max_dispatch_candidate_bars=int(
+                options["max_dispatch_candidate_bars"]
+            ),
             needed_metrics=needed_metrics,
             interrupt_check=interrupt_check,
         )

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -256,6 +256,13 @@ def _new_gpu_proxy_profile(
         "strategy": str(getattr(proxy, "strategy_kind", "unknown")),
         "candidate_count": len(candidates),
         "configured_batch_size": int(getattr(proxy, "batch_size", 0)),
+        "max_dispatch_candidate_bars": int(
+            getattr(
+                proxy,
+                "max_dispatch_candidate_bars",
+                MPS_MAX_DISPATCH_CANDIDATE_BARS,
+            )
+        ),
         "dispatch_batch_size": dispatch_batch_size,
         "dispatch_chunk_count": (
             (len(candidates) + dispatch_batch_size - 1) // dispatch_batch_size
@@ -524,10 +531,12 @@ def _btc_daily_price_context(
 
 # One MPS thread simulates one candidate across every candle stream. Long-running
 # command buffers can starve WindowServer because Apple silicon shares the GPU
-# with the desktop. Keep one dispatch below the bounded work envelope measured
-# on the supported M3 target; callers may still use larger evolutionary
-# populations and configured batches, which are split transparently.
-MPS_MAX_DISPATCH_CANDIDATE_BARS = 500_000_000
+# with the desktop. Keep one dispatch below a configurable work envelope; callers
+# may still use larger evolutionary populations and configured batches, which are
+# split transparently. The default admits roughly 512 candidates per dispatch over
+# two million bars, while 500 million remains the documented conservative value
+# for a Mac that must stay responsive during optimization.
+MPS_MAX_DISPATCH_CANDIDATE_BARS = 1_000_000_000
 
 
 def _gpu_proxy_execution_checkpoint_contract(
@@ -644,22 +653,26 @@ def _mps_dispatch_batch_size(
     n_bars: int,
     n_coins: int = 1,
     n_sides: int = 1,
+    max_candidate_bars: int = MPS_MAX_DISPATCH_CANDIDATE_BARS,
 ) -> int:
     requested_batch_size = max(1, int(requested_batch_size))
     n_bars = max(1, int(n_bars))
     n_coins = max(1, int(n_coins))
     n_sides = max(1, int(n_sides))
+    max_candidate_bars = int(max_candidate_bars)
+    if max_candidate_bars <= 0:
+        raise ValueError("max_candidate_bars must be greater than zero")
     per_candidate_work = n_bars * n_coins * n_sides
-    if per_candidate_work > MPS_MAX_DISPATCH_CANDIDATE_BARS:
+    if per_candidate_work > max_candidate_bars:
         raise ValueError(
             "one GPU candidate exceeds the Apple MPS dispatch safety envelope "
             f"(bars={n_bars}, coins={n_coins}, sides={n_sides}, "
             f"candidate_bars={per_candidate_work}, "
-            f"max_candidate_bars={MPS_MAX_DISPATCH_CANDIDATE_BARS}); "
+            f"max_candidate_bars={max_candidate_bars}); "
             "use a shorter date range or fewer coins"
         )
     safe_batch_size = max(
-        1, MPS_MAX_DISPATCH_CANDIDATE_BARS // per_candidate_work
+        1, max_candidate_bars // per_candidate_work
     )
     return min(requested_batch_size, safe_batch_size)
 
@@ -688,6 +701,7 @@ def _log_mps_dispatch_cap(
     n_bars: int,
     n_coins: int,
     n_sides: int,
+    max_candidate_bars: int,
 ) -> None:
     if dispatch_batch_size >= requested_batch_size:
         return
@@ -699,7 +713,7 @@ def _log_mps_dispatch_cap(
         n_bars,
         n_coins,
         n_sides,
-        MPS_MAX_DISPATCH_CANDIDATE_BARS,
+        max_candidate_bars,
     )
 
 _DUAL_SIDE_MULTICOIN_INTRADAY_CUTOFF_METRICS = {
@@ -1707,6 +1721,7 @@ class MpsSingleCoinProxy:
         batch_size: int,
         needed_metrics,
         interrupt_check=None,
+        max_dispatch_candidate_bars: int = MPS_MAX_DISPATCH_CANDIDATE_BARS,
     ):
         try:
             import torch
@@ -1753,6 +1768,7 @@ class MpsSingleCoinProxy:
             np.asarray(btc, dtype=np.float64).reshape(-1)
         )
         self.batch_size = max(1, int(batch_size))
+        self.max_dispatch_candidate_bars = int(max_dispatch_candidate_bars)
         self.interrupt_check = interrupt_check or (lambda: None)
         self.profile_enabled = os.environ.get(
             "PASSIVBOT_GPU_PROFILE", ""
@@ -1809,6 +1825,7 @@ class MpsSingleCoinProxy:
             self.batch_size,
             n_bars=len(hlcvs),
             n_sides=enabled_side_count,
+            max_candidate_bars=self.max_dispatch_candidate_bars,
         )
         _log_mps_dispatch_cap(
             requested_batch_size=self.batch_size,
@@ -1816,6 +1833,7 @@ class MpsSingleCoinProxy:
             n_bars=len(hlcvs),
             n_coins=1,
             n_sides=enabled_side_count,
+            max_candidate_bars=self.max_dispatch_candidate_bars,
         )
         hsl_enabled_sides = [
             side
@@ -2202,6 +2220,7 @@ class MpsSingleCoinProxy:
                 self.batch_size,
                 n_bars=effective_candle_count,
                 n_sides=side_count,
+                max_candidate_bars=self.max_dispatch_candidate_bars,
             )
         )
         profile_started = time.perf_counter() if self.profile_enabled else 0.0
@@ -2759,6 +2778,7 @@ class MpsMulticoinProxy:
         batch_size: int,
         needed_metrics,
         interrupt_check=None,
+        max_dispatch_candidate_bars: int = MPS_MAX_DISPATCH_CANDIDATE_BARS,
     ):
         try:
             import torch
@@ -2804,6 +2824,7 @@ class MpsMulticoinProxy:
             np.asarray(btc, dtype=np.float64).reshape(-1)
         )
         self.batch_size = max(1, int(batch_size))
+        self.max_dispatch_candidate_bars = int(max_dispatch_candidate_bars)
         self.interrupt_check = interrupt_check or (lambda: None)
         self.profile_enabled = os.environ.get(
             "PASSIVBOT_GPU_PROFILE", ""
@@ -2852,6 +2873,7 @@ class MpsMulticoinProxy:
             n_bars=len(values),
             n_coins=coin_count,
             n_sides=len(enabled_sides),
+            max_candidate_bars=self.max_dispatch_candidate_bars,
         )
         _log_mps_dispatch_cap(
             requested_batch_size=self.batch_size,
@@ -2859,6 +2881,7 @@ class MpsMulticoinProxy:
             n_bars=len(values),
             n_coins=coin_count,
             n_sides=len(enabled_sides),
+            max_candidate_bars=self.max_dispatch_candidate_bars,
         )
         self.shared_account_fused = len(self.sides) == 2
         self.shared_account_proxy_mode = (

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -277,9 +277,15 @@ def _directional_tm_config(*, long_enabled: bool, short_enabled: bool):
 def test_gpu_options_are_additive_and_validate_ranges():
     config = _long_only_ema_config()
     assert _resolve_options(config)["population_size"] == 1024
+    assert _resolve_options(config)["max_dispatch_candidate_bars"] == 1_000_000_000
 
     config["optimize"]["gpu"]["batch_size"] = 0
     with pytest.raises(ValueError, match="batch_size"):
+        _resolve_options(config)
+
+    config = _long_only_ema_config()
+    config["optimize"]["gpu"]["max_dispatch_candidate_bars"] = 0
+    with pytest.raises(ValueError, match="max_dispatch_candidate_bars"):
         _resolve_options(config)
 
     config = _long_only_ema_config()

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -409,16 +409,26 @@ def test_single_coin_shader_topology_is_fail_closed(
 def test_mps_dispatch_batch_size_bounds_single_and_multicoin_work():
     n_bars = 1_923_175
 
-    assert _mps_dispatch_batch_size(8192, n_bars=n_bars) == 259
-    assert _mps_dispatch_batch_size(8192, n_bars=n_bars, n_coins=4) == 64
+    assert _mps_dispatch_batch_size(8192, n_bars=n_bars) == 519
+    assert _mps_dispatch_batch_size(8192, n_bars=n_bars, n_coins=4) == 129
     assert (
         _mps_dispatch_batch_size(8192, n_bars=n_bars, n_coins=4, n_sides=2)
-        == 32
+        == 64
+    )
+    assert (
+        _mps_dispatch_batch_size(
+            8192,
+            n_bars=n_bars,
+            max_candidate_bars=500_000_000,
+        )
+        == 259
     )
     assert _mps_dispatch_batch_size(32, n_bars=1000, n_coins=4) == 32
     with pytest.raises(ValueError, match="one GPU candidate exceeds"):
-        _mps_dispatch_batch_size(8192, n_bars=10**9)
-    assert MPS_MAX_DISPATCH_CANDIDATE_BARS == 500_000_000
+        _mps_dispatch_batch_size(8192, n_bars=3 * 10**9)
+    with pytest.raises(ValueError, match="max_candidate_bars"):
+        _mps_dispatch_batch_size(32, n_bars=1000, max_candidate_bars=0)
+    assert MPS_MAX_DISPATCH_CANDIDATE_BARS == 1_000_000_000
 
 
 def _minimal_single_coin_proxy(*, interrupt_check=lambda: None):
@@ -426,6 +436,7 @@ def _minimal_single_coin_proxy(*, interrupt_check=lambda: None):
     proxy = MpsSingleCoinProxy.__new__(MpsSingleCoinProxy)
     proxy.batch_size = 8
     proxy.dispatch_batch_size = 2
+    proxy.max_dispatch_candidate_bars = MPS_MAX_DISPATCH_CANDIDATE_BARS
     proxy.interrupt_check = interrupt_check
     proxy._torch = torch
     proxy.profile_enabled = False
@@ -592,6 +603,7 @@ def test_single_coin_proxy_profile_records_dispatch_shape_and_timings(monkeypatc
 
     profile = proxy.last_profile
     assert profile["candidate_count"] == 5
+    assert profile["max_dispatch_candidate_bars"] == 1_000_000_000
     assert profile["dispatch_batch_size"] == 2
     assert profile["dispatch_chunk_count"] == 3
     assert profile["actual_dispatch_batch_sizes"] == [2, 2, 1]


### PR DESCRIPTION
## Summary

- raise the default Apple MPS work envelope from 500 million to 1 billion candidate-bars
- expose `optimize.gpu.max_dispatch_candidate_bars` so operators can restore the conservative cap or tune dedicated machines
- include the active envelope in opt-in GPU profiles and document throughput/responsiveness tradeoffs

## Benchmark

Fixed-seed, cached-data Trailing Martingale optimization on Apple MPS with one enabled side, 1,933,255 candles, and a 1024-candidate population:

- 500M envelope: four dispatches, 38.6 proxy candidates/s in the current comparison sample
- 1B envelope: two dispatches of 517 and 507 candidates; 51.3/s cold and about 53-54/s warm across eight generations
- 2B envelope: one 1024-candidate dispatch; about 48-50/s and roughly double the interrupt latency of 1B

The 1B default therefore increases GPU occupancy without selecting the slower, less interruptible single-dispatch setting. Exact Rust validation and candidate semantics are unchanged.

## Validation

- `PYTHONPATH=src python -m pytest -q tests/optimization/test_gpu_service.py tests/optimization/test_gpu_backend.py`
- `PYTHONPATH=src python -m pytest -q tests/optimization/test_backends.py tests/optimization/test_config_adapter.py tests/test_config_cleaning.py`
- `PYTHONPATH=src python -m py_compile src/config/schema.py src/optimization/backends/gpu_backend.py src/optimization/gpu/service.py`
- real Apple MPS CLI run with the new default, cached data, and graceful Ctrl+C shutdown between bounded dispatches
- `git diff --check`