### PR TITLE
Auto-size lean MPS replay parallelism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Apple MPS optimization now auto-selects a 2304-candidate population and 4.5-billion candidate-bar
+  dispatch envelope for the proven lean one-sided Trailing Martingale kernel, restoring roughly
+  110–117 proxy candidates/second in the long-history M3 benchmark while keeping command buffers
+  near 20 seconds. HSL, multicoin, suite, market-order, reducer, recursive-mode, and active-
+  volatility kernels retain the 1-billion safety envelope. Set
+  `optimize.gpu.auto_lean_parallelism` to `false`, or customize any GPU sizing setting, to disable
+  the automatic selection.
+
 - Apple MPS optimization now defaults to a 1-billion candidate-bar dispatch envelope instead of
   500 million, approximately doubling per-dispatch parallelism on long one-sided histories.
   `optimize.gpu.max_dispatch_candidate_bars` may restore the former `500000000` conservative

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,13 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
-- Apple MPS optimization now auto-selects a 2304-candidate population and 4.5-billion candidate-bar
-  dispatch envelope for the proven lean one-sided Trailing Martingale kernel, restoring roughly
-  110–117 proxy candidates/second in the long-history M3 benchmark while keeping command buffers
-  near 20 seconds. HSL, multicoin, suite, market-order, reducer, recursive-mode, and active-
-  volatility kernels retain the 1-billion safety envelope. Set
-  `optimize.gpu.auto_lean_parallelism` to `false`, or customize any GPU sizing setting, to disable
-  the automatic selection.
+- Apple M3-family MPS optimization now auto-selects a 2304-candidate population and 4.5-billion
+  candidate-bar dispatch envelope for the proven lean one-sided Trailing Martingale kernel,
+  restoring roughly 110–117 proxy candidates/second in the long-history benchmark while keeping
+  command buffers near 20 seconds. Other Apple Silicon families plus coin-overridden, HSL,
+  multicoin, suite, market-order, reducer, recursive-mode, and active-volatility kernels retain the
+  1-billion safety envelope. Set `optimize.gpu.auto_lean_parallelism` to `false`, or set any GPU
+  sizing value explicitly, to disable the automatic selection.
 
 - Apple MPS optimization now defaults to a 1-billion candidate-bar dispatch envelope instead of
   500 million, approximately doubling per-dispatch parallelism on long one-sided histories.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,10 @@ All notable user-facing changes will be documented in this file.
   restoring roughly 110–117 proxy candidates/second in the long-history benchmark while keeping
   command buffers near 20 seconds. Other Apple Silicon families plus coin-overridden, HSL,
   multicoin, suite, market-order, reducer, recursive-mode, and active-volatility kernels retain the
-  1-billion safety envelope. Set `optimize.gpu.auto_lean_parallelism` to `false`, or set any GPU
-  sizing value explicitly, to disable the automatic selection.
+  1-billion safety envelope. Runs requesting opt-in proxy metric features, including BTC analysis,
+  entry intervals, recovery distributions, equity-balance divergence, and HSL diagnostics, also
+  retain the 1-billion envelope. Set `optimize.gpu.auto_lean_parallelism` to `false`, or set any
+  GPU sizing value explicitly, to disable the automatic selection.
 
 - Apple MPS optimization now defaults to a 1-billion candidate-bar dispatch envelope instead of
   500 million, approximately doubling per-dispatch parallelism on long one-sided histories.

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -631,6 +631,7 @@ GPU-specific settings live under `optimize.gpu`:
   "optimize": {
     "backend": "gpu",
     "gpu": {
+      "auto_lean_parallelism": true,
       "batch_size": 4096,
       "max_dispatch_candidate_bars": 1000000000,
       "checkpoint_interval_seconds": 5.0,
@@ -656,9 +657,15 @@ GPU-specific settings live under `optimize.gpu`:
 The CPU-side NSGA-II proposal stage uses the same `optimize.pymoo.shared` crossover, mutation, and
 duplicate-elimination controls as the ordinary pymoo optimizer.
 
-- `population_size` is the NSGA-II proxy population. The default is 1024 so long-history runs
-  reach their first exact Rust validation batch four times sooner than the former 4096 default.
-  Larger explicit populations remain supported.
+- `population_size` is the NSGA-II proxy population. The general default is 1024 so long-history
+  runs reach their first exact Rust validation batch four times sooner than the former 4096
+  default. With untouched GPU sizing defaults, `auto_lean_parallelism` raises the effective
+  population to 2304 only for a proven one-sided Trailing Martingale kernel with HSL, unstuck,
+  exposure reducers, market orders, the realized-loss gate, recursive entry/close modes, and
+  volatility weights all compiled out. This supplies enough resident work to hide divergent replay
+  latency on the supported M3 target. Set `auto_lean_parallelism` to `false`, or explicitly tune any
+  of `population_size`, `batch_size`, or `max_dispatch_candidate_bars`, to retain the configured
+  sizing unchanged.
 - `batch_size` is the requested upper bound on candidates per MPS dispatch. Because Apple Silicon
   shares the GPU with WindowServer, the backend transparently splits a batch when its
   candidates-by-candles-by-coins-by-enabled-sides workload would make one Metal command buffer too
@@ -674,6 +681,12 @@ duplicate-elimination controls as the ordinary pymoo optimizer.
   responsiveness is more important than GPU throughput. Larger values increase the time before
   Ctrl+C can be observed and may make the shared display GPU temporarily unresponsive;
   `batch_size` remains an independent upper bound.
+  When `auto_lean_parallelism` proves the lean one-sided Trailing Martingale shape described above,
+  it raises the effective envelope to 4.5 billion together with the 2304 population. That exact
+  shape completed approximately 4.45 billion candidate-bars in about 20 seconds on the supported
+  M3 benchmark. All other shapes retain the 1-billion default; the optimizer does not apply the
+  wider envelope to HSL, multicoin, suite, market-order, reducer, recursive-mode, or active-
+  volatility kernels.
 - `successive_halving.enabled` opts a non-suite, single-coin Trailing Martingale run into
   progressively longer recent-history suffixes. The default `history_fractions` are 25%, 50%, and
   100%, measured backwards from the configured end date; each partial suffix receives the normal

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -632,8 +632,8 @@ GPU-specific settings live under `optimize.gpu`:
     "backend": "gpu",
     "gpu": {
       "auto_lean_parallelism": true,
-      "batch_size": 4096,
-      "max_dispatch_candidate_bars": 1000000000,
+      "batch_size": null,
+      "max_dispatch_candidate_bars": null,
       "checkpoint_interval_seconds": 5.0,
       "drift_halt": 0.6,
       "drift_min_samples": 32,
@@ -641,7 +641,7 @@ GPU-specific settings live under `optimize.gpu`:
       "drift_window": 128,
       "exact_workers": 0,
       "max_pending_exact": 0,
-      "population_size": 1024,
+      "population_size": null,
       "successive_halving": {
         "enabled": false,
         "history_fractions": [0.25, 0.5, 1.0],
@@ -659,13 +659,14 @@ duplicate-elimination controls as the ordinary pymoo optimizer.
 
 - `population_size` is the NSGA-II proxy population. The general default is 1024 so long-history
   runs reach their first exact Rust validation batch four times sooner than the former 4096
-  default. With untouched GPU sizing defaults, `auto_lean_parallelism` raises the effective
-  population to 2304 only for a proven one-sided Trailing Martingale kernel with HSL, unstuck,
-  exposure reducers, market orders, the realized-loss gate, recursive entry/close modes, and
-  volatility weights all compiled out. This supplies enough resident work to hide divergent replay
-  latency on the supported M3 target. Set `auto_lean_parallelism` to `false`, or explicitly tune any
-  of `population_size`, `batch_size`, or `max_dispatch_candidate_bars`, to retain the configured
-  sizing unchanged.
+  default. `null` or an omitted key requests this automatic default. On a detected Apple M3 family
+  device, with all three sizing keys left automatic, `auto_lean_parallelism` raises the effective
+  population to 2304 only for a proven one-sided Trailing Martingale kernel with no coin overrides
+  and with HSL, unstuck, exposure reducers, market orders, the realized-loss gate, recursive
+  entry/close modes, and volatility weights all compiled out. This supplies enough resident work
+  to hide divergent replay latency on the benchmarked target. Set `auto_lean_parallelism` to
+  `false`, or set any of `population_size`, `batch_size`, or `max_dispatch_candidate_bars` to a
+  number (including the ordinary default number), to retain the configured sizing unchanged.
 - `batch_size` is the requested upper bound on candidates per MPS dispatch. Because Apple Silicon
   shares the GPU with WindowServer, the backend transparently splits a batch when its
   candidates-by-candles-by-coins-by-enabled-sides workload would make one Metal command buffer too
@@ -681,12 +682,13 @@ duplicate-elimination controls as the ordinary pymoo optimizer.
   responsiveness is more important than GPU throughput. Larger values increase the time before
   Ctrl+C can be observed and may make the shared display GPU temporarily unresponsive;
   `batch_size` remains an independent upper bound.
-  When `auto_lean_parallelism` proves the lean one-sided Trailing Martingale shape described above,
-  it raises the effective envelope to 4.5 billion together with the 2304 population. That exact
-  shape completed approximately 4.45 billion candidate-bars in about 20 seconds on the supported
-  M3 benchmark. All other shapes retain the 1-billion default; the optimizer does not apply the
-  wider envelope to HSL, multicoin, suite, market-order, reducer, recursive-mode, or active-
-  volatility kernels.
+  When `auto_lean_parallelism` detects an Apple M3 family device and proves the lean one-sided
+  Trailing Martingale shape described above, it raises the effective envelope to 4.5 billion
+  together with the 2304 population. That exact shape completed approximately 4.45 billion
+  candidate-bars in about 20 seconds on the supported M3 benchmark. Other Apple Silicon families
+  and all heavier shapes retain the 1-billion default; the optimizer does not apply the wider
+  envelope to coin-overridden, HSL, multicoin, suite, market-order, reducer, recursive-mode, or
+  active-volatility kernels.
 - `successive_halving.enabled` opts a non-suite, single-coin Trailing Martingale run into
   progressively longer recent-history suffixes. The default `history_fractions` are 25%, 50%, and
   100%, measured backwards from the configured end date; each partial suffix receives the normal

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -663,10 +663,13 @@ duplicate-elimination controls as the ordinary pymoo optimizer.
   device, with all three sizing keys left automatic, `auto_lean_parallelism` raises the effective
   population to 2304 only for a proven one-sided Trailing Martingale kernel with no coin overrides
   and with HSL, unstuck, exposure reducers, market orders, the realized-loss gate, recursive
-  entry/close modes, and volatility weights all compiled out. This supplies enough resident work
-  to hide divergent replay latency on the benchmarked target. Set `auto_lean_parallelism` to
-  `false`, or set any of `population_size`, `batch_size`, or `max_dispatch_candidate_bars` to a
-  number (including the ordinary default number), to retain the configured sizing unchanged.
+  entry/close modes, volatility weights, and opt-in metric feature paths all compiled out. Metric
+  surfaces needing BTC analysis, entry intervals, recovery distributions, equity-balance
+  divergence, HSL diagnostics, or other optional proxy output paths retain the general envelope.
+  This supplies enough resident work to hide divergent replay latency on the benchmarked target.
+  Set `auto_lean_parallelism` to `false`, or set any of `population_size`, `batch_size`, or
+  `max_dispatch_candidate_bars` to a number (including the ordinary default number), to retain the
+  configured sizing unchanged.
 - `batch_size` is the requested upper bound on candidates per MPS dispatch. Because Apple Silicon
   shares the GPU with WindowServer, the backend transparently splits a batch when its
   candidates-by-candles-by-coins-by-enabled-sides workload would make one Metal command buffer too
@@ -688,7 +691,7 @@ duplicate-elimination controls as the ordinary pymoo optimizer.
   candidate-bars in about 20 seconds on the supported M3 benchmark. Other Apple Silicon families
   and all heavier shapes retain the 1-billion default; the optimizer does not apply the wider
   envelope to coin-overridden, HSL, multicoin, suite, market-order, reducer, recursive-mode, or
-  active-volatility kernels.
+  active-volatility kernels, nor to kernels with optional metric feature paths enabled.
 - `successive_halving.enabled` opts a non-suite, single-coin Trailing Martingale run into
   progressively longer recent-history suffixes. The default `history_fractions` are 25%, 50%, and
   100%, measured backwards from the configured end date; each partial suffix receives the normal

--- a/src/config/schema.py
+++ b/src/config/schema.py
@@ -501,6 +501,7 @@ def get_template_config():
                     "population_size": None,
                     "seed": None,
                     "gpu": {
+                        "auto_lean_parallelism": True,
                         "batch_size": 4096,
                         "max_dispatch_candidate_bars": 1000000000,
                         "checkpoint_interval_seconds": 5.0,

--- a/src/config/schema.py
+++ b/src/config/schema.py
@@ -502,8 +502,8 @@ def get_template_config():
                     "seed": None,
                     "gpu": {
                         "auto_lean_parallelism": True,
-                        "batch_size": 4096,
-                        "max_dispatch_candidate_bars": 1000000000,
+                        "batch_size": None,
+                        "max_dispatch_candidate_bars": None,
                         "checkpoint_interval_seconds": 5.0,
                         "drift_halt": 0.6,
                         "drift_min_samples": 32,
@@ -511,7 +511,7 @@ def get_template_config():
                         "drift_window": 128,
                         "exact_workers": 0,
                         "max_pending_exact": 0,
-                        "population_size": 1024,
+                        "population_size": None,
                         "successive_halving": {
                             "enabled": False,
                             "history_fractions": [0.25, 0.5, 1.0],

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -52,6 +52,7 @@ from utils import to_standard_exchange_name
 
 
 GPU_DEFAULTS = {
+    "auto_lean_parallelism": True,
     "population_size": 1024,
     "batch_size": 4096,
     "max_dispatch_candidate_bars": 1_000_000_000,
@@ -70,6 +71,9 @@ GPU_DEFAULTS = {
         "min_survivors": 64,
     },
 }
+
+GPU_LEAN_TM_POPULATION_SIZE = 2304
+GPU_LEAN_TM_MAX_DISPATCH_CANDIDATE_BARS = 4_500_000_000
 
 MIN_DRIFT_PROBES = 8
 
@@ -1162,6 +1166,117 @@ def _resolve_options(config: dict) -> dict:
         error_type=ValueError,
     )
     return options
+
+
+def _bound_proves(
+    bound_by_key: dict[str, Bound], key: str, predicate
+) -> bool:
+    bound = bound_by_key.get(key)
+    return bool(
+        bound is not None
+        and predicate(float(bound.low))
+        and predicate(float(bound.high))
+    )
+
+
+def _gpu_lean_tm_parallelism_eligible(
+    config: dict,
+    bound_by_key: dict[str, Bound],
+    enabled_sides,
+    *,
+    suite_enabled: bool,
+    coin_count: int,
+) -> bool:
+    """Prove the measured one-side TM kernel shape before widening dispatches."""
+
+    if (
+        suite_enabled
+        or int(coin_count) != 1
+        or str(config.get("live", {}).get("strategy_kind", "")).strip().lower()
+        != "trailing_martingale"
+    ):
+        return False
+    sides = sorted(str(side) for side in enabled_sides)
+    if len(sides) != 1 or sides[0] not in {"long", "short"}:
+        return False
+    side = sides[0]
+    bot = config.get("bot", {}).get(side, {})
+    risk = bot.get("risk", {})
+    live = config.get("live", {})
+    if (
+        bool(bot.get("hsl", {}).get("enabled", False))
+        or bool(bot.get("unstuck", {}).get("enabled", False))
+        or bool(risk.get("position_exposure_enforcer_enabled", False))
+        or bool(risk.get("total_exposure_enforcer_enabled", False))
+        or bool(live.get("market_orders_allowed", False))
+    ):
+        return False
+    try:
+        max_realized_loss_pct = float(live.get("max_realized_loss_pct", 1.0))
+    except (TypeError, ValueError):
+        return False
+    if not math.isfinite(max_realized_loss_pct) or max_realized_loss_pct < 1.0:
+        return False
+    if not all(
+        _bound_proves(bound_by_key, f"{side}_{suffix}", lambda value: value > 0.0)
+        for suffix in (
+            "entry_retracement_base_pct",
+            "close_retracement_base_pct",
+        )
+    ):
+        return False
+    return all(
+        _bound_proves(
+            bound_by_key,
+            f"{side}_{suffix}",
+            lambda value: value == 0.0,
+        )
+        for suffix in (
+            "entry_threshold_volatility_1h_weight",
+            "entry_threshold_volatility_1m_weight",
+            "entry_retracement_volatility_1h_weight",
+            "entry_retracement_volatility_1m_weight",
+            "close_threshold_volatility_1h_weight",
+            "close_threshold_volatility_1m_weight",
+            "close_retracement_volatility_1h_weight",
+            "close_retracement_volatility_1m_weight",
+        )
+    )
+
+
+def _apply_gpu_lean_tm_parallelism_defaults(
+    options: dict,
+    config: dict,
+    bound_by_key: dict[str, Bound],
+    enabled_sides,
+    *,
+    suite_enabled: bool,
+    coin_count: int,
+) -> bool:
+    """Apply the M3-tested width only when sizing is otherwise untouched."""
+
+    if not bool(options.get("auto_lean_parallelism", True)):
+        return False
+    sizing_keys = (
+        "population_size",
+        "batch_size",
+        "max_dispatch_candidate_bars",
+    )
+    if any(options[key] != GPU_DEFAULTS[key] for key in sizing_keys):
+        return False
+    if not _gpu_lean_tm_parallelism_eligible(
+        config,
+        bound_by_key,
+        enabled_sides,
+        suite_enabled=suite_enabled,
+        coin_count=coin_count,
+    ):
+        return False
+    options["population_size"] = GPU_LEAN_TM_POPULATION_SIZE
+    options["max_dispatch_candidate_bars"] = (
+        GPU_LEAN_TM_MAX_DISPATCH_CANDIDATE_BARS
+    )
+    return True
 
 
 def _validation_probe_count(
@@ -3535,7 +3650,6 @@ def run_backend(
     interrupt_check()
     reject_configured_exact_only_gpu_metrics(config)
     options = _resolve_options(config)
-    logging.info("GPU optimizer options: %s", options)
     validate_optimizer_effective_configs(config)
 
     shape = (
@@ -3908,6 +4022,22 @@ def run_backend(
             max_coin_count > 1 and len(enabled_sides) == 2
         ),
     )
+
+    if _apply_gpu_lean_tm_parallelism_defaults(
+        options,
+        proxy_config,
+        bound_by_key,
+        enabled_sides,
+        suite_enabled=suite_enabled,
+        coin_count=max_coin_count,
+    ):
+        logging.info(
+            "GPU lean Trailing Martingale parallelism selected | "
+            "population=%d max_dispatch_candidate_bars=%d",
+            int(options["population_size"]),
+            int(options["max_dispatch_candidate_bars"]),
+        )
+    logging.info("GPU optimizer options: %s", options)
 
     if suite_enabled:
         scenario_proxy_groups = {}

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -10,6 +10,8 @@ import math
 import multiprocessing
 import os
 import pickle
+import platform
+import subprocess
 import time
 from typing import Any
 
@@ -1008,7 +1010,7 @@ def _resolve_options(config: dict) -> dict:
     if configured is not None and not isinstance(configured, dict):
         raise TypeError("optimize.gpu must be an object")
     for key, default in GPU_DEFAULTS.items():
-        if key in (configured or {}):
+        if key in (configured or {}) and configured[key] is not None:
             options[key] = type(default)(configured[key])
     halving = dict(GPU_DEFAULTS["successive_halving"])
     configured_halving = options.get("successive_halving")
@@ -1192,6 +1194,7 @@ def _gpu_lean_tm_parallelism_eligible(
     if (
         suite_enabled
         or int(coin_count) != 1
+        or bool(config.get("coin_overrides"))
         or str(config.get("live", {}).get("strategy_kind", "")).strip().lower()
         != "trailing_martingale"
     ):
@@ -1244,6 +1247,25 @@ def _gpu_lean_tm_parallelism_eligible(
     )
 
 
+@functools.lru_cache(maxsize=1)
+def _apple_mps_chip_name() -> str:
+    """Return the Apple chip name without importing optional GPU packages."""
+
+    if platform.system() != "Darwin" or platform.machine() != "arm64":
+        return ""
+    try:
+        result = subprocess.run(
+            ["sysctl", "-n", "machdep.cpu.brand_string"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=2.0,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    return result.stdout.strip()
+
+
 def _apply_gpu_lean_tm_parallelism_defaults(
     options: dict,
     config: dict,
@@ -1252,10 +1274,16 @@ def _apply_gpu_lean_tm_parallelism_defaults(
     *,
     suite_enabled: bool,
     coin_count: int,
+    mps_chip_name: str | None = None,
 ) -> bool:
     """Apply the M3-tested width only when sizing is otherwise untouched."""
 
     if not bool(options.get("auto_lean_parallelism", True)):
+        return False
+    effective_chip_name = (
+        _apple_mps_chip_name() if mps_chip_name is None else str(mps_chip_name)
+    )
+    if not effective_chip_name.startswith("Apple M3"):
         return False
     sizing_keys = (
         "population_size",
@@ -1263,6 +1291,9 @@ def _apply_gpu_lean_tm_parallelism_defaults(
         "max_dispatch_candidate_bars",
     )
     if any(options[key] != GPU_DEFAULTS[key] for key in sizing_keys):
+        return False
+    configured_gpu = config.get("optimize", {}).get("gpu", {}) or {}
+    if any(configured_gpu.get(key) is not None for key in sizing_keys):
         return False
     if not _gpu_lean_tm_parallelism_eligible(
         config,

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -1188,12 +1188,14 @@ def _gpu_lean_tm_parallelism_eligible(
     *,
     suite_enabled: bool,
     coin_count: int,
+    requested_metric_features,
 ) -> bool:
     """Prove the measured one-side TM kernel shape before widening dispatches."""
 
     if (
         suite_enabled
         or int(coin_count) != 1
+        or bool(requested_metric_features)
         or bool(config.get("coin_overrides"))
         or str(config.get("live", {}).get("strategy_kind", "")).strip().lower()
         != "trailing_martingale"
@@ -1255,7 +1257,7 @@ def _apple_mps_chip_name() -> str:
         return ""
     try:
         result = subprocess.run(
-            ["sysctl", "-n", "machdep.cpu.brand_string"],
+            ["/usr/sbin/sysctl", "-n", "machdep.cpu.brand_string"],
             check=True,
             capture_output=True,
             text=True,
@@ -1274,6 +1276,7 @@ def _apply_gpu_lean_tm_parallelism_defaults(
     *,
     suite_enabled: bool,
     coin_count: int,
+    requested_metric_features,
     mps_chip_name: str | None = None,
 ) -> bool:
     """Apply the M3-tested width only when sizing is otherwise untouched."""
@@ -1301,6 +1304,7 @@ def _apply_gpu_lean_tm_parallelism_defaults(
         enabled_sides,
         suite_enabled=suite_enabled,
         coin_count=coin_count,
+        requested_metric_features=requested_metric_features,
     ):
         return False
     options["population_size"] = GPU_LEAN_TM_POPULATION_SIZE
@@ -3671,7 +3675,11 @@ def run_backend(
         HARD_STOP_PROXY_METRICS,
         validate_gpu_metric_names,
     )
-    from optimization.gpu.service import MpsMulticoinProxy, MpsSingleCoinProxy
+    from optimization.gpu.service import (
+        MpsMulticoinProxy,
+        MpsSingleCoinProxy,
+        mps_requested_metric_features,
+    )
     from optimization.warmup import (
         _finalize_optimizer_vector_config,
         validate_optimizer_effective_configs,
@@ -4061,6 +4069,9 @@ def run_backend(
         enabled_sides,
         suite_enabled=suite_enabled,
         coin_count=max_coin_count,
+        requested_metric_features=mps_requested_metric_features(
+            needed_metrics, strategy_kind=strategy_kind
+        ),
     ):
         logging.info(
             "GPU lean Trailing Martingale parallelism selected | "

--- a/src/optimization/gpu/metric_registry.py
+++ b/src/optimization/gpu/metric_registry.py
@@ -6,6 +6,45 @@ import json
 
 import hjson
 
+# Metric-name groups that toggle opt-in MPS proxy features. Keep this metadata
+# Torch-free so backend preflight and ordinary CPU-only installs can prove the
+# dispatch contract without importing the optional GPU runtime.
+BTC_INTRADAY_RISK_METRICS = frozenset(
+    {
+        "calmar_ratio_btc",
+        "drawdown_worst_btc",
+        "drawdown_worst_mean_1pct_btc",
+        "expected_shortfall_1pct_btc",
+        "sharpe_ratio_btc",
+        "sortino_ratio_btc",
+        "sterling_ratio_btc",
+    }
+)
+
+EQUITY_BALANCE_DIFF_METRICS = frozenset(
+    {
+        f"equity_balance_diff_{sign}_{stat}_{currency}"
+        for sign in ("neg", "pos")
+        for stat in ("max", "mean")
+        for currency in ("btc", "usd")
+    }
+    | {
+        f"paper_loss{middle}_ratio_{currency}"
+        for middle in ("", "_mean")
+        for currency in ("btc", "usd")
+    }
+)
+
+ENTRY_INTERVAL_METRICS = frozenset(
+    {
+        "entry_interval_hours_mean",
+        "entry_interval_hours_median",
+        "entry_interval_hours_p95",
+        "entry_interval_hours_p99",
+        "entry_interval_hours_max",
+    }
+)
+
 # These metrics remain available from exact Rust backtests and analysis, but are
 # intentionally ineligible for Metal proxy objectives and proxy-side limits.
 # The registry is Torch-free so GPU backend preflight can inspect preserved raw

--- a/src/optimization/gpu/metrics.py
+++ b/src/optimization/gpu/metrics.py
@@ -12,6 +12,9 @@ import math
 import torch
 
 from optimization.gpu.metric_registry import (
+    BTC_INTRADAY_RISK_METRICS,
+    ENTRY_INTERVAL_METRICS,
+    EQUITY_BALANCE_DIFF_METRICS,
     GPU_EXACT_ONLY_METRICS,
     HARD_STOP_LIFECYCLE_METRICS,
     HARD_STOP_PANIC_LOSS_METRICS,
@@ -72,42 +75,6 @@ _BTC_ACCOUNT_METRICS = {
     "peak_recovery_days_equity_btc",
     "peak_recovery_hours_equity_btc",
 }
-
-BTC_INTRADAY_RISK_METRICS = frozenset(
-    {
-        "calmar_ratio_btc",
-        "drawdown_worst_btc",
-        "drawdown_worst_mean_1pct_btc",
-        "expected_shortfall_1pct_btc",
-        "sharpe_ratio_btc",
-        "sortino_ratio_btc",
-        "sterling_ratio_btc",
-    }
-)
-
-EQUITY_BALANCE_DIFF_METRICS = frozenset(
-    {
-        f"equity_balance_diff_{sign}_{stat}_{currency}"
-        for sign in ("neg", "pos")
-        for stat in ("max", "mean")
-        for currency in ("btc", "usd")
-    }
-    | {
-        f"paper_loss{middle}_ratio_{currency}"
-        for middle in ("", "_mean")
-        for currency in ("btc", "usd")
-    }
-)
-
-ENTRY_INTERVAL_METRICS = frozenset(
-    {
-        "entry_interval_hours_mean",
-        "entry_interval_hours_median",
-        "entry_interval_hours_p95",
-        "entry_interval_hours_p99",
-        "entry_interval_hours_max",
-    }
-)
 
 _BTC_ACCOUNT_METRICS.update(BTC_INTRADAY_RISK_METRICS)
 _BTC_ACCOUNT_METRICS.update(

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -10,7 +10,12 @@ import time
 import numpy as np
 
 from config.shared_bot import flatten_shared_bot_side
-from optimization.gpu.metric_registry import HARD_STOP_PROXY_METRICS
+from optimization.gpu.metric_registry import (
+    BTC_INTRADAY_RISK_METRICS,
+    ENTRY_INTERVAL_METRICS,
+    EQUITY_BALANCE_DIFF_METRICS,
+    HARD_STOP_PROXY_METRICS,
+)
 from optimization.gpu.model import (
     EMA_ANCHOR_COIN_OVERRIDE_ALLOWANCE_PCT_COLUMN,
     EMA_ANCHOR_COIN_OVERRIDE_COLS,
@@ -818,12 +823,6 @@ def mps_requested_metric_features(
     needed_metrics, *, strategy_kind: str
 ) -> frozenset[str]:
     """Name opt-in MPS metric paths required by a proxy metric surface."""
-
-    from optimization.gpu.metrics import (
-        BTC_INTRADAY_RISK_METRICS,
-        ENTRY_INTERVAL_METRICS,
-        EQUITY_BALANCE_DIFF_METRICS,
-    )
 
     metrics = set(needed_metrics)
     features = {

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -814,6 +814,44 @@ _STRATEGY_EQ_RECOVERY_DISTRIBUTION_METRICS = {
 }
 
 
+def mps_requested_metric_features(
+    needed_metrics, *, strategy_kind: str
+) -> frozenset[str]:
+    """Name opt-in MPS metric paths required by a proxy metric surface."""
+
+    from optimization.gpu.metrics import (
+        BTC_INTRADAY_RISK_METRICS,
+        ENTRY_INTERVAL_METRICS,
+        EQUITY_BALANCE_DIFF_METRICS,
+    )
+
+    metrics = set(needed_metrics)
+    features = {
+        "btc_analysis": any(
+            _metric_uses_btc_analysis(metric) for metric in metrics
+        ),
+        "btc_intraday_risk": bool(metrics & BTC_INTRADAY_RISK_METRICS),
+        "equity_balance_diff": bool(metrics & EQUITY_BALANCE_DIFF_METRICS),
+        "entry_interval": bool(
+            str(strategy_kind).strip().lower() == "trailing_martingale"
+            and metrics & ENTRY_INTERVAL_METRICS
+        ),
+        "strategy_eq_recovery_distribution": bool(
+            metrics & _STRATEGY_EQ_RECOVERY_DISTRIBUTION_METRICS
+        ),
+        "hsl_ema_tail": bool(metrics & _HSL_EMA_TAIL_METRICS),
+        "hsl_raw_drawdown": bool(
+            metrics & (_HSL_RAW_DRAWDOWN_METRICS | _HSL_RAW_TAIL_METRICS)
+        ),
+        "hsl_raw_tail": bool(metrics & _HSL_RAW_TAIL_METRICS),
+        "hsl_diagnostics": _hsl_diagnostics_needed(metrics),
+        "coin_fill_counts": bool(
+            metrics & {"fills_active_symbols_count", "fills_top_symbol_share"}
+        ),
+    }
+    return frozenset(name for name, enabled in features.items() if enabled)
+
+
 def _mps_strategy_eq_recovery_distribution(output: dict, needed_metrics):
     """Run the opt-in recovery postprocessor before proxy outputs leave MPS."""
 

--- a/tests/optimization/test_backends.py
+++ b/tests/optimization/test_backends.py
@@ -70,7 +70,10 @@ def test_format_config_accepts_gpu_backend():
     out = format_config(current, verbose=False)
 
     assert out["optimize"]["backend"] == "gpu"
-    assert out["optimize"]["gpu"]["population_size"] == 1024
+    assert out["optimize"]["gpu"]["population_size"] is None
+    assert out["optimize"]["gpu"]["batch_size"] is None
+    assert out["optimize"]["gpu"]["max_dispatch_candidate_bars"] is None
+    assert out["optimize"]["gpu"]["auto_lean_parallelism"] is True
 
 
 def test_format_config_rejects_unknown_backend():

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -601,6 +601,13 @@ def test_gpu_lean_tm_metric_feature_detection(metric, expected_features):
     ) == expected_features
 
 
+def test_gpu_lean_tm_metric_feature_detection_is_torch_free(monkeypatch):
+    monkeypatch.setitem(sys.modules, "optimization.gpu.metrics", None)
+    assert mps_requested_metric_features(
+        {"entry_interval_hours_p95"}, strategy_kind="trailing_martingale"
+    ) == {"entry_interval"}
+
+
 def test_gpu_successive_halving_options_are_opt_in_and_fail_closed():
     config = _long_only_ema_config()
     options = _resolve_options(config)

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -39,6 +39,7 @@ from optimization.backends.gpu_backend import (
     _gpu_candidate_source_sides,
     _gpu_hsl_search_sides,
     _gpu_hsl_parameter_active,
+    _gpu_lean_tm_parallelism_eligible,
     _gpu_nsga2_checkpoint_contract,
     _gpu_pinned_hsl_bound_contract,
     _gpu_profile_elapsed,
@@ -64,6 +65,7 @@ from optimization.backends.gpu_backend import (
     _spearman,
     _submit_gpu_exact_validation,
     _resolve_options,
+    _apply_gpu_lean_tm_parallelism_defaults,
     _restore_gpu_result_run_contract,
     _gpu_unstuck_search_sides,
     _single_scenario_metric_surface,
@@ -91,6 +93,9 @@ from optimization.backends.gpu_backend import (
     EMA_MULTICOIN_LONG_BOUND_MAP,
     EMA_MULTICOIN_SHORT_BOUND_MAP,
     TRAILING_MARTINGALE_BOUND_MAP,
+    GPU_DEFAULTS,
+    GPU_LEAN_TM_MAX_DISPATCH_CANDIDATE_BARS,
+    GPU_LEAN_TM_POPULATION_SIZE,
 )
 from optimization.gpu.metric_registry import configured_exact_only_gpu_metrics
 from optimization.fine_tune_anchors import ANCHOR_GENE_KEY, ANCHOR_PLAN_KEY
@@ -276,6 +281,7 @@ def _directional_tm_config(*, long_enabled: bool, short_enabled: bool):
 
 def test_gpu_options_are_additive_and_validate_ranges():
     config = _long_only_ema_config()
+    assert _resolve_options(config)["auto_lean_parallelism"] is True
     assert _resolve_options(config)["population_size"] == 1024
     assert _resolve_options(config)["max_dispatch_candidate_bars"] == 1_000_000_000
 
@@ -358,6 +364,124 @@ def test_gpu_options_are_additive_and_validate_ranges():
     config["optimize"]["gpu"]["drift_halt"] = 0.0
     with pytest.raises(ValueError, match="greater than zero"):
         _resolve_options(config)
+
+
+def _lean_tm_bounds(side="long"):
+    bounds = {
+        f"{side}_entry_retracement_base_pct": Bound(0.001, 0.02),
+        f"{side}_close_retracement_base_pct": Bound(0.001, 0.02),
+    }
+    for suffix in (
+        "entry_threshold_volatility_1h_weight",
+        "entry_threshold_volatility_1m_weight",
+        "entry_retracement_volatility_1h_weight",
+        "entry_retracement_volatility_1m_weight",
+        "close_threshold_volatility_1h_weight",
+        "close_threshold_volatility_1m_weight",
+        "close_retracement_volatility_1h_weight",
+        "close_retracement_volatility_1m_weight",
+    ):
+        bounds[f"{side}_{suffix}"] = Bound(0.0, 0.0)
+    return bounds
+
+
+def test_gpu_lean_tm_parallelism_requires_complete_compileout_proof():
+    config = _directional_tm_config(long_enabled=True, short_enabled=False)
+    config["live"]["market_orders_allowed"] = False
+    config["live"]["max_realized_loss_pct"] = 1.0
+    bounds = _lean_tm_bounds()
+
+    def eligible(candidate=config, candidate_bounds=bounds, **kwargs):
+        return _gpu_lean_tm_parallelism_eligible(
+            candidate,
+            candidate_bounds,
+            kwargs.pop("enabled_sides", {"long"}),
+            suite_enabled=kwargs.pop("suite_enabled", False),
+            coin_count=kwargs.pop("coin_count", 1),
+        )
+
+    assert eligible()
+    assert not eligible(enabled_sides={"long", "short"})
+    assert not eligible(suite_enabled=True)
+    assert not eligible(coin_count=2)
+    ema_config = copy.deepcopy(config)
+    ema_config["live"]["strategy_kind"] = "ema_anchor"
+    assert not eligible(candidate=ema_config)
+    short_config = _directional_tm_config(
+        long_enabled=False, short_enabled=True
+    )
+    short_config["live"]["market_orders_allowed"] = False
+    short_config["live"]["max_realized_loss_pct"] = 1.0
+    assert _gpu_lean_tm_parallelism_eligible(
+        short_config,
+        _lean_tm_bounds("short"),
+        {"short"},
+        suite_enabled=False,
+        coin_count=1,
+    )
+
+    for path, value in (
+        (("bot", "long", "hsl", "enabled"), True),
+        (("bot", "long", "unstuck", "enabled"), True),
+        (("bot", "long", "risk", "position_exposure_enforcer_enabled"), True),
+        (("bot", "long", "risk", "total_exposure_enforcer_enabled"), True),
+        (("live", "market_orders_allowed"), True),
+        (("live", "max_realized_loss_pct"), 0.1),
+    ):
+        candidate = copy.deepcopy(config)
+        target = candidate
+        for key in path[:-1]:
+            target = target[key]
+        target[path[-1]] = value
+        assert not eligible(candidate=candidate), path
+
+    recursive_bounds = dict(bounds)
+    recursive_bounds["long_entry_retracement_base_pct"] = Bound(0.0, 0.02)
+    assert not eligible(candidate_bounds=recursive_bounds)
+    volatile_bounds = dict(bounds)
+    volatile_bounds["long_close_threshold_volatility_1h_weight"] = Bound(
+        0.0, 1.0
+    )
+    assert not eligible(candidate_bounds=volatile_bounds)
+
+
+def test_gpu_lean_tm_parallelism_auto_sizes_only_untuned_defaults():
+    config = _directional_tm_config(long_enabled=True, short_enabled=False)
+    config["live"]["market_orders_allowed"] = False
+    config["live"]["max_realized_loss_pct"] = 1.0
+    bounds = _lean_tm_bounds()
+    options = copy.deepcopy(GPU_DEFAULTS)
+
+    assert _apply_gpu_lean_tm_parallelism_defaults(
+        options,
+        config,
+        bounds,
+        {"long"},
+        suite_enabled=False,
+        coin_count=1,
+    )
+    assert options["population_size"] == GPU_LEAN_TM_POPULATION_SIZE
+    assert (
+        options["max_dispatch_candidate_bars"]
+        == GPU_LEAN_TM_MAX_DISPATCH_CANDIDATE_BARS
+    )
+
+    for key, value in (
+        ("auto_lean_parallelism", False),
+        ("population_size", 2048),
+        ("batch_size", 1024),
+        ("max_dispatch_candidate_bars", 500_000_000),
+    ):
+        tuned = copy.deepcopy(GPU_DEFAULTS)
+        tuned[key] = value
+        assert not _apply_gpu_lean_tm_parallelism_defaults(
+            tuned,
+            config,
+            bounds,
+            {"long"},
+            suite_enabled=False,
+            coin_count=1,
+        )
 
 
 def test_gpu_successive_halving_options_are_opt_in_and_fail_closed():

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -404,6 +404,11 @@ def test_gpu_lean_tm_parallelism_requires_complete_compileout_proof():
     assert not eligible(enabled_sides={"long", "short"})
     assert not eligible(suite_enabled=True)
     assert not eligible(coin_count=2)
+    overridden_config = copy.deepcopy(config)
+    overridden_config["coin_overrides"] = {
+        "BTC": {"bot": {"long": {"hsl": {"enabled": True}}}}
+    }
+    assert not eligible(candidate=overridden_config)
     ema_config = copy.deepcopy(config)
     ema_config["live"]["strategy_kind"] = "ema_anchor"
     assert not eligible(candidate=ema_config)
@@ -459,6 +464,7 @@ def test_gpu_lean_tm_parallelism_auto_sizes_only_untuned_defaults():
         {"long"},
         suite_enabled=False,
         coin_count=1,
+        mps_chip_name="Apple M3",
     )
     assert options["population_size"] == GPU_LEAN_TM_POPULATION_SIZE
     assert (
@@ -481,6 +487,31 @@ def test_gpu_lean_tm_parallelism_auto_sizes_only_untuned_defaults():
             {"long"},
             suite_enabled=False,
             coin_count=1,
+            mps_chip_name="Apple M3 Max",
+        )
+
+    for chip_name in ("", "Apple M2 Max", "Apple M4"):
+        assert not _apply_gpu_lean_tm_parallelism_defaults(
+            copy.deepcopy(GPU_DEFAULTS),
+            config,
+            bounds,
+            {"long"},
+            suite_enabled=False,
+            coin_count=1,
+            mps_chip_name=chip_name,
+        )
+
+    for key in ("population_size", "batch_size", "max_dispatch_candidate_bars"):
+        explicit_config = copy.deepcopy(config)
+        explicit_config["optimize"]["gpu"][key] = GPU_DEFAULTS[key]
+        assert not _apply_gpu_lean_tm_parallelism_defaults(
+            copy.deepcopy(GPU_DEFAULTS),
+            explicit_config,
+            bounds,
+            {"long"},
+            suite_enabled=False,
+            coin_count=1,
+            mps_chip_name="Apple M3",
         )
 
 

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -98,6 +98,7 @@ from optimization.backends.gpu_backend import (
     GPU_LEAN_TM_POPULATION_SIZE,
 )
 from optimization.gpu.metric_registry import configured_exact_only_gpu_metrics
+from optimization.gpu.service import mps_requested_metric_features
 from optimization.fine_tune_anchors import ANCHOR_GENE_KEY, ANCHOR_PLAN_KEY
 from optimization.warmup import build_optimizer_vector_config
 
@@ -398,6 +399,9 @@ def test_gpu_lean_tm_parallelism_requires_complete_compileout_proof():
             kwargs.pop("enabled_sides", {"long"}),
             suite_enabled=kwargs.pop("suite_enabled", False),
             coin_count=kwargs.pop("coin_count", 1),
+            requested_metric_features=kwargs.pop(
+                "requested_metric_features", frozenset()
+            ),
         )
 
     assert eligible()
@@ -423,7 +427,22 @@ def test_gpu_lean_tm_parallelism_requires_complete_compileout_proof():
         {"short"},
         suite_enabled=False,
         coin_count=1,
+        requested_metric_features=frozenset(),
     )
+
+    for feature in (
+        "entry_interval",
+        "strategy_eq_recovery_distribution",
+        "btc_analysis",
+        "btc_intraday_risk",
+        "equity_balance_diff",
+        "hsl_ema_tail",
+        "hsl_raw_drawdown",
+        "hsl_raw_tail",
+        "hsl_diagnostics",
+        "coin_fill_counts",
+    ):
+        assert not eligible(requested_metric_features={feature}), feature
 
     for path, value in (
         (("bot", "long", "hsl", "enabled"), True),
@@ -464,6 +483,7 @@ def test_gpu_lean_tm_parallelism_auto_sizes_only_untuned_defaults():
         {"long"},
         suite_enabled=False,
         coin_count=1,
+        requested_metric_features=frozenset(),
         mps_chip_name="Apple M3",
     )
     assert options["population_size"] == GPU_LEAN_TM_POPULATION_SIZE
@@ -471,6 +491,19 @@ def test_gpu_lean_tm_parallelism_auto_sizes_only_untuned_defaults():
         options["max_dispatch_candidate_bars"]
         == GPU_LEAN_TM_MAX_DISPATCH_CANDIDATE_BARS
     )
+
+    metric_enabled = copy.deepcopy(GPU_DEFAULTS)
+    assert not _apply_gpu_lean_tm_parallelism_defaults(
+        metric_enabled,
+        config,
+        bounds,
+        {"long"},
+        suite_enabled=False,
+        coin_count=1,
+        requested_metric_features={"entry_interval"},
+        mps_chip_name="Apple M3",
+    )
+    assert metric_enabled == GPU_DEFAULTS
 
     for key, value in (
         ("auto_lean_parallelism", False),
@@ -487,6 +520,7 @@ def test_gpu_lean_tm_parallelism_auto_sizes_only_untuned_defaults():
             {"long"},
             suite_enabled=False,
             coin_count=1,
+            requested_metric_features=frozenset(),
             mps_chip_name="Apple M3 Max",
         )
 
@@ -498,6 +532,7 @@ def test_gpu_lean_tm_parallelism_auto_sizes_only_untuned_defaults():
             {"long"},
             suite_enabled=False,
             coin_count=1,
+            requested_metric_features=frozenset(),
             mps_chip_name=chip_name,
         )
 
@@ -511,8 +546,59 @@ def test_gpu_lean_tm_parallelism_auto_sizes_only_untuned_defaults():
             {"long"},
             suite_enabled=False,
             coin_count=1,
+            requested_metric_features=frozenset(),
             mps_chip_name="Apple M3",
         )
+
+
+def test_apple_mps_chip_probe_does_not_depend_on_shell_path(monkeypatch):
+    from optimization.backends import gpu_backend
+
+    gpu_backend._apple_mps_chip_name.cache_clear()
+    monkeypatch.setattr(gpu_backend.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(gpu_backend.platform, "machine", lambda: "arm64")
+    run = MagicMock(return_value=SimpleNamespace(stdout="Apple M3\n"))
+    monkeypatch.setattr(gpu_backend.subprocess, "run", run)
+
+    assert gpu_backend._apple_mps_chip_name() == "Apple M3"
+    assert run.call_args.args[0] == [
+        "/usr/sbin/sysctl",
+        "-n",
+        "machdep.cpu.brand_string",
+    ]
+    gpu_backend._apple_mps_chip_name.cache_clear()
+
+
+@pytest.mark.parametrize(
+    ("metric", "expected_features"),
+    (
+        ("entry_interval_hours_p95", {"entry_interval"}),
+        (
+            "strategy_eq_recovery_days_p99",
+            {"strategy_eq_recovery_distribution"},
+        ),
+        ("adg_btc", {"btc_analysis"}),
+        ("drawdown_worst_btc", {"btc_analysis", "btc_intraday_risk"}),
+        (
+            "equity_balance_diff_neg_max_usd",
+            {"equity_balance_diff"},
+        ),
+        (
+            "drawdown_worst_mean_1pct_ema_strategy_eq",
+            {"hsl_ema_tail", "hsl_diagnostics"},
+        ),
+        (
+            "drawdown_worst_mean_1pct_strategy_eq_long",
+            {"hsl_raw_drawdown", "hsl_raw_tail", "hsl_diagnostics"},
+        ),
+        ("hard_stop_time_in_red_pct", {"hsl_diagnostics"}),
+        ("fills_top_symbol_share", {"coin_fill_counts"}),
+    ),
+)
+def test_gpu_lean_tm_metric_feature_detection(metric, expected_features):
+    assert mps_requested_metric_features(
+        {metric}, strategy_kind="trailing_martingale"
+    ) == expected_features
 
 
 def test_gpu_successive_halving_options_are_opt_in_and_fail_closed():


### PR DESCRIPTION
## Summary

- auto-select a 2304-candidate NSGA-II population and 4.5-billion candidate-bar dispatch envelope only on detected Apple M3-family hardware and only for the proven lean, one-sided Trailing Martingale MPS kernel without coin overrides
- retain the existing 1024 population and 1-billion envelope for HSL, multicoin, suite, market-order, reducer, recursive-mode, active-volatility, optional-metric-feature, and otherwise unproven kernel shapes
- respect every explicit sizing customization, make Apple chip detection independent of shell PATH, and provide `optimize.gpu.auto_lean_parallelism` as a direct opt-out

## Benchmark

Fixed-seed cached public-market-data benchmark on Apple M3, one enabled Trailing Martingale side, 1,933,255 candles, no HSL/unstuck/reducers/market orders/loss gate, trailing-only entry and close, zero volatility weights, and no optional metric feature paths:

- current 1-billion envelope, 2048 candidates split into four dispatches: 50.4 proxy candidates/s; 40.0 seconds of kernel work
- widened 4-billion envelope, 2048 candidates in one dispatch: 97.7/s; 20.3-second kernel
- automatic 2304 population and 4.5-billion envelope: 108.4-109.5/s cold with 20.3-second kernel work; exact-head warm generation walls of 20.23 and 19.72 seconds, equivalent to about 113.9-116.9 proxy candidates/s

The wider setting is selected only when the optimizer bounds, effective config, device, and requested metric surface prove the same compile-out contract. Explicit numeric sizing values, other Apple Silicon families, coin overrides, optional metric features, and all other topologies retain the existing watchdog-conscious envelope.

## Validation

- `PYTHONPATH=src python -m pytest -q tests/optimization/test_gpu_backend.py tests/optimization/test_gpu_service.py`
- `PYTHONPATH=src python -m pytest -q tests/optimization/test_backends.py tests/optimization/test_config_adapter.py tests/test_config_cleaning.py`
- `PYTHONPATH=src python -m pytest -q tests/optimization/test_gpu_proxy_benchmark.py tests/test_passivbot_cli.py`
- tests covering every profiling-visible optional metric feature category, explicit sizing, coin overrides, M3/non-M3 detection, PATH-independent chip probing, and Torch-free CPU-only preflight
- rebuilt and source-stamped the Python/Rust extension
- real Apple MPS fixed-seed runs with untouched sizing defaults, structured profiling, and graceful interrupt between bounded dispatches
- `PYTHONPATH=src python -m py_compile src/config/schema.py src/optimization/backends/gpu_backend.py src/optimization/gpu/service.py`
- `git diff --check`
