### PR TITLE
Align HSL GPU benchmark with production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,11 @@ All notable user-facing changes will be documented in this file.
   deterministic offline benchmark adds a single-side Trailing Martingale case with HSL enabled so
   HSL-heavy dispatch sizing and kernel changes can be measured directly.
 
+- The deterministic Apple MPS HSL benchmark now matches the production proxy feature contract:
+  it compiles HSL-only diagnostics only when requested and exercises the default 30-day finite
+  coin-PnL lookback, recording that lookback in each report. This prevents benchmark-only HSL work
+  from overstating normal optimizer cost; optimizer behavior is unchanged.
+
 - Apple MPS EMA Anchor optimization now compiles a one-side kernel when HSL is disabled, allowing
   Metal to eliminate the inactive side and HSL state from the hot candle loop. Dual-side and HSL
   runs keep the generic kernel, and exact Rust validation remains authoritative. The offline GPU

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,8 +82,9 @@ All notable user-facing changes will be documented in this file.
 
 - The deterministic Apple MPS HSL benchmark now matches the production proxy feature contract:
   it compiles HSL-only diagnostics only when requested and exercises the default 30-day finite
-  coin-PnL lookback, recording that lookback in each report. This prevents benchmark-only HSL work
-  from overstating normal optimizer cost; optimizer behavior is unchanged.
+  coin-PnL lookback in `coin` signal mode, recording that lookback and mode in each report. This
+  prevents benchmark-only HSL work from overstating or bypassing normal optimizer cost; optimizer
+  behavior is unchanged.
 
 - Apple MPS EMA Anchor optimization now compiles a one-side kernel when HSL is disabled, allowing
   Metal to eliminate the inactive side and HSL state from the hot candle loop. Dual-side and HSL

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -826,10 +826,11 @@ compile/run timing, a fixture hash, and warm p50 across five repeated runs, incl
 candidates/second, kernel time, maximum chunk wall time, dispatch count, device transfer, and host
 overhead. The HSL case uses the same fixed candles and candidate generation as ordinary Trailing
 Martingale while enabling a deterministic long-side HSL lifecycle with the production-equivalent
-30-day finite coin-PnL lookback. It derives optional HSL diagnostic compilation from the same
-requested metric surface as the production proxy; the default case requests no HSL-only
-diagnostics. Reports record the effective lookback in bars. Use identical arguments and
-immutable commits for before/after comparisons. The harness calls the production proxy evaluation
+30-day finite coin-PnL lookback in `coin` signal mode. It derives optional HSL diagnostic
+compilation from the same requested metric surface as the production proxy; the default case
+requests no HSL-only diagnostics. Reports record the effective lookback in bars and numeric
+signal-mode ID. Use identical arguments and immutable commits for before/after comparisons. The
+harness calls the production proxy evaluation
 path, including its full output transfer, metric reduction, and result materialization. Run one
 `--case` per process when comparing cold compilation; `--case all` is convenient for smoke checks,
 and shared-cache hit/miss state still keeps later cold/warm labels accurate.

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -825,7 +825,10 @@ default to 4,320 candles and eight coins. Every report records the seed and work
 compile/run timing, a fixture hash, and warm p50 across five repeated runs, including
 candidates/second, kernel time, maximum chunk wall time, dispatch count, device transfer, and host
 overhead. The HSL case uses the same fixed candles and candidate generation as ordinary Trailing
-Martingale while enabling a deterministic long-side HSL lifecycle. Use identical arguments and
+Martingale while enabling a deterministic long-side HSL lifecycle with the production-equivalent
+30-day finite coin-PnL lookback. It derives optional HSL diagnostic compilation from the same
+requested metric surface as the production proxy; the default case requests no HSL-only
+diagnostics. Reports record the effective lookback in bars. Use identical arguments and
 immutable commits for before/after comparisons. The harness calls the production proxy evaluation
 path, including its full output transfer, metric reduction, and result materialization. Run one
 `--case` per process when comparing cold compilation; `--case all` is convenient for smoke checks,

--- a/src/tools/gpu_proxy_benchmark.py
+++ b/src/tools/gpu_proxy_benchmark.py
@@ -38,6 +38,7 @@ MAX_SINGLE_BARS = 525_600
 MAX_MULTICOIN_BARS = 100_000
 MAX_COINS = 64
 MAX_DISPATCH_CANDIDATE_BARS = 500_000_000
+HSL_PNL_LOOKBACK_BARS = 30 * 24 * 60
 
 
 def _base_parameter_values() -> dict[str, float]:
@@ -206,7 +207,11 @@ def _build_case(
         MpsTrailingMartingaleRunner,
     )
     from optimization.gpu.metrics import compute_objectives
-    from optimization.gpu.service import MpsMulticoinProxy, MpsSingleCoinProxy
+    from optimization.gpu.service import (
+        MpsMulticoinProxy,
+        MpsSingleCoinProxy,
+        mps_requested_metric_features,
+    )
 
     needed_metrics = {
         "adg_strategy_eq",
@@ -253,6 +258,10 @@ def _build_case(
                 EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS, candidates, seed
             )
         else:
+            requested_metric_features = mps_requested_metric_features(
+                needed_metrics,
+                strategy_kind="trailing_martingale",
+            )
             runner = MpsTrailingMartingaleRunner(
                 market,
                 run,
@@ -260,6 +269,12 @@ def _build_case(
                 long_enabled=True,
                 short_enabled=False,
                 hsl_enabled=hsl_enabled,
+                pnl_lookback_bars=(
+                    HSL_PNL_LOOKBACK_BARS if hsl_enabled else 0
+                ),
+                hsl_diagnostics_enabled=(
+                    "hsl_diagnostics" in requested_metric_features
+                ),
             )
             side_matrix = _parameter_matrix(
                 TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS,
@@ -475,6 +490,7 @@ def run_benchmark_case(
         return statistics.median(float(item[key]) for item in warm)
 
     cold_profile = cold["proxy_profile"]
+    runner = getattr(proxy, "runner", None)
     return {
         "case": name,
         "seed": seed,
@@ -489,6 +505,9 @@ def run_benchmark_case(
                 "kernel_candidate_bars",
                 candidates * bars * coin_count * side_count,
             )
+        ),
+        "hsl_pnl_lookback_bars": int(
+            getattr(runner, "pnl_lookback_bars", 0)
         ),
         "actual_dispatch_batch_size": int(cold["batch_size"]),
         "dispatch_chunk_count": int(

--- a/src/tools/gpu_proxy_benchmark.py
+++ b/src/tools/gpu_proxy_benchmark.py
@@ -39,6 +39,7 @@ MAX_MULTICOIN_BARS = 100_000
 MAX_COINS = 64
 MAX_DISPATCH_CANDIDATE_BARS = 500_000_000
 HSL_PNL_LOOKBACK_BARS = 30 * 24 * 60
+HSL_SIGNAL_MODE_COIN = 2.0
 
 
 def _base_parameter_values() -> dict[str, float]:
@@ -110,6 +111,21 @@ def _base_parameter_values() -> dict[str, float]:
         "hsl_signal_mode": 0.0,
         "hsl_slot_count": 1.0,
         "wallet_exposure_limit": -1.0,
+    }
+
+
+def _single_coin_value_overrides(name: str) -> dict[str, float]:
+    if name != "tm-single-long-hsl":
+        return {}
+    return {
+        "hsl_enabled": 1.0,
+        "hsl_red_threshold": 0.02,
+        "hsl_ema_span_minutes": 60.0,
+        "hsl_cooldown_minutes_after_red": 1_440.0,
+        "hsl_restart_policy": 1.0,
+        "hsl_signal_mode": HSL_SIGNAL_MODE_COIN,
+        "entry_double_down_factor": 2.0,
+        "total_wallet_exposure_limit": 5.0,
     }
 
 
@@ -232,19 +248,7 @@ def _build_case(
             market,
         )
         hsl_enabled = name == "tm-single-long-hsl"
-        hsl_value_overrides = (
-            {
-                "hsl_enabled": 1.0,
-                "hsl_red_threshold": 0.02,
-                "hsl_ema_span_minutes": 60.0,
-                "hsl_cooldown_minutes_after_red": 1_440.0,
-                "hsl_restart_policy": 1.0,
-                "entry_double_down_factor": 2.0,
-                "total_wallet_exposure_limit": 5.0,
-            }
-            if hsl_enabled
-            else {}
-        )
+        hsl_value_overrides = _single_coin_value_overrides(name)
         if name == "ema-single-long":
             runner = MpsEmaAnchorRunner(
                 market,
@@ -508,6 +512,9 @@ def run_benchmark_case(
         ),
         "hsl_pnl_lookback_bars": int(
             getattr(runner, "pnl_lookback_bars", 0)
+        ),
+        "hsl_signal_mode": float(
+            candidate_dicts[0].get("long_hsl_signal_mode", 0.0)
         ),
         "actual_dispatch_batch_size": int(cold["batch_size"]),
         "dispatch_chunk_count": int(

--- a/tests/optimization/test_gpu_proxy_benchmark.py
+++ b/tests/optimization/test_gpu_proxy_benchmark.py
@@ -9,6 +9,7 @@ from optimization.gpu.model import (
     TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS,
 )
 from tools.gpu_proxy_benchmark import (
+    HSL_PNL_LOOKBACK_BARS,
     _bounded_positive,
     _fixture_sha256,
     _parameter_matrix,
@@ -79,6 +80,7 @@ def test_gpu_proxy_benchmark_exposes_single_side_tm_hsl_case():
         ]
         == 0.03
     )
+    assert HSL_PNL_LOOKBACK_BARS == 43_200
 
 
 @pytest.mark.parametrize(
@@ -154,6 +156,8 @@ def test_gpu_proxy_benchmark_rejects_oversized_dispatch(case, extra_args):
 
 def test_gpu_proxy_benchmark_reports_profiled_dispatch_chunks(monkeypatch):
     class FakeProxy:
+        runner = type("Runner", (), {"pnl_lookback_bars": 43_200})()
+
         def evaluate(self, _candidates):
             self.last_profile = {
                 "actual_dispatch_batch_sizes": [2, 2, 2, 2],
@@ -195,6 +199,7 @@ def test_gpu_proxy_benchmark_reports_profiled_dispatch_chunks(monkeypatch):
         0.4
     )
     assert report["kernel_candidate_bars"] == 80
+    assert report["hsl_pnl_lookback_bars"] == 43_200
 
 
 def test_gpu_proxy_benchmark_reports_missing_optional_gpu_dependencies(

--- a/tests/optimization/test_gpu_proxy_benchmark.py
+++ b/tests/optimization/test_gpu_proxy_benchmark.py
@@ -10,10 +10,12 @@ from optimization.gpu.model import (
 )
 from tools.gpu_proxy_benchmark import (
     HSL_PNL_LOOKBACK_BARS,
+    HSL_SIGNAL_MODE_COIN,
     _bounded_positive,
     _fixture_sha256,
     _parameter_matrix,
     _require_mps_torch,
+    _single_coin_value_overrides,
     build_parser,
     main,
     run_benchmark_case,
@@ -59,11 +61,12 @@ def test_gpu_proxy_benchmark_accepts_independent_dispatch_batch_size():
 
 def test_gpu_proxy_benchmark_exposes_single_side_tm_hsl_case():
     args = build_parser().parse_args(["--case", "tm-single-long-hsl"])
+    overrides = _single_coin_value_overrides(args.case)
     matrix = _parameter_matrix(
         TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS,
         2,
         7,
-        value_overrides={"hsl_enabled": 1.0, "hsl_red_threshold": 0.03},
+        value_overrides=overrides,
     )
 
     assert args.case == "tm-single-long-hsl"
@@ -78,7 +81,14 @@ def test_gpu_proxy_benchmark_exposes_single_side_tm_hsl_case():
                 "hsl_red_threshold"
             ),
         ]
-        == 0.03
+        == 0.02
+    )
+    assert np.all(
+        matrix[
+            :,
+            TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS.index("hsl_signal_mode"),
+        ]
+        == HSL_SIGNAL_MODE_COIN
     )
     assert HSL_PNL_LOOKBACK_BARS == 43_200
 
@@ -200,6 +210,7 @@ def test_gpu_proxy_benchmark_reports_profiled_dispatch_chunks(monkeypatch):
     )
     assert report["kernel_candidate_bars"] == 80
     assert report["hsl_pnl_lookback_bars"] == 43_200
+    assert report["hsl_signal_mode"] == 0.0
 
 
 def test_gpu_proxy_benchmark_reports_missing_optional_gpu_dependencies(


### PR DESCRIPTION
## Summary
- derive the deterministic HSL benchmark shader features from its requested proxy metric surface, matching production behavior
- exercise the default 30-day finite coin-PnL lookback in coin signal mode and report its effective bar count and mode ID
- document and test the corrected reproducible benchmark contract

This changes benchmark instrumentation only; GPU optimizer behavior and exact Rust authority are unchanged.

## Validation
- pytest -q tests/optimization/test_gpu_proxy_benchmark.py tests/test_passivbot_cli.py -k "gpu_proxy_benchmark or gpu-proxy-benchmark"
- focused GPU service and MPS HSL contract tests (74 passed)
- cargo test --no-default-features (275 passed)
- cargo check --tests
- rebuilt and verified the source-matched release extension
- MPS tm-single-long-hsl benchmark: 512 candidates, 525600 candles, 3 warm runs; diagnostics disabled, coin signal mode ID 2.0, 43200 lookback bars, warm p50 137.6 candidates/s