### PR TITLE
Speed reducer-free recursive GPU closes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Apple MPS single-coin Trailing Martingale now uses a reducer-free recursive-close fast path when
+  every active candidate side disables WEL/TWEL enforcers and auto-unstuck, avoiding redundant
+  reducer allocations while preserving the ordinary close ladder. The deterministic GPU benchmark
+  adds paired static-close and recursive-close cases so this cost remains reproducible and visible.
+
 - Apple M3-family MPS optimization now auto-selects a 2304-candidate population and 4.5-billion
   candidate-bar dispatch envelope for the proven lean one-sided Trailing Martingale kernel,
   restoring roughly 110–117 proxy candidates/second in the long-history benchmark while keeping

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -812,6 +812,8 @@ optimization results.
 ```bash
 passivbot tool gpu-proxy-benchmark --case ema-single-long
 passivbot tool gpu-proxy-benchmark --case tm-single-long
+passivbot tool gpu-proxy-benchmark --case tm-single-long-static-close
+passivbot tool gpu-proxy-benchmark --case tm-single-long-close-ladder
 passivbot tool gpu-proxy-benchmark --case tm-single-long-hsl
 passivbot tool gpu-proxy-benchmark --case ema-multicoin-overhead
 passivbot tool gpu-proxy-benchmark --case ema-multicoin-overrides
@@ -837,6 +839,12 @@ and shared-cache hit/miss state still keeps later cold/warm labels accurate.
 `--dispatch-batch-size` defaults to `--candidates`; setting it lower preserves the fixed candidate
 matrix and reports the actual chunk and strategy-dispatch counts, which isolates dispatch
 saturation from population-size changes.
+The static-close and close-ladder cases hold the Trailing Martingale fixture constant while
+switching only the recursive close inputs. Reports include the number of candidates whose fixed
+parameters can emit multiple close rungs. When every active candidate side disables WEL/TWEL
+enforcers and auto-unstuck, the directional kernel skips reducer candidate construction and
+performs the one ordinary close-grid allocation directly; exact Rust validation remains
+authoritative.
 
 ### Pymoo Configuration
 

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -1187,8 +1187,12 @@ mod tests {
         assert!(!source.contains("close_gen_psize + 1.0e-6f"));
         assert_eq!(source.matches("bool normalize_close_groups").count(), 3);
         assert_eq!(source.matches("int collapse_ordinary_rank").count(), 3);
-        assert_eq!(source.matches("recursive_close_allocation(").count(), 5);
+        assert_eq!(source.matches("recursive_close_allocation(").count(), 7);
         assert_eq!(source.matches("select_recursive_close_reducer(").count(), 3);
+        assert_eq!(
+            source.matches("#if PASSIVBOT_TM_REDUCERS_DISABLED").count(),
+            2
+        );
         assert_eq!(source.matches("ReducerCandidate candidates[3]").count(), 2);
         assert_eq!(source.matches("candidate_allocations[candidate_idx]").count(), 4);
         assert_eq!(source.matches("candidates[candidate_idx].finalized_qty").count(), 4);

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -2220,6 +2220,22 @@ inline void passivbot_single_coin_impl(
                 strategy_wel_merged = group.ticks == strategy_wel_ticks;
             }
 
+            ReducerCandidate selected_reducer = empty_reducer_candidate();
+            RecursiveCloseAllocation allocation;
+#if PASSIVBOT_TM_REDUCERS_DISABLED
+            allocation = recursive_close_allocation(
+                grid_source, true, group_count,
+                long_side.close_gen_psize,
+                0.0f, 0.0f, false,
+                qty_step, price_step, min_qty, min_cost, c_mult,
+                prefix_merge_ticks, prefix_merge_qty,
+                grid_rung_limit
+            );
+            long_side.close_is_exposure_reducer = false;
+            long_side.close_is_twel_reducer = false;
+            long_side.close_is_unstuck_reducer = false;
+            long_side.close_loss_gate_disabled_reducers = false;
+#else
             ReducerCandidate candidates[3];
             RecursiveCloseAllocation candidate_allocations[3];
             for (int candidate_idx = 0; candidate_idx < 3; ++candidate_idx) {
@@ -2335,8 +2351,6 @@ inline void passivbot_single_coin_impl(
                 loss_gate_enabled, max_realized_loss_pct
             );
 
-            ReducerCandidate selected_reducer = empty_reducer_candidate();
-            RecursiveCloseAllocation allocation;
             if (selected_candidate_idx >= 0) {
                 selected_reducer = candidates[selected_candidate_idx];
                 allocation = candidate_allocations[selected_candidate_idx];
@@ -2359,6 +2373,7 @@ inline void passivbot_single_coin_impl(
                 && (candidates[0].finalized_qty > 0.0f
                     || candidates[1].finalized_qty > 0.0f
                     || candidates[2].finalized_qty > 0.0f);
+#endif
 
             float reducer_qty = allocation.reducer_qty;
             int reducer_ticks = selected_reducer.ticks;
@@ -2982,6 +2997,22 @@ inline void passivbot_single_coin_impl(
                 strategy_wel_merged = group.ticks == strategy_wel_ticks;
             }
 
+            ReducerCandidate selected_reducer = empty_reducer_candidate();
+            RecursiveCloseAllocation allocation;
+#if PASSIVBOT_TM_REDUCERS_DISABLED
+            allocation = recursive_close_allocation(
+                grid_source, false, group_count,
+                short_side.close_gen_psize,
+                0.0f, 0.0f, false,
+                qty_step, price_step, min_qty, min_cost, c_mult,
+                prefix_merge_ticks, prefix_merge_qty,
+                grid_rung_limit
+            );
+            short_side.close_is_exposure_reducer = false;
+            short_side.close_is_twel_reducer = false;
+            short_side.close_is_unstuck_reducer = false;
+            short_side.close_loss_gate_disabled_reducers = false;
+#else
             ReducerCandidate candidates[3];
             RecursiveCloseAllocation candidate_allocations[3];
             for (int candidate_idx = 0; candidate_idx < 3; ++candidate_idx) {
@@ -3097,8 +3128,6 @@ inline void passivbot_single_coin_impl(
                 loss_gate_enabled, max_realized_loss_pct
             );
 
-            ReducerCandidate selected_reducer = empty_reducer_candidate();
-            RecursiveCloseAllocation allocation;
             if (selected_candidate_idx >= 0) {
                 selected_reducer = candidates[selected_candidate_idx];
                 allocation = candidate_allocations[selected_candidate_idx];
@@ -3121,6 +3150,7 @@ inline void passivbot_single_coin_impl(
                 && (candidates[0].finalized_qty > 0.0f
                     || candidates[1].finalized_qty > 0.0f
                     || candidates[2].finalized_qty > 0.0f);
+#endif
 
             float reducer_qty = allocation.reducer_qty;
             int reducer_ticks = selected_reducer.ticks;

--- a/src/tools/gpu_proxy_benchmark.py
+++ b/src/tools/gpu_proxy_benchmark.py
@@ -24,12 +24,20 @@ from optimization.gpu.model import (
 CASES = (
     "ema-single-long",
     "tm-single-long",
+    "tm-single-long-static-close",
+    "tm-single-long-close-ladder",
     "tm-single-long-hsl",
     "ema-multicoin-overhead",
     "ema-multicoin-overrides",
 )
 SINGLE_COIN_CASES = frozenset(
-    {"ema-single-long", "tm-single-long", "tm-single-long-hsl"}
+    {
+        "ema-single-long",
+        "tm-single-long",
+        "tm-single-long-static-close",
+        "tm-single-long-close-ladder",
+        "tm-single-long-hsl",
+    }
 )
 DEFAULT_SEED = 7
 MAX_CANDIDATES = 4096
@@ -115,6 +123,17 @@ def _base_parameter_values() -> dict[str, float]:
 
 
 def _single_coin_value_overrides(name: str) -> dict[str, float]:
+    if name in {
+        "tm-single-long-static-close",
+        "tm-single-long-close-ladder",
+    }:
+        return {
+            "close_qty_pct": 0.25,
+            "close_retracement_base_pct": 0.0,
+            "close_threshold_we_weight": (
+                0.02 if name == "tm-single-long-close-ladder" else 0.0
+            ),
+        }
     if name != "tm-single-long-hsl":
         return {}
     return {
@@ -188,6 +207,15 @@ def _fixture_sha256(*arrays) -> str:
         digest.update(str(array.shape).encode())
         digest.update(array.tobytes())
     return digest.hexdigest()
+
+
+def _recursive_close_ladder_candidate_count(candidates) -> int:
+    return sum(
+        float(candidate.get("long_close_retracement_base_pct", 1.0)) <= 0.0
+        and float(candidate.get("long_close_threshold_we_weight", 0.0)) != 0.0
+        and float(candidate.get("long_close_qty_pct", 1.0)) < 1.0
+        for candidate in candidates
+    )
 
 
 def _market_and_run(timestamps, bars: int):
@@ -515,6 +543,9 @@ def run_benchmark_case(
         ),
         "hsl_signal_mode": float(
             candidate_dicts[0].get("long_hsl_signal_mode", 0.0)
+        ),
+        "recursive_close_ladder_candidate_count": (
+            _recursive_close_ladder_candidate_count(candidate_dicts)
         ),
         "actual_dispatch_batch_size": int(cold["batch_size"]),
         "dispatch_chunk_count": int(

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -12963,6 +12963,91 @@ def test_mps_tm_zero_volatility_specialization_matches_generic(
 @pytest.mark.skipif(
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_tm_reducer_free_recursive_close_matches_generic(monkeypatch, side):
+    import optimization.gpu.mps_kernel as mps_kernel
+
+    count = 512
+    steps = np.arange(count, dtype=np.float64)
+    close = 100.0 + np.sin(steps / 17.0) * 3.0
+    high = close + 0.5
+    low = close - 0.5
+    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    market = ProxyMarket(0.001, 0.01, 0.001, 5.0, 1.0, 0.0002)
+    run = ProxyRun(
+        1_000.0,
+        1,
+        1,
+        int(timestamps[0]),
+        int(timestamps[0]),
+        int(timestamps[0]),
+        60_000,
+        0.05,
+        0,
+        count - 1,
+    )
+    data = build_mps_data(high, low, close, timestamps, run, market)
+    row = _tm_single_row()
+    for key, value in (
+        ("close_qty_pct", 0.25),
+        ("close_threshold_we_weight", 0.02),
+        ("close_retracement_base_pct", 0.0),
+    ):
+        row[TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS.index(key)] = value
+    parameters = np.asarray([row + row], dtype=np.float64)
+
+    specialized_runner = MpsTrailingMartingaleRunner(
+        market,
+        run,
+        data,
+        long_enabled=side == "long",
+        short_enabled=side == "short",
+        hsl_enabled=False,
+    )
+    specialized = specialized_runner.run(parameters, profile=True)
+    original_specialization = mps_kernel._tm_dispatch_specialization
+
+    def force_generic_reducers(*args, **kwargs):
+        features = original_specialization(*args, **kwargs)
+        return (*features[:2], False, *features[3:])
+
+    monkeypatch.setattr(
+        mps_kernel, "_tm_dispatch_specialization", force_generic_reducers
+    )
+    generic_runner = MpsTrailingMartingaleRunner(
+        market,
+        run,
+        data,
+        long_enabled=side == "long",
+        short_enabled=side == "short",
+        hsl_enabled=False,
+    )
+    generic = generic_runner.run(parameters, profile=True)
+    torch.mps.synchronize()
+
+    assert specialized_runner.last_profile["dispatch_specialization"][
+        "reducers_disabled"
+    ] is True
+    assert generic_runner.last_profile["dispatch_specialization"][
+        "reducers_disabled"
+    ] is False
+    assert specialized.keys() == generic.keys()
+    for key in specialized:
+        if isinstance(specialized[key], torch.Tensor):
+            torch.testing.assert_close(
+                specialized[key].cpu(),
+                generic[key].cpu(),
+                rtol=0.0,
+                atol=0.0,
+                equal_nan=True,
+            )
+        else:
+            assert specialized[key] == generic[key]
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
 @pytest.mark.parametrize("topology", ["long", "short", "fused"])
 def test_mps_tm_single_coin_entry_intervals_track_only_fresh_positions(topology):
     from optimization.gpu.mps_kernel import MpsTrailingMartingaleRunner
@@ -20525,8 +20610,9 @@ def test_mps_trailing_martingale_shader_contract_and_directional_smoke(
     assert source.count("bool all_below_min") == 1
     assert source.count("bool normalize_close_groups") == 3
     assert source.count("int collapse_ordinary_rank") == 3
-    assert source.count("recursive_close_allocation(") == 5
+    assert source.count("recursive_close_allocation(") == 7
     assert source.count("select_recursive_close_reducer(") == 3
+    assert source.count("#if PASSIVBOT_TM_REDUCERS_DISABLED") == 2
     assert source.count("ReducerCandidate candidates[3]") == 2
     assert source.count("candidate_allocations[candidate_idx]") == 4
     assert source.count("candidates[candidate_idx].finalized_qty") == 4

--- a/tests/optimization/test_gpu_proxy_benchmark.py
+++ b/tests/optimization/test_gpu_proxy_benchmark.py
@@ -14,6 +14,7 @@ from tools.gpu_proxy_benchmark import (
     _bounded_positive,
     _fixture_sha256,
     _parameter_matrix,
+    _recursive_close_ladder_candidate_count,
     _require_mps_torch,
     _single_coin_value_overrides,
     build_parser,
@@ -91,6 +92,65 @@ def test_gpu_proxy_benchmark_exposes_single_side_tm_hsl_case():
         == HSL_SIGNAL_MODE_COIN
     )
     assert HSL_PNL_LOOKBACK_BARS == 43_200
+
+
+@pytest.mark.parametrize(
+    ("case", "expected_weight"),
+    (
+        ("tm-single-long-static-close", 0.0),
+        ("tm-single-long-close-ladder", 0.02),
+    ),
+)
+def test_gpu_proxy_benchmark_exposes_recursive_close_comparison_cases(
+    case, expected_weight
+):
+    args = build_parser().parse_args(["--case", case])
+    matrix = _parameter_matrix(
+        TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS,
+        2,
+        7,
+        value_overrides=_single_coin_value_overrides(args.case),
+    )
+
+    assert np.all(
+        matrix[:, TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS.index("close_qty_pct")]
+        == 0.25
+    )
+    assert np.all(
+        matrix[
+            :,
+            TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS.index(
+                "close_retracement_base_pct"
+            ),
+        ]
+        == 0.0
+    )
+    assert np.all(
+        matrix[
+            :,
+            TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS.index(
+                "close_threshold_we_weight"
+            ),
+        ]
+        == expected_weight
+    )
+
+
+def test_gpu_proxy_benchmark_counts_only_recursive_close_ladder_candidates():
+    base = {
+        "long_close_qty_pct": 0.25,
+        "long_close_retracement_base_pct": 0.0,
+        "long_close_threshold_we_weight": 0.02,
+    }
+
+    assert _recursive_close_ladder_candidate_count(
+        [
+            base,
+            {**base, "long_close_qty_pct": 1.0},
+            {**base, "long_close_retracement_base_pct": 0.001},
+            {**base, "long_close_threshold_we_weight": 0.0},
+        ]
+    ) == 1
 
 
 @pytest.mark.parametrize(
@@ -211,6 +271,7 @@ def test_gpu_proxy_benchmark_reports_profiled_dispatch_chunks(monkeypatch):
     assert report["kernel_candidate_bars"] == 80
     assert report["hsl_pnl_lookback_bars"] == 43_200
     assert report["hsl_signal_mode"] == 0.0
+    assert report["recursive_close_ladder_candidate_count"] == 0
 
 
 def test_gpu_proxy_benchmark_reports_missing_optional_gpu_dependencies(


### PR DESCRIPTION
## Summary
- skip redundant reducer-candidate construction in single-coin Trailing Martingale recursive closes when every active candidate side has WEL/TWEL enforcers and auto-unstuck disabled
- preserve the ordinary recursive close allocation and exact Rust authority
- add paired deterministic static-close and recursive-close benchmark cases, report ladder-capable candidate count, and document the contract

The generic reducer-capable shader path is unchanged. This affects only Apple MPS proxy screening; CPU bot, backtest, and optimizer paths are unchanged.

## Performance
Fixed-seed in-memory benchmark, 512 candidates x 525600 one-minute candles, one dispatch:
- origin/master recursive close ladder warm p50 across 3 runs: 163.7 candidates/s
- this branch recursive close ladder warm p50 across 3 runs: 178.8 candidates/s
- improvement: about 9.2%
- a separate 5-run confirmation measured 178.6 candidates/s

The before and after fixture SHA256 was identical: 5bbaeeea211a640d8a1c4c9522411bb321f64c85746102478d1cb98e78079147.

## Validation
- benchmark and CLI tests: 17 passed
- focused recursive-close and dispatch-specialization MPS tests: 23 passed
- full tests/optimization/test_gpu_mps.py suite passed
- cargo test --no-default-features: 275 passed
- cargo check --tests
- source-matched release extension rebuilt and fingerprint verified
- CPU runtime import regression passed
- AI documentation checks passed with the existing warning-only size notices
- flake8 E9,F63,F7,F82 checks passed

cargo fmt --check still reports repository-wide pre-existing formatting drift in untouched Rust code, so no broad mechanical formatting rewrite is included.