### PR TITLE
Speed recursive Trailing Martingale GPU entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Apple MPS single-coin Trailing Martingale now selects a recursive-entry-only Metal variant when
+  every active candidate uses nonpositive entry retracement. The variant compiles out trailing
+  entry retracement/trigger work while preserving the recursive ladder and bitwise generic-kernel
+  outputs. The deterministic GPU benchmark adds a fixed recursive-entry case for repeatable
+  before/after measurements. Exact Rust validation, CPU optimization, backtests, and live behavior
+  are unchanged.
+
 - Apple MPS single-coin Trailing Martingale now uses a reducer-free recursive-close fast path when
   every active candidate side disables WEL/TWEL enforcers and auto-unstuck, avoiding redundant
   reducer allocations while preserving the ordinary close ladder. The deterministic GPU benchmark

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -793,9 +793,12 @@ available without enabling profiling or adding synchronization points.
 Single-coin Trailing Martingale runners inspect the packed rows in each dispatch before choosing a
 cached Metal library. When every enabled-side candidate has positive entry or close retracement,
 the corresponding recursive grid path is compiled out. When every enabled-side candidate disables
-the position/total-exposure enforcers and auto-unstuck, those reducer paths are compiled out as a
-group. Fixed run settings similarly specialize ordinary market execution and the realized-loss
-gate. When all eight entry/close threshold and retracement volatility weights are exactly zero for
+entry retracement, the entry path instead compiles out trailing trigger and retracement work while
+retaining recursive ladder expansion. Mixed entry modes keep the generic path. When every
+enabled-side candidate disables the position/total-exposure enforcers and auto-unstuck, those
+reducer paths are compiled out as a group. Fixed run settings similarly specialize ordinary market
+execution and the realized-loss gate. When all eight entry/close threshold and retracement
+volatility weights are exactly zero for
 every active row, the selected kernel also omits the 1-minute and 1-hour volatility EMA state,
 candle-range loads, and volatility-weight arithmetic. Any nonzero, non-finite, or mixed row keeps
 the full volatility path. A mixed dispatch keeps each relevant full path, so this changes compiled
@@ -812,6 +815,7 @@ optimization results.
 ```bash
 passivbot tool gpu-proxy-benchmark --case ema-single-long
 passivbot tool gpu-proxy-benchmark --case tm-single-long
+passivbot tool gpu-proxy-benchmark --case tm-single-long-entry-ladder
 passivbot tool gpu-proxy-benchmark --case tm-single-long-static-close
 passivbot tool gpu-proxy-benchmark --case tm-single-long-close-ladder
 passivbot tool gpu-proxy-benchmark --case tm-single-long-hsl
@@ -845,6 +849,10 @@ parameters can emit multiple close rungs. When every active candidate side disab
 enforcers and auto-unstuck, the directional kernel skips reducer candidate construction and
 performs the one ordinary close-grid allocation directly; exact Rust validation remains
 authoritative.
+The ordinary and entry-ladder Trailing Martingale cases likewise hold candles, candidate count,
+seed, and all other parameters constant while switching entry retracement from positive to zero.
+Reports include the number of recursive-entry candidates. Homogeneous recursive-entry dispatches
+select the recursive-only Metal variant; mixed entry modes retain the generic kernel.
 
 ### Pymoo Configuration
 

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -4,6 +4,10 @@ using namespace metal;
 #ifndef PASSIVBOT_TM_TRAILING_ENTRY_ONLY
 #define PASSIVBOT_TM_TRAILING_ENTRY_ONLY 0
 #endif
+
+#ifndef PASSIVBOT_TM_RECURSIVE_ENTRY_ONLY
+#define PASSIVBOT_TM_RECURSIVE_ENTRY_ONLY 0
+#endif
 #ifndef PASSIVBOT_TM_TRAILING_CLOSE_ONLY
 #define PASSIVBOT_TM_TRAILING_CLOSE_ONLY 0
 #endif
@@ -969,20 +973,32 @@ inline void generate_orders(
     float wer = we / fmax(s.allowed_wel, 1.0e-12f);
 #if PASSIVBOT_TM_VOLATILITY_DISABLED
     float tm = fmax(1.0f + wer * s.entry_threshold_we, 1.0f);
+#if !PASSIVBOT_TM_RECURSIVE_ENTRY_ONLY
     float rm = fmax(1.0f + wer * s.entry_retracement_we, 1.0f);
+#endif
 #else
     float tm = fmax(
         1.0f + s.vol1h * s.entry_threshold_v1h
             + s.vol1m * s.entry_threshold_v1m + wer * s.entry_threshold_we,
         1.0f
     );
+#if !PASSIVBOT_TM_RECURSIVE_ENTRY_ONLY
     float rm = fmax(
         1.0f + s.vol1h * s.entry_retracement_v1h
             + s.vol1m * s.entry_retracement_v1m + wer * s.entry_retracement_we,
         1.0f
     );
 #endif
+#endif
     float threshold = fmax(s.entry_threshold_base, 0.0f) * tm;
+#if PASSIVBOT_TM_RECURSIVE_ENTRY_ONLY
+    const bool trailing_entry = false;
+    bool entry_triggered = true;
+    float reentry_target = s.pprice * (
+        is_long ? 1.0f - s.entry_threshold_base * tm
+                : 1.0f + s.entry_threshold_base * tm
+    );
+#else
     float retracement = fmax(s.entry_retracement_base, 0.0f) * rm;
     const bool trailing_entry = PASSIVBOT_TM_TRAILING_ENTRY_ONLY
         || s.entry_retracement_base > 0.0f;
@@ -1011,6 +1027,7 @@ inline void generate_orders(
             );
         }
     }
+#endif
     bool reentry_target_is_touch = trailing_entry && threshold <= 0.0f;
     int raw_reentry_ticks = reentry_target_is_touch
         ? entry_touch : directional_ticks(reentry_target, price_step, entry_up);
@@ -2887,9 +2904,13 @@ inline void passivbot_single_coin_impl(
                 // candle. Market promotion guarantees rung zero's execution,
                 // but does not itself authorize expansion.
                 if (rung == 0 && !long_entry_passive_reachable) break;
+#if PASSIVBOT_TM_RECURSIVE_ENTRY_ONLY
+                if (long_side.cooldown_min != 0.0f) break;
+#else
                 if (PASSIVBOT_TM_TRAILING_ENTRY_ONLY
                     || long_side.entry_retracement_base > 0.0f
                     || long_side.cooldown_min != 0.0f) break;
+#endif
                 generate_long_orders(
                     ladder_side, ladder_balance, ep, qty_step,
                     ladder_touch_ticks, ladder_touch_ticks, ladder_touch_ticks,
@@ -3660,9 +3681,13 @@ inline void passivbot_single_coin_impl(
                 previous_ticks = entry_ticks;
                 ladder_touch_ticks = max(ladder_touch_ticks, entry_ticks);
                 if (rung == 0 && !short_entry_passive_reachable) break;
+#if PASSIVBOT_TM_RECURSIVE_ENTRY_ONLY
+                if (short_side.cooldown_min != 0.0f) break;
+#else
                 if (PASSIVBOT_TM_TRAILING_ENTRY_ONLY
                     || short_side.entry_retracement_base > 0.0f
                     || short_side.cooldown_min != 0.0f) break;
+#endif
                 generate_short_orders(
                     ladder_side, ladder_balance, ep, qty_step,
                     ladder_touch_ticks, ladder_touch_ticks, ladder_touch_ticks,

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -73,6 +73,9 @@ _ENTRY_INTERVAL_DEFINE = "#define PASSIVBOT_ENTRY_INTERVAL_ENABLED 1\n"
 _TM_TRAILING_ENTRY_ONLY_DEFINE = (
     "#define PASSIVBOT_TM_TRAILING_ENTRY_ONLY 1\n"
 )
+_TM_RECURSIVE_ENTRY_ONLY_DEFINE = (
+    "#define PASSIVBOT_TM_RECURSIVE_ENTRY_ONLY 1\n"
+)
 _TM_TRAILING_CLOSE_ONLY_DEFINE = (
     "#define PASSIVBOT_TM_TRAILING_CLOSE_ONLY 1\n"
 )
@@ -176,17 +179,27 @@ def _with_tm_dispatch_features(
     source: str,
     *,
     trailing_entry_only: bool,
+    recursive_entry_only: bool,
     trailing_close_only: bool,
     reducers_disabled: bool,
     market_orders_disabled: bool,
     loss_gate_disabled: bool,
     volatility_disabled: bool,
 ) -> str:
+    if trailing_entry_only and recursive_entry_only:
+        raise ValueError(
+            "TM trailing-entry-only and recursive-entry-only modes are mutually exclusive"
+        )
     features = (
         (
             trailing_entry_only,
             "#ifndef PASSIVBOT_TM_TRAILING_ENTRY_ONLY",
             _TM_TRAILING_ENTRY_ONLY_DEFINE,
+        ),
+        (
+            recursive_entry_only,
+            "#ifndef PASSIVBOT_TM_RECURSIVE_ENTRY_ONLY",
+            _TM_RECURSIVE_ENTRY_ONLY_DEFINE,
         ),
         (
             trailing_close_only,
@@ -285,7 +298,7 @@ def _tm_dispatch_specialization(
     short_enabled: bool,
     market_orders_allowed: bool,
     loss_gate_enabled: bool,
-) -> tuple[bool, bool, bool, bool, bool, bool]:
+) -> tuple[bool, bool, bool, bool, bool, bool, bool]:
     """Prove dispatch-wide TM features before compiling away inactive paths."""
 
     side_width = len(TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS)
@@ -305,6 +318,10 @@ def _tm_dispatch_specialization(
 
     trailing_entry_only = all_active_rows(
         lambda values: np.all(np.isfinite(values) & (values > 0.0)),
+        "entry_retracement_base_pct",
+    )
+    recursive_entry_only = all_active_rows(
+        lambda values: np.all(np.isfinite(values) & (values <= 0.0)),
         "entry_retracement_base_pct",
     )
     trailing_close_only = all_active_rows(
@@ -340,6 +357,7 @@ def _tm_dispatch_specialization(
     )
     return (
         trailing_entry_only,
+        recursive_entry_only,
         trailing_close_only,
         reducers_disabled,
         not market_orders_allowed,
@@ -679,6 +697,7 @@ def _ema_anchor_short_no_hsl_shader_library(
 @lru_cache(maxsize=16)
 def _trailing_martingale_shader_library(
     trailing_entry_only: bool = False,
+    recursive_entry_only: bool = False,
     trailing_close_only: bool = False,
     reducers_disabled: bool = False,
     market_orders_disabled: bool = False,
@@ -700,6 +719,7 @@ def _trailing_martingale_shader_library(
     source = _with_tm_dispatch_features(
         passivbot_rust.mps_trailing_martingale_source_py(),
         trailing_entry_only=trailing_entry_only,
+        recursive_entry_only=recursive_entry_only,
         trailing_close_only=trailing_close_only,
         reducers_disabled=reducers_disabled,
         market_orders_disabled=market_orders_disabled,
@@ -723,6 +743,7 @@ def _trailing_martingale_shader_library(
 @lru_cache(maxsize=16)
 def _trailing_martingale_long_hsl_shader_library(
     trailing_entry_only: bool = False,
+    recursive_entry_only: bool = False,
     trailing_close_only: bool = False,
     reducers_disabled: bool = False,
     market_orders_disabled: bool = False,
@@ -744,6 +765,7 @@ def _trailing_martingale_long_hsl_shader_library(
     source = _with_tm_dispatch_features(
         passivbot_rust.mps_trailing_martingale_long_hsl_source_py(),
         trailing_entry_only=trailing_entry_only,
+        recursive_entry_only=recursive_entry_only,
         trailing_close_only=trailing_close_only,
         reducers_disabled=reducers_disabled,
         market_orders_disabled=market_orders_disabled,
@@ -767,6 +789,7 @@ def _trailing_martingale_long_hsl_shader_library(
 @lru_cache(maxsize=16)
 def _trailing_martingale_short_hsl_shader_library(
     trailing_entry_only: bool = False,
+    recursive_entry_only: bool = False,
     trailing_close_only: bool = False,
     reducers_disabled: bool = False,
     market_orders_disabled: bool = False,
@@ -788,6 +811,7 @@ def _trailing_martingale_short_hsl_shader_library(
     source = _with_tm_dispatch_features(
         passivbot_rust.mps_trailing_martingale_short_hsl_source_py(),
         trailing_entry_only=trailing_entry_only,
+        recursive_entry_only=recursive_entry_only,
         trailing_close_only=trailing_close_only,
         reducers_disabled=reducers_disabled,
         market_orders_disabled=market_orders_disabled,
@@ -811,6 +835,7 @@ def _trailing_martingale_short_hsl_shader_library(
 @lru_cache(maxsize=8)
 def _trailing_martingale_long_no_hsl_shader_library(
     trailing_entry_only: bool = False,
+    recursive_entry_only: bool = False,
     trailing_close_only: bool = False,
     reducers_disabled: bool = False,
     market_orders_disabled: bool = False,
@@ -828,6 +853,7 @@ def _trailing_martingale_long_no_hsl_shader_library(
     source = _with_tm_dispatch_features(
         passivbot_rust.mps_trailing_martingale_long_no_hsl_source_py(),
         trailing_entry_only=trailing_entry_only,
+        recursive_entry_only=recursive_entry_only,
         trailing_close_only=trailing_close_only,
         reducers_disabled=reducers_disabled,
         market_orders_disabled=market_orders_disabled,
@@ -847,6 +873,7 @@ def _trailing_martingale_long_no_hsl_shader_library(
 @lru_cache(maxsize=8)
 def _trailing_martingale_short_no_hsl_shader_library(
     trailing_entry_only: bool = False,
+    recursive_entry_only: bool = False,
     trailing_close_only: bool = False,
     reducers_disabled: bool = False,
     market_orders_disabled: bool = False,
@@ -864,6 +891,7 @@ def _trailing_martingale_short_no_hsl_shader_library(
     source = _with_tm_dispatch_features(
         passivbot_rust.mps_trailing_martingale_short_no_hsl_source_py(),
         trailing_entry_only=trailing_entry_only,
+        recursive_entry_only=recursive_entry_only,
         trailing_close_only=trailing_close_only,
         reducers_disabled=reducers_disabled,
         market_orders_disabled=market_orders_disabled,
@@ -2849,10 +2877,13 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
 
     def _shader_library_cache_call(
         self,
-        dispatch_features: tuple[bool, bool, bool, bool, bool, bool] | None = None,
+        dispatch_features: tuple[
+            bool, bool, bool, bool, bool, bool, bool
+        ] | None = None,
     ):
         if dispatch_features is None:
             dispatch_features = (
+                False,
                 False,
                 False,
                 False,
@@ -3182,11 +3213,12 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
                 - max(0, effective_history_start),
                 "dispatch_specialization": {
                     "trailing_entry_only": dispatch_features[0],
-                    "trailing_close_only": dispatch_features[1],
-                    "reducers_disabled": dispatch_features[2],
-                    "market_orders_disabled": dispatch_features[3],
-                    "loss_gate_disabled": dispatch_features[4],
-                    "volatility_disabled": dispatch_features[5],
+                    "recursive_entry_only": dispatch_features[1],
+                    "trailing_close_only": dispatch_features[2],
+                    "reducers_disabled": dispatch_features[3],
+                    "market_orders_disabled": dispatch_features[4],
+                    "loss_gate_disabled": dispatch_features[5],
+                    "volatility_disabled": dispatch_features[6],
                 },
             }
         else:

--- a/src/tools/gpu_proxy_benchmark.py
+++ b/src/tools/gpu_proxy_benchmark.py
@@ -24,6 +24,7 @@ from optimization.gpu.model import (
 CASES = (
     "ema-single-long",
     "tm-single-long",
+    "tm-single-long-entry-ladder",
     "tm-single-long-static-close",
     "tm-single-long-close-ladder",
     "tm-single-long-hsl",
@@ -34,6 +35,7 @@ SINGLE_COIN_CASES = frozenset(
     {
         "ema-single-long",
         "tm-single-long",
+        "tm-single-long-entry-ladder",
         "tm-single-long-static-close",
         "tm-single-long-close-ladder",
         "tm-single-long-hsl",
@@ -123,6 +125,10 @@ def _base_parameter_values() -> dict[str, float]:
 
 
 def _single_coin_value_overrides(name: str) -> dict[str, float]:
+    if name == "tm-single-long-entry-ladder":
+        return {
+            "entry_retracement_base_pct": 0.0,
+        }
     if name in {
         "tm-single-long-static-close",
         "tm-single-long-close-ladder",
@@ -214,6 +220,14 @@ def _recursive_close_ladder_candidate_count(candidates) -> int:
         float(candidate.get("long_close_retracement_base_pct", 1.0)) <= 0.0
         and float(candidate.get("long_close_threshold_we_weight", 0.0)) != 0.0
         and float(candidate.get("long_close_qty_pct", 1.0)) < 1.0
+        for candidate in candidates
+    )
+
+
+def _recursive_entry_ladder_candidate_count(candidates) -> int:
+    return sum(
+        float(candidate.get("long_entry_retracement_base_pct", 1.0)) <= 0.0
+        and float(candidate.get("long_entry_cooldown_minutes", 0.0)) == 0.0
         for candidate in candidates
     )
 
@@ -546,6 +560,9 @@ def run_benchmark_case(
         ),
         "recursive_close_ladder_candidate_count": (
             _recursive_close_ladder_candidate_count(candidate_dicts)
+        ),
+        "recursive_entry_ladder_candidate_count": (
+            _recursive_entry_ladder_candidate_count(candidate_dicts)
         ),
         "actual_dispatch_batch_size": int(cold["batch_size"]),
         "dispatch_chunk_count": int(

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -12776,7 +12776,7 @@ def test_tm_dispatch_specialization_requires_every_enabled_side_and_row():
         short_enabled=False,
         market_orders_allowed=False,
         loss_gate_enabled=False,
-    ) == (True, True, True, True, True, True)
+    ) == (True, False, True, True, True, True, True)
 
     entry_column = TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS.index(
         "entry_retracement_base_pct"
@@ -12788,7 +12788,16 @@ def test_tm_dispatch_specialization_requires_every_enabled_side_and_row():
         short_enabled=False,
         market_orders_allowed=True,
         loss_gate_enabled=True,
-    ) == (False, True, True, False, False, True)
+    ) == (False, False, True, True, False, False, True)
+
+    matrix[:, entry_column] = 0.0
+    assert _tm_dispatch_specialization(
+        matrix,
+        long_enabled=True,
+        short_enabled=False,
+        market_orders_allowed=False,
+        loss_gate_enabled=False,
+    )[:2] == (False, True)
 
     volatility_column = TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS.index(
         "entry_threshold_volatility_1m_weight"
@@ -12800,10 +12809,10 @@ def test_tm_dispatch_specialization_requires_every_enabled_side_and_row():
         short_enabled=False,
         market_orders_allowed=False,
         loss_gate_enabled=False,
-    )[5] is False
+    )[6] is False
     matrix[1, volatility_column] = 0.0
 
-    matrix[1, entry_column] = 0.001
+    matrix[:, entry_column] = 0.001
     side_width = len(TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS)
     short_wel_column = side_width + TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS.index(
         "wel_enforcer_enabled"
@@ -12815,14 +12824,14 @@ def test_tm_dispatch_specialization_requires_every_enabled_side_and_row():
         short_enabled=False,
         market_orders_allowed=False,
         loss_gate_enabled=False,
-    )[2] is True
+    )[3] is True
     assert _tm_dispatch_specialization(
         matrix,
         long_enabled=True,
         short_enabled=True,
         market_orders_allowed=False,
         loss_gate_enabled=False,
-    )[2] is False
+    )[3] is False
 
 
 def test_tm_dispatch_feature_defines_are_opt_in_and_guarded():
@@ -12832,6 +12841,7 @@ def test_tm_dispatch_feature_defines_are_opt_in_and_guarded():
     transformed = _with_tm_dispatch_features(
         source,
         trailing_entry_only=True,
+        recursive_entry_only=False,
         trailing_close_only=True,
         reducers_disabled=True,
         market_orders_disabled=True,
@@ -12853,12 +12863,130 @@ def test_tm_dispatch_feature_defines_are_opt_in_and_guarded():
     assert _with_tm_dispatch_features(
         source,
         trailing_entry_only=False,
+        recursive_entry_only=False,
         trailing_close_only=False,
         reducers_disabled=False,
         market_orders_disabled=False,
         loss_gate_disabled=False,
         volatility_disabled=False,
     ) == source
+
+    recursive = _with_tm_dispatch_features(
+        source,
+        trailing_entry_only=False,
+        recursive_entry_only=True,
+        trailing_close_only=False,
+        reducers_disabled=False,
+        market_orders_disabled=False,
+        loss_gate_disabled=False,
+        volatility_disabled=False,
+    )
+    assert "#define PASSIVBOT_TM_RECURSIVE_ENTRY_ONLY 1" in recursive
+    assert "#ifndef PASSIVBOT_TM_RECURSIVE_ENTRY_ONLY" in recursive
+
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        _with_tm_dispatch_features(
+            source,
+            trailing_entry_only=True,
+            recursive_entry_only=True,
+            trailing_close_only=False,
+            reducers_disabled=False,
+            market_orders_disabled=False,
+            loss_gate_disabled=False,
+            volatility_disabled=False,
+        )
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_tm_recursive_entry_specialization_matches_generic(
+    monkeypatch, side
+):
+    import optimization.gpu.mps_kernel as mps_kernel
+
+    count = 512
+    steps = np.arange(count, dtype=np.float64)
+    close = 100.0 + np.sin(steps / 17.0) * 6.0
+    high = close + 0.75
+    low = close - 0.75
+    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
+    market = ProxyMarket(0.001, 0.01, 0.001, 5.0, 1.0, 0.0002)
+    run = ProxyRun(
+        1_000.0,
+        1,
+        1,
+        int(timestamps[0]),
+        int(timestamps[0]),
+        int(timestamps[0]),
+        60_000,
+        0.05,
+        0,
+        count - 1,
+    )
+    data = build_mps_data(high, low, close, timestamps, run, market)
+    row = _tm_single_row(initial_ema_dist=0.0, gate_initial=0.0, gate_reentry=0.0)
+    row[TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS.index(
+        "entry_double_down_factor"
+    )] = 1.5
+    row[TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS.index(
+        "entry_initial_qty_pct"
+    )] = 0.05
+    row[TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS.index(
+        "entry_retracement_base_pct"
+    )] = 0.0
+    parameters = np.asarray([row + row], dtype=np.float64)
+
+    specialized_runner = MpsTrailingMartingaleRunner(
+        market,
+        run,
+        data,
+        long_enabled=side == "long",
+        short_enabled=side == "short",
+        hsl_enabled=False,
+    )
+    specialized = specialized_runner.run(parameters, profile=True)
+    original_specialization = mps_kernel._tm_dispatch_specialization
+
+    def force_generic_recursive_entry(*args, **kwargs):
+        features = original_specialization(*args, **kwargs)
+        return (features[0], False, *features[2:])
+
+    monkeypatch.setattr(
+        mps_kernel,
+        "_tm_dispatch_specialization",
+        force_generic_recursive_entry,
+    )
+    generic_runner = MpsTrailingMartingaleRunner(
+        market,
+        run,
+        data,
+        long_enabled=side == "long",
+        short_enabled=side == "short",
+        hsl_enabled=False,
+    )
+    generic = generic_runner.run(parameters, profile=True)
+    torch.mps.synchronize()
+
+    assert specialized_runner.last_profile["dispatch_specialization"][
+        "recursive_entry_only"
+    ] is True
+    assert generic_runner.last_profile["dispatch_specialization"][
+        "recursive_entry_only"
+    ] is False
+    assert specialized.keys() == generic.keys()
+    for key in specialized:
+        if isinstance(specialized[key], torch.Tensor):
+            torch.testing.assert_close(
+                specialized[key].cpu(),
+                generic[key].cpu(),
+                rtol=0.0,
+                atol=0.0,
+                equal_nan=True,
+            )
+        else:
+            assert specialized[key] == generic[key]
 
 
 @pytest.mark.skipif(
@@ -12924,7 +13052,7 @@ def test_mps_tm_zero_volatility_specialization_matches_generic(
 
     def force_generic_volatility(*args, **kwargs):
         features = original_specialization(*args, **kwargs)
-        return (*features[:5], False)
+        return (*features[:6], False)
 
     monkeypatch.setattr(
         mps_kernel, "_tm_dispatch_specialization", force_generic_volatility
@@ -13009,7 +13137,7 @@ def test_mps_tm_reducer_free_recursive_close_matches_generic(monkeypatch, side):
 
     def force_generic_reducers(*args, **kwargs):
         features = original_specialization(*args, **kwargs)
-        return (*features[:2], False, *features[3:])
+        return (*features[:3], False, *features[4:])
 
     monkeypatch.setattr(
         mps_kernel, "_tm_dispatch_specialization", force_generic_reducers
@@ -20633,6 +20761,7 @@ def test_mps_trailing_martingale_shader_contract_and_directional_smoke(
         in source
     )
     assert "#ifndef PASSIVBOT_TM_TRAILING_ENTRY_ONLY" in source
+    assert "#ifndef PASSIVBOT_TM_RECURSIVE_ENTRY_ONLY" in source
     assert "#ifndef PASSIVBOT_TM_TRAILING_CLOSE_ONLY" in source
     assert "#ifndef PASSIVBOT_TM_REDUCERS_DISABLED" in source
     assert (
@@ -20674,6 +20803,7 @@ def test_mps_trailing_martingale_shader_contract_and_directional_smoke(
     assert "gate_market_entry_by_twel_strict" not in source
     assert source.count("gate_entry_by_twel_strict(") == 4
     assert "s.entry_retracement_base > 0.0f" in source
+    assert "#if PASSIVBOT_TM_RECURSIVE_ENTRY_ONLY" in source
     assert "s.close_retracement_base > 0.0f" in source
     assert "the proxy uses a zero-loss envelope" in source
     assert "const bool filter_by_min_effective_cost" in source

--- a/tests/optimization/test_gpu_proxy_benchmark.py
+++ b/tests/optimization/test_gpu_proxy_benchmark.py
@@ -15,6 +15,7 @@ from tools.gpu_proxy_benchmark import (
     _fixture_sha256,
     _parameter_matrix,
     _recursive_close_ladder_candidate_count,
+    _recursive_entry_ladder_candidate_count,
     _require_mps_torch,
     _single_coin_value_overrides,
     build_parser,
@@ -92,6 +93,41 @@ def test_gpu_proxy_benchmark_exposes_single_side_tm_hsl_case():
         == HSL_SIGNAL_MODE_COIN
     )
     assert HSL_PNL_LOOKBACK_BARS == 43_200
+
+
+def test_gpu_proxy_benchmark_exposes_recursive_entry_comparison_case():
+    args = build_parser().parse_args(["--case", "tm-single-long-entry-ladder"])
+    matrix = _parameter_matrix(
+        TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS,
+        2,
+        7,
+        value_overrides=_single_coin_value_overrides(args.case),
+    )
+
+    assert np.all(
+        matrix[
+            :,
+            TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS.index(
+                "entry_retracement_base_pct"
+            ),
+        ]
+        == 0.0
+    )
+
+
+def test_gpu_proxy_benchmark_counts_only_recursive_entry_ladder_candidates():
+    base = {
+        "long_entry_retracement_base_pct": 0.0,
+        "long_entry_cooldown_minutes": 0.0,
+    }
+
+    assert _recursive_entry_ladder_candidate_count(
+        [
+            base,
+            {**base, "long_entry_retracement_base_pct": 0.001},
+            {**base, "long_entry_cooldown_minutes": 1.0},
+        ]
+    ) == 1
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- detect homogeneous nonpositive entry-retracement dispatches and select a recursive-entry-only Metal variant
- compile out trailing entry retracement and trigger work while retaining the recursive ladder
- add a deterministic paired entry-ladder benchmark plus exact specialized-versus-generic parity coverage
- document the specialization and update the Unreleased changelog

Exact Rust validation remains authoritative. CPU optimization, backtests, live behavior, mixed entry-mode dispatches, and Trailing Grid v7 are unchanged.

## Performance
Fixed synthetic single-coin Trailing Martingale fixture: 1,024 candidates, 60,000 one-minute bars, one dispatch, seed 7, seven warm runs.

| Measurement | Base `f4055a768` | Head `a9eb8e4f8` | Change |
|---|---:|---:|---:|
| Recursive-entry warm p50 | 1,400.2 candidates/s | 1,476.1 candidates/s | +5.4% |
| Recursive-entry kernel p50 | 0.6900 s | 0.6524 s | -5.4% |

The paired positive-retracement control remains effectively unchanged: 1,586.1 candidates/s on the base measurement and 1,591.3 candidates/s on the head. The recursive fixture hash is `7aebc01bf8cfb29b449e7e871fd34b304bd5c961f1b3b597244b2ff59f63c7d1`.

## Validation
- `PYTHONPATH=src python -m pytest -q tests/optimization/test_gpu_mps.py`
- focused dispatcher, exact long/short bitwise parity, benchmark, and CPU-import regression tests
- `cargo test --manifest-path passivbot-rust/Cargo.toml --no-default-features` (275 passed)
- `cargo check --manifest-path passivbot-rust/Cargo.toml --tests`
- rebuilt Python extension and verified its embedded source fingerprint
- `python src/tools/check_ai_docs.py`
- `python -m py_compile` and focused flake8 fatal-error checks
- deterministic committed-head recursive-entry and paired control benchmarks