### PR TITLE
Bootstrap GPU optimizer seeds authoritatively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- GPU optimization now bootstraps `--start` configs into an authoritative exact-Rust seed archive.
+  The default `auto` policy exact-evaluates up to 128 deduplicated seeds; larger pools receive one
+  full-history Metal proxy screen followed by capped exact validation of diverse proxy-Pareto
+  members, objective extremes, and broad probes. Bootstrap evaluations are additional to
+  `optimize.iters`, exact and proxy fitness remain isolated, and crash-safe checkpoints preserve
+  incomplete seed plans. CPU optimization retains exact evaluation of every starting config.
+
 - Apple MPS single-coin Trailing Martingale now selects a recursive-entry-only Metal variant when
   every active candidate uses nonpositive entry retracement. The variant compiles out trailing
   entry retracement/trigger work while preserving the recursive ladder and bitwise generic-kernel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ All notable user-facing changes will be documented in this file.
   full-history Metal proxy screen followed by capped exact validation of diverse proxy-Pareto
   members, objective extremes, and broad probes. Bootstrap evaluations are additional to
   `optimize.iters`, exact and proxy fitness remain isolated, and crash-safe checkpoints preserve
-  incomplete seed plans. CPU optimization retains exact evaluation of every starting config.
+  incomplete seed plans and anchored fine-tune context. CPU optimization retains exact evaluation
+  of every starting config.
 
 - Apple MPS single-coin Trailing Martingale now selects a recursive-entry-only Metal variant when
   every active candidate uses nonpositive entry retracement. The variant compiles out trailing

--- a/docs/ai/features/strategy_runtime.md
+++ b/docs/ai/features/strategy_runtime.md
@@ -63,6 +63,20 @@ Optimizer selector contract:
   `optimize.bounds` are clamped into bounds with aggregated source/key logging. Without
   `--fine_tune_params`, `--start` remains seed-only.
 
+Seed evaluation contract:
+
+- Shared ingestion normalizes, clamps, quantizes, and deduplicates starting configs before each
+  backend applies its seed policy.
+- CPU optimization exact-Rust evaluates every deduplicated seed before population trimming.
+- GPU `seed_bootstrap.mode=auto` exact-evaluates small pools and full-history proxy-screens pools
+  larger than `max_exact`. Screened pools exact-Rust validate a capped, constraint-aware diverse
+  proxy set; only that subset enters the authoritative exact archive.
+- Seed-bootstrap exact evaluations are recorded separately from the GPU evolutionary
+  `optimize.iters` budget. Exact fitness seeds the archive and vector-only initial sampling; exact
+  and proxy fitness must never share an NSGA objective matrix.
+- An incomplete bootstrap checkpoint owns its normalized seed plan. Resume does not depend on the
+  original seed files and must recover any exact seed result already flushed to durable history.
+
 Timeframe-specific EMA spans use explicit horizon suffixes in canonical config names. Use `_1m`
 for 1-minute candle inputs and `_1h` for 1-hour candle inputs, for example
 `volatility_ema_span_1m`, `volatility_ema_span_1h`, `forager_volume_ema_span_1m`, and

--- a/docs/ai/features/strategy_runtime.md
+++ b/docs/ai/features/strategy_runtime.md
@@ -75,7 +75,8 @@ Seed evaluation contract:
   `optimize.iters` budget. Exact fitness seeds the archive and vector-only initial sampling; exact
   and proxy fitness must never share an NSGA objective matrix.
 - An incomplete bootstrap checkpoint owns its normalized seed plan. Resume does not depend on the
-  original seed files and must recover any exact seed result already flushed to durable history.
+  original seed files, including for anchored fine-tuning, and must recover any exact seed result
+  already flushed to durable history.
 
 Timeframe-specific EMA spans use explicit horizon suffixes in canonical config names. Use `_1m`
 for 1-minute candle inputs and `_1h` for 1-hour candle inputs, for example

--- a/docs/ai/runbooks/commands.md
+++ b/docs/ai/runbooks/commands.md
@@ -68,6 +68,12 @@ fine-tune anchors: non-tuned optimizer-bound bot params are fixed from the selec
 only the fine-tune selectors are optimized. Runtime policy from the base config still wins, and
 seed/anchor values outside `optimize.bounds` are clamped with aggregated source/key logging.
 
+CPU optimizers exact-evaluate every deduplicated `--start` config. The GPU backend defaults to
+`optimize.gpu.seed_bootstrap.mode=auto`: it exact-evaluates pools of at most 128 seeds and
+proxy-screens larger pools before capped exact validation. Use `mode=exact` only when the startup
+cost of exact-evaluating the complete pool is intentional. GPU bootstrap exact work is additional
+to `optimize.iters`.
+
 ## Rust
 
 ```bash

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -492,6 +492,19 @@ against the GPU scope: an anchor cannot change enabled sides or introduce unsupp
 behavior. Base-config runtime policy fields still win over anchor configs as described in
 [Fine-Tuning Specific Parameters](#fine-tuning-specific-parameters).
 
+Starting configs are normalized, clamped, quantized, and deduplicated through the shared optimizer
+loader before either backend evaluates them. CPU optimization retains its exact-all contract: every
+deduplicated seed is evaluated by the exact Rust backtester before population trimming. GPU
+optimization uses `optimize.gpu.seed_bootstrap`: the default `auto` mode also exact-evaluates every
+seed when the pool contains at most `max_exact` entries (128 by default). Larger pools are screened
+once by the full-history Metal proxy; a deterministic, constraint-aware mixture of diverse proxy-
+Pareto members, per-objective extremes, and off-front probes is then exact-evaluated, capped at
+`max_exact`. The authoritative Pareto archive contains only those exact results, so screened mode
+does not claim that the unevaluated remainder of the seed pool has an exact Pareto classification.
+Exact-selected seeds are placed first in the initial GPU population, followed by proxy-diverse
+seeds and then random candidates. Their exact objective values are never inserted into the proxy
+NSGA-II fitness matrix.
+
 The V8 `optimize.enable_overrides` values `mirror_short_from_long` and
 `lossless_close_trailing` are applied to Metal candidates in the same order as exact candidate
 materialization. Mirroring may be used with the supported single-coin directional scopes; short
@@ -620,9 +633,10 @@ The backend is hybrid rather than a replacement backtester:
    comparable broad probes. Window and exact-budget validation reserve enough total probes to retain
    those eight whenever the configured probe constraint-agreement gate has not already failed.
 
-`optimize.iters` remains the number of exact Rust validations. GPU screening counts and throughput
-are reported separately in the log. `n_cpus` controls the exact-validation worker pool; MPS device
-scheduling is managed by Metal.
+`optimize.iters` remains the number of evolutionary exact Rust validations. Any exact seed-
+bootstrap evaluations are additional and are reported separately. GPU screening counts and
+throughput are also logged separately. `n_cpus` controls the exact-validation worker pool; MPS
+device scheduling is managed by Metal.
 
 GPU-specific settings live under `optimize.gpu`:
 
@@ -642,6 +656,10 @@ GPU-specific settings live under `optimize.gpu`:
       "exact_workers": 0,
       "max_pending_exact": 0,
       "population_size": null,
+      "seed_bootstrap": {
+        "max_exact": 128,
+        "mode": "auto"
+      },
       "successive_halving": {
         "enabled": false,
         "history_fractions": [0.25, 0.5, 1.0],
@@ -692,6 +710,15 @@ duplicate-elimination controls as the ordinary pymoo optimizer.
   and all heavier shapes retain the 1-billion default; the optimizer does not apply the wider
   envelope to coin-overridden, HSL, multicoin, suite, market-order, reducer, recursive-mode, or
   active-volatility kernels, nor to kernels with optional metric feature paths enabled.
+- `seed_bootstrap.mode` controls `-t/--start` handling. `auto` exact-evaluates all deduplicated seeds
+  up to `seed_bootstrap.max_exact`, then switches to full-history proxy screening plus capped exact
+  validation for larger pools. `exact` forces exact evaluation of every seed even above the cap;
+  `screened` always performs proxy screening and validates at most the cap; and `legacy` restores
+  the former behavior of copying seeds directly into the first proxy population without an
+  authoritative bootstrap archive. Bootstrap exact evaluations are recorded in `all_results.bin`
+  and the Pareto store but do not consume `optimize.iters`, which remains the subsequent
+  evolutionary exact-validation budget. Checkpoints preserve incomplete bootstrap plans and can
+  recover a seed result durably flushed immediately before a restart.
 - `successive_halving.enabled` opts a non-suite, single-coin Trailing Martingale run into
   progressively longer recent-history suffixes. The default `history_fractions` are 25%, 50%, and
   100%, measured backwards from the configured end date; each partial suffix receives the normal
@@ -1146,8 +1173,9 @@ be constrained through `drawdown_worst_strategy_eq`, `drawdown_worst_ema_strateg
 `drawdown_worst_mean_1pct_strategy_eq`, `drawdown_worst_mean_1pct_ema_strategy_eq`, and
 `strategy_eq_recovery_days_max` instead of being prematurely truncated.
 
-When you provide many starting configs, optimizer bounds how many seed evaluations may be in flight
-at once. For the DEAP backend, the same cap also applies to generation offspring evaluations:
+When you provide many starting configs to a CPU optimizer, it bounds how many seed evaluations may
+be in flight at once. For the DEAP backend, the same cap also applies to generation offspring
+evaluations:
 
 ```json
 "optimize": {
@@ -1158,8 +1186,9 @@ at once. For the DEAP backend, the same cap also applies to generation offspring
 Effective cap:
 
 - `max_pending = n_cpus * max_pending_starting_evals_per_cpu`
-- All provided starting configs are still evaluated before the optimizer trims them down to the
-  backend's initial population.
+- All provided starting configs are still exact-evaluated before a CPU optimizer trims them down to
+  its initial population. GPU `auto` and `screened` seed bootstrapping instead use the capped policy
+  described above.
 
 This is mainly a memory-control knob for large seed pools and DEAP generation batches, especially
 in suite mode where each candidate returns a larger metrics payload. Lower it first if the VPS

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -718,7 +718,8 @@ duplicate-elimination controls as the ordinary pymoo optimizer.
   authoritative bootstrap archive. Bootstrap exact evaluations are recorded in `all_results.bin`
   and the Pareto store but do not consume `optimize.iters`, which remains the subsequent
   evolutionary exact-validation budget. Checkpoints preserve incomplete bootstrap plans and can
-  recover a seed result durably flushed immediately before a restart.
+  recover a seed result durably flushed immediately before a restart. Anchored fine-tune context
+  is checkpoint-owned as well, so resume does not require the original starting-config files.
 - `successive_halving.enabled` opts a non-suite, single-coin Trailing Martingale run into
   progressively longer recent-history suffixes. The default `history_fractions` are 25%, 50%, and
   100%, measured backwards from the configured end date; each partial suffix receives the normal

--- a/src/config/schema.py
+++ b/src/config/schema.py
@@ -512,6 +512,10 @@ def get_template_config():
                         "exact_workers": 0,
                         "max_pending_exact": 0,
                         "population_size": None,
+                        "seed_bootstrap": {
+                            "max_exact": 128,
+                            "mode": "auto",
+                        },
                         "successive_halving": {
                             "enabled": False,
                             "history_fractions": [0.25, 0.5, 1.0],

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -2655,6 +2655,22 @@ def _select_seed_bootstrap_indices(
     }
     feasible = np.flatnonzero(np.isfinite(violations) & (violations <= 0.0))
     primary = feasible if len(feasible) else np.arange(len(objectives), dtype=np.int64)
+    constraint_priority = []
+    if len(feasible) == 0:
+        # Proxy constraints can drift from exact Rust constraints, so retain
+        # objective diversity, but explicitly reserve part of the exact budget
+        # for the seeds closest to feasibility.  Otherwise an all-infeasible
+        # objective front can crowd out the most promising constraint repairs.
+        reserve = min(total, max(1, requested_probes))
+        constraint_priority = sorted(
+            map(int, primary),
+            key=lambda index: (
+                float(violations[index])
+                if np.isfinite(violations[index])
+                else float("inf"),
+                float(scores[index]),
+            ),
+        )[:reserve]
     extremes = []
     for column in range(objectives.shape[1]):
         values = objectives[primary, column]
@@ -2692,6 +2708,8 @@ def _select_seed_bootstrap_indices(
         selected_ids.add(int(index))
 
     front_target = max(1, total - requested_probes)
+    for index in constraint_priority:
+        append(index)
     for index in extremes[:front_target]:
         append(index)
     for index, _is_probe, is_front in preference:
@@ -5321,7 +5339,11 @@ def run_backend(
                     }
                     seed_exact_done += 1
                     completed_hashes.add(digest)
-                    maybe_save_checkpoint(force=True)
+                    # all_results.bin is flushed for every exact result and
+                    # recovery replays durable results beyond a stale
+                    # checkpoint.  Honor the configured checkpoint interval
+                    # instead of rewriting the complete seed plan per seed.
+                    maybe_save_checkpoint()
         except KeyboardInterrupt:
             cancel_pending_async_results(pending_seed)
             maybe_save_checkpoint(force=True)

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -2590,6 +2590,24 @@ def _effective_seed_bootstrap_mode(policy: dict, seed_count: int) -> str:
     return "exact" if int(seed_count) <= int(policy["max_exact"]) else "screened"
 
 
+def _deduplicate_canonical_seed_vectors(
+    vectors,
+    *,
+    hash_vector,
+) -> tuple[list, int]:
+    """Drop seeds that become identical after GPU runtime overrides."""
+
+    deduplicated = []
+    seen = set()
+    for vector in vectors:
+        digest = hash_vector(vector)
+        if digest in seen:
+            continue
+        seen.add(digest)
+        deduplicated.append(vector)
+    return deduplicated, len(vectors) - len(deduplicated)
+
+
 def _select_seed_bootstrap_indices(
     objectives: np.ndarray,
     scores: np.ndarray,
@@ -2694,6 +2712,7 @@ def _validate_seed_bootstrap_plan(
     proxy_metrics=None,
     proxy_objectives=None,
     proxy_violations=None,
+    screen_complete: bool = True,
 ) -> None:
     """Fail closed when an incomplete checkpoint seed plan is inconsistent."""
 
@@ -2705,7 +2724,6 @@ def _validate_seed_bootstrap_plan(
     if (
         int(contract.get("seed_count", -1)) != seed_count
         or contract.get("seed_pool_sha256") != digest
-        or int(contract.get("selected_exact_count", -1)) != len(selections)
     ):
         raise RuntimeError(
             "GPU checkpoint seed-bootstrap plan does not match its seed contract"
@@ -2715,6 +2733,31 @@ def _validate_seed_bootstrap_plan(
         raise RuntimeError(
             "GPU checkpoint has an incomplete seed-bootstrap plan for unsupported "
             f"mode {mode!r}"
+        )
+    if len(hashes) != len(set(hashes)):
+        raise RuntimeError(
+            "GPU checkpoint seed-bootstrap plan contains canonical duplicate seeds"
+        )
+    expected_selected = int(contract.get("selected_exact_count", -1))
+    if not screen_complete:
+        if (
+            mode != "screened"
+            or expected_selected != min(
+                seed_count, int(contract.get("max_exact", -1))
+            )
+            or selections
+            or population_indices
+            or proxy_metrics is not None
+            or proxy_objectives is not None
+            or proxy_violations is not None
+        ):
+            raise RuntimeError(
+                "GPU checkpoint pending seed screen has invalid partial evidence"
+            )
+        return
+    if expected_selected != len(selections):
+        raise RuntimeError(
+            "GPU checkpoint seed-bootstrap plan does not match its seed contract"
         )
     selected_ids = [int(index) for index, _probe, _front in selections]
     if (
@@ -4608,6 +4651,7 @@ def run_backend(
     seed_proxy_scores = None
     seed_bootstrap_selections = []
     seed_population_indices = []
+    seed_screen_complete = True
     checkpoint_seed_plan = (
         checkpoint.get("seed_bootstrap_plan") if checkpoint is not None else None
     )
@@ -4638,6 +4682,9 @@ def run_backend(
         seed_population_indices = [
             int(index) for index in checkpoint_seed_plan["population_indices"]
         ]
+        seed_screen_complete = bool(
+            checkpoint_seed_plan.get("screen_complete", True)
+        )
         seed_proxy_metrics = checkpoint_seed_plan.get("proxy_metrics")
         if checkpoint_seed_plan.get("proxy_objectives") is not None:
             seed_proxy_objectives = np.asarray(
@@ -4658,12 +4705,14 @@ def run_backend(
             proxy_metrics=seed_proxy_metrics,
             proxy_objectives=seed_proxy_objectives,
             proxy_violations=seed_proxy_violations,
+            screen_complete=seed_screen_complete,
         )
     elif checkpoint_seed_contract is not None:
         starting_vectors = []
         seed_bootstrap_mode = str(
             checkpoint_seed_contract.get("effective_mode", "none")
         )
+        seed_screen_complete = True
         seed_bootstrap_contract = deepcopy(checkpoint_seed_contract)
     else:
         starting_vectors = load_starting_individuals(
@@ -4677,6 +4726,19 @@ def run_backend(
             bounds=bounds,
             sig_digits=sig_digits,
         )
+        if str(seed_policy["mode"]) != "legacy":
+            starting_vectors, duplicate_count = (
+                _deduplicate_canonical_seed_vectors(
+                    starting_vectors,
+                    hash_vector=vector_hash,
+                )
+            )
+            if duplicate_count:
+                logging.info(
+                    "Dropped %d GPU seed configs made equivalent by runtime "
+                    "overrides",
+                    duplicate_count,
+                )
         seed_bootstrap_mode = _effective_seed_bootstrap_mode(
             seed_policy, len(starting_vectors)
         )
@@ -4690,45 +4752,16 @@ def run_backend(
                 (index, False, False) for index in range(len(starting_vectors))
             ]
         elif seed_bootstrap_mode == "screened":
-            seed_rows = np.asarray(
-                [normalize_vector(vector) for vector in starting_vectors],
-                dtype=np.float64,
-            )
-            logging.info(
-                "GPU seed proxy screen started | seeds=%d exact_cap=%d",
-                len(starting_vectors),
-                int(seed_policy["max_exact"]),
-            )
-            seed_proxy_started = time.perf_counter()
-            proxy_metric_rows = evaluate_proxy(parameter_dicts(seed_rows))
-            seed_proxy_seconds = time.perf_counter() - seed_proxy_started
-            logging.info(
-                "GPU seed proxy screen complete | seeds=%d wall=%.2fs rate=%.1f/s",
-                len(starting_vectors),
-                seed_proxy_seconds,
-                len(starting_vectors) / max(seed_proxy_seconds, 1.0e-9),
-            )
-            seed_proxy_objectives, seed_proxy_violations = proxy_fitness(
-                proxy_metric_rows
-            )
-            objective_scale.fit(seed_proxy_objectives)
-            seed_proxy_scores = objective_scale.score(seed_proxy_objectives)
-            seed_bootstrap_selections = _select_seed_bootstrap_indices(
-                seed_proxy_objectives,
-                seed_proxy_scores,
-                seed_proxy_violations,
-                total=min(len(starting_vectors), int(seed_policy["max_exact"])),
-            )
-            seed_proxy_metrics = {
-                int(index): proxy_metric_rows[int(index)]
-                for index, _probe, _front in seed_bootstrap_selections
-            }
-            seed_population_indices = _select_seed_population_indices(
-                seed_proxy_objectives,
-                seed_proxy_violations,
-                count=min(len(starting_vectors), population_size - 1),
-            )
+            seed_screen_complete = False
         seed_hashes = [vector_hash(vector) for vector in starting_vectors]
+        if seed_bootstrap_mode == "exact":
+            selected_exact_count = len(starting_vectors)
+        elif seed_bootstrap_mode == "screened":
+            selected_exact_count = min(
+                len(starting_vectors), int(seed_policy["max_exact"])
+            )
+        else:
+            selected_exact_count = 0
         seed_bootstrap_contract = (
             {
                 "version": 1,
@@ -4736,7 +4769,7 @@ def run_backend(
                 "effective_mode": seed_bootstrap_mode,
                 "max_exact": int(seed_policy["max_exact"]),
                 "seed_count": len(starting_vectors),
-                "selected_exact_count": len(seed_bootstrap_selections),
+                "selected_exact_count": selected_exact_count,
                 "all_seeds_exact": seed_bootstrap_mode == "exact",
                 "seed_pool_sha256": hashlib.sha256(
                     "\n".join(seed_hashes).encode()
@@ -4745,7 +4778,7 @@ def run_backend(
             if starting_vectors
             else None
         )
-    if starting_vectors:
+    if starting_vectors and seed_screen_complete:
         logging.info(
             "GPU seed bootstrap prepared | mode=%s seeds=%d exact=%d population=%d",
             seed_bootstrap_mode,
@@ -4986,6 +5019,7 @@ def run_backend(
         if not seed_bootstrap_complete and starting_vectors:
             seed_plan = {
                 "effective_mode": seed_bootstrap_mode,
+                "screen_complete": seed_screen_complete,
                 "starting_vectors": starting_vectors,
                 "selections": seed_bootstrap_selections,
                 "population_indices": seed_population_indices,
@@ -5062,10 +5096,77 @@ def run_backend(
             entry.setdefault("metrics", {})["gpu_seed_bootstrap"] = seed_metadata
         recorder.record(_restore_gpu_result_run_contract(entry, config))
 
+    def prepare_seed_proxy_screen() -> None:
+        nonlocal seed_screen_complete
+        nonlocal seed_proxy_metrics, seed_proxy_objectives
+        nonlocal seed_proxy_violations, seed_proxy_scores
+        nonlocal seed_bootstrap_selections, seed_population_indices
+        if seed_bootstrap_mode != "screened" or seed_screen_complete:
+            return
+
+        # Persist the normalized canonical seed pool before the potentially
+        # long Metal dispatch. An interruption can resume without the original
+        # --start input; a completed screen is checkpointed again immediately.
+        maybe_save_checkpoint(force=True)
+        logging.info(
+            "GPU seed proxy screen started | seeds=%d exact_cap=%d",
+            len(starting_vectors),
+            int(seed_policy["max_exact"]),
+        )
+        seed_proxy_started = time.perf_counter()
+        seed_rows = np.asarray(
+            [normalize_vector(vector) for vector in starting_vectors],
+            dtype=np.float64,
+        )
+        proxy_metric_rows = evaluate_proxy(parameter_dicts(seed_rows))
+        seed_proxy_seconds = time.perf_counter() - seed_proxy_started
+        logging.info(
+            "GPU seed proxy screen complete | seeds=%d wall=%.2fs rate=%.1f/s",
+            len(starting_vectors),
+            seed_proxy_seconds,
+            len(starting_vectors) / max(seed_proxy_seconds, 1.0e-9),
+        )
+        seed_proxy_objectives, seed_proxy_violations = proxy_fitness(
+            proxy_metric_rows
+        )
+        objective_scale.fit(seed_proxy_objectives)
+        seed_proxy_scores = objective_scale.score(seed_proxy_objectives)
+        seed_bootstrap_selections = _select_seed_bootstrap_indices(
+            seed_proxy_objectives,
+            seed_proxy_scores,
+            seed_proxy_violations,
+            total=min(len(starting_vectors), int(seed_policy["max_exact"])),
+        )
+        seed_proxy_metrics = {
+            int(index): proxy_metric_rows[int(index)]
+            for index, _probe, _front in seed_bootstrap_selections
+        }
+        seed_population_indices = _select_seed_population_indices(
+            seed_proxy_objectives,
+            seed_proxy_violations,
+            count=min(len(starting_vectors), population_size - 1),
+        )
+        # Keep only compact objective arrays and the selected exact-validation
+        # metric rows. Full per-seed metrics and normalized screen inputs can be
+        # substantial for large seed archives.
+        del proxy_metric_rows
+        del seed_rows
+        seed_screen_complete = True
+        maybe_save_checkpoint(force=True)
+        logging.info(
+            "GPU seed bootstrap prepared | mode=%s seeds=%d exact=%d population=%d",
+            seed_bootstrap_mode,
+            len(starting_vectors),
+            len(seed_bootstrap_selections),
+            population_size,
+        )
+
     def run_seed_bootstrap() -> None:
         nonlocal seed_exact_done, seed_bootstrap_complete, persisted_halt_reason
         if seed_bootstrap_complete:
             return
+
+        prepare_seed_proxy_screen()
 
         # Preserve the normalized seed pool and proxy-screening result before
         # starting exact work. A hard interruption can then resume without

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -66,6 +66,10 @@ GPU_DEFAULTS = {
     "drift_halt": 0.60,
     "exact_workers": 0,
     "max_pending_exact": 0,
+    "seed_bootstrap": {
+        "mode": "auto",
+        "max_exact": 128,
+    },
     "successive_halving": {
         "enabled": False,
         "history_fractions": [0.25, 0.5, 1.0],
@@ -73,6 +77,9 @@ GPU_DEFAULTS = {
         "min_survivors": 64,
     },
 }
+
+GPU_SEED_BOOTSTRAP_MODES = frozenset({"auto", "exact", "screened", "legacy"})
+GPU_SEED_BOOTSTRAP_PROBE_FRACTION = 0.25
 
 GPU_LEAN_TM_POPULATION_SIZE = 2304
 GPU_LEAN_TM_MAX_DISPATCH_CANDIDATE_BARS = 4_500_000_000
@@ -1009,11 +1016,42 @@ def _resolve_options(config: dict) -> dict:
     configured = config.get("optimize", {}).get("gpu", {})
     if configured is not None and not isinstance(configured, dict):
         raise TypeError("optimize.gpu must be an object")
+    nested_options = {"seed_bootstrap", "successive_halving"}
     for key, default in GPU_DEFAULTS.items():
+        if key in nested_options:
+            continue
         if key in (configured or {}) and configured[key] is not None:
             options[key] = type(default)(configured[key])
+    seed_bootstrap = dict(GPU_DEFAULTS["seed_bootstrap"])
+    configured_seed_bootstrap = (configured or {}).get("seed_bootstrap")
+    if configured_seed_bootstrap is not None and not isinstance(
+        configured_seed_bootstrap, dict
+    ):
+        raise TypeError("optimize.gpu.seed_bootstrap must be an object")
+    seed_bootstrap.update(configured_seed_bootstrap or {})
+    unknown_seed_bootstrap = sorted(
+        set(seed_bootstrap) - set(GPU_DEFAULTS["seed_bootstrap"])
+    )
+    if unknown_seed_bootstrap:
+        raise ValueError(
+            "unknown optimize.gpu.seed_bootstrap settings: "
+            + ", ".join(unknown_seed_bootstrap)
+        )
+    seed_bootstrap["mode"] = str(seed_bootstrap["mode"]).strip().lower()
+    if seed_bootstrap["mode"] not in GPU_SEED_BOOTSTRAP_MODES:
+        allowed = ", ".join(sorted(GPU_SEED_BOOTSTRAP_MODES))
+        raise ValueError(
+            "optimize.gpu.seed_bootstrap.mode must be one of "
+            f"{{{allowed}}}"
+        )
+    seed_bootstrap["max_exact"] = int(seed_bootstrap["max_exact"])
+    if seed_bootstrap["max_exact"] <= 0:
+        raise ValueError(
+            "optimize.gpu.seed_bootstrap.max_exact must be greater than zero"
+        )
+    options["seed_bootstrap"] = seed_bootstrap
     halving = dict(GPU_DEFAULTS["successive_halving"])
-    configured_halving = options.get("successive_halving")
+    configured_halving = (configured or {}).get("successive_halving")
     if configured_halving is not None and not isinstance(configured_halving, dict):
         raise TypeError("optimize.gpu.successive_halving must be an object")
     halving.update(configured_halving or {})
@@ -2541,6 +2579,178 @@ def _select_validation_indices(
     return selected
 
 
+def _effective_seed_bootstrap_mode(policy: dict, seed_count: int) -> str:
+    """Resolve auto without silently weakening an explicit exact request."""
+
+    mode = str(policy["mode"])
+    if int(seed_count) <= 0:
+        return "none"
+    if mode != "auto":
+        return mode
+    return "exact" if int(seed_count) <= int(policy["max_exact"]) else "screened"
+
+
+def _select_seed_bootstrap_indices(
+    objectives: np.ndarray,
+    scores: np.ndarray,
+    violations: np.ndarray,
+    *,
+    total: int,
+) -> list[tuple[int, bool, bool]]:
+    """Select objective extremes, a diverse proxy front, and broad probes."""
+
+    objectives = np.asarray(objectives, dtype=np.float64)
+    scores = np.asarray(scores, dtype=np.float64)
+    violations = np.asarray(violations, dtype=np.float64)
+    total = min(max(0, int(total)), len(objectives))
+    if total == 0:
+        return []
+    if objectives.ndim != 2 or len(scores) != len(objectives) or len(
+        violations
+    ) != len(objectives):
+        raise ValueError(
+            "GPU seed-bootstrap objectives, scores and violations must align"
+        )
+
+    requested_probes = min(
+        total - 1,
+        max(1, int(round(total * GPU_SEED_BOOTSTRAP_PROBE_FRACTION))),
+    )
+    preference = _select_validation_indices(
+        objectives,
+        scores,
+        violations,
+        total=total,
+        probes=requested_probes,
+    )
+    classification = {
+        int(index): (bool(is_probe), bool(is_front))
+        for index, is_probe, is_front in preference
+    }
+    feasible = np.flatnonzero(np.isfinite(violations) & (violations <= 0.0))
+    primary = feasible if len(feasible) else np.arange(len(objectives), dtype=np.int64)
+    extremes = []
+    for column in range(objectives.shape[1]):
+        values = objectives[primary, column]
+        finite = np.isfinite(values)
+        if not np.any(finite):
+            continue
+        eligible = primary[finite]
+        index = int(eligible[int(np.argmin(values[finite]))])
+        if index not in extremes:
+            extremes.append(index)
+
+    selected: list[tuple[int, bool, bool]] = []
+    selected_ids = set()
+
+    def append(index: int) -> None:
+        if len(selected) >= total or index in selected_ids:
+            return
+        is_probe, is_front = classification[int(index)]
+        selected.append((int(index), is_probe, is_front))
+        selected_ids.add(int(index))
+
+    for index in extremes:
+        append(index)
+    front_target = max(1, total - requested_probes)
+    for index, _is_probe, is_front in preference:
+        if is_front and sum(front for _idx, _probe, front in selected) < front_target:
+            append(index)
+    for index, is_probe, _is_front in preference:
+        if is_probe:
+            append(index)
+    for index, _is_probe, _is_front in preference:
+        append(index)
+    return selected
+
+
+def _select_seed_population_indices(
+    objectives: np.ndarray,
+    violations: np.ndarray,
+    *,
+    count: int,
+) -> list[int]:
+    """Reduce a seed pool with constraint-aware Pareto diversity."""
+
+    return list(
+        map(
+            int,
+            _successive_halving_survivor_indices(
+                objectives,
+                violations,
+                count=count,
+            ),
+        )
+    )
+
+
+def _validate_seed_bootstrap_plan(
+    starting_vectors,
+    selections,
+    population_indices,
+    contract,
+    *,
+    hash_vector,
+    proxy_metrics=None,
+    proxy_objectives=None,
+    proxy_violations=None,
+) -> None:
+    """Fail closed when an incomplete checkpoint seed plan is inconsistent."""
+
+    if not isinstance(contract, dict):
+        raise RuntimeError("GPU checkpoint seed-bootstrap plan has no contract")
+    seed_count = len(starting_vectors)
+    hashes = [hash_vector(vector) for vector in starting_vectors]
+    digest = hashlib.sha256("\n".join(hashes).encode()).hexdigest()
+    if (
+        int(contract.get("seed_count", -1)) != seed_count
+        or contract.get("seed_pool_sha256") != digest
+        or int(contract.get("selected_exact_count", -1)) != len(selections)
+    ):
+        raise RuntimeError(
+            "GPU checkpoint seed-bootstrap plan does not match its seed contract"
+        )
+    mode = str(contract.get("effective_mode"))
+    if mode not in {"exact", "screened"}:
+        raise RuntimeError(
+            "GPU checkpoint has an incomplete seed-bootstrap plan for unsupported "
+            f"mode {mode!r}"
+        )
+    selected_ids = [int(index) for index, _probe, _front in selections]
+    if (
+        len(selected_ids) != len(set(selected_ids))
+        or any(index < 0 or index >= seed_count for index in selected_ids)
+        or len(population_indices) != len(set(map(int, population_indices)))
+        or any(
+            int(index) < 0 or int(index) >= seed_count
+            for index in population_indices
+        )
+    ):
+        raise RuntimeError("GPU checkpoint seed-bootstrap plan has invalid indices")
+    if mode == "exact":
+        if selected_ids != list(range(seed_count)) or not bool(
+            contract.get("all_seeds_exact")
+        ):
+            raise RuntimeError(
+                "GPU checkpoint exact seed-bootstrap plan is incomplete"
+            )
+        return
+    objectives = np.asarray(proxy_objectives, dtype=np.float64)
+    violations = np.asarray(proxy_violations, dtype=np.float64)
+    if (
+        not isinstance(proxy_metrics, dict)
+        or set(map(int, proxy_metrics)) != set(selected_ids)
+        or objectives.ndim != 2
+        or len(objectives) != seed_count
+        or violations.shape != (seed_count,)
+        or bool(contract.get("all_seeds_exact"))
+        or any(bool(probe) == bool(front) for _index, probe, front in selections)
+    ):
+        raise RuntimeError(
+            "GPU checkpoint screened seed-bootstrap plan has invalid proxy evidence"
+        )
+
+
 class _ProxyFrontValidationPending(RuntimeError):
     """The current proxy front has exact work in flight but no ready evidence."""
 
@@ -3076,6 +3286,7 @@ def _gpu_search_checkpoint_contract(
     sig_digits,
     algorithm_contract,
     proxy_evaluation_policy=None,
+    seed_bootstrap_contract=None,
 ) -> dict:
     """Fingerprint fixed and dormant search inputs omitted from active genes."""
 
@@ -3111,6 +3322,9 @@ def _gpu_search_checkpoint_contract(
     if proxy_evaluation_policy is not None:
         contract["version"] = 2
         contract["proxy_evaluation"] = deepcopy(proxy_evaluation_policy)
+    if seed_bootstrap_contract is not None:
+        contract["version"] = 3
+        contract["seed_bootstrap"] = deepcopy(seed_bootstrap_contract)
     return contract
 
 
@@ -3640,6 +3854,121 @@ def _recover_durable_validations(
     return recovered, drift_pairs
 
 
+def _recover_durable_seed_bootstrap(
+    entries,
+    *,
+    start_index: int,
+    stop_index: int,
+    vector_from_entry,
+    hash_vector,
+) -> tuple[
+    dict[str, dict[str, Any]],
+    set[str],
+    list[tuple[float, float, bool, bool, bool]],
+]:
+    """Recover exact seed payloads flushed after a stale bootstrap checkpoint."""
+
+    payloads: dict[str, dict[str, Any]] = {}
+    recovered: set[str] = set()
+    drift_pairs: list[tuple[float, float, bool, bool, bool]] = []
+    consumed = 0
+    for index, entry in enumerate(entries):
+        if index < start_index:
+            continue
+        if index >= stop_index:
+            break
+        metrics = entry.get("metrics") or {}
+        metadata = metrics.get("gpu_seed_bootstrap")
+        if not isinstance(metadata, dict) or metadata.get("schema_version") != 1:
+            raise RuntimeError(
+                "GPU resume cannot recover seed-bootstrap evidence from "
+                f"durable result {index}"
+            )
+        try:
+            mode = str(metadata["mode"])
+            source_index = int(metadata["source_index"])
+            objectives = [float(value) for value in metadata["exact_objectives"]]
+            violation = float(metadata["exact_violation"])
+        except (KeyError, TypeError, ValueError) as exc:
+            raise RuntimeError(
+                "GPU resume found invalid seed-bootstrap evidence in "
+                f"durable result {index}"
+            ) from exc
+        if (
+            mode not in {"exact", "screened"}
+            or source_index < 0
+            or not objectives
+            or not all(np.isfinite(objectives))
+            or not np.isfinite(violation)
+        ):
+            raise RuntimeError(
+                "GPU resume found non-finite seed-bootstrap evidence in "
+                f"durable result {index}"
+            )
+        digest = hash_vector(vector_from_entry(entry))
+        if digest in payloads:
+            raise RuntimeError(
+                "GPU resume found duplicate durable seed-bootstrap evidence for "
+                f"result {index}"
+            )
+        payloads[digest] = {
+            "source_index": source_index,
+            "F": objectives,
+            "G": [violation],
+        }
+        recovered.add(digest)
+        validation = metrics.get("gpu_validation")
+        if mode == "screened" and validation is None:
+            raise RuntimeError(
+                "GPU resume found screened seed-bootstrap evidence without "
+                f"proxy/exact metadata in durable result {index}"
+            )
+        if validation is not None:
+            if (
+                not isinstance(validation, dict)
+                or validation.get("schema_version") != 2
+                or validation.get("phase") != "seed_bootstrap"
+            ):
+                raise RuntimeError(
+                    "GPU resume found invalid proxy/exact seed-bootstrap evidence "
+                    f"in durable result {index}"
+                )
+            try:
+                proxy_score = float(validation["proxy_score"])
+                exact_score = float(validation["exact_score"])
+                probe = validation["probe"]
+                proxy_front = validation["proxy_front"]
+                mismatch = validation["constraint_classification_mismatch"]
+            except (KeyError, TypeError, ValueError) as exc:
+                raise RuntimeError(
+                    "GPU resume found invalid proxy/exact seed-bootstrap evidence "
+                    f"in durable result {index}"
+                ) from exc
+            if (
+                not np.isfinite(proxy_score)
+                or not np.isfinite(exact_score)
+                or not isinstance(probe, bool)
+                or not isinstance(proxy_front, bool)
+                or probe == proxy_front
+                or not isinstance(mismatch, bool)
+            ):
+                raise RuntimeError(
+                    "GPU resume found invalid proxy/exact seed-bootstrap evidence "
+                    f"in durable result {index}"
+                )
+            drift_pairs.append(
+                (proxy_score, exact_score, probe, mismatch, proxy_front)
+            )
+        consumed += 1
+    expected = max(0, stop_index - start_index)
+    if consumed != expected:
+        raise RuntimeError(
+            "GPU resume could not reconstruct all durable seed-bootstrap results: "
+            f"expected {expected}, recovered {consumed}"
+        )
+    return payloads, recovered, drift_pairs
+
+
 def run_backend(
     *,
     config: dict[str, Any],
@@ -3690,6 +4019,12 @@ def run_backend(
     reject_configured_exact_only_gpu_metrics(config)
     options = _resolve_options(config)
     validate_optimizer_effective_configs(config)
+    checkpoint = None
+    if resume:
+        if checkpoint_path is None or not os.path.isfile(checkpoint_path):
+            raise FileNotFoundError(f"GPU checkpoint not found: {checkpoint_path}")
+        with open(checkpoint_path, "rb") as file:
+            checkpoint = pickle.load(file)
 
     shape = (
         optimization_shape
@@ -4171,6 +4506,35 @@ def run_backend(
                 )
             return proxy.evaluate(candidates)
 
+    def proxy_fitness(metric_rows: list[dict]) -> tuple[np.ndarray, np.ndarray]:
+        objectives = np.empty((len(metric_rows), len(specs)), dtype=np.float64)
+        violations = np.empty(len(metric_rows), dtype=np.float64)
+        for row, metrics in enumerate(metric_rows):
+            if _GPU_SUITE_OBJECTIVES_KEY in metrics:
+                objective_values = np.asarray(
+                    metrics[_GPU_SUITE_OBJECTIVES_KEY], dtype=np.float64
+                )
+                if len(objective_values) != len(specs):
+                    raise ValueError(
+                        "GPU suite proxy objective length mismatch: "
+                        f"expected {len(specs)}, got {len(objective_values)}"
+                    )
+                objectives[row] = objective_values
+                violations[row] = float(metrics[_GPU_SUITE_VIOLATION_KEY])
+                continue
+            flattened = _single_scenario_metric_surface(metrics)
+            objective_values = [
+                metrics[canonicalize_metric_name(spec.metric)] for spec in specs
+            ]
+            fitness, violation = evaluator.calc_fitness(
+                flattened,
+                limit_metrics=flattened,
+                objective_values=objective_values,
+            )
+            objectives[row] = fitness
+            violations[row] = float(violation)
+        return objectives, violations
+
     active_low = np.asarray(
         [bound.low for _name, _index, bound in active], dtype=np.float64
     )
@@ -4227,26 +4591,168 @@ def run_backend(
 
     population_size = max(8, int(options["population_size"]))
     seed = config["optimize"].get("seed")
-    if seed is None:
+    if checkpoint is not None and checkpoint.get("seed") is not None:
+        seed = int(checkpoint["seed"])
+    elif seed is None:
         seed = int(np.random.SeedSequence().generate_state(1)[0])
         logging.info("GPU optimizer generated reproducible seed %d", seed)
     seed = int(seed)
     rng = np.random.default_rng(seed)
     sampling = rng.random((population_size, len(active)))
     sampling[0] = normalize_vector(base_vector)
-    starting_vectors = load_starting_individuals(
-        starting_configs_path=starting_configs_path,
-        population_size=population_size,
-        get_starting_configs=get_starting_configs,
-        configs_to_individuals=configs_to_individuals,
-        iter_starting_configs=iter_starting_configs,
-        configs_to_individuals_streaming=configs_to_individuals_streaming,
-        optimization_shape=shape,
-        bounds=bounds,
-        sig_digits=sig_digits,
+    seed_policy = options["seed_bootstrap"]
+    objective_scale = _ObjectiveScale()
+    seed_proxy_metrics = None
+    seed_proxy_objectives = None
+    seed_proxy_violations = None
+    seed_proxy_scores = None
+    seed_bootstrap_selections = []
+    seed_population_indices = []
+    checkpoint_seed_plan = (
+        checkpoint.get("seed_bootstrap_plan") if checkpoint is not None else None
     )
-    for index, vector in enumerate(starting_vectors[: population_size - 1], start=1):
-        sampling[index] = normalize_vector(vector)
+    checkpoint_seed_contract = (
+        checkpoint.get("seed_bootstrap_contract")
+        if checkpoint is not None
+        else None
+    )
+    if checkpoint_seed_contract is not None and (
+        str(checkpoint_seed_contract.get("requested_mode"))
+        != str(seed_policy["mode"])
+        or int(checkpoint_seed_contract.get("max_exact", -1))
+        != int(seed_policy["max_exact"])
+    ):
+        raise ValueError(
+            "GPU checkpoint does not match current seed-bootstrap policy"
+        )
+    if checkpoint_seed_plan:
+        starting_vectors = [
+            [float(value) for value in vector]
+            for vector in checkpoint_seed_plan["starting_vectors"]
+        ]
+        seed_bootstrap_mode = str(checkpoint_seed_plan["effective_mode"])
+        seed_bootstrap_selections = [
+            (int(index), bool(probe), bool(front))
+            for index, probe, front in checkpoint_seed_plan["selections"]
+        ]
+        seed_population_indices = [
+            int(index) for index in checkpoint_seed_plan["population_indices"]
+        ]
+        seed_proxy_metrics = checkpoint_seed_plan.get("proxy_metrics")
+        if checkpoint_seed_plan.get("proxy_objectives") is not None:
+            seed_proxy_objectives = np.asarray(
+                checkpoint_seed_plan["proxy_objectives"], dtype=np.float64
+            )
+            seed_proxy_violations = np.asarray(
+                checkpoint_seed_plan["proxy_violations"], dtype=np.float64
+            )
+            objective_scale.fit(seed_proxy_objectives)
+            seed_proxy_scores = objective_scale.score(seed_proxy_objectives)
+        seed_bootstrap_contract = deepcopy(checkpoint_seed_contract)
+        _validate_seed_bootstrap_plan(
+            starting_vectors,
+            seed_bootstrap_selections,
+            seed_population_indices,
+            seed_bootstrap_contract,
+            hash_vector=vector_hash,
+            proxy_metrics=seed_proxy_metrics,
+            proxy_objectives=seed_proxy_objectives,
+            proxy_violations=seed_proxy_violations,
+        )
+    elif checkpoint_seed_contract is not None:
+        starting_vectors = []
+        seed_bootstrap_mode = str(
+            checkpoint_seed_contract.get("effective_mode", "none")
+        )
+        seed_bootstrap_contract = deepcopy(checkpoint_seed_contract)
+    else:
+        starting_vectors = load_starting_individuals(
+            starting_configs_path=starting_configs_path,
+            population_size=population_size,
+            get_starting_configs=get_starting_configs,
+            configs_to_individuals=configs_to_individuals,
+            iter_starting_configs=iter_starting_configs,
+            configs_to_individuals_streaming=configs_to_individuals_streaming,
+            optimization_shape=shape,
+            bounds=bounds,
+            sig_digits=sig_digits,
+        )
+        seed_bootstrap_mode = _effective_seed_bootstrap_mode(
+            seed_policy, len(starting_vectors)
+        )
+        if seed_bootstrap_mode == "legacy":
+            for index, vector in enumerate(
+                starting_vectors[: population_size - 1], start=1
+            ):
+                sampling[index] = normalize_vector(vector)
+        elif seed_bootstrap_mode == "exact":
+            seed_bootstrap_selections = [
+                (index, False, False) for index in range(len(starting_vectors))
+            ]
+        elif seed_bootstrap_mode == "screened":
+            seed_rows = np.asarray(
+                [normalize_vector(vector) for vector in starting_vectors],
+                dtype=np.float64,
+            )
+            logging.info(
+                "GPU seed proxy screen started | seeds=%d exact_cap=%d",
+                len(starting_vectors),
+                int(seed_policy["max_exact"]),
+            )
+            seed_proxy_started = time.perf_counter()
+            proxy_metric_rows = evaluate_proxy(parameter_dicts(seed_rows))
+            seed_proxy_seconds = time.perf_counter() - seed_proxy_started
+            logging.info(
+                "GPU seed proxy screen complete | seeds=%d wall=%.2fs rate=%.1f/s",
+                len(starting_vectors),
+                seed_proxy_seconds,
+                len(starting_vectors) / max(seed_proxy_seconds, 1.0e-9),
+            )
+            seed_proxy_objectives, seed_proxy_violations = proxy_fitness(
+                proxy_metric_rows
+            )
+            objective_scale.fit(seed_proxy_objectives)
+            seed_proxy_scores = objective_scale.score(seed_proxy_objectives)
+            seed_bootstrap_selections = _select_seed_bootstrap_indices(
+                seed_proxy_objectives,
+                seed_proxy_scores,
+                seed_proxy_violations,
+                total=min(len(starting_vectors), int(seed_policy["max_exact"])),
+            )
+            seed_proxy_metrics = {
+                int(index): proxy_metric_rows[int(index)]
+                for index, _probe, _front in seed_bootstrap_selections
+            }
+            seed_population_indices = _select_seed_population_indices(
+                seed_proxy_objectives,
+                seed_proxy_violations,
+                count=min(len(starting_vectors), population_size - 1),
+            )
+        seed_hashes = [vector_hash(vector) for vector in starting_vectors]
+        seed_bootstrap_contract = (
+            {
+                "version": 1,
+                "requested_mode": str(seed_policy["mode"]),
+                "effective_mode": seed_bootstrap_mode,
+                "max_exact": int(seed_policy["max_exact"]),
+                "seed_count": len(starting_vectors),
+                "selected_exact_count": len(seed_bootstrap_selections),
+                "all_seeds_exact": seed_bootstrap_mode == "exact",
+                "seed_pool_sha256": hashlib.sha256(
+                    "\n".join(seed_hashes).encode()
+                ).hexdigest(),
+            }
+            if starting_vectors
+            else None
+        )
+    if starting_vectors:
+        logging.info(
+            "GPU seed bootstrap prepared | mode=%s seeds=%d exact=%d population=%d",
+            seed_bootstrap_mode,
+            len(starting_vectors),
+            len(seed_bootstrap_selections),
+            population_size,
+        )
 
     problem = Problem(
         n_var=len(active),
@@ -4270,8 +4776,10 @@ def run_backend(
     algorithm.setup(problem, termination=NoTermination(), seed=seed, verbose=False)
     generation = 0
     exact_done = 0
+    seed_exact_done = 0
     completed_hashes: set[str] = set()
-    objective_scale = _ObjectiveScale()
+    seed_bootstrap_payloads = {}
+    seed_bootstrap_complete = seed_bootstrap_mode in {"none", "legacy"}
     drift_monitor = _DriftMonitor(options)
     persisted_halt_reason = None
     signature = _checkpoint_signature(
@@ -4313,6 +4821,7 @@ def run_backend(
                 if halving_policy["enabled"]
                 else None
             ),
+            seed_bootstrap_contract=seed_bootstrap_contract,
         ),
     )
     budget = int(config["optimize"]["iters"])
@@ -4320,10 +4829,6 @@ def run_backend(
         raise ValueError("optimize.iters must be greater than zero")
 
     if resume:
-        if checkpoint_path is None or not os.path.isfile(checkpoint_path):
-            raise FileNotFoundError(f"GPU checkpoint not found: {checkpoint_path}")
-        with open(checkpoint_path, "rb") as file:
-            checkpoint = pickle.load(file)
         if checkpoint.get("signature") != signature:
             raise ValueError(
                 "GPU checkpoint does not match current search, scoring, suite, "
@@ -4333,18 +4838,30 @@ def run_backend(
         seed = int(checkpoint.get("seed", seed))
         generation = int(checkpoint["generation"])
         exact_done = int(checkpoint["exact_done"])
+        seed_exact_done = int(checkpoint.get("seed_exact_done", 0))
+        seed_bootstrap_complete = bool(
+            checkpoint.get("seed_bootstrap_complete", True)
+        )
+        if not seed_bootstrap_complete and not checkpoint_seed_plan:
+            raise RuntimeError(
+                "GPU checkpoint is missing its incomplete seed-bootstrap plan"
+            )
+        seed_bootstrap_payloads = dict(
+            checkpoint.get("seed_bootstrap_payloads", {})
+        )
         completed_hashes = set(checkpoint.get("completed_hashes", []))
         objective_scale.median = checkpoint.get("scale_median")
         objective_scale.spread = checkpoint.get("scale_spread")
         drift_monitor.pairs.extend(checkpoint.get("drift_pairs", []))
         persisted_halt_reason = checkpoint.get("halt_reason")
         recorded_exact = int(getattr(getattr(recorder, "store", None), "n_iters", 0))
-        if recorded_exact < exact_done:
+        checkpoint_exact_total = seed_exact_done + exact_done
+        if recorded_exact < checkpoint_exact_total:
             raise RuntimeError(
                 "GPU checkpoint is ahead of durable all_results.bin state: "
-                f"checkpoint={exact_done}, durable={recorded_exact}"
+                f"checkpoint={checkpoint_exact_total}, durable={recorded_exact}"
             )
-        if recorded_exact > exact_done:
+        if recorded_exact > checkpoint_exact_total:
             from opt_utils import load_results
 
             results_file = getattr(getattr(recorder, "results_file", None), "name", None)
@@ -4365,13 +4882,29 @@ def run_backend(
                     )
                 return vectors[0]
 
-            recovered_hashes, recovered_pairs = _recover_durable_validations(
-                load_results(results_file),
-                start_index=exact_done,
-                stop_index=recorded_exact,
-                vector_from_entry=vector_from_entry,
-                hash_vector=vector_hash,
-            )
+            if seed_bootstrap_complete:
+                recovered_hashes, recovered_pairs = _recover_durable_validations(
+                    load_results(results_file),
+                    start_index=checkpoint_exact_total,
+                    stop_index=recorded_exact,
+                    vector_from_entry=vector_from_entry,
+                    hash_vector=vector_hash,
+                )
+                exact_done += recorded_exact - checkpoint_exact_total
+            else:
+                (
+                    recovered_seed_payloads,
+                    recovered_hashes,
+                    recovered_pairs,
+                ) = _recover_durable_seed_bootstrap(
+                    load_results(results_file),
+                    start_index=checkpoint_exact_total,
+                    stop_index=recorded_exact,
+                    vector_from_entry=vector_from_entry,
+                    hash_vector=vector_hash,
+                )
+                seed_bootstrap_payloads.update(recovered_seed_payloads)
+                seed_exact_done += recorded_exact - checkpoint_exact_total
             completed_hashes.update(recovered_hashes)
             drift_monitor.pairs.extend(recovered_pairs)
             recovered_drift_status = drift_monitor.evaluate()
@@ -4384,10 +4917,9 @@ def run_backend(
                 "GPU checkpoint records %d exact evaluations but all_results.bin "
                 "records %d; recovered the missing durable candidate identities "
                 "and safety evidence",
-                exact_done,
+                checkpoint_exact_total,
                 recorded_exact,
             )
-            exact_done = recorded_exact
         if persisted_halt_reason:
             raise RuntimeError(
                 "Cannot resume a GPU run stopped by its drift safety gate: "
@@ -4400,8 +4932,10 @@ def run_backend(
             options=options,
         )
         logging.info(
-            "Resumed GPU optimizer at generation %d with %d exact evaluations",
+            "Resumed GPU optimizer at generation %d with %d seed and %d "
+            "evolution exact evaluations",
             generation,
+            seed_exact_done,
             exact_done,
         )
 
@@ -4444,16 +4978,42 @@ def run_backend(
     last_warning = None
     last_probe_shortfall = None
     last_checkpoint_at = 0.0
-    last_checkpoint_exact = exact_done
+    last_checkpoint_exact = seed_exact_done + exact_done
     generation_in_progress = False
 
     def checkpoint_state() -> dict:
+        seed_plan = None
+        if not seed_bootstrap_complete and starting_vectors:
+            seed_plan = {
+                "effective_mode": seed_bootstrap_mode,
+                "starting_vectors": starting_vectors,
+                "selections": seed_bootstrap_selections,
+                "population_indices": seed_population_indices,
+                "proxy_metrics": seed_proxy_metrics,
+                "proxy_objectives": (
+                    None
+                    if seed_proxy_objectives is None
+                    else seed_proxy_objectives.tolist()
+                ),
+                "proxy_violations": (
+                    None
+                    if seed_proxy_violations is None
+                    else seed_proxy_violations.tolist()
+                ),
+            }
         return {
             "signature": signature,
             "algorithm": algorithm,
             "generation": generation,
             "seed": seed,
             "exact_done": exact_done,
+            "seed_exact_done": seed_exact_done,
+            "seed_bootstrap_complete": seed_bootstrap_complete,
+            "seed_bootstrap_payloads": (
+                {} if seed_bootstrap_complete else seed_bootstrap_payloads
+            ),
+            "seed_bootstrap_contract": deepcopy(seed_bootstrap_contract),
+            "seed_bootstrap_plan": seed_plan,
             "completed_hashes": sorted(completed_hashes),
             "scale_median": objective_scale.median,
             "scale_spread": objective_scale.spread,
@@ -4465,7 +5025,8 @@ def run_backend(
         nonlocal last_checkpoint_at, last_checkpoint_exact
         now = time.monotonic()
         due = now - last_checkpoint_at >= float(options["checkpoint_interval_seconds"])
-        if not force and (exact_done == last_checkpoint_exact or not due):
+        result_count = seed_exact_done + exact_done
+        if not force and (result_count == last_checkpoint_exact or not due):
             return
         profile_started = time.perf_counter() if profile_enabled else 0.0
         _save_checkpoint(checkpoint_path, checkpoint_state())
@@ -4474,38 +5035,15 @@ def run_backend(
                 time.perf_counter() - profile_started
             )
         last_checkpoint_at = now
-        last_checkpoint_exact = exact_done
+        last_checkpoint_exact = result_count
 
-    def proxy_fitness(metric_rows: list[dict]) -> tuple[np.ndarray, np.ndarray]:
-        objectives = np.empty((len(metric_rows), len(specs)), dtype=np.float64)
-        violations = np.empty(len(metric_rows), dtype=np.float64)
-        for row, metrics in enumerate(metric_rows):
-            if _GPU_SUITE_OBJECTIVES_KEY in metrics:
-                objective_values = np.asarray(
-                    metrics[_GPU_SUITE_OBJECTIVES_KEY], dtype=np.float64
-                )
-                if len(objective_values) != len(specs):
-                    raise ValueError(
-                        "GPU suite proxy objective length mismatch: "
-                        f"expected {len(specs)}, got {len(objective_values)}"
-                    )
-                objectives[row] = objective_values
-                violations[row] = float(metrics[_GPU_SUITE_VIOLATION_KEY])
-                continue
-            flattened = _single_scenario_metric_surface(metrics)
-            objective_values = [
-                metrics[canonicalize_metric_name(spec.metric)] for spec in specs
-            ]
-            fitness, violation = evaluator.calc_fitness(
-                flattened,
-                limit_metrics=flattened,
-                objective_values=objective_values,
-            )
-            objectives[row] = fitness
-            violations[row] = float(violation)
-        return objectives, violations
-
-    def record_exact(vector, payload, *, validation_metadata: dict) -> None:
+    def record_exact(
+        vector,
+        payload,
+        *,
+        validation_metadata: dict | None = None,
+        seed_metadata: dict | None = None,
+    ) -> None:
         entry = build_pymoo_record_entry(
             vector=payload.get("evaluation_vector", vector),
             metrics=payload.get("metrics") or {},
@@ -4518,8 +5056,210 @@ def run_backend(
             overrides_fn=overrides_fn,
             overrides_list=overrides_list,
         )
-        entry.setdefault("metrics", {})["gpu_validation"] = validation_metadata
+        if validation_metadata is not None:
+            entry.setdefault("metrics", {})["gpu_validation"] = validation_metadata
+        if seed_metadata is not None:
+            entry.setdefault("metrics", {})["gpu_seed_bootstrap"] = seed_metadata
         recorder.record(_restore_gpu_result_run_contract(entry, config))
+
+    def run_seed_bootstrap() -> None:
+        nonlocal seed_exact_done, seed_bootstrap_complete, persisted_halt_reason
+        if seed_bootstrap_complete:
+            return
+
+        # Preserve the normalized seed pool and proxy-screening result before
+        # starting exact work. A hard interruption can then resume without
+        # rereading private seed files or repeating the GPU screen.
+        maybe_save_checkpoint(force=True)
+
+        selected = []
+        for source_index, is_probe, is_proxy_front in seed_bootstrap_selections:
+            vector = starting_vectors[int(source_index)]
+            digest = vector_hash(vector)
+            if digest in seed_bootstrap_payloads:
+                continue
+            selected.append(
+                (
+                    int(source_index),
+                    bool(is_probe),
+                    bool(is_proxy_front),
+                    vector,
+                    digest,
+                )
+            )
+
+        pending_seed = {}
+        cursor = 0
+        try:
+            while cursor < len(selected) or pending_seed:
+                interrupt_check()
+                while cursor < len(selected) and len(pending_seed) < max_pending:
+                    item = selected[cursor]
+                    result = _submit_gpu_exact_validation(
+                        pool,
+                        item[3],
+                        interrupt_check,
+                        profile=profile_enabled,
+                    )
+                    pending_seed[result] = item
+                    cursor += 1
+                ready = _ready_submission_prefix(pending_seed)
+                if not ready:
+                    PymooAsyncRecordingRunner._raise_if_pool_workers_exited(
+                        pool_workers
+                    )
+                    time.sleep(0.05)
+                    continue
+                for result in ready:
+                    interrupt_check()
+                    (
+                        source_index,
+                        is_probe,
+                        is_proxy_front,
+                        vector,
+                        digest,
+                    ) = pending_seed.pop(result)
+                    payload = result.get()
+                    PymooAsyncRecordingRunner._raise_if_worker_failure(
+                        payload, source_index
+                    )
+                    validation_metadata = None
+                    proxy_score = None
+                    proxy_violation = None
+                    classification_mismatch = False
+                    if seed_bootstrap_mode == "screened":
+                        proxy_score = float(seed_proxy_scores[source_index])
+                        proxy_violation = float(seed_proxy_violations[source_index])
+                        exact_score = float(
+                            objective_scale.score(
+                                np.asarray(payload["F"], dtype=np.float64).reshape(
+                                    1, -1
+                                )
+                            )[0]
+                        )
+                        classification_mismatch = (
+                            _constraint_classification_mismatch(
+                                proxy_violation, payload
+                            )
+                        )
+                        validation_metadata = {
+                            "schema_version": 2,
+                            "phase": "seed_bootstrap",
+                            "proxy_score": proxy_score,
+                            "exact_score": exact_score,
+                            "probe": is_probe,
+                            "proxy_front": is_proxy_front,
+                            "constraint_classification_mismatch": (
+                                classification_mismatch
+                            ),
+                            "constraint_diagnostics": _constraint_diagnostics(
+                                evaluator,
+                                seed_proxy_metrics[source_index],
+                                payload,
+                            ),
+                        }
+                        drift_monitor.add(
+                            proxy_score,
+                            exact_score,
+                            probe=is_probe,
+                            proxy_front=is_proxy_front,
+                            constraint_mismatch=classification_mismatch,
+                        )
+                    seed_metadata = {
+                        "schema_version": 1,
+                        "mode": seed_bootstrap_mode,
+                        "source_index": source_index,
+                        "seed_count": len(starting_vectors),
+                        "selected_exact_count": len(seed_bootstrap_selections),
+                        "proxy_evaluated": seed_bootstrap_mode == "screened",
+                        "all_seeds_exact": seed_bootstrap_mode == "exact",
+                        "exact_objectives": np.asarray(
+                            payload["F"], dtype=np.float64
+                        ).tolist(),
+                        "exact_violation": float(
+                            np.asarray(payload.get("G", [-1.0])).reshape(-1)[0]
+                        ),
+                    }
+                    record_exact(
+                        vector,
+                        payload,
+                        validation_metadata=validation_metadata,
+                        seed_metadata=seed_metadata,
+                    )
+                    seed_bootstrap_payloads[digest] = {
+                        "source_index": source_index,
+                        "F": np.asarray(payload["F"], dtype=np.float64).tolist(),
+                        "G": np.asarray(
+                            payload.get("G", [-1.0]), dtype=np.float64
+                        ).tolist(),
+                    }
+                    seed_exact_done += 1
+                    completed_hashes.add(digest)
+                    maybe_save_checkpoint(force=True)
+        except KeyboardInterrupt:
+            cancel_pending_async_results(pending_seed)
+            maybe_save_checkpoint(force=True)
+            raise
+
+        ordered_payloads = []
+        for source_index, _is_probe, _is_proxy_front in seed_bootstrap_selections:
+            digest = vector_hash(starting_vectors[int(source_index)])
+            payload = seed_bootstrap_payloads.get(digest)
+            if payload is None:
+                raise RuntimeError(
+                    "GPU seed bootstrap completed without exact evidence for "
+                    f"source index {source_index}"
+                )
+            ordered_payloads.append(payload)
+        exact_objectives = np.asarray(
+            [payload["F"] for payload in ordered_payloads], dtype=np.float64
+        )
+        exact_violations = np.asarray(
+            [
+                float(np.asarray(payload["G"]).reshape(-1)[0])
+                for payload in ordered_payloads
+            ],
+            dtype=np.float64,
+        )
+        exact_preference = _select_seed_population_indices(
+            exact_objectives,
+            exact_violations,
+            count=min(len(ordered_payloads), population_size - 1),
+        )
+        exact_source_indices = [
+            int(seed_bootstrap_selections[index][0]) for index in exact_preference
+        ]
+        if seed_bootstrap_mode == "exact":
+            population_seed_indices = exact_source_indices
+        else:
+            population_seed_indices = list(exact_source_indices)
+            population_seed_ids = set(population_seed_indices)
+            population_seed_indices.extend(
+                index
+                for index in seed_population_indices
+                if index not in population_seed_ids
+            )
+        for slot, source_index in enumerate(
+            population_seed_indices[: population_size - 1], start=1
+        ):
+            sampling[slot] = normalize_vector(starting_vectors[source_index])
+        algorithm.initialization.sampling = sampling
+
+        status = drift_monitor.evaluate()
+        if status["halt_reason"]:
+            persisted_halt_reason = status["halt_reason"]
+            maybe_save_checkpoint(force=True)
+            raise RuntimeError(status["halt_reason"])
+        seed_bootstrap_complete = True
+        logging.info(
+            "GPU seed bootstrap complete | mode=%s proxy=%d exact=%d "
+            "population_seeds=%d",
+            seed_bootstrap_mode,
+            len(starting_vectors) if seed_bootstrap_mode == "screened" else 0,
+            seed_exact_done,
+            min(len(population_seed_indices), population_size - 1),
+        )
+        maybe_save_checkpoint(force=True)
 
     def consume_ready(*, wait_for_one: bool = False) -> None:
         nonlocal exact_done, last_warning, persisted_halt_reason
@@ -4629,6 +5369,7 @@ def run_backend(
         maybe_save_checkpoint(force=True)
 
     try:
+        run_seed_bootstrap()
         while exact_done < budget:
             interrupt_check()
             consume_ready()
@@ -4884,9 +5625,11 @@ def run_backend(
                 exact_validation_cumulative_seconds=dict(profile_totals),
             )
         logging.info(
-            "GPU optimization complete | generations=%d proxy=%d exact=%d wall=%.1fs",
+            "GPU optimization complete | generations=%d proxy=%d seed_exact=%d "
+            "evolution_exact=%d wall=%.1fs",
             generation,
             proxy_evaluations,
+            seed_exact_done,
             exact_done,
             time.time() - start_time,
         )

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -111,6 +111,14 @@ def _ask_gpu_population(algorithm, interrupt_check: InterruptCheck):
     return algorithm.ask()
 
 
+def _disable_gpu_exact_duplicate_guard(evaluator) -> None:
+    """GPU owns canonical submission deduplication and exact revalidation."""
+
+    base_evaluator = getattr(evaluator, "base", evaluator)
+    if hasattr(base_evaluator, "use_duplicate_guard"):
+        base_evaluator.use_duplicate_guard = False
+
+
 def _submit_gpu_exact_validation(
     pool,
     vector,
@@ -2654,7 +2662,22 @@ def _select_seed_bootstrap_indices(
         if not np.any(finite):
             continue
         eligible = primary[finite]
-        index = int(eligible[int(np.argmin(values[finite]))])
+        finite_values = values[finite]
+        minimum = float(np.min(finite_values))
+        minima = eligible[
+            np.isclose(finite_values, minimum, rtol=0.0, atol=1.0e-12)
+        ]
+        front_minima = np.asarray(
+            [
+                index
+                for index in minima
+                if int(index) in classification
+                and classification[int(index)][1]
+            ],
+            dtype=np.int64,
+        )
+        choices = front_minima if len(front_minima) else minima
+        index = int(min(choices, key=lambda item: float(scores[int(item)])))
         if index not in extremes:
             extremes.append(index)
 
@@ -2668,9 +2691,9 @@ def _select_seed_bootstrap_indices(
         selected.append((int(index), is_probe, is_front))
         selected_ids.add(int(index))
 
-    for index in extremes:
-        append(index)
     front_target = max(1, total - requested_probes)
+    for index in extremes[:front_target]:
+        append(index)
     for index, _is_probe, is_front in preference:
         if is_front and sum(front for _idx, _probe, front in selected) < front_target:
             append(index)
@@ -4972,6 +4995,7 @@ def run_backend(
             exact_done,
         )
 
+    _disable_gpu_exact_duplicate_guard(evaluator_for_pool)
     adapter = PymooEvaluatorAdapter(evaluator_for_pool, overrides_list=overrides_list)
     profile_enabled = any(
         bool(getattr(item, "profile_enabled", False)) for item in profile_proxies
@@ -5048,6 +5072,7 @@ def run_backend(
             ),
             "seed_bootstrap_contract": deepcopy(seed_bootstrap_contract),
             "seed_bootstrap_plan": seed_plan,
+            "anchor_plan": deepcopy(get_anchor_plan(config)),
             "completed_hashes": sorted(completed_hashes),
             "scale_median": objective_scale.median,
             "scale_spread": objective_scale.spread,

--- a/src/optimize.py
+++ b/src/optimize.py
@@ -471,17 +471,20 @@ class ResultRecorder:
             self.results_file = open(filename, "ab")
             self.packer = msgpack.Packer(use_bin_type=True)
         self.prev_data = previous_data
-        self.counter = int(starting_iters)
 
     def record(self, data: dict) -> None:
         if self.write_all and self.results_file:
             if self.compress:
-                if self.prev_data is None or self.counter % 100 == 0:
+                # The on-disk format is an overlay stream: readers apply every
+                # object to the preceding result.  A plain "full" object at a
+                # periodic boundary therefore cannot clear keys that existed
+                # only in the previous result.  Emit a diff after the first
+                # record so deletion markers remain explicit at every boundary.
+                if self.prev_data is None:
                     output_data = make_json_serializable(data)
                 else:
                     diff = generate_incremental_diff(self.prev_data, data)
                     output_data = make_json_serializable(diff)
-                self.counter += 1
                 self.prev_data = data
             else:
                 output_data = data
@@ -909,6 +912,14 @@ def _restore_gpu_resume_anchor_plan(config: dict, checkpoint_path: str) -> bool:
         len(anchor_plan["anchors"]),
     )
     return True
+
+
+def _should_apply_fine_tune_bounds(
+    *, restored_resume_anchor_plan: bool, installing_anchor_plan: bool
+) -> bool:
+    """Keep a checkpoint-owned optimizer shape stable across GPU resume."""
+
+    return not restored_resume_anchor_plan and not installing_anchor_plan
 
 
 def _gpu_checkpoint_allows_empty_results(
@@ -3452,11 +3463,16 @@ async def main():
 
     resume_results_dir = None
     resume_checkpoint_path = None
+    restored_resume_anchor_plan = False
     if args.resume:
         resume_results_dir = _resolve_resume_results_dir(args.resume)
         resume_checkpoint_path = _require_resume_checkpoint(resume_results_dir)
         if get_anchor_plan(config) is None:
-            _restore_gpu_resume_anchor_plan(config, resume_checkpoint_path)
+            restored_resume_anchor_plan = _restore_gpu_resume_anchor_plan(
+                config, resume_checkpoint_path
+            )
+        else:
+            restored_resume_anchor_plan = True
 
     preselected_starting_configs = None
     if args.filter_starting_configs or args.starting_configs_max is not None:
@@ -3482,14 +3498,18 @@ async def main():
     }
     if polish_bounds_pct is not None:
         apply_polish_bounds(config, polish_bounds_pct, bounds_mode=polish_bounds_mode)
-    if fine_tune_params and args.starting_configs:
+    installing_anchor_plan = bool(fine_tune_params and args.starting_configs)
+    if installing_anchor_plan:
         install_anchored_fine_tune_plan(
             config,
             fine_tune_params,
             args.starting_configs,
             starting_configs_override=preselected_starting_configs,
         )
-    else:
+    elif _should_apply_fine_tune_bounds(
+        restored_resume_anchor_plan=restored_resume_anchor_plan,
+        installing_anchor_plan=installing_anchor_plan,
+    ):
         apply_fine_tune_bounds(config, fine_tune_params, cli_bounds_overrides)
     validate_optimizer_effective_configs(config)
     backtest_exchanges = require_config_value(config, "backtest.exchanges")

--- a/src/optimize.py
+++ b/src/optimize.py
@@ -155,7 +155,13 @@ except ImportError:  # pragma: no cover - allow import in minimal test envs
 import math
 import fcntl
 from optimizer_overrides import optimizer_overrides, validate_optimizer_overrides
-from opt_utils import make_json_serializable, generate_incremental_diff, round_floats, quantize_floats
+from opt_utils import (
+    deep_updated,
+    generate_incremental_diff,
+    make_json_serializable,
+    quantize_floats,
+    round_floats,
+)
 from limit_utils import expand_limit_checks, compute_limit_violation
 from pareto_store import ParetoStore
 import msgpack
@@ -442,6 +448,7 @@ class ResultRecorder:
         pareto_max_size: int = 1000,
         bounds: Optional[Sequence[Bound]] = None,
         starting_iters: int = 0,
+        previous_data: dict | None = None,
     ):
         self.scoring_specs = extract_objective_specs(scoring_keys)
         self.scoring_keys = [spec.metric for spec in self.scoring_specs]
@@ -463,8 +470,8 @@ class ResultRecorder:
             filename = os.path.join(results_dir, "all_results.bin")
             self.results_file = open(filename, "ab")
             self.packer = msgpack.Packer(use_bin_type=True)
-        self.prev_data = None
-        self.counter = 0
+        self.prev_data = previous_data
+        self.counter = int(starting_iters)
 
     def record(self, data: dict) -> None:
         if self.write_all and self.results_file:
@@ -869,6 +876,41 @@ def _require_resume_checkpoint(results_dir: str) -> str:
     return checkpoint_path
 
 
+def _restore_gpu_resume_anchor_plan(config: dict, checkpoint_path: str) -> bool:
+    """Restore checkpoint-owned fine-tune anchors before building optimizer shape."""
+
+    if config.get("optimize", {}).get("backend") != "gpu":
+        return False
+    try:
+        import pickle
+
+        with open(checkpoint_path, "rb") as file:
+            checkpoint = pickle.load(file)
+    except Exception as exc:
+        raise ValueError(
+            f"Cannot resume: failed to read checkpoint: {checkpoint_path}"
+        ) from exc
+    anchor_plan = checkpoint.get("anchor_plan")
+    if anchor_plan is None:
+        return False
+    if not isinstance(anchor_plan, dict) or not anchor_plan.get("anchors"):
+        raise ValueError("Cannot resume: GPU checkpoint has an invalid anchor plan")
+    checkpoint_strategy = normalize_strategy_kind(anchor_plan.get("strategy_kind"))
+    config_strategy = normalize_strategy_kind(
+        config.get("live", {}).get("strategy_kind")
+    )
+    if checkpoint_strategy != config_strategy:
+        raise ValueError(
+            "Cannot resume: GPU checkpoint anchor strategy does not match config"
+        )
+    config[ANCHOR_PLAN_KEY] = deepcopy(anchor_plan)
+    logging.info(
+        "Restored %d checkpoint-owned fine-tune anchors",
+        len(anchor_plan["anchors"]),
+    )
+    return True
+
+
 def _gpu_checkpoint_allows_empty_results(
     checkpoint_path: str | None,
     config: dict,
@@ -904,12 +946,15 @@ def _validate_resume_results(
     config: dict,
     *,
     checkpoint_path: str | None = None,
+    resume_state: dict | None = None,
 ) -> int:
     results_filename = os.path.join(results_dir, "all_results.bin")
     if not os.path.isfile(results_filename):
         raise ValueError(f"Cannot resume: all_results.bin not found: {results_filename}")
     if os.path.getsize(results_filename) <= 0:
         if _gpu_checkpoint_allows_empty_results(checkpoint_path, config):
+            if resume_state is not None:
+                resume_state["previous_data"] = None
             logging.info(
                 "Resuming GPU seed bootstrap before its first durable exact result"
             )
@@ -917,6 +962,7 @@ def _validate_resume_results(
         raise ValueError(f"Cannot resume: all_results.bin is empty: {results_filename}")
 
     previous_evals = 0
+    previous_data = {}
     try:
         with open(results_filename, "rb") as f:
             for entry in _iter_strict_msgpack_objects(
@@ -933,6 +979,7 @@ def _validate_resume_results(
                         f"Cannot resume: all_results.bin entry {previous_evals} is not a result object: "
                         f"{results_filename}"
                     )
+                previous_data = deep_updated(previous_data, entry)
                 if previous_evals == 1:
                     mismatches = _resume_config_mismatches(entry, config)
                     if mismatches:
@@ -952,6 +999,8 @@ def _validate_resume_results(
 
     if previous_evals <= 0:
         raise ValueError(f"Cannot resume: all_results.bin contains no entries: {results_filename}")
+    if resume_state is not None:
+        resume_state["previous_data"] = previous_data
     logging.info("Resuming with %d previous evaluations from all_results.bin", previous_evals)
     return previous_evals
 
@@ -3401,6 +3450,14 @@ async def main():
         scenario_labels=active_suite_scenario_labels,
     )
 
+    resume_results_dir = None
+    resume_checkpoint_path = None
+    if args.resume:
+        resume_results_dir = _resolve_resume_results_dir(args.resume)
+        resume_checkpoint_path = _require_resume_checkpoint(resume_results_dir)
+        if get_anchor_plan(config) is None:
+            _restore_gpu_resume_anchor_plan(config, resume_checkpoint_path)
+
     preselected_starting_configs = None
     if args.filter_starting_configs or args.starting_configs_max is not None:
         preselected_starting_configs = preselect_starting_configs(
@@ -3601,16 +3658,18 @@ async def main():
             )
         )
         previous_evals = 0
+        resume_recorder_state = {}
         checkpoint_path = None
         if args.resume:
             if not config["optimize"].get("write_all_results", True):
                 raise ValueError("Cannot resume with optimize.write_all_results=false")
-            results_dir = _resolve_resume_results_dir(args.resume)
-            checkpoint_path = _require_resume_checkpoint(results_dir)
+            results_dir = resume_results_dir
+            checkpoint_path = resume_checkpoint_path
             previous_evals = _validate_resume_results(
                 results_dir,
                 config,
                 checkpoint_path=checkpoint_path,
+                resume_state=resume_recorder_state,
             )
         else:
             results_dir = make_get_filepath(
@@ -3665,6 +3724,7 @@ async def main():
             pareto_max_size=pareto_max,
             bounds=evaluator.bounds,
             starting_iters=previous_evals,
+            previous_data=resume_recorder_state.get("previous_data"),
         )
         backend_name = config["optimize"]["backend"]
         logging.info("Selected optimizer backend: %s", backend_name)

--- a/src/optimize.py
+++ b/src/optimize.py
@@ -869,11 +869,51 @@ def _require_resume_checkpoint(results_dir: str) -> str:
     return checkpoint_path
 
 
-def _validate_resume_results(results_dir: str, config: dict) -> int:
+def _gpu_checkpoint_allows_empty_results(
+    checkpoint_path: str | None,
+    config: dict,
+) -> bool:
+    """Permit the durable pre-result checkpoint of a GPU seed bootstrap."""
+
+    if (
+        config.get("optimize", {}).get("backend") != "gpu"
+        or checkpoint_path is None
+    ):
+        return False
+    try:
+        import pickle
+
+        with open(checkpoint_path, "rb") as file:
+            checkpoint = pickle.load(file)
+    except Exception:
+        return False
+    plan = checkpoint.get("seed_bootstrap_plan")
+    return bool(
+        not checkpoint.get("seed_bootstrap_complete", True)
+        and int(checkpoint.get("seed_exact_done", -1)) == 0
+        and int(checkpoint.get("exact_done", -1)) == 0
+        and isinstance(checkpoint.get("seed_bootstrap_contract"), dict)
+        and isinstance(plan, dict)
+        and plan.get("starting_vectors")
+        and plan.get("effective_mode") in {"exact", "screened"}
+    )
+
+
+def _validate_resume_results(
+    results_dir: str,
+    config: dict,
+    *,
+    checkpoint_path: str | None = None,
+) -> int:
     results_filename = os.path.join(results_dir, "all_results.bin")
     if not os.path.isfile(results_filename):
         raise ValueError(f"Cannot resume: all_results.bin not found: {results_filename}")
     if os.path.getsize(results_filename) <= 0:
+        if _gpu_checkpoint_allows_empty_results(checkpoint_path, config):
+            logging.info(
+                "Resuming GPU seed bootstrap before its first durable exact result"
+            )
+            return 0
         raise ValueError(f"Cannot resume: all_results.bin is empty: {results_filename}")
 
     previous_evals = 0
@@ -3567,7 +3607,11 @@ async def main():
                 raise ValueError("Cannot resume with optimize.write_all_results=false")
             results_dir = _resolve_resume_results_dir(args.resume)
             checkpoint_path = _require_resume_checkpoint(results_dir)
-            previous_evals = _validate_resume_results(results_dir, config)
+            previous_evals = _validate_resume_results(
+                results_dir,
+                config,
+                checkpoint_path=checkpoint_path,
+            )
         else:
             results_dir = make_get_filepath(
                 f"optimize_results/{date_fname}_{exchanges_fname}_{n_days}days_{coins_fname}_{hash_snippet}/"

--- a/tests/optimization/test_backends.py
+++ b/tests/optimization/test_backends.py
@@ -74,6 +74,10 @@ def test_format_config_accepts_gpu_backend():
     assert out["optimize"]["gpu"]["batch_size"] is None
     assert out["optimize"]["gpu"]["max_dispatch_candidate_bars"] is None
     assert out["optimize"]["gpu"]["auto_lean_parallelism"] is True
+    assert out["optimize"]["gpu"]["seed_bootstrap"] == {
+        "max_exact": 128,
+        "mode": "auto",
+    }
 
 
 def test_format_config_rejects_unknown_backend():

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -1,4 +1,5 @@
 import copy
+import hashlib
 import json
 import os
 from pathlib import Path
@@ -33,6 +34,7 @@ from optimization.backends.gpu_backend import (
     _ema_multicoin_bound_map,
     _evaluate_gpu_suite_proxies,
     _evaluate_successive_halving,
+    _effective_seed_bootstrap_mode,
     _format_constraint_diagnostics,
     _gpu_fixed_bound_context,
     _gpu_candidate_search_sides,
@@ -58,6 +60,7 @@ from optimization.backends.gpu_backend import (
     _profiled_gpu_exact_worker,
     _DriftMonitor,
     _ObjectiveScale,
+    _recover_durable_seed_bootstrap,
     _recover_durable_validations,
     _ready_submission_prefix,
     _update_novelty_stall,
@@ -74,6 +77,8 @@ from optimization.backends.gpu_backend import (
     _trailing_martingale_multicoin_bound_map,
     _ProxyFrontValidationPending,
     _select_exact_validations,
+    _select_seed_bootstrap_indices,
+    _select_seed_population_indices,
     _select_validation_indices,
     _update_probe_shortfall_log,
     _validate_directional_search_space,
@@ -82,6 +87,7 @@ from optimization.backends.gpu_backend import (
     _validate_gpu_coin_overrides,
     _validate_pinned_scope_bounds,
     _validate_resume_evidence_budget,
+    _validate_seed_bootstrap_plan,
     _validate_seed_side_match,
     _validate_scope,
     _validate_tm_market_mode_bounds,
@@ -282,9 +288,11 @@ def _directional_tm_config(*, long_enabled: bool, short_enabled: bool):
 
 def test_gpu_options_are_additive_and_validate_ranges():
     config = _long_only_ema_config()
-    assert _resolve_options(config)["auto_lean_parallelism"] is True
-    assert _resolve_options(config)["population_size"] == 1024
-    assert _resolve_options(config)["max_dispatch_candidate_bars"] == 1_000_000_000
+    options = _resolve_options(config)
+    assert options["auto_lean_parallelism"] is True
+    assert options["population_size"] == 1024
+    assert options["max_dispatch_candidate_bars"] == 1_000_000_000
+    assert options["seed_bootstrap"] == {"mode": "auto", "max_exact": 128}
 
     config["optimize"]["gpu"]["batch_size"] = 0
     with pytest.raises(ValueError, match="batch_size"):
@@ -365,6 +373,156 @@ def test_gpu_options_are_additive_and_validate_ranges():
     config["optimize"]["gpu"]["drift_halt"] = 0.0
     with pytest.raises(ValueError, match="greater than zero"):
         _resolve_options(config)
+
+
+def test_gpu_seed_bootstrap_options_are_explicit_and_fail_closed():
+    config = _long_only_ema_config()
+    config["optimize"]["gpu"]["seed_bootstrap"] = {
+        "mode": "SCREENED",
+        "max_exact": 64,
+    }
+    assert _resolve_options(config)["seed_bootstrap"] == {
+        "mode": "screened",
+        "max_exact": 64,
+    }
+
+    config["optimize"]["gpu"]["seed_bootstrap"]["mode"] = "best-effort"
+    with pytest.raises(ValueError, match="seed_bootstrap.mode"):
+        _resolve_options(config)
+
+    config["optimize"]["gpu"]["seed_bootstrap"] = {
+        "mode": "auto",
+        "max_exact": 0,
+    }
+    with pytest.raises(ValueError, match="max_exact"):
+        _resolve_options(config)
+
+    config["optimize"]["gpu"]["seed_bootstrap"] = {
+        "mode": "auto",
+        "max_exact": 64,
+        "unexpected": True,
+    }
+    with pytest.raises(ValueError, match="unknown.*unexpected"):
+        _resolve_options(config)
+
+    config["optimize"]["gpu"]["seed_bootstrap"] = "auto"
+    with pytest.raises(TypeError, match="seed_bootstrap must be an object"):
+        _resolve_options(config)
+
+
+def test_gpu_seed_bootstrap_auto_switches_only_at_the_exact_cap():
+    policy = {"mode": "auto", "max_exact": 128}
+
+    assert _effective_seed_bootstrap_mode(policy, 0) == "none"
+    assert _effective_seed_bootstrap_mode(policy, 128) == "exact"
+    assert _effective_seed_bootstrap_mode(policy, 129) == "screened"
+    assert (
+        _effective_seed_bootstrap_mode({"mode": "exact", "max_exact": 1}, 500)
+        == "exact"
+    )
+
+
+def test_gpu_seed_bootstrap_selection_keeps_extremes_front_and_probe_coverage():
+    objectives = np.asarray(
+        [
+            [0.0, 10.0],
+            [2.0, 7.0],
+            [5.0, 5.0],
+            [7.0, 2.0],
+            [10.0, 0.0],
+            [8.0, 8.0],
+        ],
+        dtype=np.float64,
+    )
+    scores = np.sum(objectives, axis=1)
+    violations = np.full(len(objectives), -1.0, dtype=np.float64)
+
+    selected = _select_seed_bootstrap_indices(
+        objectives,
+        scores,
+        violations,
+        total=4,
+    )
+
+    selected_ids = {index for index, _probe, _front in selected}
+    assert {0, 4}.issubset(selected_ids)
+    assert len(selected) == 4
+    assert any(probe and not front for _index, probe, front in selected)
+
+
+def test_gpu_seed_bootstrap_selection_reserves_front_and_probe_slots():
+    objectives = np.asarray(
+        [[float(index), float(9 - index)] for index in range(10)]
+        + [[20.0 + index, 20.0 + index] for index in range(10)],
+        dtype=np.float64,
+    )
+    scores = np.sum(objectives, axis=1)
+    violations = np.full(len(objectives), -1.0, dtype=np.float64)
+
+    selected = _select_seed_bootstrap_indices(
+        objectives,
+        scores,
+        violations,
+        total=8,
+    )
+
+    assert len(selected) == 8
+    assert sum(front for _index, _probe, front in selected) == 6
+    assert sum(probe for _index, probe, _front in selected) == 2
+    assert {0, 9}.issubset({index for index, _probe, _front in selected})
+
+
+def test_gpu_seed_population_reduction_prefers_feasible_pareto_diversity():
+    objectives = np.asarray(
+        [[0.0, 4.0], [2.0, 2.0], [4.0, 0.0], [1.0, 1.0]],
+        dtype=np.float64,
+    )
+    violations = np.asarray([-1.0, -1.0, -1.0, 0.5], dtype=np.float64)
+
+    selected = _select_seed_population_indices(
+        objectives,
+        violations,
+        count=3,
+    )
+
+    assert set(selected) == {0, 1, 2}
+
+
+def test_gpu_seed_bootstrap_checkpoint_plan_fails_closed_on_pool_drift():
+    vectors = [[0.1], [0.2], [0.3]]
+    digest = hashlib.sha256(b"0.1\n0.2\n0.3").hexdigest()
+    contract = {
+        "effective_mode": "screened",
+        "seed_count": 3,
+        "selected_exact_count": 2,
+        "all_seeds_exact": False,
+        "seed_pool_sha256": digest,
+    }
+    kwargs = {
+        "hash_vector": lambda vector: str(vector[0]),
+        "proxy_metrics": {0: {}, 2: {}},
+        "proxy_objectives": [[0.0, 2.0], [1.0, 1.0], [2.0, 0.0]],
+        "proxy_violations": [-1.0, -1.0, -1.0],
+    }
+
+    _validate_seed_bootstrap_plan(
+        vectors,
+        [(0, False, True), (2, True, False)],
+        [0, 2, 1],
+        contract,
+        **kwargs,
+    )
+
+    changed = copy.deepcopy(vectors)
+    changed[1][0] = 0.25
+    with pytest.raises(RuntimeError, match="does not match its seed contract"):
+        _validate_seed_bootstrap_plan(
+            changed,
+            [(0, False, True), (2, True, False)],
+            [0, 2, 1],
+            contract,
+            **kwargs,
+        )
 
 
 def _lean_tm_bounds(side="long"):
@@ -854,6 +1012,35 @@ def test_gpu_nsga2_uses_configured_pymoo_variation_operators():
         "mutation": {"operator": "pm", "prob": 0.2, "eta": 13.0},
         "eliminate_duplicates": False,
     }
+
+
+def test_gpu_nsga2_accepts_exact_seed_sampling_before_first_ask():
+    from pymoo.core.problem import Problem
+    from pymoo.core.termination import NoTermination
+
+    config = _long_only_ema_config()
+    initial = np.zeros((8, 2), dtype=np.float64)
+    exact_seed_sampling = np.asarray(
+        [[index / 10.0, (index + 1) / 10.0] for index in range(8)],
+        dtype=np.float64,
+    )
+    algorithm = _build_gpu_nsga2(
+        config,
+        sampling=initial,
+        population_size=8,
+        n_params=2,
+    )
+    algorithm.setup(
+        Problem(n_var=2, n_obj=1, xl=np.zeros(2), xu=np.ones(2)),
+        termination=NoTermination(),
+        seed=1,
+        verbose=False,
+    )
+
+    algorithm.initialization.sampling = exact_seed_sampling
+    population = algorithm.ask()
+
+    np.testing.assert_allclose(population.get("X"), exact_seed_sampling)
 
 
 def test_trailing_martingale_bound_map_covers_both_directional_shapes():
@@ -6747,6 +6934,29 @@ def test_gpu_checkpoint_signature_tracks_full_fixed_search_contract():
         "historical_prefix_v1"
     )
     mutations.append(changed_history_window)
+    changed_seed_bootstrap = _gpu_search_checkpoint_contract(
+        key_paths=key_paths,
+        bounds=bounds,
+        base_vector=base,
+        fixed_bound_values={"long_base_qty_pct": 0.02},
+        fixed_parameter_overrides={"long_base_qty_pct": 0.02},
+        optimizer_overrides=set(),
+        sig_digits=3,
+        algorithm_contract=contract["algorithm"],
+        proxy_evaluation_policy=contract["proxy_evaluation"],
+        seed_bootstrap_contract={
+            "version": 1,
+            "requested_mode": "auto",
+            "effective_mode": "screened",
+            "max_exact": 128,
+            "seed_count": 1000,
+            "selected_exact_count": 128,
+            "all_seeds_exact": False,
+            "seed_pool_sha256": "abc123",
+        },
+    )
+    assert changed_seed_bootstrap["version"] == 3
+    mutations.append(changed_seed_bootstrap)
 
     assert all(
         _checkpoint_signature(active, scoring, search_contract=changed)
@@ -7207,6 +7417,85 @@ def test_resume_recovers_hashes_and_drift_for_results_ahead_of_checkpoint():
         (2.0, 2.5, False, False, True),
         (3.0, 3.5, True, False, False),
     ]
+
+
+def test_resume_recovers_exact_and_screened_seed_bootstrap_results():
+    entries = [
+        {
+            "id": 7,
+            "metrics": {
+                "gpu_seed_bootstrap": {
+                    "schema_version": 1,
+                    "mode": "exact",
+                    "source_index": 3,
+                    "exact_objectives": [0.1, 0.2],
+                    "exact_violation": -1.0,
+                }
+            },
+        },
+        {
+            "id": 8,
+            "metrics": {
+                "gpu_seed_bootstrap": {
+                    "schema_version": 1,
+                    "mode": "screened",
+                    "source_index": 5,
+                    "exact_objectives": [0.3, 0.4],
+                    "exact_violation": 0.5,
+                },
+                "gpu_validation": {
+                    "schema_version": 2,
+                    "phase": "seed_bootstrap",
+                    "proxy_score": 0.25,
+                    "exact_score": 0.35,
+                    "probe": True,
+                    "proxy_front": False,
+                    "constraint_classification_mismatch": True,
+                },
+            },
+        },
+    ]
+
+    payloads, recovered, drift_pairs = _recover_durable_seed_bootstrap(
+        entries,
+        start_index=0,
+        stop_index=2,
+        vector_from_entry=lambda entry: [float(entry["id"])],
+        hash_vector=lambda vector: f"hash-{vector[0]}",
+    )
+
+    assert recovered == {"hash-7.0", "hash-8.0"}
+    assert payloads["hash-7.0"] == {
+        "source_index": 3,
+        "F": [0.1, 0.2],
+        "G": [-1.0],
+    }
+    assert payloads["hash-8.0"]["source_index"] == 5
+    assert drift_pairs == [(0.25, 0.35, True, True, False)]
+
+
+def test_resume_rejects_screened_seed_without_proxy_exact_evidence():
+    with pytest.raises(RuntimeError, match="without proxy/exact metadata"):
+        _recover_durable_seed_bootstrap(
+            [
+                {
+                    "id": 1,
+                    "metrics": {
+                        "gpu_seed_bootstrap": {
+                            "schema_version": 1,
+                            "mode": "screened",
+                            "source_index": 0,
+                            "exact_objectives": [0.1],
+                            "exact_violation": -1.0,
+                        }
+                    },
+                }
+            ],
+            start_index=0,
+            stop_index=1,
+            vector_from_entry=lambda entry: [float(entry["id"])],
+            hash_vector=lambda vector: f"hash-{vector[0]}",
+        )
 
 
 def test_resume_hash_recovery_fails_if_durable_tail_is_missing():

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -32,6 +32,7 @@ from optimization.backends.gpu_backend import (
     _constraint_classification_mismatch,
     _constraint_diagnostics,
     _deduplicate_canonical_seed_vectors,
+    _disable_gpu_exact_duplicate_guard,
     _ema_multicoin_bound_map,
     _evaluate_gpu_suite_proxies,
     _evaluate_successive_halving,
@@ -435,6 +436,15 @@ def test_gpu_seed_bootstrap_deduplicates_runtime_override_equivalents():
     assert dropped == 1
 
 
+def test_gpu_exact_validation_disables_evaluator_duplicate_perturbation():
+    base = SimpleNamespace(use_duplicate_guard=True)
+    suite = SimpleNamespace(base=base)
+
+    _disable_gpu_exact_duplicate_guard(suite)
+
+    assert base.use_duplicate_guard is False
+
+
 def test_gpu_seed_bootstrap_selection_keeps_extremes_front_and_probe_coverage():
     objectives = np.asarray(
         [
@@ -483,6 +493,27 @@ def test_gpu_seed_bootstrap_selection_reserves_front_and_probe_slots():
     assert sum(front for _index, _probe, front in selected) == 6
     assert sum(probe for _index, probe, _front in selected) == 2
     assert {0, 9}.issubset({index for index, _probe, _front in selected})
+
+
+def test_gpu_seed_bootstrap_extremes_do_not_consume_reserved_probes():
+    objective_count = 8
+    extremes = np.full((objective_count, objective_count), 10.0)
+    for index in range(objective_count):
+        extremes[index, index] = 0.0
+    dominated = np.full((4, objective_count), 20.0)
+    objectives = np.vstack((extremes, dominated))
+    scores = np.sum(objectives, axis=1)
+    violations = np.full(len(objectives), -1.0, dtype=np.float64)
+
+    selected = _select_seed_bootstrap_indices(
+        objectives,
+        scores,
+        violations,
+        total=8,
+    )
+
+    assert sum(front for _index, _probe, front in selected) == 6
+    assert sum(probe for _index, probe, _front in selected) == 2
 
 
 def test_gpu_seed_population_reduction_prefers_feasible_pareto_diversity():

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -31,6 +31,7 @@ from optimization.backends.gpu_backend import (
     _checkpoint_gpu_interrupt,
     _constraint_classification_mismatch,
     _constraint_diagnostics,
+    _deduplicate_canonical_seed_vectors,
     _ema_multicoin_bound_map,
     _evaluate_gpu_suite_proxies,
     _evaluate_successive_halving,
@@ -422,6 +423,18 @@ def test_gpu_seed_bootstrap_auto_switches_only_at_the_exact_cap():
     )
 
 
+def test_gpu_seed_bootstrap_deduplicates_runtime_override_equivalents():
+    vectors = [[0.1, 0.2], [0.1, 0.9], [0.3, 0.4]]
+
+    deduplicated, dropped = _deduplicate_canonical_seed_vectors(
+        vectors,
+        hash_vector=lambda vector: str(vector[0]),
+    )
+
+    assert deduplicated == [vectors[0], vectors[2]]
+    assert dropped == 1
+
+
 def test_gpu_seed_bootstrap_selection_keeps_extremes_front_and_probe_coverage():
     objectives = np.asarray(
         [
@@ -522,6 +535,37 @@ def test_gpu_seed_bootstrap_checkpoint_plan_fails_closed_on_pool_drift():
             [0, 2, 1],
             contract,
             **kwargs,
+        )
+
+
+def test_gpu_seed_bootstrap_checkpoint_accepts_only_valid_pending_screen():
+    vectors = [[0.1], [0.2], [0.3]]
+    contract = {
+        "effective_mode": "screened",
+        "max_exact": 2,
+        "seed_count": 3,
+        "selected_exact_count": 2,
+        "all_seeds_exact": False,
+        "seed_pool_sha256": hashlib.sha256(b"0.1\n0.2\n0.3").hexdigest(),
+    }
+
+    _validate_seed_bootstrap_plan(
+        vectors,
+        [],
+        [],
+        contract,
+        hash_vector=lambda vector: str(vector[0]),
+        screen_complete=False,
+    )
+
+    with pytest.raises(RuntimeError, match="invalid partial evidence"):
+        _validate_seed_bootstrap_plan(
+            vectors,
+            [(0, False, True)],
+            [],
+            contract,
+            hash_vector=lambda vector: str(vector[0]),
+            screen_complete=False,
         )
 
 

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -516,6 +516,24 @@ def test_gpu_seed_bootstrap_extremes_do_not_consume_reserved_probes():
     assert sum(probe for _index, probe, _front in selected) == 2
 
 
+def test_gpu_seed_bootstrap_all_infeasible_reserves_lowest_violations():
+    objectives = np.asarray(
+        [[0.0, 10.0], [10.0, 0.0], [6.0, 6.0], [7.0, 7.0]],
+        dtype=np.float64,
+    )
+    scores = np.sum(objectives, axis=1)
+    violations = np.asarray([10.0, 8.0, 0.01, 0.02], dtype=np.float64)
+
+    selected = _select_seed_bootstrap_indices(
+        objectives,
+        scores,
+        violations,
+        total=2,
+    )
+
+    assert 2 in {index for index, _probe, _front in selected}
+
+
 def test_gpu_seed_population_reduction_prefers_feasible_pareto_diversity():
     objectives = np.asarray(
         [[0.0, 4.0], [2.0, 2.0], [4.0, 0.0], [1.0, 1.0]],

--- a/tests/optimization/test_optimize.py
+++ b/tests/optimization/test_optimize.py
@@ -12,6 +12,7 @@ import argparse
 import builtins
 import json
 import logging
+import pickle
 from multiprocessing.reduction import ForkingPickler
 import tempfile
 from collections import defaultdict
@@ -5235,6 +5236,62 @@ def test_validate_resume_results_rejects_empty_all_results(tmp_path: Path):
 
     with pytest.raises(ValueError, match="all_results.bin is empty"):
         optimize._validate_resume_results(str(tmp_path), config)
+
+
+def test_validate_resume_results_allows_empty_gpu_seed_bootstrap_checkpoint(
+    tmp_path: Path,
+):
+    config = _resume_validation_entry()
+    config["optimize"]["backend"] = "gpu"
+    results_path = tmp_path / "all_results.bin"
+    results_path.write_bytes(b"")
+    checkpoint_path = tmp_path / "checkpoint.pkl"
+    checkpoint = {
+        "seed_bootstrap_complete": False,
+        "seed_exact_done": 0,
+        "exact_done": 0,
+        "seed_bootstrap_contract": {"version": 1},
+        "seed_bootstrap_plan": {
+            "effective_mode": "screened",
+            "starting_vectors": [[0.1]],
+        },
+    }
+    with open(checkpoint_path, "wb") as file:
+        pickle.dump(checkpoint, file)
+
+    assert (
+        optimize._validate_resume_results(
+            str(tmp_path),
+            config,
+            checkpoint_path=str(checkpoint_path),
+        )
+        == 0
+    )
+
+
+def test_validate_resume_results_rejects_empty_completed_gpu_checkpoint(
+    tmp_path: Path,
+):
+    config = _resume_validation_entry()
+    config["optimize"]["backend"] = "gpu"
+    (tmp_path / "all_results.bin").write_bytes(b"")
+    checkpoint_path = tmp_path / "checkpoint.pkl"
+    with open(checkpoint_path, "wb") as file:
+        pickle.dump(
+            {
+                "seed_bootstrap_complete": True,
+                "seed_exact_done": 0,
+                "exact_done": 0,
+            },
+            file,
+        )
+
+    with pytest.raises(ValueError, match="all_results.bin is empty"):
+        optimize._validate_resume_results(
+            str(tmp_path),
+            config,
+            checkpoint_path=str(checkpoint_path),
+        )
 
 
 def test_validate_resume_results_rejects_corrupt_all_results(tmp_path: Path):

--- a/tests/optimization/test_optimize.py
+++ b/tests/optimization/test_optimize.py
@@ -24,6 +24,7 @@ import numpy as np
 import pytest
 
 import optimize
+from opt_utils import load_results
 from optimize import (
     _apply_config_overrides,
     _analysis_indicates_liquidation,
@@ -5344,6 +5345,68 @@ def test_validate_resume_results_counts_entries(tmp_path: Path):
     _write_msgpack_entries(tmp_path / "all_results.bin", [entry, deepcopy(entry)])
 
     assert optimize._validate_resume_results(str(tmp_path), deepcopy(entry)) == 2
+
+
+def test_compressed_result_resume_clears_seed_bootstrap_metadata(tmp_path: Path):
+    seed_entry = _resume_validation_entry()
+    seed_entry["metrics"] = {
+        "objectives": {"adg_strategy_eq": 0.1},
+        "constraint_violation": 0.0,
+        "gpu_seed_bootstrap": {"mode": "exact", "source_index": 0},
+    }
+    _write_msgpack_entries(tmp_path / "all_results.bin", [seed_entry])
+    resume_state = {}
+    assert (
+        optimize._validate_resume_results(
+            str(tmp_path),
+            deepcopy(seed_entry),
+            resume_state=resume_state,
+        )
+        == 1
+    )
+    recorder = ResultRecorder(
+        results_dir=str(tmp_path),
+        sig_digits=6,
+        flush_interval=60,
+        scoring_keys=["adg_strategy_eq"],
+        compress=True,
+        write_all_results=True,
+        starting_iters=1,
+        previous_data=resume_state["previous_data"],
+    )
+    recorder.store.add_entry = Mock(return_value=False)
+    evolution_entry = deepcopy(seed_entry)
+    evolution_entry["metrics"].pop("gpu_seed_bootstrap")
+    evolution_entry["metrics"]["objectives"]["adg_strategy_eq"] = 0.2
+    recorder.record(evolution_entry)
+    recorder.close()
+
+    results = list(load_results(tmp_path / "all_results.bin"))
+    assert results[0]["metrics"]["gpu_seed_bootstrap"]["source_index"] == 0
+    assert "gpu_seed_bootstrap" not in results[1]["metrics"]
+
+
+def test_restore_gpu_resume_anchor_plan_before_shape_build(tmp_path: Path):
+    checkpoint_path = tmp_path / "checkpoint.pkl"
+    anchor_plan = {
+        "anchors": [{"seed_bot": {}, "fixed_values": [], "source": "checkpoint"}],
+        "fixed_keys": ["long_base_qty_pct"],
+        "key_paths": [["bot", "long", "base_qty_pct"]],
+        "strategy_kind": "trailing_martingale",
+        "tunable_keys": ["long_base_qty_pct"],
+    }
+    with open(checkpoint_path, "wb") as file:
+        pickle.dump({"anchor_plan": anchor_plan}, file)
+    config = {
+        "live": {"strategy_kind": "trailing_martingale"},
+        "optimize": {"backend": "gpu"},
+    }
+
+    assert optimize._restore_gpu_resume_anchor_plan(
+        config, str(checkpoint_path)
+    )
+    assert config[optimize.ANCHOR_PLAN_KEY] == anchor_plan
+    assert config[optimize.ANCHOR_PLAN_KEY] is not anchor_plan
 
 
 def test_optimizer_exit_code_is_nonzero_for_fatal_errors():

--- a/tests/optimization/test_optimize.py
+++ b/tests/optimization/test_optimize.py
@@ -5386,6 +5386,36 @@ def test_compressed_result_resume_clears_seed_bootstrap_metadata(tmp_path: Path)
     assert "gpu_seed_bootstrap" not in results[1]["metrics"]
 
 
+def test_compressed_result_boundary_clears_seed_bootstrap_metadata(tmp_path: Path):
+    seed_entry = _resume_validation_entry()
+    seed_entry["metrics"] = {
+        "objectives": {"adg_strategy_eq": 0.1},
+        "constraint_violation": 0.0,
+        "gpu_seed_bootstrap": {"mode": "exact", "source_index": 99},
+    }
+    _write_msgpack_entries(tmp_path / "all_results.bin", [seed_entry])
+    recorder = ResultRecorder(
+        results_dir=str(tmp_path),
+        sig_digits=6,
+        flush_interval=60,
+        scoring_keys=["adg_strategy_eq"],
+        compress=True,
+        write_all_results=True,
+        starting_iters=100,
+        previous_data=seed_entry,
+    )
+    recorder.store.add_entry = Mock(return_value=False)
+    evolution_entry = deepcopy(seed_entry)
+    evolution_entry["metrics"].pop("gpu_seed_bootstrap")
+    evolution_entry["metrics"]["objectives"]["adg_strategy_eq"] = 0.2
+    recorder.record(evolution_entry)
+    recorder.close()
+
+    results = list(load_results(tmp_path / "all_results.bin"))
+    assert results[0]["metrics"]["gpu_seed_bootstrap"]["source_index"] == 99
+    assert "gpu_seed_bootstrap" not in results[1]["metrics"]
+
+
 def test_restore_gpu_resume_anchor_plan_before_shape_build(tmp_path: Path):
     checkpoint_path = tmp_path / "checkpoint.pkl"
     anchor_plan = {
@@ -5407,6 +5437,21 @@ def test_restore_gpu_resume_anchor_plan_before_shape_build(tmp_path: Path):
     )
     assert config[optimize.ANCHOR_PLAN_KEY] == anchor_plan
     assert config[optimize.ANCHOR_PLAN_KEY] is not anchor_plan
+
+
+def test_restored_gpu_anchor_plan_skips_ordinary_fine_tune_bounds():
+    assert not optimize._should_apply_fine_tune_bounds(
+        restored_resume_anchor_plan=True,
+        installing_anchor_plan=False,
+    )
+    assert not optimize._should_apply_fine_tune_bounds(
+        restored_resume_anchor_plan=False,
+        installing_anchor_plan=True,
+    )
+    assert optimize._should_apply_fine_tune_bounds(
+        restored_resume_anchor_plan=False,
+        installing_anchor_plan=False,
+    )
 
 
 def test_optimizer_exit_code_is_nonzero_for_fatal_errors():


### PR DESCRIPTION
## Summary

- give GPU optimization an authoritative exact-Rust seed bootstrap while preserving the CPU optimizer's exact-all seed contract
- default to exact validation for up to 128 deduplicated seeds, and use one full-history Metal screen plus capped diverse exact validation for larger pools
- keep bootstrap exact work separate from optimize.iters, keep exact fitness out of the proxy NSGA-II matrix, and make incomplete bootstrap plans crash-resumable

## Behavior

GPU seed bootstrap supports four explicit modes under optimize.gpu.seed_bootstrap:

- auto: exact-all through max_exact, screened above it
- exact: exact-Rust evaluate every seed
- screened: proxy-screen every seed and exact-validate a capped mix of constraint-aware Pareto diversity, objective extremes, and truthful off-front probes
- legacy: retain the former first-proxy-population-only behavior

The exact-selected vectors seed the initial proxy population, but their exact objective values are recorded only in the authoritative result/Pareto archive. Bootstrap evaluations do not consume the later evolutionary exact-validation budget. Checkpoints fingerprint the normalized seed pool and policy, persist incomplete plans, and recover exact results durably flushed just before a restart.

## Validation

- Python optimizer/config regression suite: GPU backend, backend selection, pymoo backend, optimizer orchestration, config utilities, and config pipeline all pass
- Python syntax compilation and git diff checks pass
- AI documentation checker: 0 errors; the two repository-wide word-count warnings predate this change
- rebuilt and fingerprint-verified the release Python extension before MPS integration testing
- Apple MPS exact-mode smoke with 50 seeds: 50 exact seed records plus the full 64 evolutionary exact validations
- Apple MPS screened-mode smoke with 50 seeds and an exact cap of 8: one 50-seed proxy screen, 8 authoritative exact seed records, then the full 64 evolutionary exact validations
- completed checkpoint resume without the original start-config argument performs no repeated proxy or exact work
