### PR TITLE
Expand trailing inspect behavior overview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Expanded `passivbot tool trailing-inspect` with a config-first overview of both long and short
+  behavior across example volatility and exposure regimes. The report now includes threshold,
+  retracement, nominal confirmation, and emitted-order reference prices from a configurable anchor;
+  active/dormant side status; and plain-language explanations of sensitivity, entry cooldown and
+  ladder staging, EMA gating, and recursive closes. The existing detailed single-scenario and JSON
+  interfaces remain available.
+
 - GPU optimization now bootstraps `--start` configs into an authoritative exact-Rust seed archive.
   The default `auto` policy exact-evaluates up to 128 deduplicated seeds; larger pools receive one
   full-history Metal proxy screen followed by capped exact validation of diverse proxy-Pareto

--- a/docs/ai/features/trailing_diagnostics.md
+++ b/docs/ai/features/trailing_diagnostics.md
@@ -18,6 +18,15 @@
    canonical nested strategy parameters and mirrors the Rust formulas: entry distances are
    multiplicative, close threshold terms are additive, and close retracement has no wallet-exposure
    term.
+7. A positional config path defaults to a both-sides scenario overview. The overview uses explicit
+   example volatility and exposure-ratio inputs, a configurable price anchor, and descriptive
+   behavior categories. It must distinguish dormant sides, threshold-gated versus immediately
+   armed trailing, passive ladders, entry cooldown staging, and recursive closes without claiming
+   that a category predicts profitability.
+8. Scenario confirmation prices are nominal illustrations where the reversal begins exactly at the
+   threshold. The report must say that real confirmation follows the running extreme and that the
+   emitted price remains subject to market touch, tick rounding, EMA gates, sizing, and exposure
+   constraints.
 
 ## Validation
 
@@ -26,7 +35,8 @@
 3. command handling should mutate inputs deterministically and support dump/reset/help flows
 4. the tool wrapper should start with `--help` without import errors
 5. the one-shot inspector should cover additive close thresholds, separate entry multipliers,
-   long/short geometry, config extraction, overrides, and unified CLI dispatch
+   long/short geometry, config extraction, overrides, scenario grids, passive-entry cooldown modes,
+   dormant sides, price anchors, and unified CLI dispatch
 
 ## Key Code
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -177,9 +177,10 @@ versus staged entry ladders, EMA gating, volatility/exposure sensitivity, recurs
 and the difference between threshold-gated trailing and an immediately armed trailing stop.
 The descriptions are heuristics for intuition, not assessments of strategy quality.
 
-Without `--config`, the command uses the Rust-owned strategy defaults. With `--config`, it loads the
-selected side's canonical `bot.<side>.strategy.trailing_martingale` parameters. Individual flags
-override either source. Percent values use config ratios, so `0.01` means 1%.
+Without either a positional config path or `--config`, the command uses the Rust-owned strategy
+defaults. A positional config path or the legacy `--config` form loads canonical
+`bot.<side>.strategy.trailing_martingale` parameters. Individual flags override either source.
+Percent values use config ratios, so `0.01` means 1%.
 
 ```shell
 passivbot tool trailing-inspect configs/examples/default_trailing_martingale_long.json

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -172,10 +172,11 @@ effective exposure limit. Each row shows the threshold and retracement percentag
 price, nominal reversal-confirmation price, and Rust order-reference price from a readable 100.0
 average-position-price anchor. Use `--price-anchor` to change it.
 
-The overview labels each side as active or dormant and explains entry cooldown, simultaneous
-versus staged entry ladders, EMA gating, volatility/exposure sensitivity, recursive close sizing,
-and the difference between threshold-gated trailing and an immediately armed trailing stop.
-The descriptions are heuristics for intuition, not assessments of strategy quality.
+With a config, the overview labels each side as active or dormant and explains entry cooldown,
+simultaneous versus staged entry ladders, EMA gating, volatility/exposure sensitivity, recursive
+close sizing, and relevant portfolio/PnL risk paths. Without a config, only strategy defaults are
+loaded, so runtime paths are explicitly labeled as unknown. The descriptions are heuristics for
+intuition, not assessments of strategy quality.
 
 Without either a positional config path or `--config`, the command uses the Rust-owned strategy
 defaults. A positional config path or the legacy `--config` form loads canonical

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -166,24 +166,39 @@ passivbot tool iterative-history-plot backtests/.../fills.csv
 ## Trailing parameter inspector
 
 `passivbot tool trailing-inspect` explains the effective `trailing_martingale` entry and close
-thresholds for a hypothetical position. It is offline and read-only. It shows each wallet-exposure
-and volatility contribution, the threshold boundary, the retracement distance from the running
-extreme, the nominal confirmation price if the reversal starts exactly at the threshold, and the
-order-reference price used after both conditions pass.
+behavior. It is offline and read-only. Passing only a config path produces an overview for both
+sides across quiet, normal, and high example volatility plus 0%, 50%, and 90% usage of the
+effective exposure limit. Each row shows the threshold and retracement percentages, threshold
+price, nominal reversal-confirmation price, and Rust order-reference price from a readable 100.0
+average-position-price anchor. Use `--price-anchor` to change it.
+
+The overview labels each side as active or dormant and explains entry cooldown, simultaneous
+versus staged entry ladders, EMA gating, volatility/exposure sensitivity, recursive close sizing,
+and the difference between threshold-gated trailing and an immediately armed trailing stop.
+The descriptions are heuristics for intuition, not assessments of strategy quality.
 
 Without `--config`, the command uses the Rust-owned strategy defaults. With `--config`, it loads the
 selected side's canonical `bot.<side>.strategy.trailing_martingale` parameters. Individual flags
 override either source. Percent values use config ratios, so `0.01` means 1%.
 
 ```shell
+passivbot tool trailing-inspect configs/examples/default_trailing_martingale_long.json
+passivbot tool trailing-inspect configs/examples/default_trailing_martingale_long.json \
+  --side long --price-anchor 250
+
+# Customize the overview grid (values are config ratios, not percentage numbers).
+passivbot tool trailing-inspect configs/examples/default_trailing_martingale_long.json \
+  --exposure-ratios 0,0.25,0.5,0.75,0.95 \
+  --volatility-scenarios quiet:0.001:0.0005,normal:0.005:0.0025,high:0.015:0.0075
+
+# Detailed single-scenario mode remains available.
 passivbot tool trailing-inspect \
   --symbol COIN --side long \
   --position-size 150 --position-price 20 \
   --wallet-exposure 0.6 --effective-wallet-exposure-limit 0.9 \
   --volatility-ema-1m 0.007 --volatility-ema-1h 0.0033
 
-passivbot tool trailing-inspect \
-  --config configs/examples/default_trailing_martingale_long.json \
+passivbot tool trailing-inspect configs/examples/default_trailing_martingale_long.json \
   --side long --position-price 20 \
   --wallet-exposure 0.6 --effective-wallet-exposure-limit 0.9 \
   --volatility-ema-1m 0.007 --volatility-ema-1h 0.0033 \

--- a/src/tools/trailing_inspect.py
+++ b/src/tools/trailing_inspect.py
@@ -176,15 +176,24 @@ def _extract_side_context(config: Mapping[str, Any], pside: str) -> dict[str, An
         ) from exc
     coin_overrides = _require_mapping(config.get("coin_overrides", {}), "coin_overrides")
     coin_strategy_override_symbols: list[str] = []
+    coin_context_override_descriptions: list[str] = []
     hsl_enabled_override_symbols: list[str] = []
     for symbol, raw_override in coin_overrides.items():
         override = _require_mapping(raw_override, f"coin_overrides.{symbol}")
+        context_paths: list[str] = []
+        override_live = override.get("live", {})
+        if isinstance(override_live, Mapping) and f"forced_mode_{pside}" in override_live:
+            context_paths.append(f"live.forced_mode_{pside}")
         override_bot = override.get("bot", {})
         if not isinstance(override_bot, Mapping):
             continue
         override_side = override_bot.get(pside, {})
         if not isinstance(override_side, Mapping):
             continue
+        for group, value in override_side.items():
+            if group == "strategy" or value is None or value == {}:
+                continue
+            context_paths.append(f"bot.{pside}.{group}")
         override_strategies = override_side.get("strategy", {})
         if isinstance(override_strategies, Mapping):
             strategy_override = override_strategies.get(STRATEGY_KIND, {})
@@ -197,6 +206,10 @@ def _extract_side_context(config: Mapping[str, Any], pside: str) -> dict[str, An
             and bool(hsl_override.get("enabled", hsl.get("enabled", False)))
         ):
             hsl_enabled_override_symbols.append(str(symbol))
+        if context_paths:
+            coin_context_override_descriptions.append(
+                f"{symbol} ({', '.join(sorted(context_paths))})"
+            )
     hsl_enabled_global = bool(hsl.get("enabled", False))
     return {
         "active": total_wallet_exposure_limit > 0.0 and n_positions > 0,
@@ -207,7 +220,9 @@ def _extract_side_context(config: Mapping[str, Any], pside: str) -> dict[str, An
         "hsl_enabled_global": hsl_enabled_global,
         "hsl_enabled_override_symbols": sorted(hsl_enabled_override_symbols),
         "hsl_signal_mode": str(live.get("hsl_signal_mode", "unknown")),
+        "hedge_mode": bool(live.get("hedge_mode", False)),
         "coin_strategy_override_symbols": sorted(coin_strategy_override_symbols),
+        "coin_context_override_descriptions": sorted(coin_context_override_descriptions),
         "max_realized_loss_pct": _finite_float(
             live.get("max_realized_loss_pct", 1.0), "live.max_realized_loss_pct"
         ),
@@ -704,11 +719,19 @@ def _classify_side(
     cooldown = context["entry_cooldown_minutes"] if context else None
     if not entry_trailing:
         if cooldown == 0.0:
-            if entry["threshold_pct"] <= 0.0:
+            if entry["threshold_pct"] == 0.0:
                 entry_comments.append(
                     "Trailing entries are disabled, entry cooldown is zero, and the passive threshold "
-                    "is non-positive: Rust clamps the first add to current bid/ask, then stops because "
-                    "the next simulated rung duplicates that price. Only one market-touch rung is emitted."
+                    "is zero: the first add remains at the position price, and the next simulated rung "
+                    "duplicates it, so Rust emits one at-position rung."
+                )
+            elif entry["threshold_pct"] < 0.0:
+                entry_comments.append(
+                    "Trailing entries are disabled, entry cooldown is zero, and the passive threshold "
+                    "is negative. Rust emits only one market-touch rung when min(reference, bid) for a "
+                    "long or max(reference, ask) for a short clamps the first add to the current touch; "
+                    "if that clamp does not bind, recursive simulation may produce distinct ladder rungs. "
+                    "The overview has no current bid/ask, so it cannot know which case applies."
                 )
             else:
                 entry_comments.append(
@@ -818,6 +841,13 @@ def _classify_side(
                 f"{context['total_wallet_exposure_limit'] * 100.0:.2f}% across "
                 f"{context['n_positions']} configured position slot(s)."
             )
+        elif context.get("hsl_enabled", False):
+            overall.append(
+                f"Global forced mode {forced_mode!r} is the fallback for this config, but HSL runtime "
+                "state has precedence. ORANGE or RED may replace that static mode with graceful-stop, "
+                "tp-only, or panic behavior, so the table paths remain HSL-dependent rather than wholly "
+                "dormant."
+            )
         elif forced_mode == "panic":
             overall.append(
                 "Global forced mode 'panic' supersedes trailing_martingale: Rust emits an "
@@ -859,8 +889,10 @@ def _classify_side(
             )
         overall.append(
             "Each add starts from the greater of current absolute position size × "
-            f"{context['entry_double_down_factor']:.4g} or initial-entry quantity, before "
-            "minimum-quantity, rounding, and exposure-cropping rules."
+            f"{context['entry_double_down_factor']:.4g} or the configured initial exposure slice "
+            "converted to quantity at the re-entry order price, before minimum-quantity, rounding, "
+            "and exposure-cropping rules. A lower re-entry price therefore produces a larger quantity "
+            "floor for the same exposure slice."
         )
         passive_full_close = (
             not close_trailing
@@ -883,7 +915,10 @@ def _classify_side(
             )
         if context.get("position_exposure_enforcer_enabled", False):
             enforcer_threshold = context.get("position_exposure_enforcer_threshold", 0.0)
-            if context["active"] and forced_mode not in {"panic", "manual"}:
+            if context["active"] and (
+                forced_mode not in {"panic", "manual"}
+                or context.get("hsl_enabled", False)
+            ):
                 overall.append(
                     "Position-exposure enforcement is enabled at "
                     f"{enforcer_threshold * 100.0:g}% WE / effective WEL. CLOSE rows above that "
@@ -906,12 +941,15 @@ def _classify_side(
         if context.get("total_exposure_enforcer_enabled", False):
             twel_threshold = context.get("total_exposure_enforcer_threshold", 0.0)
             twel_policy = context.get("total_exposure_enforcer_policy", "unknown")
-            if context["active"] and forced_mode not in {"panic", "manual"}:
+            if context["active"] and (
+                forced_mode not in {"panic", "manual"}
+                or context.get("hsl_enabled", False)
+            ):
                 overall.append(
                     "The account-wide total-exposure enforcer is enabled at "
                     f"{twel_threshold * 100.0:g}% of side TWEL with policy {twel_policy!r}. CLOSE "
-                    "rows are account-dependent: Rust may append a TWEL repair close to the selected "
-                    "position alongside its strategy close, based on the full same-side portfolio."
+                    "rows are account-dependent: Rust may contribute a TWEL repair candidate for the "
+                    "selected position alongside its strategy close, based on the full same-side portfolio."
                 )
             else:
                 overall.append(
@@ -924,7 +962,7 @@ def _classify_side(
                 f"{context['unstuck_close_pct'] * 100.0:g}%, loss allowance "
                 f"{context['unstuck_loss_allowance_pct'] * 100.0:g}%, and position threshold "
                 f"{context['unstuck_threshold'] * 100.0:g}%. CLOSE rows are unstuck-dependent: "
-                "Rust may append one globally selected unstuck close based on realized PnL and "
+                "Rust may contribute a globally selected unstuck candidate based on realized PnL and "
                 "portfolio/position state."
             )
         elif context.get("unstuck_enabled", False):
@@ -953,6 +991,29 @@ def _classify_side(
                 "replace strategy closes with panic closes at RED, or leave the strategy path unchanged. "
                 "An offline config report cannot know the live HSL tier."
             )
+        if (
+            context.get("position_exposure_enforcer_enabled", False)
+            or context.get("total_exposure_enforcer_enabled", False)
+            or _unstuck_active(context)
+        ):
+            overall.append(
+                "Protective close paths are candidates, not additive orders: finalization retains at "
+                "most one protective reducer per coin and position side. Panic has precedence; otherwise "
+                "Rust selects the largest loss-admissible candidate, which may coexist with ordinary "
+                "strategy closes after aggregate close quantity is capped."
+            )
+        if not context.get("hedge_mode", False):
+            overall.append(
+                "One-way mode is configured. When both sides are flat and eligible for the same coin, "
+                "Rust permits only one initial side, selected by relative EMA-band trigger distance "
+                "with a long-side tie break; the other initial entry is blocked."
+            )
+        else:
+            overall.append(
+                "Hedge mode is requested by the config, but effective hedge mode also requires exchange "
+                "support. A one-way-only connector still activates the initial-side arbitration described "
+                "below."
+            )
         coin_strategy_override_symbols = context.get("coin_strategy_override_symbols", ())
         if coin_strategy_override_symbols:
             overall.append(
@@ -961,6 +1022,17 @@ def _classify_side(
                 + ". They are explicitly omitted from these tables, which show only the global "
                 "bot-side parameters; the listed coins may have different effective thresholds, "
                 "retracements, and prices at runtime."
+            )
+        coin_context_override_descriptions = context.get(
+            "coin_context_override_descriptions", ()
+        )
+        if coin_context_override_descriptions:
+            overall.append(
+                "Coin-specific non-strategy runtime overrides are also omitted from the global table "
+                "context: "
+                + "; ".join(coin_context_override_descriptions)
+                + ". Those coins may therefore use different forced modes, cooldowns, risk enforcement, "
+                "exposure limits, or unstuck behavior than the runtime-path labels shown here."
             )
     else:
         overall.append(
@@ -1065,8 +1137,10 @@ def build_overview(
                 enforcer_enabled = bool(
                     context
                     and context["active"]
-                    and context.get("forced_mode", "normal")
-                    not in {"panic", "manual"}
+                    and (
+                        context.get("forced_mode", "normal") not in {"panic", "manual"}
+                        or context.get("hsl_enabled", False)
+                    )
                     and context.get("position_exposure_enforcer_enabled", False)
                 )
                 enforcer_threshold = (
@@ -1337,9 +1411,10 @@ def _scenario_runtime_path(
         if not context["active"]:
             return "side disabled"
         forced_mode = context.get("forced_mode", "normal")
-        if forced_mode in {"panic", "manual"}:
+        hsl_enabled = context.get("hsl_enabled", False)
+        if forced_mode in {"panic", "manual"} and not hsl_enabled:
             return f"{forced_mode} dormant"
-        if kind == "entry" and forced_mode == "tp_only":
+        if kind == "entry" and forced_mode == "tp_only" and not hsl_enabled:
             return "tp_only blocked"
     if kind == "entry":
         if payload.get("inactive_reason") in {
@@ -1354,6 +1429,13 @@ def _scenario_runtime_path(
         qualifiers = []
         if context.get("hsl_enabled", False):
             qualifiers.append("HSL-dependent")
+            if context.get("forced_mode", "normal") != "normal":
+                forced_mode = context["forced_mode"]
+                qualifiers.append(
+                    f"{forced_mode} fallback blocks entry"
+                    if forced_mode in {"panic", "manual", "tp_only"}
+                    else f"{forced_mode} fallback"
+                )
         if context.get("total_exposure_entry_gate_enabled", False):
             qualifiers.append("portfolio-dependent")
         return " / ".join(qualifiers) if qualifiers else "re-entry"
@@ -1364,6 +1446,8 @@ def _scenario_runtime_path(
         qualifiers.append("WEL-first")
     if context.get("hsl_enabled", False):
         qualifiers.append("HSL-dependent")
+        if context.get("forced_mode", "normal") != "normal":
+            qualifiers.append(f"{context['forced_mode']} fallback")
     if context.get("total_exposure_enforcer_enabled", False):
         qualifiers.append("TWEL-dependent")
     if _unstuck_active(context):
@@ -1503,8 +1587,10 @@ def render_overview(result: Mapping[str, Any]) -> str:
             "* Order ref is Rust's analytical emitted-order reference after both conditions pass; "
             "the live price is also constrained by bid/ask, tick rounding, sizing, exposure caps, and EMA gating.",
             "* Re-entry/add rows apply only after the position reaches at least 80% of the calculated "
-            "initial-entry quantity. While flat, Rust submits the normal initial entry; below that 80% "
-            "boundary, it submits a partial initial entry. Both initial paths bypass trailing "
+            "initial-entry quantity. While flat, an eligible side may submit the normal initial entry; "
+            "below that 80% boundary, it submits a partial initial entry. In one-way mode, if both sides "
+            "are flat and eligible for the same coin, Rust uses EMA-band distance to permit only one "
+            "initial side. Both initial paths bypass trailing "
             "threshold/retracement and use the initial bid/ask price, optionally pushed farther from "
             "market by the configured initial-entry EMA gate.",
             "* A RE-ENTRY / ADD row marked 'exposure-capped' emits no entry: passive entries stop at "
@@ -1525,10 +1611,13 @@ def render_overview(result: Mapping[str, Any]) -> str:
             "running high, which a positive-priced market cannot satisfy.",
             "* 'HSL-dependent' means the configured equity hard stop may block entries or replace "
             "strategy closes according to live drawdown state that this offline report cannot observe.",
+            "* WEL, TWEL, unstuck, and panic protective paths are competing reducer candidates. "
+            "Finalization keeps at most one per coin and position side rather than summing their "
+            "quantities; panic wins, otherwise the largest loss-admissible candidate is selected.",
             "* A CLOSE runtime path containing 'TWEL-dependent' may coexist with an account-wide "
             "repair close. Which position is reduced and by how much requires full same-side portfolio state.",
-            "* 'unstuck-dependent' means a globally selected auto-unstuck close may coexist when its "
-            "realized-PnL allowance, EMA gate, and position conditions pass.",
+            "* 'unstuck-dependent' means auto-unstuck may become the selected protective reducer when "
+            "its realized-PnL allowance, EMA gate, and position conditions pass.",
             "* 'PnL-gated' means the realized-loss batch gate may remove losing strategy or protective "
             "closes after projected PnL and fees are evaluated against account-wide allowance.",
             "* 'context unknown' is used for strategy-default reports without a config; no claim is "

--- a/src/tools/trailing_inspect.py
+++ b/src/tools/trailing_inspect.py
@@ -973,7 +973,8 @@ def _classify_side(
                 "Auto-unstuck is active with close quantity "
                 f"{context['unstuck_close_pct'] * 100.0:g}%, loss allowance "
                 f"{context['unstuck_loss_allowance_pct'] * 100.0:g}%, and position threshold "
-                f"{context['unstuck_threshold'] * 100.0:g}%. CLOSE rows are unstuck-dependent: "
+                f"{context['unstuck_threshold'] * 100.0:g}%. Eligible CLOSE rows strictly above that "
+                "WE / effective WEL threshold are marked unstuck-dependent: "
                 "Rust may contribute a globally selected unstuck candidate based on realized PnL and "
                 f"portfolio/position state. {unstuck_ema_note}"
             )
@@ -1416,7 +1417,10 @@ def _scenario_input_pct(value: float) -> str:
 
 
 def _scenario_runtime_path(
-    side: Mapping[str, Any], kind: str, payload: Mapping[str, Any]
+    side: Mapping[str, Any],
+    kind: str,
+    payload: Mapping[str, Any],
+    exposure_ratio: float,
 ) -> str:
     context = side.get("context")
     if context:
@@ -1462,7 +1466,7 @@ def _scenario_runtime_path(
             qualifiers.append(f"{context['forced_mode']} fallback")
     if context.get("total_exposure_enforcer_enabled", False):
         qualifiers.append("TWEL-dependent")
-    if _unstuck_active(context):
+    if _unstuck_active(context) and exposure_ratio > context.get("unstuck_threshold", 0.0):
         qualifiers.append("unstuck-dependent")
     if context.get("max_realized_loss_pct", 1.0) < 1.0:
         qualifiers.append("PnL-gated")
@@ -1479,7 +1483,9 @@ def _scenario_rows(side: Mapping[str, Any], kind: str) -> list[list[str]]:
     for scenario in side["scenarios"]:
         payload = scenario[kind]
         geometry = payload["geometry"]
-        runtime_path = _scenario_runtime_path(side, kind, payload)
+        runtime_path = _scenario_runtime_path(
+            side, kind, payload, scenario["exposure_ratio"]
+        )
         if payload.get("post_reduction_geometry") == "requires_runtime_sizing_inputs":
             confirmation = "post-WE varies"
             threshold_price = "post-WE varies"

--- a/src/tools/trailing_inspect.py
+++ b/src/tools/trailing_inspect.py
@@ -360,13 +360,21 @@ def inspect_trailing(
             "entry.retracement_we_weight",
         ),
     )
-    entry_threshold_base = max(
-        0.0,
-        _finite_float(entry.get("threshold_base_pct", 0.0), "entry.threshold_base_pct"),
+    entry_threshold_base_configured = _finite_float(
+        entry.get("threshold_base_pct", 0.0),
+        "entry.threshold_base_pct",
     )
     entry_retracement_base = _finite_float(
         entry.get("retracement_base_pct", 0.0),
         "entry.retracement_base_pct",
+    )
+    entry_trailing_enabled = entry_retracement_base > 0.0
+    # Rust clamps the threshold only in calc_trailing_entry_{long,short}. Passive
+    # calc_reentry_price_{bid,ask} uses the configured signed value directly.
+    entry_threshold_base = (
+        max(0.0, entry_threshold_base_configured)
+        if entry_trailing_enabled
+        else entry_threshold_base_configured
     )
     entry_threshold_pct = entry_threshold_base * entry_threshold_multiplier["effective"]
     entry_retracement_pct = max(0.0, entry_retracement_base) * entry_retracement_multiplier[
@@ -427,7 +435,7 @@ def inspect_trailing(
         "parameter_source": parameter_source,
         "overridden_parameters": list(overridden_parameters),
         "entry": {
-            "trailing_enabled": entry_retracement_base > 0.0,
+            "trailing_enabled": entry_trailing_enabled,
             "threshold_base_pct": entry_threshold_base,
             "threshold_multiplier": entry_threshold_multiplier,
             "threshold_pct": entry_threshold_pct,

--- a/src/tools/trailing_inspect.py
+++ b/src/tools/trailing_inspect.py
@@ -187,6 +187,16 @@ def _extract_side_context(config: Mapping[str, Any], pside: str) -> dict[str, An
         "total_exposure_entry_gate_enabled": bool(
             risk.get("total_exposure_entry_gate_enabled", False)
         ),
+        "total_exposure_enforcer_enabled": bool(
+            risk.get("total_exposure_enforcer_enabled", False)
+        ),
+        "total_exposure_enforcer_threshold": _finite_float(
+            risk.get("total_exposure_enforcer_threshold", 0.0),
+            f"bot.{pside}.risk.total_exposure_enforcer_threshold",
+        ),
+        "total_exposure_enforcer_policy": str(
+            risk.get("total_exposure_enforcer_policy", "unknown")
+        ),
         "entry_cooldown_minutes": _finite_float(
             risk.get("entry_cooldown_minutes", 0.0),
             f"bot.{pside}.risk.entry_cooldown_minutes",
@@ -640,10 +650,17 @@ def _classify_side(
     cooldown = context["entry_cooldown_minutes"] if context else None
     if not entry_trailing:
         if cooldown == 0.0:
-            entry_comments.append(
-                "Trailing entries are disabled and entry cooldown is zero: Rust may expose the "
-                "full recursive entry ladder simultaneously."
-            )
+            if entry["threshold_pct"] <= 0.0:
+                entry_comments.append(
+                    "Trailing entries are disabled, entry cooldown is zero, and the passive threshold "
+                    "is non-positive: Rust clamps the first add to current bid/ask, then stops because "
+                    "the next simulated rung duplicates that price. Only one market-touch rung is emitted."
+                )
+            else:
+                entry_comments.append(
+                    "Trailing entries are disabled and entry cooldown is zero: Rust may expose the "
+                    "full recursive entry ladder simultaneously."
+                )
         elif cooldown is not None:
             entry_comments.append(
                 "Trailing entries are disabled, but the entry cooldown is positive: the bot does "
@@ -832,6 +849,21 @@ def _classify_side(
                 "rows are marked 'portfolio-dependent': after strategy calculation, the orchestrator "
                 "may crop or remove the order based on exposure consumed by all positions on this side."
             )
+        if context.get("total_exposure_enforcer_enabled", False):
+            twel_threshold = context.get("total_exposure_enforcer_threshold", 0.0)
+            twel_policy = context.get("total_exposure_enforcer_policy", "unknown")
+            if context["active"] and forced_mode not in {"panic", "manual"}:
+                overall.append(
+                    "The account-wide total-exposure enforcer is enabled at "
+                    f"{twel_threshold * 100.0:g}% of side TWEL with policy {twel_policy!r}. CLOSE "
+                    "rows are account-dependent: Rust may append a TWEL repair close to the selected "
+                    "position alongside its strategy close, based on the full same-side portfolio."
+                )
+            else:
+                overall.append(
+                    "The account-wide total-exposure enforcer is configured, but the disabled side or "
+                    "current forced mode keeps that repair path dormant."
+                )
     if representative["volatility_scenario_count"] == 1:
         basis = (
             f"Headlines use {representative['normal_label']!r} volatility at "
@@ -918,7 +950,9 @@ def build_overview(
                     else exposure_ratio >= 0.999
                 )
                 entry_payload["inactive_reason"] = (
-                    "exposure_cap" if entry_exposure_capped else None
+                    "unreachable_long_threshold"
+                    if pside == "long" and entry_payload["threshold_pct"] >= 1.0
+                    else ("exposure_cap" if entry_exposure_capped else None)
                 )
                 enforcer_enabled = bool(
                     context
@@ -1191,13 +1225,18 @@ def _scenario_runtime_path(
         if kind == "entry" and forced_mode == "tp_only":
             return "tp_only blocked"
     if kind == "entry":
+        if payload.get("inactive_reason") == "unreachable_long_threshold":
+            return "unreachable"
         if payload.get("inactive_reason") == "exposure_cap":
             return "exposure-capped"
         if context and context.get("total_exposure_entry_gate_enabled", False):
             return "portfolio-dependent"
         return "re-entry"
+    twel_dependent = bool(context and context.get("total_exposure_enforcer_enabled", False))
     if payload.get("preceded_by") == "position_exposure_enforcer":
-        return "WEL reducer first"
+        return "WEL first; TWEL-dependent" if twel_dependent else "WEL reducer first"
+    if twel_dependent:
+        return "TWEL-dependent close"
     return "strategy close"
 
 
@@ -1207,7 +1246,11 @@ def _scenario_rows(side: Mapping[str, Any], kind: str) -> list[list[str]]:
         payload = scenario[kind]
         geometry = payload["geometry"]
         runtime_path = _scenario_runtime_path(side, kind, payload)
-        if payload.get("post_reduction_geometry") == "requires_runtime_sizing_inputs":
+        if payload.get("inactive_reason") == "unreachable_long_threshold":
+            confirmation = "n/a"
+            threshold_price = "unreachable"
+            order_reference = "n/a"
+        elif payload.get("post_reduction_geometry") == "requires_runtime_sizing_inputs":
             confirmation = "post-WE varies"
             threshold_price = "post-WE varies"
             order_reference = "post-WE varies"
@@ -1330,6 +1373,10 @@ def render_overview(result: Mapping[str, Any]) -> str:
             "cannot be inferred without balance, position, exchange-step, and minimum-quantity inputs.",
             "* A RE-ENTRY / ADD row marked 'portfolio-dependent' passed the per-position calculation, "
             "but the account-wide total-exposure gate may crop or remove it using all positions on that side.",
+            "* A long RE-ENTRY / ADD row marked 'unreachable' has a threshold of at least 100%: "
+            "the passive price is non-positive, and a positive market cannot cross the trailing target.",
+            "* A CLOSE runtime path containing 'TWEL-dependent' may coexist with an account-wide "
+            "repair close. Which position is reduced and by how much requires full same-side portfolio state.",
             "* With close trailing enabled, a non-positive threshold is immediate: trailing is "
             "armed from position open. With close trailing disabled, the row is passive and no "
             "extrema or reversal confirmation participate.",

--- a/src/tools/trailing_inspect.py
+++ b/src/tools/trailing_inspect.py
@@ -11,6 +11,20 @@ from typing import Any, Mapping, Sequence
 
 STRATEGY_KIND = "trailing_martingale"
 
+DEFAULT_VOLATILITY_SCENARIOS = (
+    ("quiet", 0.001, 0.0005),
+    ("normal", 0.005, 0.0025),
+    ("high", 0.015, 0.0075),
+)
+DEFAULT_EXPOSURE_RATIOS = (0.0, 0.5, 0.9)
+
+
+class _HelpFormatter(
+    argparse.ArgumentDefaultsHelpFormatter,
+    argparse.RawDescriptionHelpFormatter,
+):
+    pass
+
 PARAMETER_FLAGS = {
     "entry_threshold_base_pct": ("entry", "threshold_base_pct"),
     "entry_threshold_we_weight": ("entry", "threshold_we_weight"),
@@ -117,6 +131,79 @@ def load_parameter_source(config_path: str | None, pside: str) -> tuple[dict[str
         },
         pside,
     ), f"Rust-owned {STRATEGY_KIND} defaults ({pside})"
+
+
+def _extract_side_context(config: Mapping[str, Any], pside: str) -> dict[str, Any]:
+    bot = _require_mapping(config.get("bot"), "bot")
+    side = _require_mapping(bot.get(pside), f"bot.{pside}")
+    risk = _require_mapping(side.get("risk"), f"bot.{pside}.risk")
+    strategies = _require_mapping(side.get("strategy"), f"bot.{pside}.strategy")
+    strategy = _require_mapping(
+        strategies.get(STRATEGY_KIND),
+        f"bot.{pside}.strategy.{STRATEGY_KIND}",
+    )
+    entry = _require_mapping(strategy.get("entry"), "strategy.entry")
+    close = _require_mapping(strategy.get("close"), "strategy.close")
+    total_wallet_exposure_limit = _finite_float(
+        risk.get("total_wallet_exposure_limit"),
+        f"bot.{pside}.risk.total_wallet_exposure_limit",
+    )
+    n_positions = int(_finite_float(risk.get("n_positions"), f"bot.{pside}.risk.n_positions"))
+    return {
+        "active": total_wallet_exposure_limit > 0.0 and n_positions > 0,
+        "total_wallet_exposure_limit": total_wallet_exposure_limit,
+        "n_positions": n_positions,
+        "entry_cooldown_minutes": _finite_float(
+            risk.get("entry_cooldown_minutes", 0.0),
+            f"bot.{pside}.risk.entry_cooldown_minutes",
+        ),
+        "entry_ema_gate_mode": str(entry.get("ema_gate_mode", "unknown")),
+        "entry_initial_ema_dist": _finite_float(
+            entry.get("initial_ema_dist", 0.0), "entry.initial_ema_dist"
+        ),
+        "entry_initial_qty_pct": _finite_float(
+            entry.get("initial_qty_pct", 0.0), "entry.initial_qty_pct"
+        ),
+        "entry_double_down_factor": _finite_float(
+            entry.get("double_down_factor", 0.0), "entry.double_down_factor"
+        ),
+        "close_qty_pct": _finite_float(close.get("qty_pct", 0.0), "close.qty_pct"),
+        "volatility_ema_span_1m": _finite_float(
+            strategy.get("volatility_ema_span_1m", 0.0), "volatility_ema_span_1m"
+        ),
+        "volatility_ema_span_1h": _finite_float(
+            strategy.get("volatility_ema_span_1h", 0.0), "volatility_ema_span_1h"
+        ),
+    }
+
+
+def load_overview_sources(
+    config_path: str | None, psides: Sequence[str]
+) -> tuple[dict[str, dict[str, Any]], str]:
+    if config_path:
+        from config import load_prepared_config
+
+        config = load_prepared_config(
+            config_path,
+            live_only=True,
+            verbose=False,
+            target="canonical",
+            log_info=False,
+        )
+        sources = {
+            pside: {
+                "params": _extract_strategy_params(config, pside),
+                "context": _extract_side_context(config, pside),
+            }
+            for pside in psides
+        }
+        return sources, f"config {config_path}"
+
+    sources = {}
+    for pside in psides:
+        params, _ = load_parameter_source(None, pside)
+        sources[pside] = {"params": params, "context": None}
+    return sources, f"Rust-owned {STRATEGY_KIND} defaults"
 
 
 def apply_parameter_overrides(params: dict[str, Any], args: argparse.Namespace) -> list[str]:
@@ -373,6 +460,344 @@ def inspect_trailing(
     }
 
 
+def _threshold_style(kind: str, threshold_pct: float) -> str:
+    if threshold_pct <= 0.0:
+        return "immediate (no threshold gate)"
+    cutoffs = (
+        ((0.005 if kind == "entry" else 0.003), "aggressive/near"),
+        ((0.02 if kind == "entry" else 0.01), "moderate"),
+        ((0.05 if kind == "entry" else 0.03), "patient/deep"),
+    )
+    for cutoff, label in cutoffs:
+        if threshold_pct <= cutoff:
+            return label
+    return "very deep"
+
+
+def _retracement_style(retracement_pct: float) -> str:
+    if retracement_pct <= 0.0:
+        return "disabled"
+    if retracement_pct <= 0.001:
+        return "tight"
+    if retracement_pct <= 0.005:
+        return "modest"
+    if retracement_pct <= 0.015:
+        return "selective"
+    return "deep"
+
+
+def _sensitivity_style(low_value: float, high_value: float) -> str:
+    scale = max(abs(low_value), 0.001)
+    relative_change = abs(high_value - low_value) / scale
+    if relative_change < 0.1:
+        return "low effective volatility sensitivity"
+    if relative_change < 0.35:
+        return "light volatility sensitivity"
+    if relative_change < 0.75:
+        return "strong volatility sensitivity"
+    return "very strong volatility sensitivity"
+
+
+def _movement_description(
+    delta: float,
+    subject: str,
+    low_exposure_ratio: float,
+    high_exposure_ratio: float,
+    volatility_label: str,
+) -> str:
+    if low_exposure_ratio == high_exposure_ratio:
+        return f"Only one exposure ratio is shown, so {subject} exposure sensitivity is not compared."
+    if abs(delta) < 0.00005:
+        return f"Exposure has almost no effect on the {subject}."
+    verb = "widens" if delta > 0.0 else "narrows"
+    return (
+        f"Moving from {low_exposure_ratio * 100.0:g}% to {high_exposure_ratio * 100.0:g}% "
+        f"of the exposure limit {verb} the {subject} by "
+        f"{abs(delta) * 100.0:.4f} percentage points in the "
+        f"{volatility_label!r} volatility example."
+    )
+
+
+def _classify_side(
+    *,
+    pside: str,
+    context: Mapping[str, Any] | None,
+    representative: Mapping[str, Mapping[str, Any]],
+) -> dict[str, Any]:
+    normal = representative["normal"]
+    quiet = representative["quiet"]
+    high = representative["high"]
+    exposure_low = representative["exposure_low"]
+    exposure_high = representative["exposure_high"]
+    entry = normal["entry"]
+    close = normal["close"]
+    entry_trailing = entry["trailing_enabled"]
+    close_trailing = close["trailing_enabled"]
+
+    volatility_style = (
+        "one volatility scenario shown"
+        if representative["volatility_scenario_count"] == 1
+        else _sensitivity_style(quiet["entry"]["threshold_pct"], high["entry"]["threshold_pct"])
+    )
+    close_volatility_style = (
+        "one volatility scenario shown"
+        if representative["volatility_scenario_count"] == 1
+        else _sensitivity_style(quiet["close"]["threshold_pct"], high["close"]["threshold_pct"])
+    )
+    entry_headline = (
+        f"{volatility_style}; "
+        f"{_threshold_style('entry', entry['threshold_pct'])} entry threshold with "
+        f"{_retracement_style(entry['retracement_pct'])} retracement"
+    )
+    close_headline = (
+        f"{close_volatility_style}; "
+        f"{_threshold_style('close', close['threshold_pct'])} close threshold with "
+        f"{_retracement_style(close['retracement_pct'])} retracement"
+    )
+
+    entry_comments: list[str] = []
+    close_comments: list[str] = []
+    cooldown = context["entry_cooldown_minutes"] if context else None
+    if not entry_trailing:
+        if cooldown == 0.0:
+            entry_comments.append(
+                "Trailing entries are disabled and entry cooldown is zero: Rust may expose the "
+                "full recursive entry ladder simultaneously."
+            )
+        elif cooldown is not None:
+            entry_comments.append(
+                "Trailing entries are disabled, but the entry cooldown is positive: the bot does "
+                "not wait for a reversal; it stages only the next rung and waits "
+                f"{cooldown:g} minutes after an entry fill before another add."
+            )
+        else:
+            entry_comments.append(
+                "Trailing entries are disabled: re-entries use passive recursive limit prices."
+            )
+    else:
+        entry_comments.append(
+            "Only the next add is staged. Price must first cross the adverse threshold, then "
+            "reverse by the retracement distance from the running extreme."
+        )
+        if cooldown and cooldown > 0.0:
+            entry_comments.append(
+                f"After an entry fill, the {cooldown:g}-minute cooldown blocks the next add even "
+                "if its trailing conditions are already satisfied."
+            )
+    if entry["threshold_pct"] <= 0.0 and entry_trailing:
+        entry_comments.append(
+            "The threshold gate is immediate, so reversal tracking begins as soon as the position changes."
+        )
+    entry_comments.append(
+        _movement_description(
+            exposure_high["entry"]["threshold_pct"] - exposure_low["entry"]["threshold_pct"],
+            "entry threshold",
+            representative["exposure_low_ratio"],
+            representative["exposure_high_ratio"],
+            representative["normal_label"],
+        )
+    )
+    entry_retracement_delta = (
+        exposure_high["entry"]["retracement_pct"]
+        - exposure_low["entry"]["retracement_pct"]
+    )
+    entry_comments.append(
+        _movement_description(
+            entry_retracement_delta,
+            "entry retracement",
+            representative["exposure_low_ratio"],
+            representative["exposure_high_ratio"],
+            representative["normal_label"],
+        )
+    )
+
+    close_params = representative["params"]["close"]
+    if not close_trailing:
+        if _finite_float(close_params.get("threshold_we_weight", 0.0), "threshold_we_weight") == 0.0:
+            close_comments.append(
+                "Trailing closes are disabled and the threshold has no exposure weight: Rust emits "
+                "one full-position passive close instead of duplicate same-price slices."
+            )
+        else:
+            close_comments.append(
+                "Trailing closes are disabled: Rust builds passive recursive close slices and "
+                "recomputes the exposure-weighted threshold after each hypothetical slice."
+            )
+    else:
+        close_comments.append(
+            "The close arms after favorable movement reaches the threshold, then confirms only "
+            "after price reverses from the running favorable extreme."
+        )
+    if close["threshold_pct"] <= 0.0 and close_trailing:
+        close_comments.append(
+            "At this scenario the close threshold is non-positive, so the close behaves like an "
+            "immediately armed trailing stop rather than waiting for profit first."
+        )
+    close_comments.append(
+        _movement_description(
+            exposure_high["close"]["threshold_pct"] - exposure_low["close"]["threshold_pct"],
+            "close threshold",
+            representative["exposure_low_ratio"],
+            representative["exposure_high_ratio"],
+            representative["normal_label"],
+        )
+    )
+    close_comments.append(
+        "Close retracement has no exposure term in Rust; only volatility changes it."
+    )
+
+    overall: list[str] = []
+    if context:
+        if context["active"]:
+            overall.append(
+                f"{pside.capitalize()} is enabled: total exposure limit "
+                f"{context['total_wallet_exposure_limit'] * 100.0:.2f}% across "
+                f"{context['n_positions']} configured position slot(s)."
+            )
+        else:
+            overall.append(
+                f"{pside.capitalize()} is disabled by its zero exposure limit or position count. "
+                "The tables below describe dormant parameters, not orders the current config will place."
+            )
+        ema_gate_mode = context["entry_ema_gate_mode"]
+        if ema_gate_mode in {"all", "reentry"}:
+            overall.append(
+                f"Entry EMA gate mode is {ema_gate_mode!r}; trailing re-entry prices may be pushed "
+                "farther from market by the EMA gate before exchange rounding."
+            )
+        elif ema_gate_mode == "initial":
+            overall.append(
+                "Entry EMA gate mode is 'initial': initial entries are EMA-gated, but trailing "
+                "re-entry prices are not."
+            )
+        else:
+            overall.append(
+                f"Entry EMA gate mode is {ema_gate_mode!r}; strategy entry prices are not EMA-gated."
+            )
+        overall.append(
+            f"Adds scale from the previous fill by {context['entry_double_down_factor']:.4g}x; "
+            f"each trailing close targets {context['close_qty_pct'] * 100.0:.2f}% before minimum-size "
+            "and remaining-position rules."
+        )
+    return {
+        "entry_headline": entry_headline,
+        "entry_comments": entry_comments,
+        "close_headline": close_headline,
+        "close_comments": close_comments,
+        "overall_comments": overall,
+        "basis": (
+            f"Headlines use {representative['normal_label']!r} volatility at "
+            f"{representative['middle_ratio'] * 100.0:g}% WE/WEL."
+        ),
+    }
+
+
+def build_overview(
+    *,
+    sources: Mapping[str, Mapping[str, Any]],
+    parameter_source: str,
+    price_anchor: float,
+    volatility_scenarios: Sequence[tuple[str, float, float]] = DEFAULT_VOLATILITY_SCENARIOS,
+    exposure_ratios: Sequence[float] = DEFAULT_EXPOSURE_RATIOS,
+    overridden_parameters: Mapping[str, Sequence[str]] | None = None,
+) -> dict[str, Any]:
+    price_anchor = _finite_float(price_anchor, "price_anchor")
+    if price_anchor <= 0.0:
+        raise ValueError("price_anchor must be greater than zero")
+    if not volatility_scenarios:
+        raise ValueError("at least one volatility scenario is required")
+    if not exposure_ratios:
+        raise ValueError("at least one exposure ratio is required")
+    checked_scenarios = []
+    for label, volatility_ema_1m, volatility_ema_1h in volatility_scenarios:
+        vol_1m = _finite_float(volatility_ema_1m, f"{label} volatility_ema_1m")
+        vol_1h = _finite_float(volatility_ema_1h, f"{label} volatility_ema_1h")
+        if vol_1m < 0.0 or vol_1h < 0.0:
+            raise ValueError("volatility scenario values must not be negative")
+        checked_scenarios.append((str(label), vol_1m, vol_1h))
+    checked_ratios = [_finite_float(value, "exposure_ratio") for value in exposure_ratios]
+    if any(value < 0.0 for value in checked_ratios):
+        raise ValueError("exposure ratios must not be negative")
+
+    sides: dict[str, Any] = {}
+    for pside, source in sources.items():
+        params = _require_mapping(source.get("params"), f"source.{pside}.params")
+        context = source.get("context")
+        rows = []
+        scenario_results: dict[tuple[str, float], Mapping[str, Any]] = {}
+        for label, volatility_ema_1m, volatility_ema_1h in checked_scenarios:
+            for exposure_ratio in checked_ratios:
+                result = inspect_trailing(
+                    symbol="ANCHOR",
+                    pside=pside,
+                    position_price=price_anchor,
+                    position_size=None,
+                    wallet_exposure=exposure_ratio,
+                    effective_wallet_exposure_limit=1.0,
+                    volatility_ema_1m=volatility_ema_1m,
+                    volatility_ema_1h=volatility_ema_1h,
+                    params=params,
+                    parameter_source=parameter_source,
+                    overridden_parameters=(overridden_parameters or {}).get(pside, ()),
+                )
+                scenario_results[(label, exposure_ratio)] = result
+                rows.append(
+                    {
+                        "volatility_label": label,
+                        "volatility_ema_1m": volatility_ema_1m,
+                        "volatility_ema_1h": volatility_ema_1h,
+                        "exposure_ratio": exposure_ratio,
+                        "entry": result["entry"],
+                        "close": result["close"],
+                    }
+                )
+
+        normal_label = min(
+            checked_scenarios,
+            key=lambda item: abs(item[1] - 0.005) + abs(item[2] - 0.0025),
+        )[0]
+        quiet_label = checked_scenarios[0][0]
+        high_label = checked_scenarios[-1][0]
+        middle_ratio = min(checked_ratios, key=lambda value: abs(value - 0.5))
+        low_ratio = min(checked_ratios)
+        high_ratio = max(checked_ratios)
+        representative = {
+            "normal": scenario_results[(normal_label, middle_ratio)],
+            "quiet": scenario_results[(quiet_label, middle_ratio)],
+            "high": scenario_results[(high_label, middle_ratio)],
+            "exposure_low": scenario_results[(normal_label, low_ratio)],
+            "exposure_high": scenario_results[(normal_label, high_ratio)],
+            "exposure_low_ratio": low_ratio,
+            "exposure_high_ratio": high_ratio,
+            "middle_ratio": middle_ratio,
+            "normal_label": normal_label,
+            "volatility_scenario_count": len(checked_scenarios),
+            "params": params,
+        }
+        sides[pside] = {
+            "context": context,
+            "parameters": deepcopy(dict(params)),
+            "overridden_parameters": list((overridden_parameters or {}).get(pside, ())),
+            "classification": _classify_side(
+                pside=pside,
+                context=context,
+                representative=representative,
+            ),
+            "scenarios": rows,
+        }
+    return {
+        "mode": "overview",
+        "parameter_source": parameter_source,
+        "price_anchor": price_anchor,
+        "volatility_scenarios": [
+            {"label": label, "volatility_ema_1m": vol_1m, "volatility_ema_1h": vol_1h}
+            for label, vol_1m, vol_1h in checked_scenarios
+        ],
+        "exposure_ratios": checked_ratios,
+        "sides": sides,
+    }
+
+
 def _fmt_number(value: float | None) -> str:
     if value is None:
         return "-"
@@ -514,6 +939,173 @@ def render_report(result: Mapping[str, Any]) -> str:
     return "\n".join(lines)
 
 
+def _format_table(headers: Sequence[str], rows: Sequence[Sequence[str]]) -> list[str]:
+    widths = [len(header) for header in headers]
+    for row in rows:
+        for index, value in enumerate(row):
+            widths[index] = max(widths[index], len(value))
+    rendered = [
+        "  " + "  ".join(header.ljust(widths[index]) for index, header in enumerate(headers)),
+        "  " + "  ".join("-" * width for width in widths),
+    ]
+    for row in rows:
+        rendered.append(
+            "  "
+            + "  ".join(
+                value.ljust(widths[index]) if index == 0 else value.rjust(widths[index])
+                for index, value in enumerate(row)
+            )
+        )
+    return rendered
+
+
+def _scenario_price(value: float | None, *, fallback: str = "-") -> str:
+    return fallback if value is None else f"{value:.4f}"
+
+
+def _scenario_rows(side: Mapping[str, Any], kind: str) -> list[list[str]]:
+    rows: list[list[str]] = []
+    for scenario in side["scenarios"]:
+        payload = scenario[kind]
+        geometry = payload["geometry"]
+        if not payload["trailing_enabled"]:
+            confirmation = "passive"
+            order_reference = _scenario_price(geometry["threshold_price"], fallback="market")
+        elif not geometry["threshold_gate_active"]:
+            confirmation = "extreme-based"
+            order_reference = "market"
+        else:
+            confirmation = _scenario_price(geometry["nominal_confirmation_price"])
+            order_reference = _scenario_price(geometry["order_reference_price"])
+        rows.append(
+            [
+                scenario["volatility_label"],
+                f"{scenario['volatility_ema_1m'] * 100.0:.2f}/{scenario['volatility_ema_1h'] * 100.0:.2f}%",
+                f"{scenario['exposure_ratio'] * 100.0:.0f}%",
+                _fmt_pct(payload["threshold_pct"], signed=kind == "close"),
+                _scenario_price(geometry["threshold_price"], fallback="immediate"),
+                _fmt_pct(payload["retracement_pct"]),
+                confirmation,
+                order_reference,
+            ]
+        )
+    return rows
+
+
+def _parameter_summary(side: Mapping[str, Any], kind: str) -> list[str]:
+    params = side["parameters"][kind]
+    threshold = (
+        f"base {_fmt_pct(_finite_float(params.get('threshold_base_pct', 0.0), 'threshold base'), signed=kind == 'close')}, "
+        f"weights WE {_finite_float(params.get('threshold_we_weight', 0.0), 'threshold WE'):g}, "
+        f"1m {_finite_float(params.get('threshold_volatility_1m_weight', 0.0), 'threshold 1m'):g}, "
+        f"1h {_finite_float(params.get('threshold_volatility_1h_weight', 0.0), 'threshold 1h'):g}"
+    )
+    retracement_parts = [
+        f"base {_fmt_pct(_finite_float(params.get('retracement_base_pct', 0.0), 'retracement base'))}"
+    ]
+    if kind == "entry":
+        retracement_parts.append(
+            f"WE {_finite_float(params.get('retracement_we_weight', 0.0), 'retracement WE'):g}"
+        )
+    retracement_parts.extend(
+        [
+            f"1m {_finite_float(params.get('retracement_volatility_1m_weight', 0.0), 'retracement 1m'):g}",
+            f"1h {_finite_float(params.get('retracement_volatility_1h_weight', 0.0), 'retracement 1h'):g}",
+        ]
+    )
+    return [f"  Threshold params: {threshold}", f"  Retracement params: {', '.join(retracement_parts)}"]
+
+
+def render_overview(result: Mapping[str, Any]) -> str:
+    lines = [
+        "Trailing behavior overview",
+        f"Parameters: {result['parameter_source']}",
+        f"Price anchor (average position price): {_fmt_number(result['price_anchor'])}",
+        "Scenario cells use volatility EMA values as 1m/1h percentages and exposure as WE / effective WEL.",
+        "Entry distance = base × max(1, 1 + 1m term + 1h term + exposure term).",
+        "Close threshold = base + 1m term + 1h term + exposure term; close retracement has no exposure term.",
+    ]
+    headers = (
+        "Vol",
+        "1m/1h",
+        "WE/WEL",
+        "Threshold",
+        "T price",
+        "Retrace",
+        "R confirm*",
+        "Order ref*",
+    )
+    for pside, side in result["sides"].items():
+        classification = side["classification"]
+        context = side["context"]
+        lines.extend(["", f"{pside.upper()} — BEHAVIOR"])
+        lines.append(f"  {classification['basis']}")
+        lines.extend(f"  {comment}" for comment in classification["overall_comments"])
+        if context:
+            lines.append(
+                "  Volatility EMA spans: "
+                f"1m {context['volatility_ema_span_1m']:g}, "
+                f"1h {context['volatility_ema_span_1h']:g}."
+            )
+        if side["overridden_parameters"]:
+            lines.append("  Overrides: " + ", ".join(side["overridden_parameters"]))
+
+        lines.extend(["", f"  ENTRY — {classification['entry_headline']}"])
+        lines.extend(_parameter_summary(side, "entry"))
+        lines.extend(f"  • {comment}" for comment in classification["entry_comments"])
+        lines.extend(_format_table(headers, _scenario_rows(side, "entry")))
+
+        lines.extend(["", f"  CLOSE — {classification['close_headline']}"])
+        lines.extend(_parameter_summary(side, "close"))
+        lines.extend(f"  • {comment}" for comment in classification["close_comments"])
+        lines.extend(_format_table(headers, _scenario_rows(side, "close")))
+
+    lines.extend(
+        [
+            "",
+            "* R confirm is the nominal price if reversal starts exactly at T price. In reality, "
+            "confirmation follows the running low/high, so a farther extreme moves the trigger.",
+            "* Order ref is Rust's analytical emitted-order reference after both conditions pass; "
+            "the live price is also constrained by bid/ask, tick rounding, sizing, exposure caps, and EMA gating.",
+            "* A non-positive close threshold is shown as immediate: trailing is armed from position open.",
+            "* Trailing extrema reset after every fill for the same coin and position side.",
+            "* Categories are descriptive heuristics for intuition, not trading-quality judgments.",
+            "Percent inputs use config ratios: 0.01 = 1%.",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _parse_exposure_ratios(value: str) -> tuple[float, ...]:
+    try:
+        ratios = tuple(float(item.strip()) for item in value.split(",") if item.strip())
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("expected comma-separated ratios, e.g. 0,0.5,0.9") from exc
+    if not ratios or any(not math.isfinite(item) or item < 0.0 for item in ratios):
+        raise argparse.ArgumentTypeError("exposure ratios must be finite and non-negative")
+    return ratios
+
+
+def _parse_volatility_scenarios(value: str) -> tuple[tuple[str, float, float], ...]:
+    scenarios = []
+    try:
+        for raw_scenario in value.split(","):
+            label, vol_1m, vol_1h = (item.strip() for item in raw_scenario.split(":"))
+            if not label:
+                raise ValueError
+            values = float(vol_1m), float(vol_1h)
+            if any(not math.isfinite(item) or item < 0.0 for item in values):
+                raise ValueError
+            scenarios.append((label, *values))
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            "expected label:1m:1h scenarios, e.g. quiet:0.001:0.0005,high:0.015:0.0075"
+        ) from exc
+    if not scenarios:
+        raise argparse.ArgumentTypeError("at least one volatility scenario is required")
+    return tuple(scenarios)
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="passivbot tool trailing-inspect",
@@ -521,35 +1113,67 @@ def build_parser() -> argparse.ArgumentParser:
             "Inspect trailing_martingale entry and close thresholds without starting a bot. "
             "Percent inputs use config ratios (0.01 = 1%)."
         ),
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        formatter_class=_HelpFormatter,
         epilog=(
             "Example:\n"
+            "  passivbot tool trailing-inspect path/to/config.json\n"
+            "  passivbot tool trailing-inspect path/to/config.json --price-anchor 250\n\n"
+            "Detailed single-scenario mode (backward compatible):\n"
             "  passivbot tool trailing-inspect --symbol COIN --side long "
             "--position-size 150 --position-price 20 --wallet-exposure 0.6 "
             "--effective-wallet-exposure-limit 0.9 --volatility-ema-1m 0.007 "
             "--volatility-ema-1h 0.0033\n\n"
-            "Add --config path/to/config.json to use that side's active strategy parameters. "
+            "A positional config path is preferred; --config remains available for compatibility. "
             "Any parameter flag below overrides the config/default value."
         ),
     )
+    parser.add_argument(
+        "config_path",
+        nargs="?",
+        help="Canonical config to inspect; omit to inspect Rust-owned defaults",
+    )
     state = parser.add_argument_group("position and market state")
     state.add_argument("--symbol", default="COIN", help="Display label only")
-    state.add_argument("--side", choices=("long", "short"), default="long")
+    state.add_argument(
+        "--side",
+        choices=("long", "short", "both"),
+        default=None,
+        help="Overview defaults to both sides; detailed mode defaults to long",
+    )
     state.add_argument("--position-size", type=float, default=None, help="Display-only position size")
-    state.add_argument("--position-price", type=float, required=True)
-    state.add_argument("--wallet-exposure", type=float, required=True, help="Current WE ratio")
+    state.add_argument(
+        "--price-anchor",
+        "--position-price",
+        dest="price_anchor",
+        type=float,
+        default=100.0,
+        help="Average position price used for example trigger geometry",
+    )
+    state.add_argument("--wallet-exposure", type=float, default=None, help="Current WE ratio")
     state.add_argument(
         "--effective-wallet-exposure-limit",
         type=float,
-        required=True,
+        default=None,
         help="Effective per-position WEL used by the strategy",
     )
-    state.add_argument("--volatility-ema-1m", type=float, default=0.0)
-    state.add_argument("--volatility-ema-1h", type=float, default=0.0)
+    state.add_argument("--volatility-ema-1m", type=float, default=None)
+    state.add_argument("--volatility-ema-1h", type=float, default=None)
     state.add_argument(
         "--config",
         default=None,
-        help="Canonical config source; otherwise Rust-owned defaults are used",
+        help="Legacy alternative to the positional config path",
+    )
+    state.add_argument(
+        "--exposure-ratios",
+        type=_parse_exposure_ratios,
+        default=DEFAULT_EXPOSURE_RATIOS,
+        help="Overview WE/WEL examples as comma-separated ratios",
+    )
+    state.add_argument(
+        "--volatility-scenarios",
+        type=_parse_volatility_scenarios,
+        default=DEFAULT_VOLATILITY_SCENARIOS,
+        help="Overview examples as comma-separated label:1m:1h triples",
     )
     state.add_argument("--json", action="store_true", help="Emit machine-readable JSON")
 
@@ -579,26 +1203,71 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
     try:
-        params, source = load_parameter_source(args.config, args.side)
-        overridden = apply_parameter_overrides(params, args)
-        result = inspect_trailing(
-            symbol=args.symbol,
-            pside=args.side,
-            position_price=args.position_price,
-            position_size=args.position_size,
-            wallet_exposure=args.wallet_exposure,
-            effective_wallet_exposure_limit=args.effective_wallet_exposure_limit,
-            volatility_ema_1m=args.volatility_ema_1m,
-            volatility_ema_1h=args.volatility_ema_1h,
-            params=params,
-            parameter_source=source,
-            overridden_parameters=overridden,
+        if args.config_path and args.config and args.config_path != args.config:
+            raise ValueError("positional config path and --config name different files")
+        config_path = args.config_path or args.config
+        detailed_mode = any(
+            value is not None
+            for value in (
+                args.position_size,
+                args.wallet_exposure,
+                args.effective_wallet_exposure_limit,
+                args.volatility_ema_1m,
+                args.volatility_ema_1h,
+            )
         )
+        if detailed_mode:
+            if args.side == "both":
+                raise ValueError("detailed single-scenario mode requires --side long or --side short")
+            pside = args.side or "long"
+            params, source = load_parameter_source(config_path, pside)
+            overridden = apply_parameter_overrides(params, args)
+            result = inspect_trailing(
+                symbol=args.symbol,
+                pside=pside,
+                position_price=args.price_anchor,
+                position_size=args.position_size,
+                wallet_exposure=(
+                    args.wallet_exposure if args.wallet_exposure is not None else 0.0
+                ),
+                effective_wallet_exposure_limit=(
+                    args.effective_wallet_exposure_limit
+                    if args.effective_wallet_exposure_limit is not None
+                    else 1.0
+                ),
+                volatility_ema_1m=(
+                    args.volatility_ema_1m if args.volatility_ema_1m is not None else 0.0
+                ),
+                volatility_ema_1h=(
+                    args.volatility_ema_1h if args.volatility_ema_1h is not None else 0.0
+                ),
+                params=params,
+                parameter_source=source,
+                overridden_parameters=overridden,
+            )
+        else:
+            psides = (args.side,) if args.side in {"long", "short"} else ("long", "short")
+            sources, source = load_overview_sources(config_path, psides)
+            overridden_by_side = {}
+            for pside in psides:
+                overridden_by_side[pside] = apply_parameter_overrides(
+                    sources[pside]["params"], args
+                )
+            result = build_overview(
+                sources=sources,
+                parameter_source=source,
+                price_anchor=args.price_anchor,
+                volatility_scenarios=args.volatility_scenarios,
+                exposure_ratios=args.exposure_ratios,
+                overridden_parameters=overridden_by_side,
+            )
     except (FileNotFoundError, KeyError, RuntimeError, ValueError) as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2
     if args.json:
         print(json.dumps(result, indent=2, sort_keys=True))
+    elif result.get("mode") == "overview":
+        print(render_overview(result))
     else:
         print(render_report(result))
     return 0

--- a/src/tools/trailing_inspect.py
+++ b/src/tools/trailing_inspect.py
@@ -153,6 +153,7 @@ def _extract_side_context(config: Mapping[str, Any], pside: str) -> dict[str, An
     bot = _require_mapping(config.get("bot"), "bot")
     side = _require_mapping(bot.get(pside), f"bot.{pside}")
     risk = _require_mapping(side.get("risk"), f"bot.{pside}.risk")
+    unstuck = _require_mapping(side.get("unstuck", {}), f"bot.{pside}.unstuck")
     strategies = _require_mapping(side.get("strategy"), f"bot.{pside}.strategy")
     strategy = _require_mapping(
         strategies.get(STRATEGY_KIND),
@@ -177,6 +178,9 @@ def _extract_side_context(config: Mapping[str, Any], pside: str) -> dict[str, An
         "total_wallet_exposure_limit": total_wallet_exposure_limit,
         "n_positions": n_positions,
         "forced_mode": forced_mode,
+        "max_realized_loss_pct": _finite_float(
+            live.get("max_realized_loss_pct", 1.0), "live.max_realized_loss_pct"
+        ),
         "position_exposure_enforcer_enabled": bool(
             risk.get("position_exposure_enforcer_enabled", False)
         ),
@@ -196,6 +200,17 @@ def _extract_side_context(config: Mapping[str, Any], pside: str) -> dict[str, An
         ),
         "total_exposure_enforcer_policy": str(
             risk.get("total_exposure_enforcer_policy", "unknown")
+        ),
+        "unstuck_enabled": bool(unstuck.get("enabled", False)),
+        "unstuck_close_pct": _finite_float(
+            unstuck.get("close_pct", 0.0), f"bot.{pside}.unstuck.close_pct"
+        ),
+        "unstuck_loss_allowance_pct": _finite_float(
+            unstuck.get("loss_allowance_pct", 0.0),
+            f"bot.{pside}.unstuck.loss_allowance_pct",
+        ),
+        "unstuck_threshold": _finite_float(
+            unstuck.get("threshold", 0.0), f"bot.{pside}.unstuck.threshold"
         ),
         "entry_cooldown_minutes": _finite_float(
             risk.get("entry_cooldown_minutes", 0.0),
@@ -597,6 +612,15 @@ def _movement_description(
     )
 
 
+def _unstuck_active(context: Mapping[str, Any] | None) -> bool:
+    return bool(
+        context
+        and context.get("unstuck_enabled", False)
+        and context.get("unstuck_close_pct", 0.0) > 0.0
+        and context.get("unstuck_loss_allowance_pct", 0.0) > 0.0
+    )
+
+
 def _classify_side(
     *,
     pside: str,
@@ -833,7 +857,7 @@ def _classify_side(
                 overall.append(
                     "Position-exposure enforcement is enabled at "
                     f"{enforcer_threshold * 100.0:g}% WE / effective WEL. CLOSE rows above that "
-                    "ratio are marked 'WEL reducer first': the next-close path returns a market-side "
+                    "ratio are marked 'WEL-first': the next-close path returns a market-side "
                     "reducer before strategy close logic, including in 'tp_only' mode. Expanded close "
                     "generation simulates that reduction and may then add strategy closes recomputed at "
                     "the lower exposure. Post-reduction prices require runtime sizing and exchange inputs."
@@ -864,6 +888,33 @@ def _classify_side(
                     "The account-wide total-exposure enforcer is configured, but the disabled side or "
                     "current forced mode keeps that repair path dormant."
                 )
+        if _unstuck_active(context):
+            overall.append(
+                "Auto-unstuck is active with close quantity "
+                f"{context['unstuck_close_pct'] * 100.0:g}%, loss allowance "
+                f"{context['unstuck_loss_allowance_pct'] * 100.0:g}%, and position threshold "
+                f"{context['unstuck_threshold'] * 100.0:g}%. CLOSE rows are unstuck-dependent: "
+                "Rust may append one globally selected unstuck close based on realized PnL and "
+                "portfolio/position state."
+            )
+        elif context.get("unstuck_enabled", False):
+            overall.append(
+                "Auto-unstuck is enabled but inactive because its close quantity or loss allowance "
+                "is non-positive."
+            )
+        if context.get("max_realized_loss_pct", 1.0) < 1.0:
+            overall.append(
+                "The realized-loss gate is active at "
+                f"{context['max_realized_loss_pct'] * 100.0:g}% of peak balance. CLOSE rows are "
+                "PnL-gated: Rust may remove losing strategy closes or protective reducers after "
+                "evaluating projected batch PnL, fees, and account-wide realized-loss allowance."
+            )
+    else:
+        overall.append(
+            "No config was supplied, so only strategy defaults are known. Side enablement, forced "
+            "mode, cooldowns, risk enforcement, auto-unstuck, and realized-PnL gates are unknown; "
+            "runtime-path labels are intentionally marked 'context unknown'."
+        )
     if representative["volatility_scenario_count"] == 1:
         basis = (
             f"Headlines use {representative['normal_label']!r} volatility at "
@@ -972,6 +1023,11 @@ def build_overview(
                 close_payload["preceded_by"] = (
                     "position_exposure_enforcer"
                     if enforcer_enabled and exposure_ratio > enforcer_threshold
+                    else None
+                )
+                close_payload["inactive_reason"] = (
+                    "unreachable_short_threshold"
+                    if pside == "short" and close_payload["threshold_pct"] >= 1.0
                     else None
                 )
                 close_payload["post_reduction_geometry"] = (
@@ -1229,15 +1285,25 @@ def _scenario_runtime_path(
             return "unreachable"
         if payload.get("inactive_reason") == "exposure_cap":
             return "exposure-capped"
-        if context and context.get("total_exposure_entry_gate_enabled", False):
+        if context is None:
+            return "context unknown"
+        if context.get("total_exposure_entry_gate_enabled", False):
             return "portfolio-dependent"
         return "re-entry"
-    twel_dependent = bool(context and context.get("total_exposure_enforcer_enabled", False))
+    if payload.get("inactive_reason") == "unreachable_short_threshold":
+        return "unreachable"
+    if context is None:
+        return "context unknown"
+    qualifiers = []
     if payload.get("preceded_by") == "position_exposure_enforcer":
-        return "WEL first; TWEL-dependent" if twel_dependent else "WEL reducer first"
-    if twel_dependent:
-        return "TWEL-dependent close"
-    return "strategy close"
+        qualifiers.append("WEL-first")
+    if context.get("total_exposure_enforcer_enabled", False):
+        qualifiers.append("TWEL-dependent")
+    if _unstuck_active(context):
+        qualifiers.append("unstuck-dependent")
+    if context.get("max_realized_loss_pct", 1.0) < 1.0:
+        qualifiers.append("PnL-gated")
+    return " / ".join(qualifiers) if qualifiers else "strategy close"
 
 
 def _scenario_rows(side: Mapping[str, Any], kind: str) -> list[list[str]]:
@@ -1246,7 +1312,10 @@ def _scenario_rows(side: Mapping[str, Any], kind: str) -> list[list[str]]:
         payload = scenario[kind]
         geometry = payload["geometry"]
         runtime_path = _scenario_runtime_path(side, kind, payload)
-        if payload.get("inactive_reason") == "unreachable_long_threshold":
+        if payload.get("inactive_reason") in {
+            "unreachable_long_threshold",
+            "unreachable_short_threshold",
+        }:
             confirmation = "n/a"
             threshold_price = "unreachable"
             order_reference = "n/a"
@@ -1366,7 +1435,7 @@ def render_overview(result: Mapping[str, Any]) -> str:
             "market by the configured initial-entry EMA gate.",
             "* A RE-ENTRY / ADD row marked 'exposure-capped' emits no entry: passive entries stop at "
             "99.9% of effective WEL, while trailing entries stop only when strictly above 99.9%.",
-            "* A CLOSE row marked 'WEL reducer first' remains relevant: a next-close request returns "
+            "* A CLOSE runtime path containing 'WEL-first' remains relevant: a next-close request returns "
             "the reducer first, while expanded ideal-order generation simulates its fill and may then "
             "include strategy closes whose WE-weighted threshold is recomputed after reduction. The "
             "threshold/retracement percentages shown are pre-reducer examples; post-reduction prices "
@@ -1375,8 +1444,16 @@ def render_overview(result: Mapping[str, Any]) -> str:
             "but the account-wide total-exposure gate may crop or remove it using all positions on that side.",
             "* A long RE-ENTRY / ADD row marked 'unreachable' has a threshold of at least 100%: "
             "the passive price is non-positive, and a positive market cannot cross the trailing target.",
+            "* A short CLOSE row marked 'unreachable' has a threshold of at least 100%: its target "
+            "price is non-positive, so a positive market cannot satisfy the trailing threshold.",
             "* A CLOSE runtime path containing 'TWEL-dependent' may coexist with an account-wide "
             "repair close. Which position is reduced and by how much requires full same-side portfolio state.",
+            "* 'unstuck-dependent' means a globally selected auto-unstuck close may coexist when its "
+            "realized-PnL allowance, EMA gate, and position conditions pass.",
+            "* 'PnL-gated' means the realized-loss batch gate may remove losing strategy or protective "
+            "closes after projected PnL and fees are evaluated against account-wide allowance.",
+            "* 'context unknown' is used for strategy-default reports without a config; no claim is "
+            "made about live side enablement or orchestration/risk paths.",
             "* With close trailing enabled, a non-positive threshold is immediate: trailing is "
             "armed from position open. With close trailing disabled, the row is passive and no "
             "extrema or reversal confirmation participate.",

--- a/src/tools/trailing_inspect.py
+++ b/src/tools/trailing_inspect.py
@@ -486,9 +486,13 @@ def _retracement_style(retracement_pct: float) -> str:
     return "deep"
 
 
-def _sensitivity_style(low_value: float, high_value: float) -> str:
-    scale = max(abs(low_value), 0.001)
-    relative_change = abs(high_value - low_value) / scale
+def _sensitivity_style(
+    low_values: Sequence[float], high_values: Sequence[float]
+) -> str:
+    relative_change = max(
+        abs(high_value - low_value) / max(abs(low_value), 0.001)
+        for low_value, high_value in zip(low_values, high_values, strict=True)
+    )
     if relative_change < 0.1:
         return "low effective volatility sensitivity"
     if relative_change < 0.35:
@@ -537,12 +541,30 @@ def _classify_side(
     volatility_style = (
         "one volatility scenario shown"
         if representative["volatility_scenario_count"] == 1
-        else _sensitivity_style(quiet["entry"]["threshold_pct"], high["entry"]["threshold_pct"])
+        else _sensitivity_style(
+            (
+                quiet["entry"]["threshold_pct"],
+                quiet["entry"]["retracement_pct"],
+            ),
+            (
+                high["entry"]["threshold_pct"],
+                high["entry"]["retracement_pct"],
+            ),
+        )
     )
     close_volatility_style = (
         "one volatility scenario shown"
         if representative["volatility_scenario_count"] == 1
-        else _sensitivity_style(quiet["close"]["threshold_pct"], high["close"]["threshold_pct"])
+        else _sensitivity_style(
+            (
+                quiet["close"]["threshold_pct"],
+                quiet["close"]["retracement_pct"],
+            ),
+            (
+                high["close"]["threshold_pct"],
+                high["close"]["retracement_pct"],
+            ),
+        )
     )
     entry_headline = (
         f"{volatility_style}; "
@@ -675,9 +697,13 @@ def _classify_side(
                 f"Entry EMA gate mode is {ema_gate_mode!r}; strategy entry prices are not EMA-gated."
             )
         overall.append(
-            f"Adds scale from the previous fill by {context['entry_double_down_factor']:.4g}x; "
-            f"each trailing close targets {context['close_qty_pct'] * 100.0:.2f}% before minimum-size "
-            "and remaining-position rules."
+            "Each add starts from the greater of current absolute position size × "
+            f"{context['entry_double_down_factor']:.4g} or initial-entry quantity, before "
+            "minimum-quantity, rounding, and exposure-cropping rules."
+        )
+        overall.append(
+            f"Each trailing close targets {context['close_qty_pct'] * 100.0:.2f}% before "
+            "minimum-size and remaining-position rules."
         )
     return {
         "entry_headline": entry_headline,
@@ -756,8 +782,14 @@ def build_overview(
             checked_scenarios,
             key=lambda item: abs(item[1] - 0.005) + abs(item[2] - 0.0025),
         )[0]
-        quiet_label = checked_scenarios[0][0]
-        high_label = checked_scenarios[-1][0]
+        quiet_label = min(
+            checked_scenarios,
+            key=lambda item: (item[1] + item[2], item[1], item[2], item[0]),
+        )[0]
+        high_label = max(
+            checked_scenarios,
+            key=lambda item: (item[1] + item[2], item[1], item[2], item[0]),
+        )[0]
         middle_ratio = min(checked_ratios, key=lambda value: abs(value - 0.5))
         low_ratio = min(checked_ratios)
         high_ratio = max(checked_ratios)

--- a/src/tools/trailing_inspect.py
+++ b/src/tools/trailing_inspect.py
@@ -468,7 +468,11 @@ def inspect_trailing(
     }
 
 
-def _threshold_style(kind: str, threshold_pct: float) -> str:
+def _threshold_style(kind: str, threshold_pct: float, *, trailing_enabled: bool) -> str:
+    if not trailing_enabled:
+        if threshold_pct == 0.0:
+            return "passive at-position"
+        return f"passive {_threshold_style(kind, abs(threshold_pct), trailing_enabled=True)}"
     if threshold_pct <= 0.0:
         return "immediate (no threshold gate)"
     cutoffs = (
@@ -494,12 +498,11 @@ def _retracement_style(retracement_pct: float) -> str:
     return "deep"
 
 
-def _sensitivity_style(
-    low_values: Sequence[float], high_values: Sequence[float]
-) -> str:
+def _sensitivity_style(scenario_values: Sequence[Sequence[float]]) -> str:
     relative_change = max(
-        abs(high_value - low_value) / max(abs(low_value), 0.001)
-        for low_value, high_value in zip(low_values, high_values, strict=True)
+        (max(component_values) - min(component_values))
+        / max(min(abs(value) for value in component_values), 0.001)
+        for component_values in zip(*scenario_values, strict=True)
     )
     if relative_change < 0.1:
         return "low effective volatility sensitivity"
@@ -511,20 +514,38 @@ def _sensitivity_style(
 
 
 def _movement_description(
-    delta: float,
+    low_value: float,
+    high_value: float,
     subject: str,
     low_exposure_ratio: float,
     high_exposure_ratio: float,
     volatility_label: str,
+    *,
+    compare_absolute_distance: bool = False,
 ) -> str:
     if low_exposure_ratio == high_exposure_ratio:
         return f"Only one exposure ratio is shown, so {subject} exposure sensitivity is not compared."
+    signed_delta = high_value - low_value
+    delta = abs(high_value) - abs(low_value) if compare_absolute_distance else signed_delta
     if abs(delta) < 0.00005:
+        if compare_absolute_distance and abs(signed_delta) >= 0.00005:
+            return (
+                f"Moving from {low_exposure_ratio * 100.0:g}% to "
+                f"{high_exposure_ratio * 100.0:g}% of the exposure limit changes the signed "
+                f"{subject} from {_fmt_pct(low_value, signed=True)} to "
+                f"{_fmt_pct(high_value, signed=True)}, while its absolute distance is nearly unchanged."
+            )
         return f"Exposure has almost no effect on the {subject}."
     verb = "widens" if delta > 0.0 else "narrows"
+    distance_qualifier = "absolute " if compare_absolute_distance else ""
+    endpoints = (
+        f" from {_fmt_pct(abs(low_value))} to {_fmt_pct(abs(high_value))}"
+        if compare_absolute_distance
+        else ""
+    )
     return (
         f"Moving from {low_exposure_ratio * 100.0:g}% to {high_exposure_ratio * 100.0:g}% "
-        f"of the exposure limit {verb} the {subject} by "
+        f"of the exposure limit {verb} the {distance_qualifier}{subject} distance{endpoints} by "
         f"{abs(delta) * 100.0:.4f} percentage points in the "
         f"{volatility_label!r} volatility example."
     )
@@ -534,11 +555,10 @@ def _classify_side(
     *,
     pside: str,
     context: Mapping[str, Any] | None,
-    representative: Mapping[str, Mapping[str, Any]],
+    representative: Mapping[str, Any],
 ) -> dict[str, Any]:
     normal = representative["normal"]
-    quiet = representative["quiet"]
-    high = representative["high"]
+    volatility_results = representative["volatility_results"]
     exposure_low = representative["exposure_low"]
     exposure_high = representative["exposure_high"]
     entry = normal["entry"]
@@ -550,38 +570,32 @@ def _classify_side(
         "one volatility scenario shown"
         if representative["volatility_scenario_count"] == 1
         else _sensitivity_style(
-            (
-                quiet["entry"]["threshold_pct"],
-                quiet["entry"]["retracement_pct"],
-            ),
-            (
-                high["entry"]["threshold_pct"],
-                high["entry"]["retracement_pct"],
-            ),
+            tuple(
+                (result["entry"]["threshold_pct"], result["entry"]["retracement_pct"])
+                for result in volatility_results
+            )
         )
     )
     close_volatility_style = (
         "one volatility scenario shown"
         if representative["volatility_scenario_count"] == 1
         else _sensitivity_style(
-            (
-                quiet["close"]["threshold_pct"],
-                quiet["close"]["retracement_pct"],
-            ),
-            (
-                high["close"]["threshold_pct"],
-                high["close"]["retracement_pct"],
-            ),
+            tuple(
+                (result["close"]["threshold_pct"], result["close"]["retracement_pct"])
+                for result in volatility_results
+            )
         )
     )
     entry_headline = (
         f"{volatility_style}; "
-        f"{_threshold_style('entry', entry['threshold_pct'])} entry threshold with "
+        f"{_threshold_style('entry', entry['threshold_pct'], trailing_enabled=entry_trailing)} "
+        "entry threshold with "
         f"{_retracement_style(entry['retracement_pct'])} retracement"
     )
     close_headline = (
         f"{close_volatility_style}; "
-        f"{_threshold_style('close', close['threshold_pct'])} close threshold with "
+        f"{_threshold_style('close', close['threshold_pct'], trailing_enabled=close_trailing)} "
+        "close threshold with "
         f"{_retracement_style(close['retracement_pct'])} retracement"
     )
 
@@ -620,20 +634,19 @@ def _classify_side(
         )
     entry_comments.append(
         _movement_description(
-            exposure_high["entry"]["threshold_pct"] - exposure_low["entry"]["threshold_pct"],
+            exposure_low["entry"]["threshold_pct"],
+            exposure_high["entry"]["threshold_pct"],
             "entry threshold",
             representative["exposure_low_ratio"],
             representative["exposure_high_ratio"],
             representative["normal_label"],
+            compare_absolute_distance=True,
         )
-    )
-    entry_retracement_delta = (
-        exposure_high["entry"]["retracement_pct"]
-        - exposure_low["entry"]["retracement_pct"]
     )
     entry_comments.append(
         _movement_description(
-            entry_retracement_delta,
+            exposure_low["entry"]["retracement_pct"],
+            exposure_high["entry"]["retracement_pct"],
             "entry retracement",
             representative["exposure_low_ratio"],
             representative["exposure_high_ratio"],
@@ -665,11 +678,13 @@ def _classify_side(
         )
     close_comments.append(
         _movement_description(
-            exposure_high["close"]["threshold_pct"] - exposure_low["close"]["threshold_pct"],
+            exposure_low["close"]["threshold_pct"],
+            exposure_high["close"]["threshold_pct"],
             "close threshold",
             representative["exposure_low_ratio"],
             representative["exposure_high_ratio"],
             representative["normal_label"],
+            compare_absolute_distance=True,
         )
     )
     close_comments.append(
@@ -713,16 +728,24 @@ def _classify_side(
             f"Each trailing close targets {context['close_qty_pct'] * 100.0:.2f}% before "
             "minimum-size and remaining-position rules."
         )
+    if representative["volatility_scenario_count"] == 1:
+        basis = (
+            f"Headlines use {representative['normal_label']!r} volatility at "
+            f"{representative['middle_ratio'] * 100.0:g}% WE/WEL."
+        )
+    else:
+        basis = (
+            f"Threshold/retracement style uses {representative['normal_label']!r} volatility at "
+            f"{representative['middle_ratio'] * 100.0:g}% WE/WEL; volatility sensitivity spans "
+            f"all {representative['volatility_scenario_count']} displayed scenarios at that exposure."
+        )
     return {
         "entry_headline": entry_headline,
         "entry_comments": entry_comments,
         "close_headline": close_headline,
         "close_comments": close_comments,
         "overall_comments": overall,
-        "basis": (
-            f"Headlines use {representative['normal_label']!r} volatility at "
-            f"{representative['middle_ratio'] * 100.0:g}% WE/WEL."
-        ),
+        "basis": basis,
     }
 
 
@@ -798,21 +821,15 @@ def build_overview(
             checked_scenarios,
             key=lambda item: abs(item[1] - 0.005) + abs(item[2] - 0.0025),
         )[0]
-        quiet_label = min(
-            checked_scenarios,
-            key=lambda item: (item[1] + item[2], item[1], item[2], item[0]),
-        )[0]
-        high_label = max(
-            checked_scenarios,
-            key=lambda item: (item[1] + item[2], item[1], item[2], item[0]),
-        )[0]
         middle_ratio = min(checked_ratios, key=lambda value: abs(value - 0.5))
         low_ratio = min(checked_ratios)
         high_ratio = max(checked_ratios)
         representative = {
             "normal": scenario_results[(normal_label, middle_ratio)],
-            "quiet": scenario_results[(quiet_label, middle_ratio)],
-            "high": scenario_results[(high_label, middle_ratio)],
+            "volatility_results": [
+                scenario_results[(label, middle_ratio)]
+                for label, _volatility_ema_1m, _volatility_ema_1h in checked_scenarios
+            ],
             "exposure_low": scenario_results[(normal_label, low_ratio)],
             "exposure_high": scenario_results[(normal_label, high_ratio)],
             "exposure_low_ratio": low_ratio,
@@ -1006,7 +1023,16 @@ def _format_table(headers: Sequence[str], rows: Sequence[Sequence[str]]) -> list
 
 
 def _scenario_price(value: float | None, *, fallback: str = "-") -> str:
-    return fallback if value is None else f"{value:.4f}"
+    if value is None:
+        return fallback
+    if value == 0.0:
+        return "0.0000"
+    magnitude = math.floor(math.log10(abs(value)))
+    if magnitude >= -3:
+        return f"{value:.4f}"
+    if magnitude >= -8:
+        return f"{value:.{-magnitude + 4}f}"
+    return f"{value:.6g}"
 
 
 def _scenario_rows(side: Mapping[str, Any], kind: str) -> list[list[str]]:

--- a/src/tools/trailing_inspect.py
+++ b/src/tools/trailing_inspect.py
@@ -744,7 +744,8 @@ def _classify_side(
         elif forced_mode == "tp_only":
             overall.append(
                 "Global forced mode 'tp_only' blocks all entries. For a held position Rust still "
-                "uses strategy close orders, so the ENTRY table is dormant and the CLOSE table applies."
+                "uses strategy close orders, so the RE-ENTRY / ADD table is dormant and the CLOSE "
+                "table applies."
             )
         elif forced_mode == "graceful_stop":
             overall.append(
@@ -772,12 +773,25 @@ def _classify_side(
             f"{context['entry_double_down_factor']:.4g} or initial-entry quantity, before "
             "minimum-quantity, rounding, and exposure-cropping rules."
         )
-        overall.append(
-            "Each strategy close starts from the allowed full-position size × "
-            f"{context['close_qty_pct'] * 100.0:.2f}%, adds any current position size above "
-            "that allowed full size, then caps at the remaining position and applies minimum-quantity, "
-            "rounding, and dust-remainder rules."
+        passive_full_close = (
+            not close_trailing
+            and _finite_float(
+                close_params.get("threshold_we_weight", 0.0), "threshold_we_weight"
+            )
+            == 0.0
         )
+        if passive_full_close:
+            overall.append(
+                "This passive close path ignores the configured close quantity percentage and "
+                "targets the full remaining position because its threshold has no exposure weight."
+            )
+        else:
+            overall.append(
+                "Each strategy close starts from the allowed full-position size × "
+                f"{context['close_qty_pct'] * 100.0:.2f}%, adds any current position size above "
+                "that allowed full size, then caps at the remaining position and applies "
+                "minimum-quantity, rounding, and dust-remainder rules."
+            )
         if context.get("position_exposure_enforcer_enabled", False):
             enforcer_threshold = context.get("position_exposure_enforcer_threshold", 0.0)
             overall.append(
@@ -864,7 +878,16 @@ def build_overview(
                     overridden_parameters=(overridden_parameters or {}).get(pside, ()),
                 )
                 scenario_results[(label, exposure_ratio)] = result
+                entry_payload = deepcopy(result["entry"])
                 close_payload = deepcopy(result["close"])
+                entry_exposure_capped = (
+                    exposure_ratio > 0.999
+                    if entry_payload["trailing_enabled"]
+                    else exposure_ratio >= 0.999
+                )
+                entry_payload["inactive_reason"] = (
+                    "exposure_cap" if entry_exposure_capped else None
+                )
                 enforcer_enabled = bool(
                     context and context.get("position_exposure_enforcer_enabled", False)
                 )
@@ -887,7 +910,7 @@ def build_overview(
                         "volatility_ema_1m": volatility_ema_1m,
                         "volatility_ema_1h": volatility_ema_1h,
                         "exposure_ratio": exposure_ratio,
-                        "entry": result["entry"],
+                        "entry": entry_payload,
                         "close": close_payload,
                     }
                 )
@@ -1114,16 +1137,31 @@ def _scenario_input_pct(value: float) -> str:
     return f"{value * 100.0:.10g}"
 
 
+def _scenario_runtime_path(
+    side: Mapping[str, Any], kind: str, payload: Mapping[str, Any]
+) -> str:
+    context = side.get("context")
+    if context:
+        if not context["active"]:
+            return "side disabled"
+        forced_mode = context.get("forced_mode", "normal")
+        if forced_mode in {"panic", "manual"}:
+            return f"{forced_mode} dormant"
+        if kind == "entry" and forced_mode == "tp_only":
+            return "tp_only blocked"
+    if kind == "entry":
+        return "exposure-capped" if payload.get("inactive_reason") == "exposure_cap" else "re-entry"
+    if payload.get("superseded_by") == "position_exposure_enforcer":
+        return "WEL auto-reduce"
+    return "strategy close"
+
+
 def _scenario_rows(side: Mapping[str, Any], kind: str) -> list[list[str]]:
     rows: list[list[str]] = []
     for scenario in side["scenarios"]:
         payload = scenario[kind]
         geometry = payload["geometry"]
-        runtime_path = (
-            "WEL auto-reduce"
-            if payload.get("superseded_by") == "position_exposure_enforcer"
-            else ("re-entry" if kind == "entry" else "strategy close")
-        )
+        runtime_path = _scenario_runtime_path(side, kind, payload)
         if not payload["trailing_enabled"]:
             confirmation = "passive"
             threshold_price = "n/a"
@@ -1229,9 +1267,13 @@ def render_overview(result: Mapping[str, Any]) -> str:
             "confirmation follows the running low/high, so a farther extreme moves the trigger.",
             "* Order ref is Rust's analytical emitted-order reference after both conditions pass; "
             "the live price is also constrained by bid/ask, tick rounding, sizing, exposure caps, and EMA gating.",
-            "* Re-entry/add rows apply only while a position already exists. While flat, Rust bypasses "
-            "trailing threshold/retracement and submits the initial entry at bid/ask, optionally pushed "
-            "farther from market by the configured initial-entry EMA gate.",
+            "* Re-entry/add rows apply only after the position reaches at least 80% of the calculated "
+            "initial-entry quantity. While flat, Rust submits the normal initial entry; below that 80% "
+            "boundary, it submits a partial initial entry. Both initial paths bypass trailing "
+            "threshold/retracement and use the initial bid/ask price, optionally pushed farther from "
+            "market by the configured initial-entry EMA gate.",
+            "* A RE-ENTRY / ADD row marked 'exposure-capped' emits no entry: passive entries stop at "
+            "99.9% of effective WEL, while trailing entries stop only when strictly above 99.9%.",
             "* A CLOSE row marked 'WEL auto-reduce' is superseded at that exposure ratio: Rust returns "
             "the position-exposure-enforcer order before evaluating the displayed strategy close.",
             "* With close trailing enabled, a non-positive threshold is immediate: trailing is "

--- a/src/tools/trailing_inspect.py
+++ b/src/tools/trailing_inspect.py
@@ -84,6 +84,19 @@ def _require_mapping(value: Any, path: str) -> Mapping[str, Any]:
     return value
 
 
+def _validate_derived_finite(value: Any, path: str = "result") -> None:
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            _validate_derived_finite(item, f"{path}.{key}")
+    elif isinstance(value, (list, tuple)):
+        for index, item in enumerate(value):
+            _validate_derived_finite(item, f"{path}[{index}]")
+    elif isinstance(value, float) and not math.isfinite(value):
+        raise ValueError(
+            f"derived value {path} is not finite; reduce scenario inputs or parameter weights"
+        )
+
+
 def _extract_strategy_params(config: Mapping[str, Any], pside: str) -> dict[str, Any]:
     live = _require_mapping(config.get("live"), "live")
     strategy_kind = str(live.get("strategy_kind") or STRATEGY_KIND).strip().lower()
@@ -441,7 +454,7 @@ def inspect_trailing(
         "effective"
     ]
 
-    return {
+    result = {
         "symbol": symbol,
         "pside": pside,
         "position": {"size": position_size, "price": position_price},
@@ -484,6 +497,8 @@ def inspect_trailing(
             ),
         },
     }
+    _validate_derived_finite(result)
+    return result
 
 
 def _threshold_style(kind: str, threshold_pct: float, *, trailing_enabled: bool) -> str:
@@ -797,8 +812,9 @@ def _classify_side(
             overall.append(
                 "Position-exposure enforcement is enabled at "
                 f"{enforcer_threshold * 100.0:g}% WE / effective WEL. CLOSE rows above that "
-                "ratio are marked 'WEL auto-reduce': Rust returns a market-side exposure-reduction "
-                "order before trailing/passive close logic, including in 'tp_only' mode."
+                "ratio are marked 'WEL reducer first': the next-close path returns a market-side "
+                "reducer before strategy close logic, including in 'tp_only' mode. Expanded close "
+                "generation simulates that reduction and may then add the displayed strategy closes."
             )
     if representative["volatility_scenario_count"] == 1:
         basis = (
@@ -899,7 +915,7 @@ def build_overview(
                     if context
                     else 0.0
                 )
-                close_payload["superseded_by"] = (
+                close_payload["preceded_by"] = (
                     "position_exposure_enforcer"
                     if enforcer_enabled and exposure_ratio > enforcer_threshold
                     else None
@@ -1151,8 +1167,8 @@ def _scenario_runtime_path(
             return "tp_only blocked"
     if kind == "entry":
         return "exposure-capped" if payload.get("inactive_reason") == "exposure_cap" else "re-entry"
-    if payload.get("superseded_by") == "position_exposure_enforcer":
-        return "WEL auto-reduce"
+    if payload.get("preceded_by") == "position_exposure_enforcer":
+        return "WEL reducer first"
     return "strategy close"
 
 
@@ -1274,8 +1290,9 @@ def render_overview(result: Mapping[str, Any]) -> str:
             "market by the configured initial-entry EMA gate.",
             "* A RE-ENTRY / ADD row marked 'exposure-capped' emits no entry: passive entries stop at "
             "99.9% of effective WEL, while trailing entries stop only when strictly above 99.9%.",
-            "* A CLOSE row marked 'WEL auto-reduce' is superseded at that exposure ratio: Rust returns "
-            "the position-exposure-enforcer order before evaluating the displayed strategy close.",
+            "* A CLOSE row marked 'WEL reducer first' remains relevant: a next-close request returns "
+            "the reducer first, while expanded ideal-order generation simulates its fill and may then "
+            "include ordinary strategy closes using the displayed geometry.",
             "* With close trailing enabled, a non-positive threshold is immediate: trailing is "
             "armed from position open. With close trailing disabled, the row is passive and no "
             "extrema or reversal confirmation participate.",
@@ -1478,15 +1495,16 @@ def main(argv: Sequence[str] | None = None) -> int:
                 exposure_ratios=args.exposure_ratios,
                 overridden_parameters=overridden_by_side,
             )
+        if args.json:
+            output = json.dumps(result, indent=2, sort_keys=True, allow_nan=False)
+        elif result.get("mode") == "overview":
+            output = render_overview(result)
+        else:
+            output = render_report(result)
     except (FileNotFoundError, KeyError, RuntimeError, ValueError) as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2
-    if args.json:
-        print(json.dumps(result, indent=2, sort_keys=True))
-    elif result.get("mode") == "overview":
-        print(render_overview(result))
-    else:
-        print(render_report(result))
+    print(output)
     return 0
 
 

--- a/src/tools/trailing_inspect.py
+++ b/src/tools/trailing_inspect.py
@@ -1116,7 +1116,9 @@ def render_overview(result: Mapping[str, Any]) -> str:
             "confirmation follows the running low/high, so a farther extreme moves the trigger.",
             "* Order ref is Rust's analytical emitted-order reference after both conditions pass; "
             "the live price is also constrained by bid/ask, tick rounding, sizing, exposure caps, and EMA gating.",
-            "* A non-positive close threshold is shown as immediate: trailing is armed from position open.",
+            "* With close trailing enabled, a non-positive threshold is immediate: trailing is "
+            "armed from position open. With close trailing disabled, the row is passive and no "
+            "extrema or reversal confirmation participate.",
             "* Trailing extrema reset after every fill for the same coin and position side.",
             "* Categories are descriptive heuristics for intuition, not trading-quality judgments.",
             "Percent inputs use config ratios: 0.01 = 1%.",
@@ -1268,6 +1270,14 @@ def main(argv: Sequence[str] | None = None) -> int:
         if detailed_mode:
             if args.side == "both":
                 raise ValueError("detailed single-scenario mode requires --side long or --side short")
+            if (
+                args.wallet_exposure is None
+                or args.effective_wallet_exposure_limit is None
+            ):
+                raise ValueError(
+                    "detailed single-scenario mode requires both --wallet-exposure and "
+                    "--effective-wallet-exposure-limit"
+                )
             pside = args.side or "long"
             params, source = load_parameter_source(config_path, pside)
             overridden = apply_parameter_overrides(params, args)
@@ -1276,14 +1286,8 @@ def main(argv: Sequence[str] | None = None) -> int:
                 pside=pside,
                 position_price=args.price_anchor,
                 position_size=args.position_size,
-                wallet_exposure=(
-                    args.wallet_exposure if args.wallet_exposure is not None else 0.0
-                ),
-                effective_wallet_exposure_limit=(
-                    args.effective_wallet_exposure_limit
-                    if args.effective_wallet_exposure_limit is not None
-                    else 1.0
-                ),
+                wallet_exposure=args.wallet_exposure,
+                effective_wallet_exposure_limit=args.effective_wallet_exposure_limit,
                 volatility_ema_1m=(
                     args.volatility_ema_1m if args.volatility_ema_1m is not None else 0.0
                 ),

--- a/src/tools/trailing_inspect.py
+++ b/src/tools/trailing_inspect.py
@@ -134,6 +134,9 @@ def load_parameter_source(config_path: str | None, pside: str) -> tuple[dict[str
 
 
 def _extract_side_context(config: Mapping[str, Any], pside: str) -> dict[str, Any]:
+    from config_utils import expand_PB_mode
+
+    live = _require_mapping(config.get("live"), "live")
     bot = _require_mapping(config.get("bot"), "bot")
     side = _require_mapping(bot.get(pside), f"bot.{pside}")
     risk = _require_mapping(side.get("risk"), f"bot.{pside}.risk")
@@ -149,10 +152,13 @@ def _extract_side_context(config: Mapping[str, Any], pside: str) -> dict[str, An
         f"bot.{pside}.risk.total_wallet_exposure_limit",
     )
     n_positions = int(_finite_float(risk.get("n_positions"), f"bot.{pside}.risk.n_positions"))
+    forced_mode_raw = str(live.get(f"forced_mode_{pside}", "") or "").strip()
+    forced_mode = expand_PB_mode(forced_mode_raw) if forced_mode_raw else "normal"
     return {
         "active": total_wallet_exposure_limit > 0.0 and n_positions > 0,
         "total_wallet_exposure_limit": total_wallet_exposure_limit,
         "n_positions": n_positions,
+        "forced_mode": forced_mode,
         "entry_cooldown_minutes": _finite_float(
             risk.get("entry_cooldown_minutes", 0.0),
             f"bot.{pside}.risk.entry_cooldown_minutes",
@@ -693,16 +699,46 @@ def _classify_side(
 
     overall: list[str] = []
     if context:
-        if context["active"]:
+        forced_mode = context.get("forced_mode", "normal")
+        if not context["active"]:
+            forced_mode_note = (
+                f" Global forced mode is {forced_mode!r}, but it cannot reactivate a disabled side."
+                if forced_mode != "normal"
+                else ""
+            )
+            overall.append(
+                f"{pside.capitalize()} is disabled by its zero exposure limit or position count. "
+                "The tables below describe dormant parameters, not orders the current config will place."
+                + forced_mode_note
+            )
+        elif forced_mode == "normal":
             overall.append(
                 f"{pside.capitalize()} is enabled: total exposure limit "
                 f"{context['total_wallet_exposure_limit'] * 100.0:.2f}% across "
                 f"{context['n_positions']} configured position slot(s)."
             )
-        else:
+        elif forced_mode == "panic":
             overall.append(
-                f"{pside.capitalize()} is disabled by its zero exposure limit or position count. "
-                "The tables below describe dormant parameters, not orders the current config will place."
+                "Global forced mode 'panic' supersedes trailing_martingale: Rust emits an "
+                "immediate panic close for a held position and no strategy entries or closes; "
+                "if flat, it emits no order. Both tables below are dormant while this mode applies."
+            )
+        elif forced_mode == "manual":
+            overall.append(
+                "Global forced mode 'manual' supersedes trailing_martingale: Rust emits no "
+                "strategy orders and ignores any held position. Both tables below are dormant "
+                "while this mode applies."
+            )
+        elif forced_mode == "tp_only":
+            overall.append(
+                "Global forced mode 'tp_only' blocks all entries. For a held position Rust still "
+                "uses strategy close orders, so the ENTRY table is dormant and the CLOSE table applies."
+            )
+        elif forced_mode == "graceful_stop":
+            overall.append(
+                "Global forced mode 'graceful_stop' blocks a new initial entry while flat. With a "
+                "held position Rust manages the strategy normally, so re-entries and closes use "
+                "the tables until the position is flat."
             )
         ema_gate_mode = context["entry_ema_gate_mode"]
         if ema_gate_mode in {"all", "reentry"}:
@@ -1035,6 +1071,10 @@ def _scenario_price(value: float | None, *, fallback: str = "-") -> str:
     return f"{value:.6g}"
 
 
+def _scenario_input_pct(value: float) -> str:
+    return f"{value * 100.0:.10g}"
+
+
 def _scenario_rows(side: Mapping[str, Any], kind: str) -> list[list[str]]:
     rows: list[list[str]] = []
     for scenario in side["scenarios"]:
@@ -1055,8 +1095,9 @@ def _scenario_rows(side: Mapping[str, Any], kind: str) -> list[list[str]]:
         rows.append(
             [
                 scenario["volatility_label"],
-                f"{scenario['volatility_ema_1m'] * 100.0:.2f}/{scenario['volatility_ema_1h'] * 100.0:.2f}%",
-                f"{scenario['exposure_ratio'] * 100.0:.0f}%",
+                f"{_scenario_input_pct(scenario['volatility_ema_1m'])}/"
+                f"{_scenario_input_pct(scenario['volatility_ema_1h'])}%",
+                f"{_scenario_input_pct(scenario['exposure_ratio'])}%",
                 _fmt_pct(payload["threshold_pct"], signed=kind == "close"),
                 threshold_price,
                 _fmt_pct(payload["retracement_pct"]),

--- a/src/tools/trailing_inspect.py
+++ b/src/tools/trailing_inspect.py
@@ -152,6 +152,7 @@ def _extract_side_context(config: Mapping[str, Any], pside: str) -> dict[str, An
     live = _require_mapping(config.get("live"), "live")
     bot = _require_mapping(config.get("bot"), "bot")
     side = _require_mapping(bot.get(pside), f"bot.{pside}")
+    hsl = _require_mapping(side.get("hsl", {}), f"bot.{pside}.hsl")
     risk = _require_mapping(side.get("risk"), f"bot.{pside}.risk")
     unstuck = _require_mapping(side.get("unstuck", {}), f"bot.{pside}.unstuck")
     strategies = _require_mapping(side.get("strategy"), f"bot.{pside}.strategy")
@@ -173,11 +174,40 @@ def _extract_side_context(config: Mapping[str, Any], pside: str) -> dict[str, An
         raise ValueError(
             f"invalid live.forced_mode_{pside}={forced_mode_raw!r}: {exc}"
         ) from exc
+    coin_overrides = _require_mapping(config.get("coin_overrides", {}), "coin_overrides")
+    coin_strategy_override_symbols: list[str] = []
+    hsl_enabled_override_symbols: list[str] = []
+    for symbol, raw_override in coin_overrides.items():
+        override = _require_mapping(raw_override, f"coin_overrides.{symbol}")
+        override_bot = override.get("bot", {})
+        if not isinstance(override_bot, Mapping):
+            continue
+        override_side = override_bot.get(pside, {})
+        if not isinstance(override_side, Mapping):
+            continue
+        override_strategies = override_side.get("strategy", {})
+        if isinstance(override_strategies, Mapping):
+            strategy_override = override_strategies.get(STRATEGY_KIND, {})
+            if isinstance(strategy_override, Mapping) and strategy_override:
+                coin_strategy_override_symbols.append(str(symbol))
+        hsl_override = override_side.get("hsl", {})
+        if (
+            isinstance(hsl_override, Mapping)
+            and hsl_override
+            and bool(hsl_override.get("enabled", hsl.get("enabled", False)))
+        ):
+            hsl_enabled_override_symbols.append(str(symbol))
+    hsl_enabled_global = bool(hsl.get("enabled", False))
     return {
         "active": total_wallet_exposure_limit > 0.0 and n_positions > 0,
         "total_wallet_exposure_limit": total_wallet_exposure_limit,
         "n_positions": n_positions,
         "forced_mode": forced_mode,
+        "hsl_enabled": hsl_enabled_global or bool(hsl_enabled_override_symbols),
+        "hsl_enabled_global": hsl_enabled_global,
+        "hsl_enabled_override_symbols": sorted(hsl_enabled_override_symbols),
+        "hsl_signal_mode": str(live.get("hsl_signal_mode", "unknown")),
+        "coin_strategy_override_symbols": sorted(coin_strategy_override_symbols),
         "max_realized_loss_pct": _finite_float(
             live.get("max_realized_loss_pct", 1.0), "live.max_realized_loss_pct"
         ),
@@ -909,6 +939,29 @@ def _classify_side(
                 "PnL-gated: Rust may remove losing strategy closes or protective reducers after "
                 "evaluating projected batch PnL, fees, and account-wide realized-loss allowance."
             )
+        if context.get("hsl_enabled", False):
+            hsl_scope = (
+                "globally for this side"
+                if context.get("hsl_enabled_global", False)
+                else "through coin overrides for "
+                + ", ".join(context.get("hsl_enabled_override_symbols", ()))
+            )
+            overall.append(
+                f"Equity hard stop loss is enabled {hsl_scope} with signal mode "
+                f"{context.get('hsl_signal_mode', 'unknown')!r}. Active rows are HSL-dependent: "
+                "the current account/position PnL drawdown tier may block entries at ORANGE or RED, "
+                "replace strategy closes with panic closes at RED, or leave the strategy path unchanged. "
+                "An offline config report cannot know the live HSL tier."
+            )
+        coin_strategy_override_symbols = context.get("coin_strategy_override_symbols", ())
+        if coin_strategy_override_symbols:
+            overall.append(
+                "Coin-specific trailing_martingale strategy overrides are configured for "
+                + ", ".join(coin_strategy_override_symbols)
+                + ". They are explicitly omitted from these tables, which show only the global "
+                "bot-side parameters; the listed coins may have different effective thresholds, "
+                "retracements, and prices at runtime."
+            )
     else:
         overall.append(
             "No config was supplied, so only strategy defaults are known. Side enablement, forced "
@@ -1003,7 +1056,11 @@ def build_overview(
                 entry_payload["inactive_reason"] = (
                     "unreachable_long_threshold"
                     if pside == "long" and entry_payload["threshold_pct"] >= 1.0
-                    else ("exposure_cap" if entry_exposure_capped else None)
+                    else (
+                        "unreachable_short_retracement"
+                        if pside == "short" and entry_payload["retracement_pct"] >= 1.0
+                        else ("exposure_cap" if entry_exposure_capped else None)
+                    )
                 )
                 enforcer_enabled = bool(
                     context
@@ -1028,7 +1085,11 @@ def build_overview(
                 close_payload["inactive_reason"] = (
                     "unreachable_short_threshold"
                     if pside == "short" and close_payload["threshold_pct"] >= 1.0
-                    else None
+                    else (
+                        "unreachable_long_retracement"
+                        if pside == "long" and close_payload["retracement_pct"] >= 1.0
+                        else None
+                    )
                 )
                 close_payload["post_reduction_geometry"] = (
                     "requires_runtime_sizing_inputs"
@@ -1281,28 +1342,39 @@ def _scenario_runtime_path(
         if kind == "entry" and forced_mode == "tp_only":
             return "tp_only blocked"
     if kind == "entry":
-        if payload.get("inactive_reason") == "unreachable_long_threshold":
+        if payload.get("inactive_reason") in {
+            "unreachable_long_threshold",
+            "unreachable_short_retracement",
+        }:
             return "unreachable"
         if payload.get("inactive_reason") == "exposure_cap":
             return "exposure-capped"
         if context is None:
             return "context unknown"
+        qualifiers = []
+        if context.get("hsl_enabled", False):
+            qualifiers.append("HSL-dependent")
         if context.get("total_exposure_entry_gate_enabled", False):
-            return "portfolio-dependent"
-        return "re-entry"
-    if payload.get("inactive_reason") == "unreachable_short_threshold":
-        return "unreachable"
+            qualifiers.append("portfolio-dependent")
+        return " / ".join(qualifiers) if qualifiers else "re-entry"
     if context is None:
         return "context unknown"
     qualifiers = []
     if payload.get("preceded_by") == "position_exposure_enforcer":
         qualifiers.append("WEL-first")
+    if context.get("hsl_enabled", False):
+        qualifiers.append("HSL-dependent")
     if context.get("total_exposure_enforcer_enabled", False):
         qualifiers.append("TWEL-dependent")
     if _unstuck_active(context):
         qualifiers.append("unstuck-dependent")
     if context.get("max_realized_loss_pct", 1.0) < 1.0:
         qualifiers.append("PnL-gated")
+    if payload.get("inactive_reason") in {
+        "unreachable_short_threshold",
+        "unreachable_long_retracement",
+    }:
+        qualifiers.append("strategy unreachable")
     return " / ".join(qualifiers) if qualifiers else "strategy close"
 
 
@@ -1312,17 +1384,19 @@ def _scenario_rows(side: Mapping[str, Any], kind: str) -> list[list[str]]:
         payload = scenario[kind]
         geometry = payload["geometry"]
         runtime_path = _scenario_runtime_path(side, kind, payload)
-        if payload.get("inactive_reason") in {
+        if payload.get("post_reduction_geometry") == "requires_runtime_sizing_inputs":
+            confirmation = "post-WE varies"
+            threshold_price = "post-WE varies"
+            order_reference = "post-WE varies"
+        elif payload.get("inactive_reason") in {
             "unreachable_long_threshold",
             "unreachable_short_threshold",
+            "unreachable_short_retracement",
+            "unreachable_long_retracement",
         }:
             confirmation = "n/a"
             threshold_price = "unreachable"
             order_reference = "n/a"
-        elif payload.get("post_reduction_geometry") == "requires_runtime_sizing_inputs":
-            confirmation = "post-WE varies"
-            threshold_price = "post-WE varies"
-            order_reference = "post-WE varies"
         elif not payload["trailing_enabled"]:
             confirmation = "passive"
             threshold_price = "n/a"
@@ -1446,6 +1520,11 @@ def render_overview(result: Mapping[str, Any]) -> str:
             "the passive price is non-positive, and a positive market cannot cross the trailing target.",
             "* A short CLOSE row marked 'unreachable' has a threshold of at least 100%: its target "
             "price is non-positive, so a positive market cannot satisfy the trailing threshold.",
+            "* A short RE-ENTRY / ADD or long CLOSE row marked 'unreachable' has retracement of at "
+            "least 100%: Rust requires a positive trailing low below a non-positive fraction of the "
+            "running high, which a positive-priced market cannot satisfy.",
+            "* 'HSL-dependent' means the configured equity hard stop may block entries or replace "
+            "strategy closes according to live drawdown state that this offline report cannot observe.",
             "* A CLOSE runtime path containing 'TWEL-dependent' may coexist with an account-wide "
             "repair close. Which position is reduced and by how much requires full same-side portfolio state.",
             "* 'unstuck-dependent' means a globally selected auto-unstuck close may coexist when its "

--- a/src/tools/trailing_inspect.py
+++ b/src/tools/trailing_inspect.py
@@ -251,10 +251,9 @@ def _geometry(
     threshold_direction = -1.0 if (kind, pside) in {("entry", "long"), ("close", "short")} else 1.0
     retracement_direction = -threshold_direction
     threshold_gate_active = threshold_pct > 0.0
+    passive_reference_price = position_price * (1.0 + threshold_direction * threshold_pct)
     threshold_price = (
-        position_price * (1.0 + threshold_direction * threshold_pct)
-        if threshold_gate_active
-        else None
+        passive_reference_price if threshold_gate_active else None
     )
     nominal_confirmation_price = (
         threshold_price * (1.0 + retracement_direction * retracement_pct)
@@ -271,6 +270,7 @@ def _geometry(
         "threshold_gate_active": threshold_gate_active,
         "threshold_direction": "below" if threshold_direction < 0.0 else "above",
         "threshold_price": threshold_price,
+        "passive_reference_price": passive_reference_price,
         "retracement_direction": "above" if retracement_direction > 0.0 else "below",
         "nominal_confirmation_price": nominal_confirmation_price,
         "nominal_confirmation_pct_from_position": (
@@ -741,6 +741,14 @@ def build_overview(
         if vol_1m < 0.0 or vol_1h < 0.0:
             raise ValueError("volatility scenario values must not be negative")
         checked_scenarios.append((str(label), vol_1m, vol_1h))
+    scenario_labels = [item[0] for item in checked_scenarios]
+    duplicate_labels = sorted(
+        label for label in set(scenario_labels) if scenario_labels.count(label) > 1
+    )
+    if duplicate_labels:
+        raise ValueError(
+            "duplicate volatility scenario label(s): " + ", ".join(duplicate_labels)
+        )
     checked_ratios = [_finite_float(value, "exposure_ratio") for value in exposure_ratios]
     if any(value < 0.0 for value in checked_ratios):
         raise ValueError("exposure ratios must not be negative")
@@ -863,14 +871,12 @@ def _format_geometry(kind: str, payload: Mapping[str, Any]) -> list[str]:
     lines: list[str] = []
     if not payload["trailing_enabled"]:
         lines.append("  Mode: trailing disabled (retracement_base_pct <= 0); passive recursive orders")
-        if geometry["threshold_gate_active"]:
-            lines.append(
-                f"  Passive threshold/reference: {_fmt_pct(payload['threshold_pct'])} "
-                f"{geometry['threshold_direction']} position price -> "
-                f"{_fmt_number(geometry['threshold_price'])}"
-            )
-        else:
-            lines.append("  Effective threshold <= 0; passive reference is at the current market touch")
+        lines.append(
+            "  Passive analytical reference from position price and signed threshold "
+            f"{_fmt_pct(payload['threshold_pct'], signed=True)} -> "
+            f"{_fmt_number(geometry['passive_reference_price'])}"
+        )
+        lines.append("  Rust then clamps this reference against the current bid/ask before rounding.")
     elif geometry["threshold_gate_active"]:
         lines.append(
             f"  Threshold: {_fmt_pct(payload['threshold_pct'])} {geometry['threshold_direction']} "
@@ -1002,12 +1008,15 @@ def _scenario_rows(side: Mapping[str, Any], kind: str) -> list[list[str]]:
         geometry = payload["geometry"]
         if not payload["trailing_enabled"]:
             confirmation = "passive"
-            order_reference = _scenario_price(geometry["threshold_price"], fallback="market")
+            threshold_price = "n/a"
+            order_reference = _scenario_price(geometry["passive_reference_price"])
         elif not geometry["threshold_gate_active"]:
             confirmation = "extreme-based"
+            threshold_price = "immediate"
             order_reference = "market"
         else:
             confirmation = _scenario_price(geometry["nominal_confirmation_price"])
+            threshold_price = _scenario_price(geometry["threshold_price"])
             order_reference = _scenario_price(geometry["order_reference_price"])
         rows.append(
             [
@@ -1015,7 +1024,7 @@ def _scenario_rows(side: Mapping[str, Any], kind: str) -> list[list[str]]:
                 f"{scenario['volatility_ema_1m'] * 100.0:.2f}/{scenario['volatility_ema_1h'] * 100.0:.2f}%",
                 f"{scenario['exposure_ratio'] * 100.0:.0f}%",
                 _fmt_pct(payload["threshold_pct"], signed=kind == "close"),
-                _scenario_price(geometry["threshold_price"], fallback="immediate"),
+                threshold_price,
                 _fmt_pct(payload["retracement_pct"]),
                 confirmation,
                 order_reference,

--- a/src/tools/trailing_inspect.py
+++ b/src/tools/trailing_inspect.py
@@ -184,6 +184,9 @@ def _extract_side_context(config: Mapping[str, Any], pside: str) -> dict[str, An
             risk.get("position_exposure_enforcer_threshold", 0.0),
             f"bot.{pside}.risk.position_exposure_enforcer_threshold",
         ),
+        "total_exposure_entry_gate_enabled": bool(
+            risk.get("total_exposure_entry_gate_enabled", False)
+        ),
         "entry_cooldown_minutes": _finite_float(
             risk.get("entry_cooldown_minutes", 0.0),
             f"bot.{pside}.risk.entry_cooldown_minutes",
@@ -809,12 +812,25 @@ def _classify_side(
             )
         if context.get("position_exposure_enforcer_enabled", False):
             enforcer_threshold = context.get("position_exposure_enforcer_threshold", 0.0)
+            if context["active"] and forced_mode not in {"panic", "manual"}:
+                overall.append(
+                    "Position-exposure enforcement is enabled at "
+                    f"{enforcer_threshold * 100.0:g}% WE / effective WEL. CLOSE rows above that "
+                    "ratio are marked 'WEL reducer first': the next-close path returns a market-side "
+                    "reducer before strategy close logic, including in 'tp_only' mode. Expanded close "
+                    "generation simulates that reduction and may then add strategy closes recomputed at "
+                    "the lower exposure. Post-reduction prices require runtime sizing and exchange inputs."
+                )
+            else:
+                overall.append(
+                    "Position-exposure enforcement is configured, but the disabled side or current "
+                    "forced mode keeps that close path dormant."
+                )
+        if context.get("total_exposure_entry_gate_enabled", False):
             overall.append(
-                "Position-exposure enforcement is enabled at "
-                f"{enforcer_threshold * 100.0:g}% WE / effective WEL. CLOSE rows above that "
-                "ratio are marked 'WEL reducer first': the next-close path returns a market-side "
-                "reducer before strategy close logic, including in 'tp_only' mode. Expanded close "
-                "generation simulates that reduction and may then add the displayed strategy closes."
+                "The account-wide total-exposure entry gate is enabled. Eligible RE-ENTRY / ADD "
+                "rows are marked 'portfolio-dependent': after strategy calculation, the orchestrator "
+                "may crop or remove the order based on exposure consumed by all positions on this side."
             )
     if representative["volatility_scenario_count"] == 1:
         basis = (
@@ -905,7 +921,11 @@ def build_overview(
                     "exposure_cap" if entry_exposure_capped else None
                 )
                 enforcer_enabled = bool(
-                    context and context.get("position_exposure_enforcer_enabled", False)
+                    context
+                    and context["active"]
+                    and context.get("forced_mode", "normal")
+                    not in {"panic", "manual"}
+                    and context.get("position_exposure_enforcer_enabled", False)
                 )
                 enforcer_threshold = (
                     _finite_float(
@@ -918,6 +938,11 @@ def build_overview(
                 close_payload["preceded_by"] = (
                     "position_exposure_enforcer"
                     if enforcer_enabled and exposure_ratio > enforcer_threshold
+                    else None
+                )
+                close_payload["post_reduction_geometry"] = (
+                    "requires_runtime_sizing_inputs"
+                    if close_payload["preceded_by"] == "position_exposure_enforcer"
                     else None
                 )
                 rows.append(
@@ -1166,7 +1191,11 @@ def _scenario_runtime_path(
         if kind == "entry" and forced_mode == "tp_only":
             return "tp_only blocked"
     if kind == "entry":
-        return "exposure-capped" if payload.get("inactive_reason") == "exposure_cap" else "re-entry"
+        if payload.get("inactive_reason") == "exposure_cap":
+            return "exposure-capped"
+        if context and context.get("total_exposure_entry_gate_enabled", False):
+            return "portfolio-dependent"
+        return "re-entry"
     if payload.get("preceded_by") == "position_exposure_enforcer":
         return "WEL reducer first"
     return "strategy close"
@@ -1178,7 +1207,11 @@ def _scenario_rows(side: Mapping[str, Any], kind: str) -> list[list[str]]:
         payload = scenario[kind]
         geometry = payload["geometry"]
         runtime_path = _scenario_runtime_path(side, kind, payload)
-        if not payload["trailing_enabled"]:
+        if payload.get("post_reduction_geometry") == "requires_runtime_sizing_inputs":
+            confirmation = "post-WE varies"
+            threshold_price = "post-WE varies"
+            order_reference = "post-WE varies"
+        elif not payload["trailing_enabled"]:
             confirmation = "passive"
             threshold_price = "n/a"
             order_reference = _scenario_price(geometry["passive_reference_price"])
@@ -1292,7 +1325,11 @@ def render_overview(result: Mapping[str, Any]) -> str:
             "99.9% of effective WEL, while trailing entries stop only when strictly above 99.9%.",
             "* A CLOSE row marked 'WEL reducer first' remains relevant: a next-close request returns "
             "the reducer first, while expanded ideal-order generation simulates its fill and may then "
-            "include ordinary strategy closes using the displayed geometry.",
+            "include strategy closes whose WE-weighted threshold is recomputed after reduction. The "
+            "threshold/retracement percentages shown are pre-reducer examples; post-reduction prices "
+            "cannot be inferred without balance, position, exchange-step, and minimum-quantity inputs.",
+            "* A RE-ENTRY / ADD row marked 'portfolio-dependent' passed the per-position calculation, "
+            "but the account-wide total-exposure gate may crop or remove it using all positions on that side.",
             "* With close trailing enabled, a non-positive threshold is immediate: trailing is "
             "armed from position open. With close trailing disabled, the row is passive and no "
             "extrema or reversal confirmation participate.",

--- a/src/tools/trailing_inspect.py
+++ b/src/tools/trailing_inspect.py
@@ -1264,8 +1264,8 @@ def build_parser() -> argparse.ArgumentParser:
         "--position-price",
         dest="price_anchor",
         type=float,
-        default=100.0,
-        help="Average position price used for example trigger geometry",
+        default=None,
+        help="Average position price used for example trigger geometry (overview default: 100)",
     )
     state.add_argument("--wallet-exposure", type=float, default=None, help="Current WE ratio")
     state.add_argument(
@@ -1345,6 +1345,10 @@ def main(argv: Sequence[str] | None = None) -> int:
                     "detailed single-scenario mode requires both --wallet-exposure and "
                     "--effective-wallet-exposure-limit"
                 )
+            if args.price_anchor is None:
+                raise ValueError(
+                    "detailed single-scenario mode requires an explicit --position-price"
+                )
             pside = args.side or "long"
             params, source = load_parameter_source(config_path, pside)
             overridden = apply_parameter_overrides(params, args)
@@ -1376,7 +1380,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             result = build_overview(
                 sources=sources,
                 parameter_source=source,
-                price_anchor=args.price_anchor,
+                price_anchor=args.price_anchor if args.price_anchor is not None else 100.0,
                 volatility_scenarios=args.volatility_scenarios,
                 exposure_ratios=args.exposure_ratios,
                 overridden_parameters=overridden_by_side,

--- a/src/tools/trailing_inspect.py
+++ b/src/tools/trailing_inspect.py
@@ -153,12 +153,24 @@ def _extract_side_context(config: Mapping[str, Any], pside: str) -> dict[str, An
     )
     n_positions = int(_finite_float(risk.get("n_positions"), f"bot.{pside}.risk.n_positions"))
     forced_mode_raw = str(live.get(f"forced_mode_{pside}", "") or "").strip()
-    forced_mode = expand_PB_mode(forced_mode_raw) if forced_mode_raw else "normal"
+    try:
+        forced_mode = expand_PB_mode(forced_mode_raw) if forced_mode_raw else "normal"
+    except Exception as exc:
+        raise ValueError(
+            f"invalid live.forced_mode_{pside}={forced_mode_raw!r}: {exc}"
+        ) from exc
     return {
         "active": total_wallet_exposure_limit > 0.0 and n_positions > 0,
         "total_wallet_exposure_limit": total_wallet_exposure_limit,
         "n_positions": n_positions,
         "forced_mode": forced_mode,
+        "position_exposure_enforcer_enabled": bool(
+            risk.get("position_exposure_enforcer_enabled", False)
+        ),
+        "position_exposure_enforcer_threshold": _finite_float(
+            risk.get("position_exposure_enforcer_threshold", 0.0),
+            f"bot.{pside}.risk.position_exposure_enforcer_threshold",
+        ),
         "entry_cooldown_minutes": _finite_float(
             risk.get("entry_cooldown_minutes", 0.0),
             f"bot.{pside}.risk.entry_cooldown_minutes",
@@ -761,9 +773,19 @@ def _classify_side(
             "minimum-quantity, rounding, and exposure-cropping rules."
         )
         overall.append(
-            f"Each trailing close targets {context['close_qty_pct'] * 100.0:.2f}% before "
-            "minimum-size and remaining-position rules."
+            "Each strategy close starts from the allowed full-position size × "
+            f"{context['close_qty_pct'] * 100.0:.2f}%, adds any current position size above "
+            "that allowed full size, then caps at the remaining position and applies minimum-quantity, "
+            "rounding, and dust-remainder rules."
         )
+        if context.get("position_exposure_enforcer_enabled", False):
+            enforcer_threshold = context.get("position_exposure_enforcer_threshold", 0.0)
+            overall.append(
+                "Position-exposure enforcement is enabled at "
+                f"{enforcer_threshold * 100.0:g}% WE / effective WEL. CLOSE rows above that "
+                "ratio are marked 'WEL auto-reduce': Rust returns a market-side exposure-reduction "
+                "order before trailing/passive close logic, including in 'tp_only' mode."
+            )
     if representative["volatility_scenario_count"] == 1:
         basis = (
             f"Headlines use {representative['normal_label']!r} volatility at "
@@ -842,6 +864,23 @@ def build_overview(
                     overridden_parameters=(overridden_parameters or {}).get(pside, ()),
                 )
                 scenario_results[(label, exposure_ratio)] = result
+                close_payload = deepcopy(result["close"])
+                enforcer_enabled = bool(
+                    context and context.get("position_exposure_enforcer_enabled", False)
+                )
+                enforcer_threshold = (
+                    _finite_float(
+                        context.get("position_exposure_enforcer_threshold", 0.0),
+                        "position_exposure_enforcer_threshold",
+                    )
+                    if context
+                    else 0.0
+                )
+                close_payload["superseded_by"] = (
+                    "position_exposure_enforcer"
+                    if enforcer_enabled and exposure_ratio > enforcer_threshold
+                    else None
+                )
                 rows.append(
                     {
                         "volatility_label": label,
@@ -849,7 +888,7 @@ def build_overview(
                         "volatility_ema_1h": volatility_ema_1h,
                         "exposure_ratio": exposure_ratio,
                         "entry": result["entry"],
-                        "close": result["close"],
+                        "close": close_payload,
                     }
                 )
 
@@ -1080,6 +1119,11 @@ def _scenario_rows(side: Mapping[str, Any], kind: str) -> list[list[str]]:
     for scenario in side["scenarios"]:
         payload = scenario[kind]
         geometry = payload["geometry"]
+        runtime_path = (
+            "WEL auto-reduce"
+            if payload.get("superseded_by") == "position_exposure_enforcer"
+            else ("re-entry" if kind == "entry" else "strategy close")
+        )
         if not payload["trailing_enabled"]:
             confirmation = "passive"
             threshold_price = "n/a"
@@ -1103,6 +1147,7 @@ def _scenario_rows(side: Mapping[str, Any], kind: str) -> list[list[str]]:
                 _fmt_pct(payload["retracement_pct"]),
                 confirmation,
                 order_reference,
+                runtime_path,
             ]
         )
     return rows
@@ -1150,6 +1195,7 @@ def render_overview(result: Mapping[str, Any]) -> str:
         "Retrace",
         "R confirm*",
         "Order ref*",
+        "Runtime path",
     )
     for pside, side in result["sides"].items():
         classification = side["classification"]
@@ -1166,7 +1212,7 @@ def render_overview(result: Mapping[str, Any]) -> str:
         if side["overridden_parameters"]:
             lines.append("  Overrides: " + ", ".join(side["overridden_parameters"]))
 
-        lines.extend(["", f"  ENTRY — {classification['entry_headline']}"])
+        lines.extend(["", f"  RE-ENTRY / ADD — {classification['entry_headline']}"])
         lines.extend(_parameter_summary(side, "entry"))
         lines.extend(f"  • {comment}" for comment in classification["entry_comments"])
         lines.extend(_format_table(headers, _scenario_rows(side, "entry")))
@@ -1183,6 +1229,11 @@ def render_overview(result: Mapping[str, Any]) -> str:
             "confirmation follows the running low/high, so a farther extreme moves the trigger.",
             "* Order ref is Rust's analytical emitted-order reference after both conditions pass; "
             "the live price is also constrained by bid/ask, tick rounding, sizing, exposure caps, and EMA gating.",
+            "* Re-entry/add rows apply only while a position already exists. While flat, Rust bypasses "
+            "trailing threshold/retracement and submits the initial entry at bid/ask, optionally pushed "
+            "farther from market by the configured initial-entry EMA gate.",
+            "* A CLOSE row marked 'WEL auto-reduce' is superseded at that exposure ratio: Rust returns "
+            "the position-exposure-enforcer order before evaluating the displayed strategy close.",
             "* With close trailing enabled, a non-positive threshold is immediate: trailing is "
             "armed from position open. With close trailing disabled, the row is passive and no "
             "extrema or reversal confirmation participate.",

--- a/src/tools/trailing_inspect.py
+++ b/src/tools/trailing_inspect.py
@@ -254,6 +254,9 @@ def _extract_side_context(config: Mapping[str, Any], pside: str) -> dict[str, An
             unstuck.get("loss_allowance_pct", 0.0),
             f"bot.{pside}.unstuck.loss_allowance_pct",
         ),
+        "unstuck_ema_gating_enabled": bool(
+            unstuck.get("ema_gating_enabled", False)
+        ),
         "unstuck_threshold": _finite_float(
             unstuck.get("threshold", 0.0), f"bot.{pside}.unstuck.threshold"
         ),
@@ -663,6 +666,7 @@ def _unstuck_active(context: Mapping[str, Any] | None) -> bool:
         and context.get("unstuck_enabled", False)
         and context.get("unstuck_close_pct", 0.0) > 0.0
         and context.get("unstuck_loss_allowance_pct", 0.0) > 0.0
+        and context.get("unstuck_threshold", 0.0) > 0.0
     )
 
 
@@ -722,8 +726,11 @@ def _classify_side(
             if entry["threshold_pct"] == 0.0:
                 entry_comments.append(
                     "Trailing entries are disabled, entry cooldown is zero, and the passive threshold "
-                    "is zero: the first add remains at the position price, and the next simulated rung "
-                    "duplicates it, so Rust emits one at-position rung."
+                    "is zero. Rust clamps the first add to bid/ask when market touch is more adverse "
+                    "than the position-price reference, and an enabled re-entry EMA gate may push it "
+                    "farther away; recursive simulation then duplicates that price, so one touch/EMA-clamped "
+                    "rung is emitted. The overview has no current market or EMA state, so its exact price "
+                    "cannot be inferred."
                 )
             elif entry["threshold_pct"] < 0.0:
                 entry_comments.append(
@@ -957,18 +964,23 @@ def _classify_side(
                     "current forced mode keeps that repair path dormant."
                 )
         if _unstuck_active(context):
+            unstuck_ema_note = (
+                "EMA gating is enabled, so EMA trigger and readiness also constrain the candidate."
+                if context.get("unstuck_ema_gating_enabled", False)
+                else "EMA gating is disabled, so EMA trigger and readiness do not constrain the candidate."
+            )
             overall.append(
                 "Auto-unstuck is active with close quantity "
                 f"{context['unstuck_close_pct'] * 100.0:g}%, loss allowance "
                 f"{context['unstuck_loss_allowance_pct'] * 100.0:g}%, and position threshold "
                 f"{context['unstuck_threshold'] * 100.0:g}%. CLOSE rows are unstuck-dependent: "
                 "Rust may contribute a globally selected unstuck candidate based on realized PnL and "
-                "portfolio/position state."
+                f"portfolio/position state. {unstuck_ema_note}"
             )
         elif context.get("unstuck_enabled", False):
             overall.append(
-                "Auto-unstuck is enabled but inactive because its close quantity or loss allowance "
-                "is non-positive."
+                "Auto-unstuck is enabled but inactive because its close quantity, loss allowance, "
+                "or position threshold is non-positive."
             )
         if context.get("max_realized_loss_pct", 1.0) < 1.0:
             overall.append(
@@ -1617,7 +1629,7 @@ def render_overview(result: Mapping[str, Any]) -> str:
             "* A CLOSE runtime path containing 'TWEL-dependent' may coexist with an account-wide "
             "repair close. Which position is reduced and by how much requires full same-side portfolio state.",
             "* 'unstuck-dependent' means auto-unstuck may become the selected protective reducer when "
-            "its realized-PnL allowance, EMA gate, and position conditions pass.",
+            "its realized-PnL allowance, position conditions, and any enabled EMA gate pass.",
             "* 'PnL-gated' means the realized-loss batch gate may remove losing strategy or protective "
             "closes after projected PnL and fees are evaluated against account-wide allowance.",
             "* 'context unknown' is used for strategy-default reports without a config; no claim is "

--- a/tests/test_trailing_inspect_tool.py
+++ b/tests/test_trailing_inspect_tool.py
@@ -52,6 +52,9 @@ def _context(
     enforcer_enabled=False,
     enforcer_threshold=0.8,
     total_entry_gate=False,
+    total_enforcer=False,
+    total_enforcer_threshold=0.9,
+    total_enforcer_policy="reduce_portfolio",
 ):
     return {
         "active": active,
@@ -61,6 +64,9 @@ def _context(
         "position_exposure_enforcer_enabled": enforcer_enabled,
         "position_exposure_enforcer_threshold": enforcer_threshold,
         "total_exposure_entry_gate_enabled": total_entry_gate,
+        "total_exposure_enforcer_enabled": total_enforcer,
+        "total_exposure_enforcer_threshold": total_enforcer_threshold,
+        "total_exposure_enforcer_policy": total_enforcer_policy,
         "entry_cooldown_minutes": cooldown,
         "entry_ema_gate_mode": "all",
         "entry_initial_ema_dist": 0.01,
@@ -301,6 +307,9 @@ def test_extract_side_context_includes_global_forced_mode():
                     "position_exposure_enforcer_enabled": True,
                     "position_exposure_enforcer_threshold": 0.8,
                     "total_exposure_entry_gate_enabled": True,
+                    "total_exposure_enforcer_enabled": True,
+                    "total_exposure_enforcer_threshold": 0.9,
+                    "total_exposure_enforcer_policy": "reduce_portfolio",
                 },
                 "strategy": {
                     "trailing_martingale": {
@@ -318,6 +327,9 @@ def test_extract_side_context_includes_global_forced_mode():
     assert context["position_exposure_enforcer_enabled"] is True
     assert context["position_exposure_enforcer_threshold"] == pytest.approx(0.8)
     assert context["total_exposure_entry_gate_enabled"] is True
+    assert context["total_exposure_enforcer_enabled"] is True
+    assert context["total_exposure_enforcer_threshold"] == pytest.approx(0.9)
+    assert context["total_exposure_enforcer_policy"] == "reduce_portfolio"
 
 
 def test_extract_side_context_translates_invalid_forced_mode_to_value_error():
@@ -426,6 +438,32 @@ def test_overview_marks_entries_portfolio_dependent_when_total_gate_enabled():
     assert "exposure-capped" in report
 
 
+def test_overview_marks_closes_account_dependent_when_total_enforcer_enabled():
+    result = trailing_inspect.build_overview(
+        sources={
+            "long": {
+                "params": _params(),
+                "context": _context(
+                    total_enforcer=True,
+                    total_enforcer_threshold=0.85,
+                    total_enforcer_policy="reduce_overweight",
+                ),
+            }
+        },
+        parameter_source="test config",
+        price_anchor=100.0,
+        volatility_scenarios=(("normal", 0.005, 0.0025),),
+        exposure_ratios=(0.5,),
+    )
+
+    report = trailing_inspect.render_overview(result)
+    assert "total-exposure enforcer is enabled at 85% of side TWEL" in report
+    assert "policy 'reduce_overweight'" in report
+    assert "TWEL-dependent close" in report
+    assert "may append a TWEL repair close" in report
+    assert "requires full same-side portfolio state" in report
+
+
 def test_overview_separates_initial_entry_and_describes_close_qty_basis():
     result = trailing_inspect.build_overview(
         sources={"long": {"params": _params(), "context": _context()}},
@@ -465,6 +503,25 @@ def test_overview_marks_entry_exposure_cap_with_exact_rust_boundaries():
         exposure_ratios=(0.999,),
     )
     assert passive["sides"]["long"]["scenarios"][0]["entry"]["inactive_reason"] == "exposure_cap"
+
+
+def test_overview_marks_long_threshold_at_100_percent_unreachable():
+    params = _params()
+    params["entry"]["threshold_base_pct"] = 1.0
+    result = trailing_inspect.build_overview(
+        sources={"long": {"params": params, "context": _context(total_entry_gate=True)}},
+        parameter_source="test config",
+        price_anchor=100.0,
+        volatility_scenarios=(("normal", 0.0, 0.0),),
+        exposure_ratios=(0.0,),
+    )
+
+    row = result["sides"]["long"]["scenarios"][0]
+    assert row["entry"]["inactive_reason"] == "unreachable_long_threshold"
+    report = trailing_inspect.render_overview(result)
+    assert "unreachable" in report
+    assert "threshold of at least 100%" in report
+    assert "positive market cannot cross the trailing target" in report
 
 
 def test_overview_qualifies_full_position_passive_close_sizing():
@@ -560,6 +617,21 @@ def test_overview_explains_passive_entry_ladder_and_cooldown(cooldown, expected)
 
     comments = " ".join(result["sides"]["long"]["classification"]["entry_comments"])
     assert expected in comments
+
+
+def test_overview_explains_nonpositive_passive_threshold_emits_one_touch_rung():
+    params = _params()
+    params["entry"]["retracement_base_pct"] = 0.0
+    params["entry"]["threshold_base_pct"] = 0.0
+    result = trailing_inspect.build_overview(
+        sources={"long": {"params": params, "context": _context(cooldown=0.0)}},
+        parameter_source="test config",
+        price_anchor=100.0,
+    )
+
+    comments = " ".join(result["sides"]["long"]["classification"]["entry_comments"])
+    assert "Only one market-touch rung is emitted" in comments
+    assert "full recursive entry ladder simultaneously" not in comments
 
 
 def test_main_positional_config_defaults_to_overview_and_accepts_price_anchor(

--- a/tests/test_trailing_inspect_tool.py
+++ b/tests/test_trailing_inspect_tool.py
@@ -367,7 +367,7 @@ def test_overview_explains_global_forced_mode(forced_mode, expected):
     assert "Long is enabled" not in comments
 
 
-def test_overview_marks_close_scenarios_superseded_by_position_enforcer():
+def test_overview_marks_position_enforcer_before_close_geometry():
     result = trailing_inspect.build_overview(
         sources={
             "long": {
@@ -384,13 +384,15 @@ def test_overview_marks_close_scenarios_superseded_by_position_enforcer():
     scenarios = result["sides"]["long"]["scenarios"]
     at_threshold = next(row for row in scenarios if row["exposure_ratio"] == 0.8)
     above_threshold = next(row for row in scenarios if row["exposure_ratio"] == 0.9)
-    assert at_threshold["close"]["superseded_by"] is None
-    assert above_threshold["close"]["superseded_by"] == "position_exposure_enforcer"
+    assert at_threshold["close"]["preceded_by"] is None
+    assert above_threshold["close"]["preceded_by"] == "position_exposure_enforcer"
 
     report = trailing_inspect.render_overview(result)
     assert "Position-exposure enforcement is enabled at 80% WE / effective WEL" in report
-    assert "WEL auto-reduce" in report
-    assert "before trailing/passive close logic" in report
+    assert "WEL reducer first" in report
+    assert "Expanded close generation simulates that reduction" in report
+    assert "may then add the displayed strategy closes" in report
+    assert "remains relevant" in report
 
 
 def test_overview_separates_initial_entry_and_describes_close_qty_basis():
@@ -448,6 +450,52 @@ def test_overview_qualifies_full_position_passive_close_sizing():
     assert "ignores the configured close quantity percentage" in comments
     assert "targets the full remaining position" in comments
     assert "allowed full-position size × 25.00%" not in comments
+
+
+def test_inspect_rejects_non_finite_derived_geometry():
+    with pytest.raises(ValueError, match=r"derived value result\..* is not finite"):
+        trailing_inspect.inspect_trailing(
+            symbol="COIN",
+            pside="long",
+            position_size=None,
+            position_price=100.0,
+            wallet_exposure=0.5,
+            effective_wallet_exposure_limit=1.0,
+            volatility_ema_1m=1e308,
+            volatility_ema_1h=0.0,
+            params=_params(),
+            parameter_source="test",
+        )
+
+
+@pytest.mark.parametrize("json_args", ((), ("--json",)))
+def test_main_reports_derived_overflow_without_traceback(monkeypatch, capsys, json_args):
+    monkeypatch.setattr(
+        trailing_inspect,
+        "load_overview_sources",
+        lambda config_path, psides: (
+            {pside: {"params": _params(), "context": _context()} for pside in psides},
+            "test config",
+        ),
+    )
+
+    assert (
+        trailing_inspect.main(
+            [
+                "--side",
+                "long",
+                "--volatility-scenarios",
+                "huge:1e308:0",
+                *json_args,
+            ]
+        )
+        == 2
+    )
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "error: derived value" in captured.err
+    assert "is not finite" in captured.err
+    assert "Traceback" not in captured.err
 
 
 def test_overview_qualifies_immediate_close_by_trailing_mode():

--- a/tests/test_trailing_inspect_tool.py
+++ b/tests/test_trailing_inspect_tool.py
@@ -212,6 +212,22 @@ def test_main_rejects_non_positive_effective_limit(monkeypatch, capsys):
     assert "must be greater than zero" in capsys.readouterr().err
 
 
+@pytest.mark.parametrize(
+    "state_args",
+    (
+        ("--wallet-exposure", "0.6"),
+        ("--effective-wallet-exposure-limit", "0.9"),
+        ("--volatility-ema-1m", "0.01"),
+    ),
+)
+def test_detailed_mode_requires_both_exposure_inputs(state_args, capsys):
+    assert trailing_inspect.main([*state_args, "--json"]) == 2
+    assert (
+        "requires both --wallet-exposure and --effective-wallet-exposure-limit"
+        in capsys.readouterr().err
+    )
+
+
 def test_overview_scenario_grid_uses_formulas_and_side_geometry():
     result = trailing_inspect.build_overview(
         sources={
@@ -243,6 +259,19 @@ def test_overview_scenario_grid_uses_formulas_and_side_geometry():
     assert "dormant parameters" in " ".join(
         result["sides"]["short"]["classification"]["overall_comments"]
     )
+
+
+def test_overview_qualifies_immediate_close_by_trailing_mode():
+    result = trailing_inspect.build_overview(
+        sources={"long": {"params": _params(), "context": _context()}},
+        parameter_source="test config",
+        price_anchor=100.0,
+    )
+
+    report = trailing_inspect.render_overview(result)
+    assert "With close trailing enabled, a non-positive threshold is immediate" in report
+    assert "With close trailing disabled, the row is passive" in report
+    assert "no extrema or reversal confirmation participate" in report
 
 
 @pytest.mark.parametrize(

--- a/tests/test_trailing_inspect_tool.py
+++ b/tests/test_trailing_inspect_tool.py
@@ -55,18 +55,28 @@ def _context(
     total_enforcer=False,
     total_enforcer_threshold=0.9,
     total_enforcer_policy="reduce_portfolio",
+    unstuck_enabled=False,
+    unstuck_close_pct=0.0,
+    unstuck_loss_allowance_pct=0.0,
+    unstuck_threshold=0.0,
+    max_realized_loss_pct=1.0,
 ):
     return {
         "active": active,
         "total_wallet_exposure_limit": 1.0 if active else 0.0,
         "n_positions": 1,
         "forced_mode": forced_mode,
+        "max_realized_loss_pct": max_realized_loss_pct,
         "position_exposure_enforcer_enabled": enforcer_enabled,
         "position_exposure_enforcer_threshold": enforcer_threshold,
         "total_exposure_entry_gate_enabled": total_entry_gate,
         "total_exposure_enforcer_enabled": total_enforcer,
         "total_exposure_enforcer_threshold": total_enforcer_threshold,
         "total_exposure_enforcer_policy": total_enforcer_policy,
+        "unstuck_enabled": unstuck_enabled,
+        "unstuck_close_pct": unstuck_close_pct,
+        "unstuck_loss_allowance_pct": unstuck_loss_allowance_pct,
+        "unstuck_threshold": unstuck_threshold,
         "entry_cooldown_minutes": cooldown,
         "entry_ema_gate_mode": "all",
         "entry_initial_ema_dist": 0.01,
@@ -295,9 +305,9 @@ def test_overview_scenario_grid_uses_formulas_and_side_geometry():
     )
 
 
-def test_extract_side_context_includes_global_forced_mode():
+def test_extract_side_context_includes_global_and_risk_paths():
     config = {
-        "live": {"forced_mode_long": "p"},
+        "live": {"forced_mode_long": "p", "max_realized_loss_pct": 0.05},
         "bot": {
             "long": {
                 "risk": {
@@ -310,6 +320,12 @@ def test_extract_side_context_includes_global_forced_mode():
                     "total_exposure_enforcer_enabled": True,
                     "total_exposure_enforcer_threshold": 0.9,
                     "total_exposure_enforcer_policy": "reduce_portfolio",
+                },
+                "unstuck": {
+                    "enabled": True,
+                    "close_pct": 0.1,
+                    "loss_allowance_pct": 0.02,
+                    "threshold": 0.7,
                 },
                 "strategy": {
                     "trailing_martingale": {
@@ -330,6 +346,11 @@ def test_extract_side_context_includes_global_forced_mode():
     assert context["total_exposure_enforcer_enabled"] is True
     assert context["total_exposure_enforcer_threshold"] == pytest.approx(0.9)
     assert context["total_exposure_enforcer_policy"] == "reduce_portfolio"
+    assert context["unstuck_enabled"] is True
+    assert context["unstuck_close_pct"] == pytest.approx(0.1)
+    assert context["unstuck_loss_allowance_pct"] == pytest.approx(0.02)
+    assert context["unstuck_threshold"] == pytest.approx(0.7)
+    assert context["max_realized_loss_pct"] == pytest.approx(0.05)
 
 
 def test_extract_side_context_translates_invalid_forced_mode_to_value_error():
@@ -409,7 +430,7 @@ def test_overview_marks_position_enforcer_before_close_geometry():
 
     report = trailing_inspect.render_overview(result)
     assert "Position-exposure enforcement is enabled at 80% WE / effective WEL" in report
-    assert "WEL reducer first" in report
+    assert "WEL-first" in report
     assert "Expanded close generation simulates that reduction" in report
     assert "strategy closes recomputed at the lower exposure" in report
     assert "remains relevant" in report
@@ -459,9 +480,54 @@ def test_overview_marks_closes_account_dependent_when_total_enforcer_enabled():
     report = trailing_inspect.render_overview(result)
     assert "total-exposure enforcer is enabled at 85% of side TWEL" in report
     assert "policy 'reduce_overweight'" in report
-    assert "TWEL-dependent close" in report
+    assert "TWEL-dependent" in report
     assert "may append a TWEL repair close" in report
     assert "requires full same-side portfolio state" in report
+
+
+def test_overview_marks_unstuck_and_realized_loss_close_dependencies():
+    result = trailing_inspect.build_overview(
+        sources={
+            "long": {
+                "params": _params(),
+                "context": _context(
+                    unstuck_enabled=True,
+                    unstuck_close_pct=0.1,
+                    unstuck_loss_allowance_pct=0.02,
+                    unstuck_threshold=0.7,
+                    max_realized_loss_pct=0.05,
+                ),
+            }
+        },
+        parameter_source="test config",
+        price_anchor=100.0,
+        volatility_scenarios=(("normal", 0.005, 0.0025),),
+        exposure_ratios=(0.5,),
+    )
+
+    report = trailing_inspect.render_overview(result)
+    assert "Auto-unstuck is active with close quantity 10%" in report
+    assert "loss allowance 2%" in report
+    assert "position threshold 70%" in report
+    assert "unstuck-dependent" in report
+    assert "realized-loss gate is active at 5% of peak balance" in report
+    assert "PnL-gated" in report
+    assert "projected batch PnL" in report
+
+
+def test_overview_without_config_marks_runtime_context_unknown():
+    result = trailing_inspect.build_overview(
+        sources={"long": {"params": _params(), "context": None}},
+        parameter_source="Rust-owned defaults",
+        price_anchor=100.0,
+        volatility_scenarios=(("normal", 0.005, 0.0025),),
+        exposure_ratios=(0.5,),
+    )
+
+    report = trailing_inspect.render_overview(result)
+    assert "only strategy defaults are known" in report
+    assert report.count("context unknown") >= 3
+    assert "runtime-path labels are intentionally marked" in report
 
 
 def test_overview_separates_initial_entry_and_describes_close_qty_basis():
@@ -522,6 +588,28 @@ def test_overview_marks_long_threshold_at_100_percent_unreachable():
     assert "unreachable" in report
     assert "threshold of at least 100%" in report
     assert "positive market cannot cross the trailing target" in report
+
+
+def test_overview_marks_short_close_threshold_at_100_percent_unreachable():
+    params = _params()
+    params["close"]["threshold_base_pct"] = 1.0
+    params["close"]["threshold_we_weight"] = 0.0
+    params["close"]["threshold_volatility_1m_weight"] = 0.0
+    params["close"]["threshold_volatility_1h_weight"] = 0.0
+    result = trailing_inspect.build_overview(
+        sources={"short": {"params": params, "context": _context()}},
+        parameter_source="test config",
+        price_anchor=100.0,
+        volatility_scenarios=(("normal", 0.0, 0.0),),
+        exposure_ratios=(0.0,),
+    )
+
+    row = result["sides"]["short"]["scenarios"][0]
+    assert row["close"]["inactive_reason"] == "unreachable_short_threshold"
+    report = trailing_inspect.render_overview(result)
+    assert "unreachable" in report
+    assert "short CLOSE row" in report
+    assert "positive market cannot satisfy the trailing threshold" in report
 
 
 def test_overview_qualifies_full_position_passive_close_sizing():

--- a/tests/test_trailing_inspect_tool.py
+++ b/tests/test_trailing_inspect_tool.py
@@ -320,3 +320,55 @@ def test_overview_single_custom_scenario_does_not_invent_sensitivity_comparison(
     assert classification["entry_headline"].startswith("one volatility scenario shown")
     assert classification["basis"] == "Headlines use 'stress' volatility at 75% WE/WEL."
     assert "Only one exposure ratio is shown" in " ".join(classification["entry_comments"])
+
+
+def test_overview_sizing_description_matches_current_position_formula():
+    result = trailing_inspect.build_overview(
+        sources={"long": {"params": _params(), "context": _context()}},
+        parameter_source="test config",
+        price_anchor=100.0,
+    )
+
+    comments = " ".join(result["sides"]["long"]["classification"]["overall_comments"])
+    assert "current absolute position size × 1.5 or initial-entry quantity" in comments
+    assert "minimum-quantity, rounding, and exposure-cropping rules" in comments
+    assert "previous fill" not in comments
+
+
+def test_volatility_sensitivity_includes_retracement_changes():
+    params = _params()
+    for kind in ("entry", "close"):
+        params[kind]["threshold_volatility_1m_weight"] = 0.0
+        params[kind]["threshold_volatility_1h_weight"] = 0.0
+        params[kind]["retracement_volatility_1m_weight"] = 100.0
+        params[kind]["retracement_volatility_1h_weight"] = 100.0
+    result = trailing_inspect.build_overview(
+        sources={"long": {"params": params, "context": _context()}},
+        parameter_source="test config",
+        price_anchor=100.0,
+    )
+
+    classification = result["sides"]["long"]["classification"]
+    assert classification["entry_headline"].startswith("very strong volatility sensitivity")
+    assert classification["close_headline"].startswith("very strong volatility sensitivity")
+
+
+def test_volatility_sensitivity_selects_extremes_independent_of_input_order():
+    params = _params()
+    params["entry"]["threshold_volatility_1m_weight"] = 20.0
+    params["entry"]["threshold_volatility_1h_weight"] = 20.0
+    params["entry"]["retracement_volatility_1m_weight"] = 0.0
+    params["entry"]["retracement_volatility_1h_weight"] = 0.0
+    result = trailing_inspect.build_overview(
+        sources={"long": {"params": params, "context": _context()}},
+        parameter_source="test config",
+        price_anchor=100.0,
+        volatility_scenarios=(
+            ("quiet", 0.001, 0.0005),
+            ("extreme", 0.05, 0.025),
+            ("normal", 0.005, 0.0025),
+        ),
+    )
+
+    headline = result["sides"]["long"]["classification"]["entry_headline"]
+    assert headline.startswith("very strong volatility sensitivity")

--- a/tests/test_trailing_inspect_tool.py
+++ b/tests/test_trailing_inspect_tool.py
@@ -44,12 +44,21 @@ def _inspect(pside="long"):
     )
 
 
-def _context(*, active=True, cooldown=1.5, forced_mode="normal"):
+def _context(
+    *,
+    active=True,
+    cooldown=1.5,
+    forced_mode="normal",
+    enforcer_enabled=False,
+    enforcer_threshold=0.8,
+):
     return {
         "active": active,
         "total_wallet_exposure_limit": 1.0 if active else 0.0,
         "n_positions": 1,
         "forced_mode": forced_mode,
+        "position_exposure_enforcer_enabled": enforcer_enabled,
+        "position_exposure_enforcer_threshold": enforcer_threshold,
         "entry_cooldown_minutes": cooldown,
         "entry_ema_gate_mode": "all",
         "entry_initial_ema_dist": 0.01,
@@ -287,6 +296,8 @@ def test_extract_side_context_includes_global_forced_mode():
                     "total_wallet_exposure_limit": 1.0,
                     "n_positions": 1,
                     "entry_cooldown_minutes": 2.0,
+                    "position_exposure_enforcer_enabled": True,
+                    "position_exposure_enforcer_threshold": 0.8,
                 },
                 "strategy": {
                     "trailing_martingale": {
@@ -301,6 +312,32 @@ def test_extract_side_context_includes_global_forced_mode():
 
     context = trailing_inspect._extract_side_context(config, "long")
     assert context["forced_mode"] == "panic"
+    assert context["position_exposure_enforcer_enabled"] is True
+    assert context["position_exposure_enforcer_threshold"] == pytest.approx(0.8)
+
+
+def test_extract_side_context_translates_invalid_forced_mode_to_value_error():
+    config = {
+        "live": {"forced_mode_long": "not-a-mode"},
+        "bot": {
+            "long": {
+                "risk": {
+                    "total_wallet_exposure_limit": 1.0,
+                    "n_positions": 1,
+                },
+                "strategy": {
+                    "trailing_martingale": {
+                        **_params(),
+                        "volatility_ema_span_1m": 100.0,
+                        "volatility_ema_span_1h": 200.0,
+                    }
+                },
+            }
+        },
+    }
+
+    with pytest.raises(ValueError, match="invalid live.forced_mode_long"):
+        trailing_inspect._extract_side_context(config, "long")
 
 
 @pytest.mark.parametrize(
@@ -328,6 +365,47 @@ def test_overview_explains_global_forced_mode(forced_mode, expected):
     assert f"Global forced mode '{forced_mode}'" in comments
     assert expected in comments
     assert "Long is enabled" not in comments
+
+
+def test_overview_marks_close_scenarios_superseded_by_position_enforcer():
+    result = trailing_inspect.build_overview(
+        sources={
+            "long": {
+                "params": _params(),
+                "context": _context(enforcer_enabled=True, enforcer_threshold=0.8),
+            }
+        },
+        parameter_source="test config",
+        price_anchor=100.0,
+        volatility_scenarios=(("normal", 0.005, 0.0025),),
+        exposure_ratios=(0.5, 0.8, 0.9),
+    )
+
+    scenarios = result["sides"]["long"]["scenarios"]
+    at_threshold = next(row for row in scenarios if row["exposure_ratio"] == 0.8)
+    above_threshold = next(row for row in scenarios if row["exposure_ratio"] == 0.9)
+    assert at_threshold["close"]["superseded_by"] is None
+    assert above_threshold["close"]["superseded_by"] == "position_exposure_enforcer"
+
+    report = trailing_inspect.render_overview(result)
+    assert "Position-exposure enforcement is enabled at 80% WE / effective WEL" in report
+    assert "WEL auto-reduce" in report
+    assert "before trailing/passive close logic" in report
+
+
+def test_overview_separates_initial_entry_and_describes_close_qty_basis():
+    result = trailing_inspect.build_overview(
+        sources={"long": {"params": _params(), "context": _context()}},
+        parameter_source="test config",
+        price_anchor=100.0,
+    )
+
+    report = trailing_inspect.render_overview(result)
+    assert "RE-ENTRY / ADD" in report
+    assert "While flat, Rust bypasses trailing threshold/retracement" in report
+    assert "initial entry at bid/ask" in report
+    assert "allowed full-position size × 25.00%" in report
+    assert "adds any current position size above that allowed full size" in report
 
 
 def test_overview_qualifies_immediate_close_by_trailing_mode():

--- a/tests/test_trailing_inspect_tool.py
+++ b/tests/test_trailing_inspect_tool.py
@@ -61,6 +61,7 @@ def _context(
     unstuck_threshold=0.0,
     max_realized_loss_pct=1.0,
     hsl_enabled=False,
+    hedge_mode=False,
 ):
     return {
         "active": active,
@@ -71,7 +72,9 @@ def _context(
         "hsl_enabled_global": hsl_enabled,
         "hsl_enabled_override_symbols": [],
         "hsl_signal_mode": "coin",
+        "hedge_mode": hedge_mode,
         "coin_strategy_override_symbols": [],
+        "coin_context_override_descriptions": [],
         "max_realized_loss_pct": max_realized_loss_pct,
         "position_exposure_enforcer_enabled": enforcer_enabled,
         "position_exposure_enforcer_threshold": enforcer_threshold,
@@ -383,9 +386,11 @@ def test_extract_side_context_reports_hsl_and_omitted_coin_strategy_overrides():
         },
         "coin_overrides": {
             "XRP": {
+                "live": {"forced_mode_long": "manual"},
                 "bot": {
                     "long": {
                         "hsl": {"enabled": True},
+                        "risk": {"entry_cooldown_minutes": 9.0},
                         "strategy": {
                             "trailing_martingale": {
                                 "entry": {"threshold_base_pct": 0.2}
@@ -405,11 +410,18 @@ def test_extract_side_context_reports_hsl_and_omitted_coin_strategy_overrides():
     assert context["hsl_enabled_override_symbols"] == ["XRP"]
     assert context["hsl_signal_mode"] == "coin"
     assert context["coin_strategy_override_symbols"] == ["XRP"]
+    assert context["coin_context_override_descriptions"] == [
+        "DOGE (bot.long.hsl)",
+        "XRP (bot.long.hsl, bot.long.risk, live.forced_mode_long)",
+    ]
 
 
 def test_overview_marks_hsl_runtime_paths_and_coin_override_omission():
     context = _context(hsl_enabled=True)
     context["coin_strategy_override_symbols"] = ["XRP"]
+    context["coin_context_override_descriptions"] = [
+        "XRP (bot.long.risk, live.forced_mode_long)"
+    ]
     result = trailing_inspect.build_overview(
         sources={"long": {"params": _params(), "context": context}},
         parameter_source="test config",
@@ -424,7 +436,38 @@ def test_overview_marks_hsl_runtime_paths_and_coin_override_omission():
     comments = " ".join(side["classification"]["overall_comments"])
     assert "offline config report cannot know the live HSL tier" in comments
     assert "explicitly omitted from these tables" in comments
+    assert "non-strategy runtime overrides are also omitted" in comments
     assert "XRP" in comments
+
+
+@pytest.mark.parametrize("forced_mode", ("panic", "manual"))
+def test_hsl_runtime_precedes_static_forced_mode_labels(forced_mode):
+    result = trailing_inspect.build_overview(
+        sources={
+            "long": {
+                "params": _params(),
+                "context": _context(
+                    hsl_enabled=True,
+                    forced_mode=forced_mode,
+                    enforcer_enabled=True,
+                    enforcer_threshold=0.4,
+                ),
+            }
+        },
+        parameter_source="test config",
+        price_anchor=100.0,
+        volatility_scenarios=(("normal", 0.0, 0.0),),
+        exposure_ratios=(0.5,),
+    )
+
+    side = result["sides"]["long"]
+    entry_path = trailing_inspect._scenario_rows(side, "entry")[0][-1]
+    close_path = trailing_inspect._scenario_rows(side, "close")[0][-1]
+    assert entry_path == f"HSL-dependent / {forced_mode} fallback blocks entry"
+    assert close_path == f"WEL-first / HSL-dependent / {forced_mode} fallback"
+    comments = " ".join(side["classification"]["overall_comments"])
+    assert "HSL runtime state has precedence" in comments
+    assert "Both tables below are dormant" not in comments
 
 
 def test_extract_side_context_translates_invalid_forced_mode_to_value_error():
@@ -555,7 +598,7 @@ def test_overview_marks_closes_account_dependent_when_total_enforcer_enabled():
     assert "total-exposure enforcer is enabled at 85% of side TWEL" in report
     assert "policy 'reduce_overweight'" in report
     assert "TWEL-dependent" in report
-    assert "may append a TWEL repair close" in report
+    assert "may contribute a TWEL repair candidate" in report
     assert "requires full same-side portfolio state" in report
 
 
@@ -615,6 +658,8 @@ def test_overview_separates_initial_entry_and_describes_close_qty_basis():
     assert "RE-ENTRY / ADD" in report
     assert "reaches at least 80% of the calculated initial-entry quantity" in report
     assert "below that 80% boundary, it submits a partial initial entry" in report
+    assert "one-way mode" in report
+    assert "permit only one initial side" in report
     assert "Both initial paths bypass trailing threshold/retracement" in report
     assert "allowed full-position size × 25.00%" in report
     assert "adds any current position size above that allowed full size" in report
@@ -845,10 +890,10 @@ def test_overview_explains_passive_entry_ladder_and_cooldown(cooldown, expected)
     assert expected in comments
 
 
-def test_overview_explains_nonpositive_passive_threshold_emits_one_touch_rung():
+def test_overview_qualifies_negative_passive_threshold_touch_clamp():
     params = _params()
     params["entry"]["retracement_base_pct"] = 0.0
-    params["entry"]["threshold_base_pct"] = 0.0
+    params["entry"]["threshold_base_pct"] = -0.1
     result = trailing_inspect.build_overview(
         sources={"long": {"params": params, "context": _context(cooldown=0.0)}},
         parameter_source="test config",
@@ -856,7 +901,9 @@ def test_overview_explains_nonpositive_passive_threshold_emits_one_touch_rung():
     )
 
     comments = " ".join(result["sides"]["long"]["classification"]["entry_comments"])
-    assert "Only one market-touch rung is emitted" in comments
+    assert "only one market-touch rung when" in comments
+    assert "if that clamp does not bind" in comments
+    assert "cannot know which case applies" in comments
     assert "full recursive entry ladder simultaneously" not in comments
 
 
@@ -925,9 +972,35 @@ def test_overview_sizing_description_matches_current_position_formula():
     )
 
     comments = " ".join(result["sides"]["long"]["classification"]["overall_comments"])
-    assert "current absolute position size × 1.5 or initial-entry quantity" in comments
+    assert "current absolute position size × 1.5" in comments
+    assert "initial exposure slice converted to quantity at the re-entry order price" in comments
+    assert "lower re-entry price therefore produces a larger quantity floor" in comments
     assert "minimum-quantity, rounding, and exposure-cropping rules" in comments
     assert "previous fill" not in comments
+
+
+def test_overview_explains_protective_reducer_consolidation():
+    result = trailing_inspect.build_overview(
+        sources={
+            "long": {
+                "params": _params(),
+                "context": _context(
+                    enforcer_enabled=True,
+                    total_enforcer=True,
+                    unstuck_enabled=True,
+                    unstuck_close_pct=0.1,
+                    unstuck_loss_allowance_pct=0.02,
+                ),
+            }
+        },
+        parameter_source="test config",
+        price_anchor=100.0,
+    )
+
+    report = trailing_inspect.render_overview(result)
+    assert "at most one protective reducer per coin and position side" in report
+    assert "Panic has precedence" in report
+    assert "largest loss-admissible candidate" in report
 
 
 def test_volatility_sensitivity_includes_retracement_changes():

--- a/tests/test_trailing_inspect_tool.py
+++ b/tests/test_trailing_inspect_tool.py
@@ -59,6 +59,7 @@ def _context(
     unstuck_close_pct=0.0,
     unstuck_loss_allowance_pct=0.0,
     unstuck_threshold=0.0,
+    unstuck_ema_gating_enabled=False,
     max_realized_loss_pct=1.0,
     hsl_enabled=False,
     hedge_mode=False,
@@ -86,6 +87,7 @@ def _context(
         "unstuck_close_pct": unstuck_close_pct,
         "unstuck_loss_allowance_pct": unstuck_loss_allowance_pct,
         "unstuck_threshold": unstuck_threshold,
+        "unstuck_ema_gating_enabled": unstuck_ema_gating_enabled,
         "entry_cooldown_minutes": cooldown,
         "entry_ema_gate_mode": "all",
         "entry_initial_ema_dist": 0.01,
@@ -359,6 +361,7 @@ def test_extract_side_context_includes_global_and_risk_paths():
     assert context["unstuck_close_pct"] == pytest.approx(0.1)
     assert context["unstuck_loss_allowance_pct"] == pytest.approx(0.02)
     assert context["unstuck_threshold"] == pytest.approx(0.7)
+    assert context["unstuck_ema_gating_enabled"] is False
     assert context["max_realized_loss_pct"] == pytest.approx(0.05)
 
 
@@ -627,9 +630,55 @@ def test_overview_marks_unstuck_and_realized_loss_close_dependencies():
     assert "loss allowance 2%" in report
     assert "position threshold 70%" in report
     assert "unstuck-dependent" in report
+    assert "EMA gating is disabled" in report
     assert "realized-loss gate is active at 5% of peak balance" in report
     assert "PnL-gated" in report
     assert "projected batch PnL" in report
+
+
+def test_unstuck_requires_positive_threshold():
+    context = _context(
+        unstuck_enabled=True,
+        unstuck_close_pct=0.1,
+        unstuck_loss_allowance_pct=0.02,
+        unstuck_threshold=0.0,
+    )
+    result = trailing_inspect.build_overview(
+        sources={"long": {"params": _params(), "context": context}},
+        parameter_source="test config",
+        price_anchor=100.0,
+        volatility_scenarios=(("normal", 0.0, 0.0),),
+        exposure_ratios=(0.5,),
+    )
+
+    side = result["sides"]["long"]
+    assert trailing_inspect._unstuck_active(context) is False
+    assert "unstuck-dependent" not in trailing_inspect._scenario_rows(side, "close")[0][-1]
+    assert "position threshold is non-positive" in trailing_inspect.render_overview(result)
+
+
+@pytest.mark.parametrize("ema_gating_enabled", (False, True))
+def test_unstuck_explanation_honors_ema_gating_toggle(ema_gating_enabled):
+    result = trailing_inspect.build_overview(
+        sources={
+            "long": {
+                "params": _params(),
+                "context": _context(
+                    unstuck_enabled=True,
+                    unstuck_close_pct=0.1,
+                    unstuck_loss_allowance_pct=0.02,
+                    unstuck_threshold=0.7,
+                    unstuck_ema_gating_enabled=ema_gating_enabled,
+                ),
+            }
+        },
+        parameter_source="test config",
+        price_anchor=100.0,
+    )
+
+    report = trailing_inspect.render_overview(result)
+    expected = "EMA gating is enabled" if ema_gating_enabled else "EMA gating is disabled"
+    assert expected in report
 
 
 def test_overview_without_config_marks_runtime_context_unknown():
@@ -907,6 +956,23 @@ def test_overview_qualifies_negative_passive_threshold_touch_clamp():
     assert "full recursive entry ladder simultaneously" not in comments
 
 
+def test_zero_passive_threshold_reports_touch_and_ema_clamp():
+    params = _params()
+    params["entry"]["retracement_base_pct"] = 0.0
+    params["entry"]["threshold_base_pct"] = 0.0
+    result = trailing_inspect.build_overview(
+        sources={"long": {"params": params, "context": _context(cooldown=0.0)}},
+        parameter_source="test config",
+        price_anchor=100.0,
+    )
+
+    comments = " ".join(result["sides"]["long"]["classification"]["entry_comments"])
+    assert "clamps the first add to bid/ask" in comments
+    assert "enabled re-entry EMA gate may push it" in comments
+    assert "one touch/EMA-clamped rung is emitted" in comments
+    assert "at-position rung" not in comments
+
+
 def test_main_positional_config_defaults_to_overview_and_accepts_price_anchor(
     monkeypatch, capsys
 ):
@@ -990,6 +1056,7 @@ def test_overview_explains_protective_reducer_consolidation():
                     unstuck_enabled=True,
                     unstuck_close_pct=0.1,
                     unstuck_loss_allowance_pct=0.02,
+                    unstuck_threshold=0.7,
                 ),
             }
         },

--- a/tests/test_trailing_inspect_tool.py
+++ b/tests/test_trailing_inspect_tool.py
@@ -139,7 +139,7 @@ def test_non_positive_retracement_reports_passive_mode():
     assert result["close"]["retracement_pct"] == 0.0
     report = trailing_inspect.render_report(result)
     assert report.count("trailing disabled") == 2
-    assert report.count("Passive threshold/reference") == 2
+    assert report.count("Passive analytical reference") == 2
 
 
 def test_extract_strategy_params_requires_canonical_trailing_martingale():
@@ -372,3 +372,46 @@ def test_volatility_sensitivity_selects_extremes_independent_of_input_order():
 
     headline = result["sides"]["long"]["classification"]["entry_headline"]
     assert headline.startswith("very strong volatility sensitivity")
+
+
+@pytest.mark.parametrize(("pside", "expected_reference"), [("long", 98.0), ("short", 102.0)])
+def test_passive_negative_close_threshold_keeps_rust_analytical_reference(
+    pside, expected_reference
+):
+    params = _params()
+    params["close"].update(
+        {
+            "retracement_base_pct": 0.0,
+            "threshold_base_pct": -0.02,
+            "threshold_we_weight": 0.0,
+            "threshold_volatility_1m_weight": 0.0,
+            "threshold_volatility_1h_weight": 0.0,
+        }
+    )
+    result = trailing_inspect.build_overview(
+        sources={pside: {"params": params, "context": _context()}},
+        parameter_source="test config",
+        price_anchor=100.0,
+        volatility_scenarios=(("only", 0.0, 0.0),),
+        exposure_ratios=(0.0,),
+    )
+
+    close = result["sides"][pside]["scenarios"][0]["close"]
+    assert close["geometry"]["threshold_price"] is None
+    assert close["geometry"]["passive_reference_price"] == pytest.approx(expected_reference)
+    table_row = trailing_inspect._scenario_rows(result["sides"][pside], "close")[0]
+    assert table_row[4] == "n/a"
+    assert table_row[7] == f"{expected_reference:.4f}"
+
+
+def test_overview_rejects_duplicate_volatility_scenario_labels():
+    with pytest.raises(ValueError, match="duplicate volatility scenario label.*same"):
+        trailing_inspect.build_overview(
+            sources={"long": {"params": _params(), "context": _context()}},
+            parameter_source="test config",
+            price_anchor=100.0,
+            volatility_scenarios=(
+                ("same", 0.001, 0.0005),
+                ("same", 0.02, 0.01),
+            ),
+        )

--- a/tests/test_trailing_inspect_tool.py
+++ b/tests/test_trailing_inspect_tool.py
@@ -404,6 +404,65 @@ def test_passive_negative_close_threshold_keeps_rust_analytical_reference(
     assert table_row[7] == f"{expected_reference:.4f}"
 
 
+@pytest.mark.parametrize(
+    ("pside", "expected_reference"), [("long", 102.0), ("short", 98.0)]
+)
+def test_passive_negative_entry_threshold_keeps_rust_analytical_reference(
+    pside, expected_reference
+):
+    params = _params()
+    params["entry"].update(
+        {
+            "retracement_base_pct": 0.0,
+            "threshold_base_pct": -0.02,
+            "threshold_we_weight": 0.0,
+            "threshold_volatility_1m_weight": 0.0,
+            "threshold_volatility_1h_weight": 0.0,
+        }
+    )
+    result = trailing_inspect.build_overview(
+        sources={pside: {"params": params, "context": _context()}},
+        parameter_source="test config",
+        price_anchor=100.0,
+        volatility_scenarios=(("only", 0.0, 0.0),),
+        exposure_ratios=(0.0,),
+    )
+
+    entry = result["sides"][pside]["scenarios"][0]["entry"]
+    assert entry["threshold_pct"] == pytest.approx(-0.02)
+    assert entry["geometry"]["threshold_price"] is None
+    assert entry["geometry"]["passive_reference_price"] == pytest.approx(expected_reference)
+    table_row = trailing_inspect._scenario_rows(result["sides"][pside], "entry")[0]
+    assert table_row[4] == "n/a"
+    assert table_row[7] == f"{expected_reference:.4f}"
+
+
+def test_trailing_negative_entry_threshold_is_clamped_like_rust():
+    params = _params()
+    params["entry"].update(
+        {
+            "retracement_base_pct": 0.01,
+            "threshold_base_pct": -0.02,
+            "threshold_we_weight": 0.0,
+            "threshold_volatility_1m_weight": 0.0,
+            "threshold_volatility_1h_weight": 0.0,
+        }
+    )
+
+    result = trailing_inspect.build_overview(
+        sources={"long": {"params": params, "context": _context()}},
+        parameter_source="test config",
+        price_anchor=100.0,
+        volatility_scenarios=(("only", 0.0, 0.0),),
+        exposure_ratios=(0.0,),
+    )
+
+    entry = result["sides"]["long"]["scenarios"][0]["entry"]
+    assert entry["trailing_enabled"] is True
+    assert entry["threshold_base_pct"] == 0.0
+    assert entry["threshold_pct"] == 0.0
+
+
 def test_overview_rejects_duplicate_volatility_scenario_labels():
     with pytest.raises(ValueError, match="duplicate volatility scenario label.*same"):
         trailing_inspect.build_overview(

--- a/tests/test_trailing_inspect_tool.py
+++ b/tests/test_trailing_inspect_tool.py
@@ -51,6 +51,7 @@ def _context(
     forced_mode="normal",
     enforcer_enabled=False,
     enforcer_threshold=0.8,
+    total_entry_gate=False,
 ):
     return {
         "active": active,
@@ -59,6 +60,7 @@ def _context(
         "forced_mode": forced_mode,
         "position_exposure_enforcer_enabled": enforcer_enabled,
         "position_exposure_enforcer_threshold": enforcer_threshold,
+        "total_exposure_entry_gate_enabled": total_entry_gate,
         "entry_cooldown_minutes": cooldown,
         "entry_ema_gate_mode": "all",
         "entry_initial_ema_dist": 0.01,
@@ -298,6 +300,7 @@ def test_extract_side_context_includes_global_forced_mode():
                     "entry_cooldown_minutes": 2.0,
                     "position_exposure_enforcer_enabled": True,
                     "position_exposure_enforcer_threshold": 0.8,
+                    "total_exposure_entry_gate_enabled": True,
                 },
                 "strategy": {
                     "trailing_martingale": {
@@ -314,6 +317,7 @@ def test_extract_side_context_includes_global_forced_mode():
     assert context["forced_mode"] == "panic"
     assert context["position_exposure_enforcer_enabled"] is True
     assert context["position_exposure_enforcer_threshold"] == pytest.approx(0.8)
+    assert context["total_exposure_entry_gate_enabled"] is True
 
 
 def test_extract_side_context_translates_invalid_forced_mode_to_value_error():
@@ -386,13 +390,40 @@ def test_overview_marks_position_enforcer_before_close_geometry():
     above_threshold = next(row for row in scenarios if row["exposure_ratio"] == 0.9)
     assert at_threshold["close"]["preceded_by"] is None
     assert above_threshold["close"]["preceded_by"] == "position_exposure_enforcer"
+    assert (
+        above_threshold["close"]["post_reduction_geometry"]
+        == "requires_runtime_sizing_inputs"
+    )
 
     report = trailing_inspect.render_overview(result)
     assert "Position-exposure enforcement is enabled at 80% WE / effective WEL" in report
     assert "WEL reducer first" in report
     assert "Expanded close generation simulates that reduction" in report
-    assert "may then add the displayed strategy closes" in report
+    assert "strategy closes recomputed at the lower exposure" in report
     assert "remains relevant" in report
+    assert "post-WE varies" in report
+    assert "post-reduction prices cannot be inferred" in report
+
+
+def test_overview_marks_entries_portfolio_dependent_when_total_gate_enabled():
+    result = trailing_inspect.build_overview(
+        sources={
+            "long": {
+                "params": _params(),
+                "context": _context(total_entry_gate=True),
+            }
+        },
+        parameter_source="test config",
+        price_anchor=100.0,
+        volatility_scenarios=(("normal", 0.005, 0.0025),),
+        exposure_ratios=(0.5, 1.0),
+    )
+
+    report = trailing_inspect.render_overview(result)
+    assert "account-wide total-exposure entry gate is enabled" in report
+    assert "portfolio-dependent" in report
+    assert "may crop or remove the order" in report
+    assert "exposure-capped" in report
 
 
 def test_overview_separates_initial_entry_and_describes_close_qty_basis():

--- a/tests/test_trailing_inspect_tool.py
+++ b/tests/test_trailing_inspect_tool.py
@@ -401,6 +401,34 @@ def test_volatility_sensitivity_selects_extremes_independent_of_input_order():
 
     headline = result["sides"]["long"]["classification"]["entry_headline"]
     assert headline.startswith("very strong volatility sensitivity")
+    assert "sensitivity spans all 3 displayed scenarios" in result["sides"]["long"][
+        "classification"
+    ]["basis"]
+
+
+def test_volatility_sensitivity_includes_effective_middle_extreme():
+    params = _params()
+    params["entry"].update(
+        {
+            "threshold_volatility_1m_weight": 20.0,
+            "threshold_volatility_1h_weight": 0.0,
+            "retracement_volatility_1m_weight": 0.0,
+            "retracement_volatility_1h_weight": 0.0,
+        }
+    )
+    result = trailing_inspect.build_overview(
+        sources={"long": {"params": params, "context": _context()}},
+        parameter_source="test config",
+        price_anchor=100.0,
+        volatility_scenarios=(
+            ("quiet", 0.0, 0.0),
+            ("large 1m effect", 0.05, 0.0),
+            ("larger summed volatility", 0.0, 0.06),
+        ),
+    )
+
+    headline = result["sides"]["long"]["classification"]["entry_headline"]
+    assert headline.startswith("very strong volatility sensitivity")
 
 
 @pytest.mark.parametrize(("pside", "expected_reference"), [("long", 98.0), ("short", 102.0)])
@@ -431,6 +459,33 @@ def test_passive_negative_close_threshold_keeps_rust_analytical_reference(
     table_row = trailing_inspect._scenario_rows(result["sides"][pside], "close")[0]
     assert table_row[4] == "n/a"
     assert table_row[7] == f"{expected_reference:.4f}"
+    headline = result["sides"][pside]["classification"]["close_headline"]
+    assert "passive" in headline
+    assert "immediate" not in headline
+
+
+def test_negative_threshold_exposure_change_uses_absolute_distance():
+    params = _params()
+    params["close"].update(
+        {
+            "retracement_base_pct": 0.0,
+            "threshold_base_pct": -0.02,
+            "threshold_we_weight": -0.1,
+            "threshold_volatility_1m_weight": 0.0,
+            "threshold_volatility_1h_weight": 0.0,
+        }
+    )
+    result = trailing_inspect.build_overview(
+        sources={"long": {"params": params, "context": _context()}},
+        parameter_source="test config",
+        price_anchor=100.0,
+        volatility_scenarios=(("only", 0.0, 0.0),),
+        exposure_ratios=(0.0, 0.9),
+    )
+
+    comments = " ".join(result["sides"]["long"]["classification"]["close_comments"])
+    assert "widens the absolute close threshold distance from 2.0000% to 11.0000%" in comments
+    assert "narrows the close threshold" not in comments
 
 
 @pytest.mark.parametrize(
@@ -464,6 +519,9 @@ def test_passive_negative_entry_threshold_keeps_rust_analytical_reference(
     table_row = trailing_inspect._scenario_rows(result["sides"][pside], "entry")[0]
     assert table_row[4] == "n/a"
     assert table_row[7] == f"{expected_reference:.4f}"
+    headline = result["sides"][pside]["classification"]["entry_headline"]
+    assert "passive" in headline
+    assert "immediate" not in headline
 
 
 def test_trailing_negative_entry_threshold_is_clamped_like_rust():
@@ -490,6 +548,21 @@ def test_trailing_negative_entry_threshold_is_clamped_like_rust():
     assert entry["trailing_enabled"] is True
     assert entry["threshold_base_pct"] == 0.0
     assert entry["threshold_pct"] == 0.0
+
+
+def test_scenario_prices_preserve_precision_for_small_anchor():
+    result = trailing_inspect.build_overview(
+        sources={"long": {"params": _params(), "context": _context()}},
+        parameter_source="test config",
+        price_anchor=0.00001,
+        volatility_scenarios=(("only", 0.005, 0.0025),),
+        exposure_ratios=(0.5,),
+    )
+
+    row = trailing_inspect._scenario_rows(result["sides"]["long"], "entry")[0]
+    for price in (row[4], row[6], row[7]):
+        assert price != "0.0000"
+        assert float(price) > 0.0
 
 
 def test_overview_rejects_duplicate_volatility_scenario_labels():

--- a/tests/test_trailing_inspect_tool.py
+++ b/tests/test_trailing_inspect_tool.py
@@ -345,7 +345,7 @@ def test_extract_side_context_translates_invalid_forced_mode_to_value_error():
     (
         ("panic", "immediate panic close"),
         ("manual", "emits no strategy orders"),
-        ("tp_only", "ENTRY table is dormant and the CLOSE table applies"),
+        ("tp_only", "RE-ENTRY / ADD table is dormant and the CLOSE table applies"),
         ("graceful_stop", "blocks a new initial entry while flat"),
     ),
 )
@@ -402,10 +402,52 @@ def test_overview_separates_initial_entry_and_describes_close_qty_basis():
 
     report = trailing_inspect.render_overview(result)
     assert "RE-ENTRY / ADD" in report
-    assert "While flat, Rust bypasses trailing threshold/retracement" in report
-    assert "initial entry at bid/ask" in report
+    assert "reaches at least 80% of the calculated initial-entry quantity" in report
+    assert "below that 80% boundary, it submits a partial initial entry" in report
+    assert "Both initial paths bypass trailing threshold/retracement" in report
     assert "allowed full-position size × 25.00%" in report
     assert "adds any current position size above that allowed full size" in report
+
+
+def test_overview_marks_entry_exposure_cap_with_exact_rust_boundaries():
+    trailing = trailing_inspect.build_overview(
+        sources={"long": {"params": _params(), "context": _context()}},
+        parameter_source="test config",
+        price_anchor=100.0,
+        volatility_scenarios=(("normal", 0.005, 0.0025),),
+        exposure_ratios=(0.999, 1.0),
+    )
+    trailing_rows = trailing["sides"]["long"]["scenarios"]
+    assert trailing_rows[0]["entry"]["inactive_reason"] is None
+    assert trailing_rows[1]["entry"]["inactive_reason"] == "exposure_cap"
+    assert "exposure-capped" in trailing_inspect.render_overview(trailing)
+
+    passive_params = _params()
+    passive_params["entry"]["retracement_base_pct"] = 0.0
+    passive = trailing_inspect.build_overview(
+        sources={"long": {"params": passive_params, "context": _context()}},
+        parameter_source="test config",
+        price_anchor=100.0,
+        volatility_scenarios=(("normal", 0.005, 0.0025),),
+        exposure_ratios=(0.999,),
+    )
+    assert passive["sides"]["long"]["scenarios"][0]["entry"]["inactive_reason"] == "exposure_cap"
+
+
+def test_overview_qualifies_full_position_passive_close_sizing():
+    params = _params()
+    params["close"]["retracement_base_pct"] = 0.0
+    params["close"]["threshold_we_weight"] = 0.0
+    result = trailing_inspect.build_overview(
+        sources={"long": {"params": params, "context": _context()}},
+        parameter_source="test config",
+        price_anchor=100.0,
+    )
+
+    comments = " ".join(result["sides"]["long"]["classification"]["overall_comments"])
+    assert "ignores the configured close quantity percentage" in comments
+    assert "targets the full remaining position" in comments
+    assert "allowed full-position size × 25.00%" not in comments
 
 
 def test_overview_qualifies_immediate_close_by_trailing_mode():

--- a/tests/test_trailing_inspect_tool.py
+++ b/tests/test_trailing_inspect_tool.py
@@ -622,7 +622,7 @@ def test_overview_marks_unstuck_and_realized_loss_close_dependencies():
         parameter_source="test config",
         price_anchor=100.0,
         volatility_scenarios=(("normal", 0.005, 0.0025),),
-        exposure_ratios=(0.5,),
+        exposure_ratios=(0.8,),
     )
 
     report = trailing_inspect.render_overview(result)
@@ -655,6 +655,36 @@ def test_unstuck_requires_positive_threshold():
     assert trailing_inspect._unstuck_active(context) is False
     assert "unstuck-dependent" not in trailing_inspect._scenario_rows(side, "close")[0][-1]
     assert "position threshold is non-positive" in trailing_inspect.render_overview(result)
+
+
+def test_unstuck_runtime_label_requires_exposure_strictly_above_threshold():
+    result = trailing_inspect.build_overview(
+        sources={
+            "long": {
+                "params": _params(),
+                "context": _context(
+                    unstuck_enabled=True,
+                    unstuck_close_pct=0.1,
+                    unstuck_loss_allowance_pct=0.02,
+                    unstuck_threshold=0.7,
+                ),
+            }
+        },
+        parameter_source="test config",
+        price_anchor=100.0,
+        volatility_scenarios=(("normal", 0.0, 0.0),),
+        exposure_ratios=(0.5, 0.7, 0.7001),
+    )
+
+    paths = {
+        row["exposure_ratio"]: trailing_inspect._scenario_rows(
+            {**result["sides"]["long"], "scenarios": [row]}, "close"
+        )[0][-1]
+        for row in result["sides"]["long"]["scenarios"]
+    }
+    assert "unstuck-dependent" not in paths[0.5]
+    assert "unstuck-dependent" not in paths[0.7]
+    assert "unstuck-dependent" in paths[0.7001]
 
 
 @pytest.mark.parametrize("ema_gating_enabled", (False, True))

--- a/tests/test_trailing_inspect_tool.py
+++ b/tests/test_trailing_inspect_tool.py
@@ -229,6 +229,22 @@ def test_detailed_mode_requires_both_exposure_inputs(state_args, capsys):
     )
 
 
+def test_detailed_mode_requires_explicit_position_price(capsys):
+    assert (
+        trailing_inspect.main(
+            [
+                "--wallet-exposure",
+                "0.6",
+                "--effective-wallet-exposure-limit",
+                "0.9",
+                "--json",
+            ]
+        )
+        == 2
+    )
+    assert "requires an explicit --position-price" in capsys.readouterr().err
+
+
 def test_overview_scenario_grid_uses_formulas_and_side_geometry():
     result = trailing_inspect.build_overview(
         sources={

--- a/tests/test_trailing_inspect_tool.py
+++ b/tests/test_trailing_inspect_tool.py
@@ -60,12 +60,18 @@ def _context(
     unstuck_loss_allowance_pct=0.0,
     unstuck_threshold=0.0,
     max_realized_loss_pct=1.0,
+    hsl_enabled=False,
 ):
     return {
         "active": active,
         "total_wallet_exposure_limit": 1.0 if active else 0.0,
         "n_positions": 1,
         "forced_mode": forced_mode,
+        "hsl_enabled": hsl_enabled,
+        "hsl_enabled_global": hsl_enabled,
+        "hsl_enabled_override_symbols": [],
+        "hsl_signal_mode": "coin",
+        "coin_strategy_override_symbols": [],
         "max_realized_loss_pct": max_realized_loss_pct,
         "position_exposure_enforcer_enabled": enforcer_enabled,
         "position_exposure_enforcer_threshold": enforcer_threshold,
@@ -353,6 +359,74 @@ def test_extract_side_context_includes_global_and_risk_paths():
     assert context["max_realized_loss_pct"] == pytest.approx(0.05)
 
 
+def test_extract_side_context_reports_hsl_and_omitted_coin_strategy_overrides():
+    config = {
+        "live": {
+            "forced_mode_long": "normal",
+            "hsl_signal_mode": "coin",
+        },
+        "bot": {
+            "long": {
+                "hsl": {"enabled": False},
+                "risk": {
+                    "total_wallet_exposure_limit": 1.0,
+                    "n_positions": 1,
+                },
+                "strategy": {
+                    "trailing_martingale": {
+                        **_params(),
+                        "volatility_ema_span_1m": 100.0,
+                        "volatility_ema_span_1h": 200.0,
+                    }
+                },
+            }
+        },
+        "coin_overrides": {
+            "XRP": {
+                "bot": {
+                    "long": {
+                        "hsl": {"enabled": True},
+                        "strategy": {
+                            "trailing_martingale": {
+                                "entry": {"threshold_base_pct": 0.2}
+                            }
+                        },
+                    }
+                }
+            },
+            "DOGE": {"bot": {"long": {"hsl": {"enabled": False}}}},
+        },
+    }
+
+    context = trailing_inspect._extract_side_context(config, "long")
+
+    assert context["hsl_enabled"] is True
+    assert context["hsl_enabled_global"] is False
+    assert context["hsl_enabled_override_symbols"] == ["XRP"]
+    assert context["hsl_signal_mode"] == "coin"
+    assert context["coin_strategy_override_symbols"] == ["XRP"]
+
+
+def test_overview_marks_hsl_runtime_paths_and_coin_override_omission():
+    context = _context(hsl_enabled=True)
+    context["coin_strategy_override_symbols"] = ["XRP"]
+    result = trailing_inspect.build_overview(
+        sources={"long": {"params": _params(), "context": context}},
+        parameter_source="test config",
+        price_anchor=100.0,
+        volatility_scenarios=(("normal", 0.0, 0.0),),
+        exposure_ratios=(0.5,),
+    )
+
+    side = result["sides"]["long"]
+    assert "HSL-dependent" in trailing_inspect._scenario_rows(side, "entry")[0][-1]
+    assert "HSL-dependent" in trailing_inspect._scenario_rows(side, "close")[0][-1]
+    comments = " ".join(side["classification"]["overall_comments"])
+    assert "offline config report cannot know the live HSL tier" in comments
+    assert "explicitly omitted from these tables" in comments
+    assert "XRP" in comments
+
+
 def test_extract_side_context_translates_invalid_forced_mode_to_value_error():
     config = {
         "live": {"forced_mode_long": "not-a-mode"},
@@ -610,6 +684,70 @@ def test_overview_marks_short_close_threshold_at_100_percent_unreachable():
     assert "unreachable" in report
     assert "short CLOSE row" in report
     assert "positive market cannot satisfy the trailing threshold" in report
+
+
+def test_wel_reducer_precedes_unreachable_short_strategy_close():
+    params = _params()
+    params["close"].update(
+        {
+            "threshold_base_pct": 1.0,
+            "threshold_we_weight": 0.0,
+            "threshold_volatility_1m_weight": 0.0,
+            "threshold_volatility_1h_weight": 0.0,
+        }
+    )
+    result = trailing_inspect.build_overview(
+        sources={
+            "short": {
+                "params": params,
+                "context": _context(enforcer_enabled=True, enforcer_threshold=0.8),
+            }
+        },
+        parameter_source="test config",
+        price_anchor=100.0,
+        volatility_scenarios=(("normal", 0.0, 0.0),),
+        exposure_ratios=(0.9,),
+    )
+
+    side = result["sides"]["short"]
+    row = side["scenarios"][0]["close"]
+    table_row = trailing_inspect._scenario_rows(side, "close")[0]
+    assert row["inactive_reason"] == "unreachable_short_threshold"
+    assert row["preceded_by"] == "position_exposure_enforcer"
+    assert table_row[4] == "post-WE varies"
+    assert table_row[6:8] == ["post-WE varies"] * 2
+    assert table_row[-1] == "WEL-first / strategy unreachable"
+
+
+@pytest.mark.parametrize(
+    ("pside", "kind", "inactive_reason"),
+    (
+        ("short", "entry", "unreachable_short_retracement"),
+        ("long", "close", "unreachable_long_retracement"),
+    ),
+)
+def test_overview_marks_100_percent_retracement_unreachable(
+    pside, kind, inactive_reason
+):
+    params = _params()
+    params[kind]["retracement_base_pct"] = 1.0
+    params[kind]["retracement_volatility_1m_weight"] = 0.0
+    params[kind]["retracement_volatility_1h_weight"] = 0.0
+    if kind == "entry":
+        params[kind]["retracement_we_weight"] = 0.0
+    result = trailing_inspect.build_overview(
+        sources={pside: {"params": params, "context": _context()}},
+        parameter_source="test config",
+        price_anchor=100.0,
+        volatility_scenarios=(("normal", 0.0, 0.0),),
+        exposure_ratios=(0.0,),
+    )
+
+    side = result["sides"][pside]
+    row = side["scenarios"][0][kind]
+    assert row["inactive_reason"] == inactive_reason
+    assert trailing_inspect._scenario_rows(side, kind)[0][-1].endswith("unreachable")
+    assert "retracement of at least 100%" in trailing_inspect.render_overview(result)
 
 
 def test_overview_qualifies_full_position_passive_close_sizing():

--- a/tests/test_trailing_inspect_tool.py
+++ b/tests/test_trailing_inspect_tool.py
@@ -44,6 +44,22 @@ def _inspect(pside="long"):
     )
 
 
+def _context(*, active=True, cooldown=1.5):
+    return {
+        "active": active,
+        "total_wallet_exposure_limit": 1.0 if active else 0.0,
+        "n_positions": 1,
+        "entry_cooldown_minutes": cooldown,
+        "entry_ema_gate_mode": "all",
+        "entry_initial_ema_dist": 0.01,
+        "entry_initial_qty_pct": 0.02,
+        "entry_double_down_factor": 1.5,
+        "close_qty_pct": 0.25,
+        "volatility_ema_span_1m": 100.0,
+        "volatility_ema_span_1h": 200.0,
+    }
+
+
 def test_inspect_trailing_matches_current_entry_and_close_formulas():
     result = _inspect()
 
@@ -194,3 +210,113 @@ def test_main_rejects_non_positive_effective_limit(monkeypatch, capsys):
         == 2
     )
     assert "must be greater than zero" in capsys.readouterr().err
+
+
+def test_overview_scenario_grid_uses_formulas_and_side_geometry():
+    result = trailing_inspect.build_overview(
+        sources={
+            "long": {"params": _params(), "context": _context()},
+            "short": {"params": _params(), "context": _context(active=False)},
+        },
+        parameter_source="test config",
+        price_anchor=100.0,
+    )
+
+    assert result["mode"] == "overview"
+    assert len(result["sides"]["long"]["scenarios"]) == 9
+    normal_half = next(
+        row
+        for row in result["sides"]["long"]["scenarios"]
+        if row["volatility_label"] == "normal" and row["exposure_ratio"] == 0.5
+    )
+    expected_entry_threshold = 0.02 * (1.0 + 0.0025 * 2.0 + 0.005 * 10.0 + 0.5 * 0.5)
+    expected_close_threshold = 0.01 + 0.5 * -0.02 + 0.0025 * 1.0 + 0.005 * 2.0
+    assert normal_half["entry"]["threshold_pct"] == pytest.approx(expected_entry_threshold)
+    assert normal_half["entry"]["geometry"]["threshold_price"] == pytest.approx(
+        100.0 * (1.0 - expected_entry_threshold)
+    )
+    assert normal_half["close"]["threshold_pct"] == pytest.approx(expected_close_threshold)
+
+    short_row = result["sides"]["short"]["scenarios"][0]
+    assert short_row["entry"]["geometry"]["threshold_price"] > 100.0
+    assert short_row["close"]["geometry"]["threshold_price"] < 100.0
+    assert "dormant parameters" in " ".join(
+        result["sides"]["short"]["classification"]["overall_comments"]
+    )
+
+
+@pytest.mark.parametrize(
+    ("cooldown", "expected"),
+    [
+        (0.0, "full recursive entry ladder simultaneously"),
+        (5.0, "waits 5 minutes after an entry fill"),
+    ],
+)
+def test_overview_explains_passive_entry_ladder_and_cooldown(cooldown, expected):
+    params = _params()
+    params["entry"]["retracement_base_pct"] = 0.0
+    result = trailing_inspect.build_overview(
+        sources={"long": {"params": params, "context": _context(cooldown=cooldown)}},
+        parameter_source="test config",
+        price_anchor=100.0,
+    )
+
+    comments = " ".join(result["sides"]["long"]["classification"]["entry_comments"])
+    assert expected in comments
+
+
+def test_main_positional_config_defaults_to_overview_and_accepts_price_anchor(
+    monkeypatch, capsys
+):
+    monkeypatch.setattr(
+        trailing_inspect,
+        "load_overview_sources",
+        lambda config_path, psides: (
+            {
+                pside: {"params": _params(), "context": _context()}
+                for pside in psides
+            },
+            f"config {config_path}",
+        ),
+    )
+
+    assert (
+        trailing_inspect.main(
+            ["config.json", "--side", "long", "--price-anchor", "250", "--json"]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["mode"] == "overview"
+    assert payload["price_anchor"] == pytest.approx(250.0)
+    assert list(payload["sides"]) == ["long"]
+
+
+def test_render_overview_includes_formula_caveats_and_scenario_prices():
+    result = trailing_inspect.build_overview(
+        sources={"long": {"params": _params(), "context": _context()}},
+        parameter_source="test config",
+        price_anchor=100.0,
+    )
+
+    report = trailing_inspect.render_overview(result)
+    assert "Entry distance = base × max(1" in report
+    assert "Close threshold = base +" in report
+    assert "R confirm*" in report
+    assert "Order ref*" in report
+    assert "Trailing extrema reset after every fill" in report
+
+
+def test_overview_single_custom_scenario_does_not_invent_sensitivity_comparison():
+    result = trailing_inspect.build_overview(
+        sources={"long": {"params": _params(), "context": _context()}},
+        parameter_source="test config",
+        price_anchor=100.0,
+        volatility_scenarios=(("stress", 0.02, 0.01),),
+        exposure_ratios=(0.75,),
+    )
+
+    classification = result["sides"]["long"]["classification"]
+    assert classification["entry_headline"].startswith("one volatility scenario shown")
+    assert classification["basis"] == "Headlines use 'stress' volatility at 75% WE/WEL."
+    assert "Only one exposure ratio is shown" in " ".join(classification["entry_comments"])

--- a/tests/test_trailing_inspect_tool.py
+++ b/tests/test_trailing_inspect_tool.py
@@ -44,11 +44,12 @@ def _inspect(pside="long"):
     )
 
 
-def _context(*, active=True, cooldown=1.5):
+def _context(*, active=True, cooldown=1.5, forced_mode="normal"):
     return {
         "active": active,
         "total_wallet_exposure_limit": 1.0 if active else 0.0,
         "n_positions": 1,
+        "forced_mode": forced_mode,
         "entry_cooldown_minutes": cooldown,
         "entry_ema_gate_mode": "all",
         "entry_initial_ema_dist": 0.01,
@@ -259,6 +260,58 @@ def test_overview_scenario_grid_uses_formulas_and_side_geometry():
     assert "dormant parameters" in " ".join(
         result["sides"]["short"]["classification"]["overall_comments"]
     )
+
+
+def test_extract_side_context_includes_global_forced_mode():
+    config = {
+        "live": {"forced_mode_long": "p"},
+        "bot": {
+            "long": {
+                "risk": {
+                    "total_wallet_exposure_limit": 1.0,
+                    "n_positions": 1,
+                    "entry_cooldown_minutes": 2.0,
+                },
+                "strategy": {
+                    "trailing_martingale": {
+                        **_params(),
+                        "volatility_ema_span_1m": 100.0,
+                        "volatility_ema_span_1h": 200.0,
+                    }
+                },
+            }
+        },
+    }
+
+    context = trailing_inspect._extract_side_context(config, "long")
+    assert context["forced_mode"] == "panic"
+
+
+@pytest.mark.parametrize(
+    ("forced_mode", "expected"),
+    (
+        ("panic", "immediate panic close"),
+        ("manual", "emits no strategy orders"),
+        ("tp_only", "ENTRY table is dormant and the CLOSE table applies"),
+        ("graceful_stop", "blocks a new initial entry while flat"),
+    ),
+)
+def test_overview_explains_global_forced_mode(forced_mode, expected):
+    result = trailing_inspect.build_overview(
+        sources={
+            "long": {
+                "params": _params(),
+                "context": _context(forced_mode=forced_mode),
+            }
+        },
+        parameter_source="test config",
+        price_anchor=100.0,
+    )
+
+    comments = " ".join(result["sides"]["long"]["classification"]["overall_comments"])
+    assert f"Global forced mode '{forced_mode}'" in comments
+    assert expected in comments
+    assert "Long is enabled" not in comments
 
 
 def test_overview_qualifies_immediate_close_by_trailing_mode():
@@ -563,6 +616,24 @@ def test_scenario_prices_preserve_precision_for_small_anchor():
     for price in (row[4], row[6], row[7]):
         assert price != "0.0000"
         assert float(price) > 0.0
+
+
+def test_scenario_inputs_preserve_small_custom_values():
+    params = _params()
+    params["entry"]["threshold_volatility_1m_weight"] = 100_000.0
+    params["entry"]["threshold_we_weight"] = 100.0
+    result = trailing_inspect.build_overview(
+        sources={"long": {"params": params, "context": _context()}},
+        parameter_source="test config",
+        price_anchor=100.0,
+        volatility_scenarios=(("zero", 0.0, 0.0), ("tiny", 0.00001, 0.0)),
+        exposure_ratios=(0.0, 0.004),
+    )
+
+    rows = trailing_inspect._scenario_rows(result["sides"]["long"], "entry")
+    assert {row[1] for row in rows} == {"0/0%", "0.001/0%"}
+    assert {row[2] for row in rows} == {"0%", "0.4%"}
+    assert len({row[3] for row in rows}) == 4
 
 
 def test_overview_rejects_duplicate_volatility_scenario_labels():


### PR DESCRIPTION
## Summary
- add a config-first overview for both long and short trailing behavior
- show threshold, retracement, nominal confirmation, and order-reference prices across configurable volatility and exposure scenarios
- explain dormant sides, cooldown and ladder staging, EMA gating, sensitivity, and recursive closes while retaining detailed single-scenario and JSON compatibility
- document the new CLI and behavior contract

## Validation
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTHONPATH=src ./venv/bin/pytest -q tests/test_trailing_inspect_tool.py tests/test_passivbot_cli.py tests/test_ai_docs.py tests/test_live_event_registry_docs.py
- PYTHONPATH=src ./venv/bin/python src/tools/check_ai_docs.py
- PYTHONPATH=src ./venv/bin/python src/tools/generate_live_event_registry.py --check
- PYTHONPATH=src ./venv/bin/python -m py_compile src/tools/trailing_inspect.py
- ./venv/bin/passivbot tool trailing-inspect configs/examples/default_trailing_martingale_long.json --side long --price-anchor 100 --json