### PR TITLE
Expose effective backtest dates and duration in result metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ All notable user-facing changes will be documented in this file.
   existing metrics payloads, preserving per-exchange and per-scenario windows. Saved backtest
   configs include current `metrics` or `suite_metrics`; `fills_analysis_duration_days` remains
   available as a compatibility alias with the same exact/CPU scoring, suite reducer, and GPU
-  exact-only policy.
+  exact-only policy. Both duration names default to maximizing duration in shorthand scoring.
+  Standalone artifacts preserve non-finite diagnostics separately from finite metric statistics.
   Saved suite configs retain the effective exchange defaults from external suite overrides.
 
 - Gate.io and KuCoin fill-history refreshes now reject unfinished pagination instead of marking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Backtest and optimizer results now expose `n_days` and effective UTC analysis dates in
+  existing metrics payloads, preserving per-exchange and per-scenario windows. Saved backtest
+  configs include current `metrics` or `suite_metrics`; `fills_analysis_duration_days` remains
+  available as a compatibility alias.
+
 - Added `fills_gap_time_weighted_mean_hours` as an exact backtest and CPU/GPU optimizer metric.
   It minimizes `sum(gap_hours^2) / sum(gap_hours)` over unique portfolio fill timestamps and the
   analysis boundaries, providing smoother selection pressure against long no-fill periods than a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ All notable user-facing changes will be documented in this file.
 - Backtest and optimizer results now expose `n_days` and effective UTC analysis dates in
   existing metrics payloads, preserving per-exchange and per-scenario windows. Saved backtest
   configs include current `metrics` or `suite_metrics`; `fills_analysis_duration_days` remains
-  available as a compatibility alias.
+  available as a compatibility alias with the same exact/CPU scoring, suite reducer, and GPU
+  exact-only policy.
+  Saved suite configs retain the effective exchange defaults from external suite overrides.
 
 - Added `fills_gap_time_weighted_mean_hours` as an exact backtest and CPU/GPU optimizer metric.
   It minimizes `sum(gap_hours^2) / sum(gap_hours)` over unique portfolio fill timestamps and the

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -12,7 +12,8 @@ expressed as percentages/ratios.
   including idle periods. This excludes pre-analysis warmup and reflects early termination.
   It is not a count of days with fills or a per-coin coverage measure.
   `fills_analysis_duration_days` remains available with the same value; both names work in
-  scoring and metric lookup, including older result files.
+  exact/CPU scoring and metric lookup, including older result files. Both remain excluded from
+  GPU proxy scoring and proxy-side limits, while computed diagnostic values stay available.
 - `effective_start_date` and `effective_end_date`: Those actual boundaries as UTC ISO timestamps.
   Empty equity histories have null dates and zero duration; a single timestamp has equal dates
   and zero duration. Dates are output metadata and are never averaged or used as scoring metrics.
@@ -26,8 +27,9 @@ Suites use `suite_metrics.metrics.n_days` for duration statistics and per-scenar
 Dates are at `suite_metrics.scenarios.<label>` and its `exchanges.<exchange>` entries;
 shared dates appear directly under `suite_metrics` only when all windows match.
 Suite backtests also save a root `config.json` containing `suite_metrics` alongside
-`suite_summary.json`. Each output config contains fresh results, replacing prior `metrics` and
-`suite_metrics` blocks. `config.original.json`, when present, remains the input snapshot.
+`suite_summary.json`, preserving effective suite exchange defaults for repeat runs. Both duration
+spellings use the same configured suite reducer. Each output config contains fresh results,
+replacing prior `metrics` and `suite_metrics` blocks. `config.original.json`, when present, remains the input snapshot.
 Requested config dates and detailed dataset coverage in the manifest retain their existing roles.
 
 ## Core growth metrics

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -11,12 +11,18 @@ expressed as percentages/ratios.
 - `n_days`: Elapsed days between the first and last actual equity-analysis timestamps,
   including idle periods. This excludes pre-analysis warmup and reflects early termination.
   It is not a count of days with fills or a per-coin coverage measure.
-  `fills_analysis_duration_days` remains available with the same value; both names work in
-  exact/CPU scoring and metric lookup, including older result files. Both remain excluded from
-  GPU proxy scoring and proxy-side limits, while computed diagnostic values stay available.
+  `fills_analysis_duration_days` remains available with the same value; both names default to
+  maximizing duration and work in exact/CPU scoring and metric lookup, including older result files.
+  Both remain excluded from GPU proxy scoring and proxy-side limits, while computed diagnostic
+  values stay available.
 - `effective_start_date` and `effective_end_date`: Those actual boundaries as UTC ISO timestamps.
   Empty equity histories have null dates and zero duration; a single timestamp has equal dates
   and zero duration. Dates are output metadata and are never averaged or used as scoring metrics.
+
+Standalone result configs keep finite values in `metrics.stats` and encode undefined numeric
+diagnostics as strings (`"inf"`, `"-inf"`, or `"nan"`) in `metrics.nonfinite_diagnostics`. The raw
+`analysis.json` remains unchanged, and fills and plots still persist. Optimizer and suite scoring
+continue to reject non-finite metric values.
 
 Standalone backtests retain the flat `analysis.json` and also embed structured results in
 `config.json` under `metrics`, matching Pareto members: duration is at `metrics.stats.n_days`

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -6,6 +6,30 @@ This page documents the main backtest metrics exposed by `passivbot-rust`. Value
 BTC collateral. Metrics without a suffix are currency-agnostic (e.g., position counts) or already
 expressed as percentages/ratios.
 
+## Effective backtest period
+
+- `n_days`: Elapsed days between the first and last actual equity-analysis timestamps,
+  including idle periods. This excludes pre-analysis warmup and reflects early termination.
+  It is not a count of days with fills or a per-coin coverage measure.
+  `fills_analysis_duration_days` remains available with the same value; both names work in
+  scoring and metric lookup, including older result files.
+- `effective_start_date` and `effective_end_date`: Those actual boundaries as UTC ISO timestamps.
+  Empty equity histories have null dates and zero duration; a single timestamp has equal dates
+  and zero duration. Dates are output metadata and are never averaged or used as scoring metrics.
+
+Standalone backtests retain the flat `analysis.json` and also embed structured results in
+`config.json` under `metrics`, matching Pareto members: duration is at `metrics.stats.n_days`
+(`mean`, `min`, `max`, `std`, `median`), and dates are directly under `metrics` when all evaluation
+windows match. `metrics.exchanges.<exchange>` preserves each exchange's dates.
+
+Suites use `suite_metrics.metrics.n_days` for duration statistics and per-scenario values.
+Dates are at `suite_metrics.scenarios.<label>` and its `exchanges.<exchange>` entries;
+shared dates appear directly under `suite_metrics` only when all windows match.
+Suite backtests also save a root `config.json` containing `suite_metrics` alongside
+`suite_summary.json`. Each output config contains fresh results, replacing prior `metrics` and
+`suite_metrics` blocks. `config.original.json`, when present, remains the input snapshot.
+Requested config dates and detailed dataset coverage in the manifest retain their existing roles.
+
 ## Core growth metrics
 - `gain`: Terminal equity divided by starting equity, where terminal equity is the mean of the
   last up to three daily equity values.

--- a/src/backtest.py
+++ b/src/backtest.py
@@ -64,7 +64,7 @@ from config.access import (
     require_live_value,
 )
 from config.pnl_lookback import parse_pnls_max_lookback_days
-from metrics_schema import attach_result_metrics, build_scenario_metrics
+from metrics_schema import attach_result_metrics, build_standalone_metrics
 from config.metrics import ANALYSIS_SHARED_KEYS
 from config.coerce import normalize_hsl_restart_after_red_policy, normalize_hsl_signal_mode
 from config.overrides import parse_overrides
@@ -2930,7 +2930,7 @@ def post_process(
         )
     else:
         sanitized_config = sanitize_prepared_config_for_dump(config)
-    attach_result_metrics(sanitized_config, metrics=build_scenario_metrics({exchange: analysis}))
+    attach_result_metrics(sanitized_config, metrics=build_standalone_metrics(analysis, exchange))
     dump_config(sanitized_config, f"{results_path}config.json")
     dump_backtest_dataset_metadata(config, exchange, results_path)
     fdf.to_csv(f"{results_path}fills.csv")

--- a/src/backtest.py
+++ b/src/backtest.py
@@ -1,4 +1,5 @@
 import os
+from datetime import datetime, timezone
 import sys
 import argparse
 from cli_utils import help_requested
@@ -63,6 +64,7 @@ from config.access import (
     require_live_value,
 )
 from config.pnl_lookback import parse_pnls_max_lookback_days
+from metrics_schema import attach_result_metrics, build_scenario_metrics
 from config.metrics import ANALYSIS_SHARED_KEYS
 from config.coerce import normalize_hsl_restart_after_red_policy, normalize_hsl_signal_mode
 from config.overrides import parse_overrides
@@ -2808,6 +2810,21 @@ def expand_analysis(analysis_usd, analysis_btc, fills, equities_array, config):
     if completion_ratio is not None:
         result["backtest_completion_ratio"] = completion_ratio
 
+    # Rust returns the actual equity timestamps even in metrics-only mode.
+    # Keep dates out of numeric aggregation and preserve the released duration key.
+    if "fills_analysis_duration_days" in result:
+        result["n_days"] = result["fills_analysis_duration_days"]
+    timestamps = np.asarray(equities_array) if equities_array is not None else np.empty((0, 1))
+    result["effective_start_date"] = (
+        datetime.fromtimestamp(int(timestamps[0, 0]) / 1000, timezone.utc)
+        .isoformat().replace("+00:00", "Z")
+        if len(timestamps) else None
+    )
+    result["effective_end_date"] = (
+        datetime.fromtimestamp(int(timestamps[-1, 0]) / 1000, timezone.utc)
+        .isoformat().replace("+00:00", "Z")
+        if len(timestamps) else None
+    )
     return result
 
 
@@ -2913,6 +2930,7 @@ def post_process(
         )
     else:
         sanitized_config = sanitize_prepared_config_for_dump(config)
+    attach_result_metrics(sanitized_config, metrics=build_scenario_metrics({exchange: analysis}))
     dump_config(sanitized_config, f"{results_path}config.json")
     dump_backtest_dataset_metadata(config, exchange, results_path)
     fdf.to_csv(f"{results_path}fills.csv")

--- a/src/config/metrics.py
+++ b/src/config/metrics.py
@@ -74,6 +74,7 @@ SHARED_METRICS = {
     "fills_active_days_ratio",
     "fills_active_symbols_count",
     "fills_analysis_duration_days",
+    "n_days",
     "fills_count",
     "fills_count_close",
     "fills_count_entry",
@@ -205,6 +206,7 @@ ANALYSIS_SHARED_KEYS = SHARED_METRICS | {
 STAT_SUFFIXES = ("min", "max", "mean", "std", "median")
 
 METRIC_ALIASES = {
+    "fills_analysis_duration_days": "n_days",
     "gain_strategy_pnl_rebased": "gain_strategy_eq",
     "adg_strategy_pnl_rebased": "adg_strategy_eq",
     "mdg_strategy_pnl_rebased": "mdg_strategy_eq",

--- a/src/config/scoring.py
+++ b/src/config/scoring.py
@@ -19,6 +19,7 @@ class ScenarioSelection(Enum):
 
 
 DEFAULT_OBJECTIVE_GOALS = {
+    "n_days": "max",
     "positions_held_per_day": "min",
     "positions_held_per_day_w": "min",
     "position_held_hours_mean": "min",

--- a/src/metrics_schema.py
+++ b/src/metrics_schema.py
@@ -8,6 +8,32 @@ import numpy as np
 
 from config.metrics import ANALYSIS_SHARED_KEYS, CURRENCY_METRICS, canonical_metric_name
 
+PERIOD_KEYS = ("effective_start_date", "effective_end_date")
+
+
+def evaluation_period(payload: Mapping[str, Any]) -> dict:
+    """Non-aggregatable evaluation boundaries, kept separate from numeric stats."""
+    return {key: payload[key] for key in PERIOD_KEYS if key in payload}
+
+
+def shared_evaluation_period(payloads: Mapping[str, Mapping[str, Any]]) -> dict:
+    periods = [evaluation_period(value) for value in payloads.values()]
+    if periods and all(period == periods[0] for period in periods):
+        return periods[0]
+    return {}
+
+
+def attach_result_metrics(config: dict, *, metrics=None, suite_metrics=None) -> dict:
+    """Replace prior evaluation output on an already sanitized config copy."""
+    config.pop("metrics", None)
+    config.pop("suite_metrics", None)
+    if metrics is not None:
+        config["metrics"] = metrics
+    if suite_metrics is not None:
+        config["suite_metrics"] = suite_metrics
+    return config
+
+
 MetricStats = Dict[str, float]
 ScenarioMetrics = Dict[str, Dict[str, MetricStats]]
 KNOWN_ANALYSIS_METRICS = set(ANALYSIS_SHARED_KEYS) | set(CURRENCY_METRICS)
@@ -89,7 +115,11 @@ def build_scenario_metrics(analyses: Mapping[str, Mapping[str, Any]]) -> Dict[st
             values.append(_safe_float(raw_value))
         stats[metric] = _build_stats(values)
 
-    return {"stats": stats}
+    payload = {"stats": stats, **shared_evaluation_period(analyses)}
+    periods = {label: evaluation_period(analysis) for label, analysis in analyses.items()}
+    if any(periods.values()):
+        payload["exchanges"] = periods
+    return payload
 
 
 def flatten_metric_stats(stats: Mapping[str, MetricStats], *, prefix: str = "") -> Dict[str, float]:
@@ -151,4 +181,14 @@ def merge_suite_payload(
     payload: Dict[str, Any] = {"metrics": suite_metrics}
     if scenario_metrics:
         payload["scenario_labels"] = list(scenario_metrics.keys())
+        periods = {
+            label: {
+                **evaluation_period(metrics),
+                **({"exchanges": metrics["exchanges"]} if "exchanges" in metrics else {}),
+            }
+            for label, metrics in scenario_metrics.items()
+        }
+        if any(periods.values()):
+            payload["scenarios"] = periods
+        payload.update(shared_evaluation_period(scenario_metrics))
     return payload

--- a/src/metrics_schema.py
+++ b/src/metrics_schema.py
@@ -122,6 +122,29 @@ def build_scenario_metrics(analyses: Mapping[str, Mapping[str, Any]]) -> Dict[st
     return payload
 
 
+def build_standalone_metrics(analysis: Mapping[str, Any], exchange: str) -> Dict[str, Any]:
+    """Persist standalone diagnostics without applying optimizer scoring validation."""
+    period = evaluation_period(analysis)
+    payload = {
+        "stats": {
+            metric: _build_stats([value])
+            for metric, value in analysis.items()
+            if _is_number(value)
+        },
+        **period,
+    }
+    if period:
+        payload["exchanges"] = {exchange: period}
+    diagnostics = {
+        metric: str(float(value))
+        for metric, value in analysis.items()
+        if _is_numeric_value(value) and not _is_number(value)
+    }
+    if diagnostics:
+        payload["nonfinite_diagnostics"] = diagnostics
+    return payload
+
+
 def flatten_metric_stats(stats: Mapping[str, MetricStats], *, prefix: str = "") -> Dict[str, float]:
     """Convert structured stats to the legacy flat format used by scoring/limits."""
 

--- a/src/optimization/gpu/metric_registry.py
+++ b/src/optimization/gpu/metric_registry.py
@@ -59,6 +59,7 @@ GPU_EXACT_ONLY_METRICS = frozenset(
         "equity_balance_diff_pos_mean_usd",
         "fills_active_days_count",
         "fills_analysis_duration_days",
+        "n_days",
         "fills_count",
         "fills_count_close",
         "fills_count_entry",

--- a/src/optimization/gpu/metrics.py
+++ b/src/optimization/gpu/metrics.py
@@ -235,6 +235,7 @@ _WEIGHTED_PNL_METRICS = {
 
 _FILL_ACTIVITY_METRICS = {
     "fills_analysis_duration_days",
+    "n_days",
     "fills_active_days_count",
     "fills_active_days_ratio",
     "fills_active_symbols_count",
@@ -1249,6 +1250,7 @@ def _fill_activity_metrics(out: dict, run, requested: set[str]) -> dict:
         / duration_days.ceil().clamp(min=1.0),
         "fills_active_symbols_count": fills_active_symbols_count,
         "fills_analysis_duration_days": duration_days,
+        "n_days": duration_days,
         "fills_count": fill_count,
         "fills_count_close": fills_count_close,
         "fills_count_entry": fills_count_entry,

--- a/src/optimize.py
+++ b/src/optimize.py
@@ -1765,7 +1765,7 @@ class Evaluator:
                 individual,
             )
         metrics_payload = {
-            "stats": aggregate_stats,
+            **scenario_metrics,
             "objectives": raw_objectives,
             "constraint_violation": total_penalty,
             "liquidated": liquidated,

--- a/src/optimize.py
+++ b/src/optimize.py
@@ -2344,7 +2344,7 @@ class SuiteEvaluator:
                         ignored_coins=None,
                     ),
                     per_exchange={},
-                    metrics={"stats": combined_metrics.get("stats", {})},
+                    metrics=combined_metrics,
                     elapsed_seconds=0.0,
                     output_path=None,
                 )

--- a/src/suite_runner.py
+++ b/src/suite_runner.py
@@ -47,7 +47,8 @@ from utils import (
 from warmup_utils import compute_backtest_warmup_minutes, compute_per_coin_warmup_minutes
 from ohlcv_utils import align_and_aggregate_hlcvs
 from shared_arrays import SharedArraySpec
-from metrics_schema import flatten_metric_stats, merge_suite_payload
+from metrics_schema import attach_result_metrics, flatten_metric_stats, merge_suite_payload
+from config_utils import dump_config, sanitize_prepared_config_for_dump
 
 _SCENARIO_KEYS = frozenset(
     {
@@ -1520,9 +1521,6 @@ async def run_backtest_scenario(
     from tools.iterative_backtester import combine_analyses
 
     combined_metrics = combine_analyses(per_exchange)
-    combined_metrics = {
-        "stats": combined_metrics.get("stats", {}),
-    }
     elapsed = (utc_ms() - start_ts) / 1000.0
     return ScenarioResult(
         scenario=scenario,
@@ -2157,6 +2155,15 @@ async def run_backtest_suite_async(
         },
     }
     (suite_dir / "suite_summary.json").write_text(json.dumps(summary_payload, indent=2))
+    saved_config = attach_result_metrics(
+        sanitize_prepared_config_for_dump(config), suite_metrics=suite_metrics
+    )
+    saved_config["backtest"].update(
+        suite_enabled=True,
+        scenarios=deepcopy(suite_cfg["scenarios"]),
+        reducer=deepcopy(reducer_cfg),
+    )
+    dump_config(saved_config, str(suite_dir / "config.json"))
 
     return SuiteSummary(
         suite_id=suite_timestamp,

--- a/src/suite_runner.py
+++ b/src/suite_runner.py
@@ -1916,9 +1916,10 @@ def reduce_metrics(
             "std": float(np.std(arr)),
             "median": float(np.median(arr)),
         }
-        mode = reducer_cfg.get(metric)
-        if mode is None and "_" in metric:
-            base = metric.rsplit("_", 1)[0]
+        canonical_metric = canonicalize_metric_name(metric)
+        mode = reducer_cfg.get(canonical_metric)
+        if mode is None and "_" in canonical_metric:
+            base = canonical_metric.rsplit("_", 1)[0]
             mode = reducer_cfg.get(base)
         mode = str(mode or default_mode).lower()
         if mode == "mean":
@@ -2160,6 +2161,7 @@ async def run_backtest_suite_async(
     )
     saved_config["backtest"].update(
         suite_enabled=True,
+        exchanges=deepcopy(suite_cfg.get("exchanges") or base_exchanges),
         scenarios=deepcopy(suite_cfg["scenarios"]),
         reducer=deepcopy(reducer_cfg),
     )

--- a/tests/optimization/test_gpu_metrics.py
+++ b/tests/optimization/test_gpu_metrics.py
@@ -99,11 +99,12 @@ def test_fill_activity_ratio_recovers_integer_steps_at_whole_day_boundary():
             "fills_active_days_ratio",
             "fills_active_symbols_count",
             "fills_analysis_duration_days",
+            "n_days",
             "fills_top_symbol_share",
         },
     )
 
-    assert metrics["fills_analysis_duration_days"].item() == 1.0
+    assert metrics["n_days"].item() == metrics["fills_analysis_duration_days"].item() == 1.0
     assert metrics["fills_active_days_ratio"].item() == 1.0
     assert metrics["fills_active_symbols_count"].item() == 1.0
     assert metrics["fills_top_symbol_share"].item() == 1.0

--- a/tests/optimization/test_gpu_metrics.py
+++ b/tests/optimization/test_gpu_metrics.py
@@ -438,6 +438,7 @@ def test_fill_activity_metrics_match_rust_full_timestamp_span_contract():
         "fills_active_days_ratio",
         "fills_active_symbols_count",
         "fills_analysis_duration_days",
+        "n_days",
         "fills_count",
         "fills_count_close",
         "fills_count_entry",
@@ -464,6 +465,7 @@ def test_fill_activity_metrics_match_rust_full_timestamp_span_contract():
         needed=requested,
     )
 
+    assert metrics["n_days"].tolist() == metrics["fills_analysis_duration_days"].tolist()
     assert set(metrics) == requested
     _assert_proxy_surface_partition(requested)
     assert metrics["fills_analysis_duration_days"].tolist() == pytest.approx(
@@ -2360,3 +2362,11 @@ def test_completion_uses_raw_requested_start_before_available_history():
     )
 
     assert metrics["backtest_completion_ratio"].item() == pytest.approx(1442.0 / 1443.0)
+
+
+@pytest.mark.parametrize("name", ["n_days", "fills_analysis_duration_days"])
+def test_duration_aliases_preserve_exact_only_gpu_metric_policy(name):
+    with pytest.raises(ValueError, match="exact Rust backtests and analysis"):
+        validate_gpu_metric_names([name])
+    assert {"n_days", "fills_analysis_duration_days"} <= GPU_EXACT_ONLY_METRICS
+    assert "n_days" not in SUPPORTED_METRICS

--- a/tests/optimization/test_optimize.py
+++ b/tests/optimization/test_optimize.py
@@ -3863,6 +3863,8 @@ class TestResultRecorder:
         }
 
         individual.evaluation_metrics = {
+            "effective_start_date": "2024-01-02T00:00:00Z",
+            "effective_end_date": "2024-01-03T00:00:00Z",
             "objectives": objectives,
             "constraint_violation": 0.0,
         }
@@ -3888,6 +3890,7 @@ class TestResultRecorder:
             pareto_files = list((Path(tmpdir) / "pareto").glob("*.json"))
             assert len(pareto_files) == 1
             saved = json.loads(pareto_files[0].read_text())
+            assert saved["metrics"]["effective_start_date"] == "2024-01-02T00:00:00Z"
             strategy_kind = saved["live"]["strategy_kind"]
 
             assert saved["bot"]["long"]["risk"] == saved["bot"]["short"]["risk"]

--- a/tests/optimization/test_optimize.py
+++ b/tests/optimization/test_optimize.py
@@ -4785,13 +4785,23 @@ class TestEvaluator:
             return_value=(None, None, {"liquidated": False}),
         ), patch(
             "tools.iterative_backtester.combine_analyses",
-            return_value={"stats": {"adg_pnl_w": {"mean": 0.1}}},
+            return_value={
+                "stats": {"adg_pnl_w": {"mean": 0.1}},
+                "exchanges": {
+                    "binance": {"effective_start_date": "2024-01-01T00:00:00Z"},
+                    "bybit": {"effective_start_date": "2024-01-02T00:00:00Z"},
+                },
+            },
         ):
             objectives, penalty, metrics, _ = unpack_evaluation_payload(
                 evaluator.evaluate(individual, [])
             )
 
         assert objectives == (-0.1,)
+        assert metrics["suite_metrics"]["scenarios"]["test"]["exchanges"] == {
+            "binance": {"effective_start_date": "2024-01-01T00:00:00Z"},
+            "bybit": {"effective_start_date": "2024-01-02T00:00:00Z"},
+        }
         assert penalty == 0.0
         assert metrics["constraint_violation"] == 0.0
         assert compile_cfg.call_count == 1

--- a/tests/test_backtest_analysis.py
+++ b/tests/test_backtest_analysis.py
@@ -1212,3 +1212,47 @@ def test_analysis_period_uses_actual_equity_timestamps(columns, count):
         "2024-01-03T00:00:00Z" if count == 3 else
         "2024-01-02T00:00:00Z" if count else None
     )
+
+
+def test_post_process_persists_artifacts_with_infinite_diagnostic(tmp_path, monkeypatch):
+    import json
+    from copy import deepcopy
+
+    fdf = pd.DataFrame(columns=["coin", "pnl"])
+    bal_eq = pd.DataFrame({"balance": [1000.0, 1000.0], "equity": [1000.0, 1000.0]})
+    monkeypatch.setattr(bt, "process_forager_fills", lambda *args, **kwargs: (fdf, {}, bal_eq))
+    monkeypatch.setattr(bt, "sanitize_prepared_config_for_dump", deepcopy)
+    monkeypatch.setattr(bt, "dump_backtest_dataset_metadata", lambda *args, **kwargs: None)
+    plot_calls = []
+    monkeypatch.setattr(
+        bt, "create_forager_balance_figures",
+        lambda *args, **kwargs: plot_calls.append("balance") or {},
+    )
+    monkeypatch.setattr(bt, "save_figures", lambda *args, **kwargs: plot_calls.append("save"))
+    config = {
+        "disable_plotting": ["twe", "pnl", "hard_stop", "coin_fills"],
+        "backtest": {"balance_sample_divider": 60, "coins": {"binance": ["BTC"]}},
+        "bot": {"long": {"total_wallet_exposure_limit": 1.0}, "short": {"total_wallet_exposure_limit": 0.0}},
+        "live": {},
+    }
+    bt.post_process(
+        config=config,
+        hlcvs=np.zeros((2, 1, 3), dtype=np.float64),
+        fills=[],
+        equities_array=np.array([[1704067200000, 1000.0, 1000.0], [1704240000000, 1000.0, 1000.0]]),
+        btc_usd_prices=np.array([]),
+        analysis={"gain_usd": 1.0, "n_days": 2.0, "equity_choppiness": float("inf"),
+                  "effective_start_date": "2024-01-01T00:00:00Z",
+                  "effective_end_date": "2024-01-03T00:00:00Z"},
+        results_path=str(tmp_path), exchange="binance",
+    )
+    result_dir = next(tmp_path.iterdir())
+    raw = json.loads((result_dir / "analysis.json").read_text())
+    saved = json.loads((result_dir / "config.json").read_text())
+    assert np.isinf(raw["equity_choppiness"])
+    assert saved["metrics"]["stats"]["n_days"]["mean"] == 2.0
+    assert saved["metrics"]["nonfinite_diagnostics"]["equity_choppiness"] == "inf"
+    assert saved["metrics"]["effective_end_date"] == "2024-01-03T00:00:00Z"
+    assert (result_dir / "fills.csv").exists()
+    assert (result_dir / "balance_and_equity.csv.gz").exists()
+    assert plot_calls == ["balance", "save"]

--- a/tests/test_backtest_analysis.py
+++ b/tests/test_backtest_analysis.py
@@ -764,6 +764,8 @@ def test_post_process_writes_original_config_for_dataset_override(tmp_path, monk
         "bot": {"long": {"total_wallet_exposure_limit": 1.0}, "short": {"total_wallet_exposure_limit": 0.0}},
         "live": {"approved_coins": {"long": ["BTC"], "short": []}},
         "_original_backtest_config": original_config,
+        "metrics": {"stale": True},
+        "suite_metrics": {"stale": True},
     }
 
     bt.post_process(
@@ -781,6 +783,9 @@ def test_post_process_writes_original_config_for_dataset_override(tmp_path, monk
     assert dumped_by_name["config.original.json"]["backtest"]["coins"]["binance"] == ["ETH"]
     assert dumped_by_name["config.original.json"]["live"]["approved_coins"]["long"] == ["ETH"]
     assert dumped_by_name["config.json"]["backtest"]["coins"]["binance"] == ["BTC"]
+    assert dumped_by_name["config.json"]["metrics"]["stats"]["gain_usd"]["mean"] == 1.0
+    assert "suite_metrics" not in dumped_by_name["config.json"]
+    assert "metrics" not in dumped_by_name["config.original.json"]
 
 
 def test_post_process_disable_plotting_coin_fills_only(tmp_path, monkeypatch):
@@ -1187,3 +1192,23 @@ def test_create_forager_hard_stop_drawdown_figure_labels_coin_mode_max_drawdown(
     assert "hard_stop_drawdown" in figs
     assert "Long Coin HSL Max Drawdown" in axes[0].titles
     assert "Max Coin Drawdown" in axes[0].ylabels
+
+
+@pytest.mark.parametrize("columns", [1, 4])
+@pytest.mark.parametrize("count", [0, 1, 3])
+def test_analysis_period_uses_actual_equity_timestamps(columns, count):
+    timestamps = np.array([1704153600000, 1704196800000, 1704240000000])[:count]
+    equities = np.ones((count, columns))
+    equities[:, 0] = timestamps
+    duration = 1.0 if count == 3 else 0.0
+    result = expand_analysis(
+        {"fills_analysis_duration_days": duration}, {}, None, equities,
+        {"bot": {"long": {}, "short": {}},
+         "backtest": {"start_date": "2020-01-01", "end_date": "2025-01-01"}},
+    )
+    assert result["n_days"] == result["fills_analysis_duration_days"] == duration
+    assert result["effective_start_date"] == ("2024-01-02T00:00:00Z" if count else None)
+    assert result["effective_end_date"] == (
+        "2024-01-03T00:00:00Z" if count == 3 else
+        "2024-01-02T00:00:00Z" if count else None
+    )

--- a/tests/test_config_scoring.py
+++ b/tests/test_config_scoring.py
@@ -260,3 +260,15 @@ def test_scoring_reducer_override_requires_effective_suite_scenario():
             default_scenario="base",
             reducer_cfg={"default": "mean"},
         )
+
+
+@pytest.mark.parametrize("metric", ["n_days", "fills_analysis_duration_days"])
+def test_duration_aliases_load_with_default_max_objective(metric):
+    from config import prepare_config
+    from config_utils import get_template_config
+
+    config = get_template_config()
+    config["optimize"]["scoring"] = [metric]
+    prepared = prepare_config(config, verbose=False)
+    assert prepared["optimize"]["scoring"] == [{"metric": "n_days", "goal": "max"}]
+    assert default_objective_goal(metric) == "max"

--- a/tests/test_metrics_schema.py
+++ b/tests/test_metrics_schema.py
@@ -99,3 +99,18 @@ def test_result_metrics_replace_previous_run_and_roundtrip(tmp_path):
     suite = {"scenarios": {"base": {"effective_start_date": None}}}
     dump_config(attach_result_metrics(config, suite_metrics=suite), str(tmp_path / "config.json"))
     assert json.loads((tmp_path / "config.json").read_text()) == {"suite_metrics": suite}
+
+
+@pytest.mark.parametrize("value", [float("inf"), float("-inf"), float("nan")])
+def test_standalone_nonfinite_diagnostics_do_not_weaken_optimizer_validation(value):
+    import json
+    from metrics_schema import build_standalone_metrics
+
+    analysis = {"equity_choppiness": value, "effective_start_date": "2024-01-01T00:00:00Z"}
+    payload = build_standalone_metrics(analysis, "binance")
+    assert payload["stats"] == {}
+    assert payload["nonfinite_diagnostics"] == {"equity_choppiness": str(value)}
+    json.dumps(payload, allow_nan=False)
+    assert payload["exchanges"]["binance"]["effective_start_date"] == analysis["effective_start_date"]
+    with pytest.raises(MetricAggregationError, match="non-finite metric"):
+        build_scenario_metrics({"binance": analysis})

--- a/tests/test_metrics_schema.py
+++ b/tests/test_metrics_schema.py
@@ -55,3 +55,47 @@ def test_merge_suite_payload_builds_structure():
     assert adg_entry["stats"]["min"] == 0.5
     assert adg_entry["scenarios"]["case_a"] == 0.8
     assert adg_entry["scenarios"]["case_b"] == 1.2
+
+
+@pytest.mark.parametrize("same", [False, True])
+def test_evaluation_dates_are_preserved_without_date_statistics(same):
+    first = {"n_days": 2.0, "effective_start_date": "2024-01-01T00:00:00Z",
+             "effective_end_date": "2024-01-03T00:00:00Z"}
+    second = dict(first) if same else dict(first, n_days=1.0, effective_start_date="2024-01-02T00:00:00Z")
+    metrics = build_scenario_metrics({"binance": first, "bybit": second})
+    assert set(metrics["stats"]) == {"n_days"}
+    assert metrics["stats"]["n_days"]["min"] == (2.0 if same else 1.0)
+    assert metrics["exchanges"]["bybit"]["effective_start_date"] == second["effective_start_date"]
+    assert ("effective_start_date" in metrics) == same
+    suite = merge_suite_payload(metrics["stats"], scenario_metrics={"base": metrics})
+    assert suite["scenarios"]["base"]["exchanges"] == metrics["exchanges"]
+    assert ("effective_start_date" in suite) == same
+
+
+def test_suite_preserves_different_scenario_windows():
+    scenarios = {
+        label: build_scenario_metrics({"combined": {"n_days": float(day),
+            "effective_start_date": f"2024-01-0{day}T00:00:00Z",
+            "effective_end_date": "2024-01-04T00:00:00Z"}})
+        for label, day in [("base", 1), ("stress", 2)]
+    }
+    suite = merge_suite_payload({}, scenario_metrics=scenarios)
+    assert "effective_start_date" not in suite
+    assert suite["scenarios"]["stress"]["effective_start_date"] == "2024-01-02T00:00:00Z"
+
+
+def test_duration_alias_resolves_old_and_new_artifacts():
+    from config.metrics import canonicalize_metric_name, resolve_metric_value
+    assert canonicalize_metric_name("fills_analysis_duration_days_mean") == "n_days_mean"
+    assert resolve_metric_value({"fills_analysis_duration_days_mean": 2.5}, "n_days_mean") == 2.5
+    assert resolve_metric_value({"n_days_mean": 2.5}, "fills_analysis_duration_days_mean") == 2.5
+
+
+def test_result_metrics_replace_previous_run_and_roundtrip(tmp_path):
+    import json
+    from config_utils import dump_config
+    from metrics_schema import attach_result_metrics
+    config = {"metrics": {"old": True}, "suite_metrics": {"old": True}}
+    suite = {"scenarios": {"base": {"effective_start_date": None}}}
+    dump_config(attach_result_metrics(config, suite_metrics=suite), str(tmp_path / "config.json"))
+    assert json.loads((tmp_path / "config.json").read_text()) == {"suite_metrics": suite}

--- a/tests/test_suite_runner.py
+++ b/tests/test_suite_runner.py
@@ -1130,3 +1130,64 @@ def test_run_combined_dataset_passes_payload_timestamps_to_post_process(tmp_path
     np.testing.assert_array_equal(seen["plot_context"].timestamps, timestamps)
     np.testing.assert_array_equal(seen["plot_context"].hlcvs, hlcvs)
     assert seen["plot_context"].hard_stop_plot_data == {"sample": True}
+
+
+@pytest.mark.parametrize("reducer_name", ["n_days", "fills_analysis_duration_days"])
+def test_reduce_metrics_applies_one_policy_to_duration_aliases(reducer_name):
+    results = [
+        ScenarioResult(
+            scenario=SuiteScenario(str(days), None, None, None, None),
+            per_exchange={},
+            metrics={"stats": {
+                "n_days": {"mean": days},
+                "fills_analysis_duration_days": {"mean": days},
+            }},
+            elapsed_seconds=0.0, output_path=None,
+        )
+        for days in (1.0, 3.0)
+    ]
+    summary = reduce_metrics(results, {"default": "mean", reducer_name: "max"})
+    assert summary["aggregated"]["n_days"] == 3.0
+    assert summary["aggregated"]["fills_analysis_duration_days"] == 3.0
+
+
+def test_saved_suite_config_preserves_effective_exchange_defaults(monkeypatch, tmp_path):
+    import json
+    import suite_runner as suite
+    from config_utils import get_template_config
+
+    config = get_template_config()
+    config["backtest"]["exchanges"] = ["binance"]
+    config["live"]["approved_coins"] = {"long": ["BTC"], "short": []}
+    config["live"]["ignored_coins"] = {"long": [], "short": []}
+    suite_cfg = {"scenarios": [{"label": "external"}], "exchanges": ["bybit"]}
+
+    async def noop(*args, **kwargs):
+        pass
+
+    async def datasets(*args, **kwargs):
+        return {"bybit": SimpleNamespace(exchange="bybit", coins=["BTC"])}
+
+    observed = []
+
+    async def run_scenario(scenario, *args, **kwargs):
+        observed.append(scenario.exchanges)
+        return ScenarioResult(scenario, {}, {"stats": {}}, 0.0, None)
+
+    for name in ("load_markets", "format_approved_ignored_coins",
+                 "reject_cross_exchange_market_identifier_collisions"):
+        monkeypatch.setattr(suite, name, noop)
+    monkeypatch.setattr(suite, "validate_suite_side_coin_lists", lambda *a: None)
+    monkeypatch.setattr(suite, "_coalesce_master_coins", lambda coins, *a: coins)
+    monkeypatch.setattr(suite, "prepare_master_datasets", datasets)
+    monkeypatch.setattr(suite, "apply_scenario", lambda *a, **kw: (config, ["BTC"]))
+    monkeypatch.setattr(suite, "_compute_effective_coin_exchange", lambda *a: {"BTC": "bybit"})
+    monkeypatch.setattr(suite, "run_backtest_scenario", run_scenario)
+    asyncio.run(suite.run_backtest_suite_async(
+        config, suite_cfg, disable_plotting=True, suite_output_root=tmp_path,
+    ))
+    saved = json.loads((tmp_path / "config.json").read_text())
+    resumed, _ = build_scenarios(saved["backtest"], base_exchanges=saved["backtest"]["exchanges"])
+    assert observed == [["bybit"]]
+    assert resumed[0].exchanges == observed[0]
+    assert config["backtest"]["exchanges"] == ["binance"]


### PR DESCRIPTION
Backtest outputs expose requested config dates, but their actual evaluated period is difficult to find. Add `n_days` and effective UTC start/end dates to existing metrics structures using Rust equity timestamps. Preserve `fills_analysis_duration_days` as a compatibility alias for lookup, suite reduction, and exact/CPU scoring; both spellings default to maximizing duration. Both retain the existing exact-only GPU scoring classification, with computed diagnostic durations available.

Keep exchange and scenario dates separate when windows differ. CPU suite optimization carries complete scenario metrics into Pareto output. Standalone configs contain fresh `metrics`; suite backtests save a root config with `suite_metrics` and effective exchange defaults. Standalone non-finite diagnostics are string-encoded separately from finite statistics, preserving raw analysis and artifact creation while optimizer/suite aggregation stays strict.

Validation: 460 tests passed on the integrated branch across analysis, metric schema, scoring/config loading, suite persistence, CPU/GPU metric plumbing, and optimizer evaluation. Earlier comprehensive validation passed 705 focused tests. The isolated Rust extension was source-fingerprint verified. Regressions cover date retention, alias reduction and scoring defaults, suite exchange inheritance, GPU eligibility, and successful standalone artifact persistence with infinite diagnostics.
