### PR TITLE
Keep HSL coverage waivers per-run for wrapped configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ All notable user-facing changes will be documented in this file.
 - The monitor relay rejects foreign or malformed browser WebSocket origins before reading or
   sending account snapshots, while preserving the dashboard and originless native clients.
 
+- Wrapped config documents now strip persisted `hsl_accept_incomplete_history` overrides before
+  normalization, so the HSL coverage waiver remains an explicit per-run CLI choice after reload.
+
 - Added `fills_gap_time_weighted_mean_hours` as an exact backtest and CPU/GPU optimizer metric.
   It minimizes `sum(gap_hours^2) / sum(gap_hours)` over unique portfolio fill timestamps and the
   analysis boundaries, providing smoother selection pressure against long no-fill periods than a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ All notable user-facing changes will be documented in this file.
   sending account snapshots, while preserving the dashboard and originless native clients.
 
 - Wrapped config documents now strip persisted `hsl_accept_incomplete_history` overrides before
-  normalization, so the HSL coverage waiver remains an explicit per-run CLI choice after reload.
+  normalization and apply CLI overrides to the wrapped payload, so the HSL coverage waiver remains
+  an explicit per-run CLI choice after reload.
 
 - Added `fills_gap_time_weighted_mean_hours` as an exact backtest and CPU/GPU optimizer metric.
   It minimizes `sum(gap_hours^2) / sum(gap_hours)` over unique portfolio fill timestamps and the

--- a/src/config/load.py
+++ b/src/config/load.py
@@ -13,10 +13,18 @@ def strip_persisted_hsl_incomplete_history_override(source: dict, config_path: s
     contract and must only ever be granted by the CLI flag of the current
     invocation; a value persisted in a config file is stripped here, before
     CLI overrides are applied, so it can never survive a restart."""
-    containers = [source]
-    live = source.get("live")
-    if isinstance(live, dict):
-        containers.append(live)
+    roots = [source]
+    # The supported nested_current document is unwrapped during normalization,
+    # after this per-run guard. Sanitize that root before taking raw snapshots.
+    wrapped = source.get("config")
+    if isinstance(wrapped, dict):
+        roots.append(wrapped)
+    containers = []
+    for root in roots:
+        containers.append(root)
+        live = root.get("live")
+        if isinstance(live, dict):
+            containers.append(live)
     for container in containers:
         if container.get("hsl_accept_incomplete_history"):
             logging.critical(

--- a/src/config/normalize.py
+++ b/src/config/normalize.py
@@ -50,20 +50,23 @@ def normalize_config(
     else:
         existing_log = []
     tracker = ConfigTransformTracker()
+    # Preserve explicit input values from the same payload that is normalized.
+    # Wrapper metadata stays on the outer document for provenance.
+    flavor = detect_flavor(config, {})
+    source_payload = config["config"] if flavor == "nested_current" else config
     optimize_suite_defined = (
-        isinstance(config.get("optimize"), dict) and "suite" in config["optimize"]
+        isinstance(source_payload.get("optimize"), dict) and "suite" in source_payload["optimize"]
     )
     raw_optimize_limits_present = (
-        isinstance(config.get("optimize"), dict) and "limits" in config["optimize"]
+        isinstance(source_payload.get("optimize"), dict) and "limits" in source_payload["optimize"]
     )
-    raw_optimize_limits = deepcopy(config.get("optimize", {}).get("limits"))
+    raw_optimize_limits = deepcopy(source_payload.get("optimize", {}).get("limits"))
     raw_optimize_snapshot = (
-        deepcopy(config.get("optimize")) if isinstance(config.get("optimize"), dict) else {}
+        deepcopy(source_payload.get("optimize")) if isinstance(source_payload.get("optimize"), dict) else {}
     )
-    coin_sources_input = deepcopy(config.get("backtest", {}).get("coin_sources"))
+    coin_sources_input = deepcopy(source_payload.get("backtest", {}).get("coin_sources"))
     live_coin_sources_input = {}
     template = get_template_config()
-    flavor = detect_flavor(config, template)
     result = build_base_config_from_flavor(config, template, flavor, verbose)
     if flavor == "nested_current" and isinstance(config.get("config"), dict):
         source_sections = set(config["config"])

--- a/src/config_utils.py
+++ b/src/config_utils.py
@@ -2242,7 +2242,8 @@ def recursive_config_update(config, key, value, path=None, verbose=False):
 def update_config_with_args(
     config, args, verbose=False, allowed_keys: Optional[set[str]] = None
 ):
-    if detect_flavor(config, get_template_config()) == "nested_current":
+    transform_root = config
+    if detect_flavor(config, {}) == "nested_current":
         config = config["config"]
     changed_keys = []
     diffs = []
@@ -2277,7 +2278,7 @@ def update_config_with_args(
         details = {"keys": changed_keys}
         if diffs:
             details["diffs"] = diffs
-        record_transform(config, "update_config_with_args", details)
+        record_transform(transform_root, "update_config_with_args", details)
 
 
 def get_template_config():

--- a/src/config_utils.py
+++ b/src/config_utils.py
@@ -2242,6 +2242,8 @@ def recursive_config_update(config, key, value, path=None, verbose=False):
 def update_config_with_args(
     config, args, verbose=False, allowed_keys: Optional[set[str]] = None
 ):
+    if detect_flavor(config, get_template_config()) == "nested_current":
+        config = config["config"]
     changed_keys = []
     diffs = []
     for key, value in vars(args).items():

--- a/src/config_utils.py
+++ b/src/config_utils.py
@@ -2239,12 +2239,16 @@ def recursive_config_update(config, key, value, path=None, verbose=False):
     )
 
 
+def effective_config_payload(config: dict) -> dict:
+    """Return the supported payload without discarding wrapper provenance."""
+    return config["config"] if detect_flavor(config, {}) == "nested_current" else config
+
+
 def update_config_with_args(
     config, args, verbose=False, allowed_keys: Optional[set[str]] = None
 ):
     transform_root = config
-    if detect_flavor(config, {}) == "nested_current":
-        config = config["config"]
+    config = effective_config_payload(config)
     changed_keys = []
     diffs = []
     for key, value in vars(args).items():

--- a/src/optimize.py
+++ b/src/optimize.py
@@ -101,6 +101,7 @@ from config_utils import (
     add_config_arguments,
     project_template_config_for_cli,
     update_config_with_args,
+    effective_config_payload,
     recursive_config_update,
     merge_negative_cli_values,
     clean_config,
@@ -3398,16 +3399,13 @@ async def main():
     initial_log_level = resolve_log_level(args.log_level, None, fallback=1)
     configure_logging(debug=initial_log_level)
     source_config, base_config_path, raw_snapshot = load_input_config(args.config_path)
-    existing_limits = deepcopy(source_config.get("optimize", {}).get("limits"))
+    existing_limits = deepcopy(effective_config_payload(source_config).get("optimize", {}).get("limits"))
     update_config_with_args(source_config, args, verbose=True, allowed_keys=allowed_config_keys)
     cli_limits_override = _resolve_cli_limits_override(args, existing_limits=existing_limits)
     if cli_limits_override is not None:
-        recursive_config_update(
-            source_config,
-            "optimize.limits",
-            cli_limits_override,
-            verbose=True,
-        )
+        update_config_with_args(source_config,
+                                argparse.Namespace(**{"optimize.limits": cli_limits_override}),
+                                verbose=True, allowed_keys={"optimize.limits"})
     config = prepare_config(
         source_config,
         base_config_path=base_config_path,

--- a/tests/optimization/test_optimize.py
+++ b/tests/optimization/test_optimize.py
@@ -472,6 +472,36 @@ class TestNormalizeOptionalBoolFlag:
         assert result == ["--suite=true", "custom_value"]
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("wrapped", [False, True])
+@pytest.mark.parametrize("flags,expected", [
+    (["--clear-limits"], []),
+    (["--limit", "adg > 0.0008"], ["drawdown_worst_usd", "adg_usd"]),
+    (["--clear-limits", "--limit", "adg > 0.0008"], ["adg_usd"]),
+])
+async def test_optimizer_cli_applies_special_limits_before_preparation(
+    tmp_path, monkeypatch, wrapped, flags, expected
+):
+    config = optimize.get_template_config()
+    config["optimize"]["limits"] = [{"metric": "drawdown_worst", "penalize_if": "greater_than", "value": 0.3}]
+    path = tmp_path / "input.json"
+    path.write_text(json.dumps({"config": config} if wrapped else config))
+    original_prepare = optimize.prepare_config
+
+    class PreparedOnly(Exception):
+        pass
+
+    def capture_prepared(source, **kwargs):
+        prepared = original_prepare(source, **kwargs)
+        assert [entry["metric"] for entry in prepared["optimize"]["limits"]] == expected
+        raise PreparedOnly
+
+    monkeypatch.setattr(optimize, "prepare_config", capture_prepared)
+    monkeypatch.setattr(optimize.sys, "argv", ["passivbot optimize", str(path), *flags])
+    with pytest.raises(PreparedOnly):
+        await optimize.main()
+
+
 class TestResolveCliLimitsOverride:
     def test_returns_none_when_no_limit_flags_present(self):
         args = argparse.Namespace(**{"optimize.limits": None, "limit_entries": None, "clear_limits": False})

--- a/tests/test_hsl_incomplete_history_override.py
+++ b/tests/test_hsl_incomplete_history_override.py
@@ -154,3 +154,20 @@ def test_wrapped_config_applies_explicit_cli_waiver_before_preparation(
     assert prepared["live"]["leverage"] == 3
     assert not raw["config"]["live"].get("hsl_accept_incomplete_history", False)
     assert "live" not in source
+    assert any(step.get("step") == "update_config_with_args"
+               for step in prepared["_transform_log"])
+
+
+@pytest.mark.parametrize("wrapped", [False, True])
+def test_cli_overrides_do_not_load_strategy_metadata(monkeypatch, wrapped):
+    import config_utils
+
+    def unavailable():
+        raise AssertionError("override processing must not load Rust metadata")
+
+    monkeypatch.setattr(config_utils, "get_template_config", unavailable)
+    payload = {"bot": {}, "live": {"leverage": 1}, "backtest": {}, "optimize": {}}
+    source = {"config": payload} if wrapped else payload
+    config_utils.update_config_with_args(source, SimpleNamespace(**{"live.leverage": 3}))
+    assert payload["live"]["leverage"] == 3
+    assert source["_transform_log"][-1]["step"] == "update_config_with_args"

--- a/tests/test_hsl_incomplete_history_override.py
+++ b/tests/test_hsl_incomplete_history_override.py
@@ -20,6 +20,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 from config.load import (  # noqa: E402
     load_input_config,
     load_prepared_config,
+    prepare_config,
     strip_persisted_hsl_incomplete_history_override,
 )
 
@@ -124,3 +125,32 @@ def test_serialized_per_run_override_is_stripped_when_wrapped_and_reloaded(tmp_p
     path.write_text(json.dumps({"config": source}))
     reloaded = load_prepared_config(str(path), verbose=False, log_info=False)
     assert reloaded["live"]["hsl_accept_incomplete_history"] is False
+
+
+@pytest.mark.parametrize("persisted_waiver", [False, True])
+def test_wrapped_config_applies_explicit_cli_waiver_before_preparation(
+    tmp_path, persisted_waiver
+):
+    from config.schema import get_template_config
+    from config_utils import update_config_with_args
+
+    config = get_template_config()
+    config["live"]["hsl_accept_incomplete_history"] = persisted_waiver
+    path = tmp_path / "config.json"
+    path.write_text(json.dumps({"config": config}))
+    source, base_path, raw = load_input_config(str(path), log_info=False)
+    update_config_with_args(
+        source,
+        SimpleNamespace(**{"live.hsl_accept_incomplete_history": True, "live.leverage": 3}),
+        allowed_keys={"live.hsl_accept_incomplete_history", "live.leverage"},
+    )
+
+    prepared = prepare_config(
+        source, base_config_path=base_path, raw_snapshot=raw,
+        live_only=True, target="live", verbose=False,
+    )
+
+    assert prepared["live"]["hsl_accept_incomplete_history"] is True
+    assert prepared["live"]["leverage"] == 3
+    assert not raw["config"]["live"].get("hsl_accept_incomplete_history", False)
+    assert "live" not in source

--- a/tests/test_hsl_incomplete_history_override.py
+++ b/tests/test_hsl_incomplete_history_override.py
@@ -13,10 +13,13 @@ import sys
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 from config.load import (  # noqa: E402
     load_input_config,
+    load_prepared_config,
     strip_persisted_hsl_incomplete_history_override,
 )
 
@@ -77,3 +80,47 @@ def test_cli_override_survives_because_it_is_applied_after_load(tmp_path):
         source, args, allowed_keys={"live.hsl_accept_incomplete_history"}
     )
     assert source["live"]["hsl_accept_incomplete_history"] is True
+
+
+@pytest.mark.parametrize("shape", ["current", "live_only", "nested_current"])
+def test_prepared_config_cannot_restore_persisted_override(tmp_path, caplog, shape):
+    from config.schema import get_template_config
+
+    config = get_template_config()
+    config["live"]["hsl_accept_incomplete_history"] = True
+    if shape == "live_only":
+        config = {key: config[key] for key in ("config_version", "bot", "live")}
+    document = {"config": config} if shape == "nested_current" else config
+    path = tmp_path / "config.json"
+    path.write_text(json.dumps(document))
+
+    with caplog.at_level(logging.CRITICAL):
+        prepared = load_prepared_config(
+            str(path), live_only=True, target="live", verbose=False, log_info=False
+        )
+
+    assert prepared["live"]["hsl_accept_incomplete_history"] is False
+    source, _, raw = load_input_config(str(path), log_info=False)
+    for snapshot in (source, raw):
+        effective = snapshot["config"] if shape == "nested_current" else snapshot
+        assert "hsl_accept_incomplete_history" not in effective["live"]
+    assert "per-run CLI-only" in caplog.text
+
+
+def test_serialized_per_run_override_is_stripped_when_wrapped_and_reloaded(tmp_path):
+    from config.schema import get_template_config
+    from config_utils import update_config_with_args
+
+    path = tmp_path / "config.json"
+    path.write_text(json.dumps(get_template_config()))
+    source, _, _ = load_input_config(str(path), log_info=False)
+    update_config_with_args(
+        source,
+        SimpleNamespace(**{"live.hsl_accept_incomplete_history": True}),
+        allowed_keys={"live.hsl_accept_incomplete_history"},
+    )
+    assert source["live"]["hsl_accept_incomplete_history"] is True
+
+    path.write_text(json.dumps({"config": source}))
+    reloaded = load_prepared_config(str(path), verbose=False, log_info=False)
+    assert reloaded["live"]["hsl_accept_incomplete_history"] is False


### PR DESCRIPTION
Wrapped configuration files could preserve a persisted HSL coverage waiver or discard explicit CLI settings. The loader now strips persisted waivers before raw-snapshot capture, and CLI overrides target the effective payload while retaining outer-document transform provenance. Optimizer `--limit` and `--clear-limits` follow the same path, and normalization preserves explicitly supplied wrapped optimizer values. Wrapper detection remains independent of Rust metadata.

Regression coverage includes persisted and per-run waivers, wrapper transform logs, metadata-independent overrides, and actual optimizer CLI load/preparation for limit clear/append combinations.

Validation: 566 config and optimizer tests passed with a rebuilt, source-verified isolated extension; AI documentation checks passed with existing advisory warnings; `git diff --check` passed.
