### PR TITLE
Revalidate account state before live order submission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ All notable user-facing changes will be documented in this file.
   normalization and apply CLI overrides to the wrapped payload, so the HSL coverage waiver remains
   an explicit per-run CLI choice after reload.
 
+- Live order creation now rechecks account invalidation after exchange configuration and quote
+  refreshes, preventing orders based on a superseded plan when a private fill update arrives.
+
 - Added `fills_gap_time_weighted_mean_hours` as an exact backtest and CPU/GPU optimizer metric.
   It minimizes `sum(gap_hours^2) / sum(gap_hours)` over unique portfolio fill timestamps and the
   analysis boundaries, providing smoother selection pressure against long no-fill periods than a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,9 @@ All notable user-facing changes will be documented in this file.
   an explicit per-run CLI choice after reload.
 
 - Live order creation now rechecks account invalidation after exchange configuration and quote
-  refreshes, preventing orders based on a superseded plan when a private fill update arrives.
+  refreshes and immediately before each connector call, preventing orders based on a superseded
+  plan when a private fill update arrives. Partial-fill updates also invalidate account state when
+  they match a recently created order.
 
 - Added `fills_gap_time_weighted_mean_hours` as an exact backtest and CPU/GPU optimizer metric.
   It minimizes `sum(gap_hours^2) / sum(gap_hours)` over unique portfolio fill timestamps and the

--- a/docs/ai/features/exchange_integrations.md
+++ b/docs/ai/features/exchange_integrations.md
@@ -57,6 +57,10 @@ make held positions wholly nontradable.
 
 ## Private Order Websocket Normalization
 
+Order rows proving fill progress (`filled > 0` or `remaining < amount`) request an authoritative
+account refresh even when their status remains open and they match a recent local creation.
+A creation acknowledgement may be a self-echo; fill progress invalidates the account-wide plan.
+
 Authoritative REST open-order reconciliation remains strict. Binance and KuCoin
 private websocket notifications for Passivbot-owned orders may omit native
 long/short metadata; only that hint path may recover `position_side`, only in

--- a/src/exchanges/ccxt_bot.py
+++ b/src/exchanges/ccxt_bot.py
@@ -142,6 +142,8 @@ class CCXTBot(Passivbot):
         """
         order["position_side"] = self._get_position_side_for_order(order)
         order["qty"] = order["amount"]
+        if self._ws_order_update_has_fill_progress(order):
+            order["_pb_order_update_requires_authoritative_refresh"] = True
         return order
 
     @staticmethod

--- a/src/exchanges/hyperliquid.py
+++ b/src/exchanges/hyperliquid.py
@@ -668,6 +668,9 @@ class HyperliquidBot(CCXTBot):
                         level=logging.DEBUG,
                     )
                 if normalized:
+                    for order in normalized:
+                        if self._hl_ws_order_has_fill_progress(order):
+                            order["_pb_order_update_requires_authoritative_refresh"] = True
                     self.handle_order_update(normalized)
             except asyncio.CancelledError:
                 break

--- a/src/live/executor.py
+++ b/src/live/executor.py
@@ -1067,6 +1067,30 @@ async def execute_order_plan(
         return to_cancel, to_create
 
 
+def record_create_connector_admission(bot, order: dict) -> None:
+    """Record submission only once the per-order account-generation guard admits it."""
+    passivbot_cls = _pb_attr("Passivbot")
+    context = getattr(bot, "_execution_connector_call_context", None) or {}
+    wave = context.get("wave")
+    index = next(
+        (idx for idx, candidate in enumerate(context.get("orders", [])) if candidate is order),
+        None,
+    )
+    passivbot_cls._record_emitted_order_custom_id(bot, order, status="submitted")
+    passivbot_cls._record_order_churn_allowance_attempts(bot, 1, action_kind="create")
+    passivbot_cls._emit_execution_order_event(
+        bot,
+        event_type=EventTypes.EXECUTION_CREATE_SENT,
+        order=order,
+        action="create",
+        status="started",
+        reason_code=ReasonCodes.SUBMITTED_TO_EXCHANGE,
+        index=index,
+        wave=wave,
+    )
+    _record_fresh_entry_orders(bot, "record_eligible_orders", [order])
+
+
 async def execute_orders_parent(bot, orders: list[dict]) -> list[dict]:
     """Submit a batch of orders after throttling and bookkeeping."""
     passivbot_cls = _pb_attr("Passivbot")
@@ -1097,19 +1121,6 @@ async def execute_orders_parent(bot, orders: list[dict]) -> list[dict]:
         grouped_orders[order["symbol"]].append(order)
     bot._log_order_action_summary(grouped_orders, "post")
     wave = getattr(bot, "_order_wave_in_progress", None)
-    for idx, order in enumerate(orders):
-        passivbot_cls._emit_execution_order_event(
-            bot,
-            event_type=EventTypes.EXECUTION_CREATE_SENT,
-            order=order,
-            action="create",
-            status="started",
-            reason_code=ReasonCodes.SUBMITTED_TO_EXCHANGE,
-            index=idx,
-            wave=wave,
-        )
-    _record_fresh_entry_orders(bot, "record_eligible_orders", orders)
-    _emit_fresh_entry_eligibility(bot, passivbot_cls, wave)
     connector_call_context = {
         "action": "create",
         "orders": orders,
@@ -1119,6 +1130,7 @@ async def execute_orders_parent(bot, orders: list[dict]) -> list[dict]:
     try:
         res = await bot.execute_orders(orders)
     except RestartBotException:
+        _emit_fresh_entry_eligibility(bot, passivbot_cls, wave)
         raise
     except Exception as exc:
         for idx, order in enumerate(orders):
@@ -1143,6 +1155,7 @@ async def execute_orders_parent(bot, orders: list[dict]) -> list[dict]:
                 reason=ReasonCodes.EXCHANGE_EXCEPTION,
                 error=exc,
             )
+        _emit_fresh_entry_eligibility(bot, passivbot_cls, wave)
         raise
     finally:
         if (
@@ -1172,6 +1185,7 @@ async def execute_orders_parent(bot, orders: list[dict]) -> list[dict]:
                 status="create_response_missing",
                 reason="empty_response",
             )
+        _emit_fresh_entry_eligibility(bot, passivbot_cls, wave)
         return []
     if len(orders) != len(res):
         for idx, order in enumerate(orders):
@@ -1201,6 +1215,7 @@ async def execute_orders_parent(bot, orders: list[dict]) -> list[dict]:
                 len(orders),
                 len(res),
             )
+        _emit_fresh_entry_eligibility(bot, passivbot_cls, wave)
         return []
     to_return = []
     for idx, (ex, order) in enumerate(zip(res, orders)):
@@ -1313,6 +1328,7 @@ async def execute_orders_parent(bot, orders: list[dict]) -> list[dict]:
             )
         bot._health_orders_placed += len(to_return)
         _request_authoritative_confirmation(bot, passivbot_cls, {"open_orders"})
+    _emit_fresh_entry_eligibility(bot, passivbot_cls, wave)
     return to_return
 
 

--- a/src/live/executor.py
+++ b/src/live/executor.py
@@ -1130,7 +1130,8 @@ async def execute_orders_parent(bot, orders: list[dict]) -> list[dict]:
     try:
         res = await bot.execute_orders(orders)
     except RestartBotException:
-        _emit_fresh_entry_eligibility(bot, passivbot_cls, wave)
+        # Batch results were not classified; do not publish a partial cycle trace.
+        bot._fresh_entry_eligibility_trace = None
         raise
     except Exception as exc:
         for idx, order in enumerate(orders):

--- a/src/live/executor.py
+++ b/src/live/executor.py
@@ -975,6 +975,48 @@ async def execute_order_plan(
             order_wave["deferred_create"] += max(
                 0, before_capacity - len(to_create_mod)
             )
+        snapshot = getattr(bot, "_current_planning_snapshot", None)
+        planned_generation = int(
+            getattr(snapshot, "account_invalidation_generation", 0) or 0
+        )
+        current_generation = int(
+            getattr(bot, "_account_invalidation_generation", 0) or 0
+        )
+        if to_create_mod and current_generation != planned_generation:
+            # Configuration and quote reads above can yield to private fill updates.
+            # Their account-wide invalidation supersedes every ordinary planned create.
+            blocked = [
+                order
+                for order in to_create_mod
+                if not _is_dedicated_protective_market_panic(
+                    bot, order, configure_creations=configure_creations
+                )
+            ]
+            blocked_ids = {id(order) for order in blocked}
+            to_create_mod = [
+                order for order in to_create_mod if id(order) not in blocked_ids
+            ]
+            if blocked:
+                if order_wave is not None:
+                    order_wave["skipped_create"] += len(blocked)
+                _record_fresh_entry_orders(
+                    bot, "record_blocked_orders", blocked, "state_change_detected"
+                )
+                passivbot_cls._emit_execution_create_filter_event(
+                    bot,
+                    event_type=EventTypes.EXECUTION_CREATE_SKIPPED,
+                    status="skipped",
+                    reason_code=ReasonCodes.STATE_CHANGE_DETECTED,
+                    order_count=len(blocked),
+                    symbols=_symbols_from_orders(blocked),
+                    wave=order_wave,
+                    message="create orders skipped because account state changed after planning",
+                    data={"blocked_symbols_count": len(set(_symbols_from_orders(blocked)))},
+                )
+                logging.info(
+                    "[order] account state changed after planning; skipped %d creates until refresh and replanning",
+                    len(blocked),
+                )
         if to_create_mod:
             res = None
             try:

--- a/src/live/executor.py
+++ b/src/live/executor.py
@@ -16,6 +16,10 @@ from pure_funcs import shorten_custom_id
 from utils import utc_ms as _utils_utc_ms
 
 
+class DeferredOrderCreation:
+    """An order deliberately withheld before the exchange connector was called."""
+
+
 def _passivbot_module():
     module = sys.modules.get("passivbot")
     if module is None:
@@ -573,6 +577,10 @@ async def execute_order_plan(
 ):
     """Execute a precomputed order plan against the exchange."""
     passivbot_cls = _pb_attr("Passivbot")
+    snapshot = getattr(bot, "_current_planning_snapshot", None)
+    planned_generation = int(
+        getattr(snapshot, "account_invalidation_generation", 0) or 0
+    )
     order_wave = passivbot_cls._begin_order_wave(bot, to_cancel, to_create)
     cancel_first_barrier = (
         bool(to_cancel)
@@ -975,10 +983,6 @@ async def execute_order_plan(
             order_wave["deferred_create"] += max(
                 0, before_capacity - len(to_create_mod)
             )
-        snapshot = getattr(bot, "_current_planning_snapshot", None)
-        planned_generation = int(
-            getattr(snapshot, "account_invalidation_generation", 0) or 0
-        )
         current_generation = int(
             getattr(bot, "_account_invalidation_generation", 0) or 0
         )
@@ -1018,6 +1022,13 @@ async def execute_order_plan(
                     len(blocked),
                 )
         if to_create_mod:
+            for order in to_create_mod:
+                order["_planned_account_invalidation_generation"] = planned_generation
+                order["_dedicated_protective_market_panic"] = (
+                    _is_dedicated_protective_market_panic(
+                        bot, order, configure_creations=configure_creations
+                    )
+                )
             res = None
             try:
                 create_started_ms = _utc_ms()
@@ -1072,9 +1083,6 @@ async def execute_orders_parent(bot, orders: list[dict]) -> list[dict]:
         int(bot.get_exchange_time()) if hasattr(bot, "get_exchange_time") else _utc_ms()
     )
     for order in orders:
-        passivbot_cls._record_emitted_order_custom_id(
-            bot, order, emitted_ts=emitted_ts, status="submitted"
-        )
         bot.log_order_action(
             order,
             "posting order",
@@ -1108,9 +1116,6 @@ async def execute_orders_parent(bot, orders: list[dict]) -> list[dict]:
         "wave": wave,
     }
     bot._execution_connector_call_context = connector_call_context
-    _pb_attr("Passivbot")._record_order_churn_allowance_attempts(
-        bot, len(orders), action_kind="create"
-    )
     try:
         res = await bot.execute_orders(orders)
     except RestartBotException:
@@ -1199,6 +1204,23 @@ async def execute_orders_parent(bot, orders: list[dict]) -> list[dict]:
         return []
     to_return = []
     for idx, (ex, order) in enumerate(zip(res, orders)):
+        if isinstance(ex, DeferredOrderCreation):
+            if wave is not None:
+                wave["skipped_create"] = wave.get("skipped_create", 0) + 1
+            _record_fresh_entry_orders(
+                bot, "record_blocked_orders", [order], "state_change_detected"
+            )
+            passivbot_cls._emit_execution_create_filter_event(
+                bot,
+                event_type=EventTypes.EXECUTION_CREATE_SKIPPED,
+                status="skipped",
+                reason_code=ReasonCodes.STATE_CHANGE_DETECTED,
+                order_count=1,
+                symbols=[order["symbol"]],
+                wave=wave,
+                message="create order skipped because account state changed before connector call",
+            )
+            continue
         if not bot.did_create_order(ex):
             if isinstance(ex, Exception):
                 reason_code = "result_exception"

--- a/src/live/planning_gates.py
+++ b/src/live/planning_gates.py
@@ -256,6 +256,9 @@ def build_staged_planning_snapshot(
     if not isinstance(data_packets, dict):
         data_packets = {}
     snapshot = PlanningSnapshot.capture(
+        account_invalidation_generation=int(
+            getattr(bot, "_account_invalidation_generation", 0) or 0
+        ),
         ts_ms=_utc_ms(),
         exchange=str(getattr(bot, "exchange", "")),
         user=str(bot.config_get(["live", "user"]) or ""),
@@ -321,6 +324,9 @@ def build_protective_planning_snapshot(
     if not isinstance(data_packets, dict):
         data_packets = {}
     snapshot = PlanningSnapshot.capture(
+        account_invalidation_generation=int(
+            getattr(bot, "_account_invalidation_generation", 0) or 0
+        ),
         ts_ms=_utc_ms(),
         exchange=str(getattr(bot, "exchange", "")),
         user=str(bot.config_get(["live", "user"]) or ""),

--- a/src/live/planning_snapshot.py
+++ b/src/live/planning_snapshot.py
@@ -71,6 +71,7 @@ class PlanningSnapshot:
     market_snapshots: tuple[PlanningMarketSnapshot, ...]
     market_snapshot_max_age_ms: int
     completed_candle_signature: Any
+    account_invalidation_generation: int = 0
     snapshot_id: str = ""
     data_packets: tuple[DataPacketMetadata, ...] = ()
 
@@ -88,6 +89,7 @@ class PlanningSnapshot:
         market_snapshots: Mapping[str, MarketSnapshot],
         market_snapshot_max_age_ms: int,
         data_packets: Mapping[str, DataPacketMetadata] | None = None,
+        account_invalidation_generation: int = 0,
     ) -> "PlanningSnapshot":
         ordered_symbols = tuple(sorted(dict.fromkeys(str(symbol) for symbol in symbols if symbol)))
         required = tuple(sorted(dict.fromkeys(str(surface) for surface in required_surfaces)))
@@ -112,6 +114,7 @@ class PlanningSnapshot:
             if data_packets is not None and surface in data_packets
         )
         snapshot_payload = {
+            "account_invalidation_generation": int(account_invalidation_generation),
             "ts_ms": int(ts_ms),
             "exchange": str(exchange),
             "user": str(user),
@@ -125,6 +128,7 @@ class PlanningSnapshot:
             "data_packets": [packet.to_dict() for packet in packet_rows],
         }
         return cls(
+            account_invalidation_generation=int(account_invalidation_generation),
             ts_ms=int(ts_ms),
             exchange=str(exchange),
             user=str(user),
@@ -187,6 +191,7 @@ class PlanningSnapshot:
 
     def to_dict(self) -> dict[str, Any]:
         return {
+            "account_invalidation_generation": self.account_invalidation_generation,
             "ts_ms": self.ts_ms,
             "exchange": self.exchange,
             "user": self.user,

--- a/src/live/reconciler.py
+++ b/src/live/reconciler.py
@@ -897,6 +897,10 @@ def mark_account_critical_state_dirty(
     level: int = logging.DEBUG,
 ) -> None:
     """Force a coherent account-state refresh before the next execution cycle."""
+    # Separate external account invalidations from intentional order-write confirmations.
+    bot._account_invalidation_generation = int(
+        getattr(bot, "_account_invalidation_generation", 0) or 0
+    ) + 1
     min_epoch = int(bot._ensure_freshness_ledger().epoch) + 1
     bot._request_authoritative_confirmation(ACCOUNT_SURFACES, min_epoch=min_epoch)
     bot.execution_scheduled = True

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -21605,7 +21605,7 @@ class Passivbot:
         """
         return {}
 
-    async def execute_order(self, order: dict) -> dict:
+    async def execute_order(self, order: dict) -> dict | executor.DeferredOrderCreation:
         """Place a single order via the exchange client."""
         params = {
             "symbol": order["symbol"],
@@ -21615,6 +21615,17 @@ class Passivbot:
             "price": order["price"],
             "params": self._build_order_params(order),
         }
+        planned_generation = order.get("_planned_account_invalidation_generation")
+        if (
+            planned_generation is not None
+            and planned_generation
+            != int(getattr(self, "_account_invalidation_generation", 0) or 0)
+            and not order.get("_dedicated_protective_market_panic", False)
+        ):
+            return executor.DeferredOrderCreation()
+        # No await between this per-order admission and entering the connector.
+        self._record_emitted_order_custom_id(order, status="submitted")
+        self._record_order_churn_allowance_attempts(1, action_kind="create")
         self._emit_execution_connector_call_started_event(
             order=order,
             action="create",

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -21624,8 +21624,7 @@ class Passivbot:
         ):
             return executor.DeferredOrderCreation()
         # No await between this per-order admission and entering the connector.
-        self._record_emitted_order_custom_id(order, status="submitted")
-        self._record_order_churn_allowance_attempts(1, action_kind="create")
+        executor.record_create_connector_admission(self, order)
         self._emit_execution_connector_call_started_event(
             order=order,
             action="create",

--- a/tests/exchanges/test_ccxt_bot.py
+++ b/tests/exchanges/test_ccxt_bot.py
@@ -654,6 +654,7 @@ class TestCCXTBotConnectorCallEvents:
         bot.user = "binance_01"
         bot.bot_id = "bot-1"
         bot.cca = CCA()
+        bot.open_orders = {}
         bot._build_order_params = lambda _order: {"postOnly": True}
         bot._live_event_current_cycle_id = "cy_3"
         bot._execution_connector_call_context = {

--- a/tests/exchanges/test_ccxt_bot.py
+++ b/tests/exchanges/test_ccxt_bot.py
@@ -671,8 +671,9 @@ class TestCCXTBotConnectorCallEvents:
         result = await bot.execute_order(order)
 
         assert result == {"id": "oid-1", "status": "open"}
-        assert [marker[0] for marker in markers] == ["event", "connector"]
-        _, event_type, event = markers[0]
+        assert [marker[0] for marker in markers] == ["event", "event", "connector"]
+        assert markers[0][1] == EventTypes.EXECUTION_CREATE_SENT
+        _, event_type, event = markers[1]
         assert event_type == EventTypes.EXECUTION_CREATE_CONNECTOR_CALL_STARTED
         assert event["reason_code"] == ReasonCodes.CONNECTOR_CALL_STARTED
         assert event["order_wave_id"] == "ow_3"

--- a/tests/test_fresh_entry_eligibility_integration.py
+++ b/tests/test_fresh_entry_eligibility_integration.py
@@ -226,9 +226,21 @@ class _CreateBot:
     def _resolve_pb_order_type(self, order):
         return str(order.get("pb_order_type") or "unknown")
 
+    def _build_order_params(self, _order):
+        return {}
+
+    def _emit_execution_connector_call_started_event(self, **_kwargs):
+        return None
+
     async def execute_orders(self, orders):
+        from types import SimpleNamespace
+
+        async def create_order(**_params):
+            return {"id": "created"}
+
+        self.cca = SimpleNamespace(create_order=create_order)
         self.submitted = list(orders)
-        return [{"id": "created", **order} for order in orders]
+        return [await Passivbot.execute_order(self, order) for order in orders]
 
     def did_create_order(self, _result):
         return True

--- a/tests/test_fresh_entry_eligibility_integration.py
+++ b/tests/test_fresh_entry_eligibility_integration.py
@@ -649,3 +649,59 @@ async def test_connector_bound_create_attempt_is_counted_once_even_when_ambiguou
             "wave": {"event_id": "ow_1"},
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_restart_after_mixed_create_results_omits_unclassified_eligibility(
+    monkeypatch,
+):
+    from types import MethodType, SimpleNamespace
+    from exchanges.ccxt_bot import CCXTBot
+    from passivbot_exceptions import RestartBotException
+
+    orders = [_initial("ADA/USDT:USDT"), _initial("BTC/USDT:USDT")]
+    for order in orders:
+        order["_planned_account_invalidation_generation"] = 0
+    trace = FreshEntryEligibilityTrace()
+    trace.record_ideal_orders(orders)
+    for order in orders:
+        trace.record_evaluated(order["symbol"], "long")
+    bot = _CreateBot(trace)
+    live_value = bot.live_value
+    bot.live_value = lambda key: (
+        2 if key == "max_n_creations_per_batch" else live_value(key)
+    )
+    bot.execute_order = MethodType(Passivbot.execute_order, bot)
+    bot.execute_orders = MethodType(CCXTBot.execute_orders, bot)
+    connector_calls = []
+
+    async def fail_create(**params):
+        connector_calls.append(params)
+        bot._account_invalidation_generation = 1
+        raise RuntimeError("connector write failed")
+
+    async def exhaust_error_budget(failures):
+        assert len(failures) == 1
+        raise RestartBotException("restart required")
+
+    bot.cca = SimpleNamespace(create_order=fail_create)
+    bot._handle_order_write_failures = exhaust_error_budget
+    emitted = []
+    monkeypatch.setattr(
+        Passivbot, "_record_emitted_order_custom_id", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(
+        Passivbot, "_emit_execution_order_event", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(
+        Passivbot,
+        "_emit_initial_entry_eligibility_event",
+        lambda *args, **kwargs: emitted.append(kwargs),
+    )
+
+    with pytest.raises(RestartBotException, match="restart required"):
+        await executor.execute_orders_parent(bot, orders)
+
+    assert len(connector_calls) == 1
+    assert emitted == []
+    assert bot._fresh_entry_eligibility_trace is None

--- a/tests/test_fresh_entry_eligibility_integration.py
+++ b/tests/test_fresh_entry_eligibility_integration.py
@@ -595,17 +595,35 @@ async def test_connector_bound_create_attempt_is_counted_once_even_when_ambiguou
     bot = _CreateBot(FreshEntryEligibilityTrace())
     bot._order_churn_gate_state = OrderChurnGateState()
 
-    async def fail_batch(_orders):
+    from types import SimpleNamespace
+
+    async def fail_create(**_params):
         raise RuntimeError("ambiguous connector failure")
 
+    async def fail_batch(orders):
+        return [await Passivbot.execute_order(bot, order) for order in orders]
+
+    bot.cca = SimpleNamespace(create_order=fail_create)
+    bot._build_order_params = lambda _order: {}
+    bot._record_emitted_order_custom_id = lambda *args, **kwargs: None
+    bot._record_order_churn_allowance_attempts = (
+        lambda count, **kwargs: Passivbot._record_order_churn_allowance_attempts(
+            bot, count, **kwargs
+        )
+    )
+    bot._emit_execution_connector_call_started_event = lambda **kwargs: None
     bot.execute_orders = fail_batch
     bot.add_to_recent_order_executions = lambda _order: None
     emitted = []
     bot._emit_order_churn_actions_accounted_event = lambda **kwargs: emitted.append(
         kwargs
     )
-    monkeypatch.setattr(Passivbot, "_record_emitted_order_custom_id", lambda *args, **kwargs: None)
-    monkeypatch.setattr(Passivbot, "_emit_execution_order_event", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        Passivbot, "_record_emitted_order_custom_id", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(
+        Passivbot, "_emit_execution_order_event", lambda *args, **kwargs: None
+    )
 
     with pytest.raises(RuntimeError, match="ambiguous connector failure"):
         await executor.execute_orders_parent(bot, [order])

--- a/tests/test_order_churn_cancel_first.py
+++ b/tests/test_order_churn_cancel_first.py
@@ -650,12 +650,33 @@ async def test_account_invalidation_rechecked_inside_each_connector_task(
         )
         for i in range(2)
     ]
+    from live.fresh_entry_eligibility import FreshEntryEligibilityTrace
+
+    trace = FreshEntryEligibilityTrace()
+    if not order_kind.endswith("panic"):
+        for order in orders:
+            order["pb_order_type"] = "entry_initial_normal_long"
+    trace.record_ideal_orders(orders)
+    trace.record_evaluated(orders[0]["symbol"], "long")
+    bot._fresh_entry_eligibility_trace = trace
+    eligibility = []
+    monkeypatch.setattr(
+        Passivbot, "_emit_initial_entry_eligibility_event",
+        lambda _bot, *, data, wave=None: eligibility.append(data),
+    )
     await executor.execute_order_plan(
         bot, [], orders, configure_creations=not dedicated_panic
     )
 
     expected_calls = 2 if dedicated_panic else int(invalidate_at == "first_connector")
     assert len(calls) == expected_calls
+    assert len(eligibility) == 1
+    assert sum(row["eligible_count"] for row in eligibility[0]["records"]) == (
+        0 if order_kind.endswith("panic") else expected_calls
+    )
+    assert sum(
+        event["event_type"] == EventTypes.EXECUTION_CREATE_SENT for event in order_events
+    ) == expected_calls
     assert len(bot._order_churn_gate_state.action_attempt_timestamps) == expected_calls
     assert sum(
         call.kwargs.get("status") == "submitted" for call in recorded_orders.call_args_list

--- a/tests/test_order_churn_cancel_first.py
+++ b/tests/test_order_churn_cancel_first.py
@@ -549,3 +549,125 @@ async def test_account_invalidation_preserves_dedicated_market_panic_bypass(
     monkeypatch.setattr(Passivbot, "_filter_fresh_market_snapshot_creations", market_refresh)
     await executor.execute_order_plan(bot, [], [desired], configure_creations=False)
     assert bot.created == [desired]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("batch_route", ["ccxt", "base", "hyperliquid"])
+@pytest.mark.parametrize("invalidate_at", ["batch_yield", "first_connector"])
+@pytest.mark.parametrize("order_kind", ["entry", "market_entry", "normal_panic", "dedicated_panic"])
+async def test_account_invalidation_rechecked_inside_each_connector_task(
+    execution_shell, monkeypatch, batch_route, invalidate_at, order_kind
+):
+    import asyncio
+    from types import SimpleNamespace
+    from unittest.mock import Mock
+    from exchanges.ccxt_bot import CCXTBot
+    from exchanges.hyperliquid import HyperliquidBot
+    from live import reconciler
+    from live.freshness import FreshnessLedger
+
+    class Bot(_PlanBot, Passivbot):
+        execute_orders_parent = Passivbot.execute_orders_parent
+        _execute_order_and_record_ack = HyperliquidBot._execute_order_and_record_ack
+        did_create_order = Passivbot.did_create_order
+
+    _wave, filter_events = execution_shell
+    dedicated_panic = order_kind == "dedicated_panic"
+    bot = Bot()
+    bot._current_planning_snapshot = SimpleNamespace(account_invalidation_generation=0)
+    bot._order_churn_gate_state = OrderChurnGateState()
+    bot._health_orders_placed = 0
+    bot.get_exchange_time = lambda: 1_000_000
+    bot.live_value = lambda key: {
+        "max_n_creations_per_batch": 10,
+        "order_replacement_churn_gate_activation_count": 10,
+        "order_replacement_churn_gate_window_minutes": 10.0,
+        "order_replacement_churn_gate_market_dist_pct": 0.005,
+    }[key]
+    ledger = FreshnessLedger()
+    ledger.begin_epoch()
+    bot._ensure_freshness_ledger = lambda: ledger
+    bot._request_authoritative_confirmation = lambda surfaces, **kwargs: None
+    for name in (
+        "log_order_action",
+        "_log_order_action_summary",
+        "_log_market_execution_notice",
+        "add_to_recent_order_executions",
+        "add_new_order",
+        "_monitor_record_event",
+        "_monitor_order_payload",
+        "_emit_execution_connector_call_started_event",
+        "_schedule_forager_candidate_candle_refresh",
+    ):
+        setattr(bot, name, Mock())
+    recorded_orders = Mock()
+    monkeypatch.setattr(Passivbot, "_record_emitted_order_custom_id", recorded_orders)
+    order_events = []
+    monkeypatch.setattr(
+        Passivbot,
+        "_emit_execution_order_event",
+        lambda *args, **kwargs: order_events.append(kwargs),
+    )
+    failures = []
+
+    async def handle_failures(items):
+        failures.extend(items)
+
+    bot._handle_order_write_failures = handle_failures
+
+    def invalidate():
+        reconciler.mark_account_critical_state_dirty(
+            bot, reason="order_ws_fill", symbols=["ETH/USDT:USDT"], source="order_ws"
+        )
+
+    calls = []
+
+    async def create_order(**params):
+        calls.append(params)
+        if invalidate_at == "first_connector" and len(calls) == 1:
+            invalidate()
+        return {"id": str(len(calls)), "status": "open"}
+
+    bot.cca = SimpleNamespace(create_order=create_order)
+    route = {
+        "ccxt": CCXTBot.execute_orders,
+        "base": Passivbot.execute_orders,
+        "hyperliquid": HyperliquidBot.execute_orders,
+    }[batch_route]
+
+    async def execute_orders(orders):
+        # The coroutine is entered only after the executor's batch-level check.
+        if invalidate_at == "batch_yield":
+            asyncio.get_running_loop().call_soon(invalidate)
+        return await route(bot, orders)
+
+    bot.execute_orders = execute_orders
+    orders = [
+        _order(
+            str(i),
+            execution_type="limit" if order_kind == "entry" else "market",
+            panic=order_kind.endswith("panic"),
+        )
+        for i in range(2)
+    ]
+    await executor.execute_order_plan(
+        bot, [], orders, configure_creations=not dedicated_panic
+    )
+
+    expected_calls = 2 if dedicated_panic else int(invalidate_at == "first_connector")
+    assert len(calls) == expected_calls
+    assert len(bot._order_churn_gate_state.action_attempt_timestamps) == expected_calls
+    assert sum(
+        call.kwargs.get("status") == "submitted" for call in recorded_orders.call_args_list
+    ) == expected_calls
+    assert failures == []
+    assert not any(
+        event["event_type"] == EventTypes.EXECUTION_AMBIGUOUS for event in order_events
+    )
+    assert (
+        sum(
+            event["event_type"] == EventTypes.EXECUTION_CREATE_SKIPPED
+            for event in filter_events
+        )
+        == 2 - expected_calls
+    )

--- a/tests/test_order_churn_cancel_first.py
+++ b/tests/test_order_churn_cancel_first.py
@@ -458,3 +458,94 @@ async def test_capacity_selects_later_admissible_order_after_churn_deferral(
     assert bot.configured == [[stable["symbol"], far_churn["symbol"]]]
     assert bot.created == [stable]
     assert far_churn["_churn_gate_reason"] == "allowance_exhausted"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("dirty_stage", ["before_execution", "configuration", "market_refresh"])
+async def test_account_invalidation_after_planning_defers_all_ordinary_creates(
+    execution_shell, monkeypatch, dirty_stage
+):
+    from types import SimpleNamespace
+    from live import reconciler
+    from live.freshness import FreshnessLedger
+
+    wave, events = execution_shell
+    bot = _PlanBot()
+    ledger = FreshnessLedger()
+    ledger.begin_epoch()
+    bot._ensure_freshness_ledger = lambda: ledger
+    bot._request_authoritative_confirmation = (
+        lambda surfaces, **kwargs: bot.confirmations.append(set(surfaces))
+    )
+    bot._current_planning_snapshot = SimpleNamespace(account_invalidation_generation=0)
+    desired = _order("desired")
+
+    def invalidate():
+        # A different symbol's fill still changes account balance/exposure.
+        reconciler.mark_account_critical_state_dirty(
+            bot, reason="order_ws_fill", symbols=["ETH/USDT:USDT"], source="order_ws"
+        )
+
+    async def configure(symbols):
+        if dirty_stage == "configuration":
+            invalidate()
+        return set(symbols)
+
+    async def market_refresh(_bot, orders):
+        if dirty_stage == "market_refresh":
+            invalidate()
+        return orders
+
+    bot.update_exchange_configs = configure
+    monkeypatch.setattr(Passivbot, "_filter_fresh_market_snapshot_creations", market_refresh)
+    if dirty_stage == "before_execution":
+        invalidate()
+
+    await executor.execute_order_plan(bot, [], [desired])
+
+    assert bot.created == []
+    assert wave["skipped_create"] == 1
+    assert bot.confirmations == [{"balance", "positions", "open_orders", "fills"}]
+    assert any(event["reason_code"] == ReasonCodes.STATE_CHANGE_DETECTED for event in events)
+
+    # A newly planned authoritative cohort may trade again; invalidations do not latch.
+    bot._current_planning_snapshot.account_invalidation_generation = (
+        bot._account_invalidation_generation
+    )
+    bot.update_exchange_configs = _PlanBot.update_exchange_configs.__get__(bot)
+
+    async def fresh_market(_bot, orders):
+        return orders
+
+    monkeypatch.setattr(Passivbot, "_filter_fresh_market_snapshot_creations", fresh_market)
+    await executor.execute_order_plan(bot, [], [desired])
+    assert bot.created == [desired]
+
+
+@pytest.mark.asyncio
+async def test_account_invalidation_preserves_dedicated_market_panic_bypass(
+    execution_shell, monkeypatch
+):
+    from types import SimpleNamespace
+    from live import reconciler
+    from live.freshness import FreshnessLedger
+
+    bot = _PlanBot()
+    ledger = FreshnessLedger()
+    ledger.begin_epoch()
+    bot._ensure_freshness_ledger = lambda: ledger
+    bot._request_authoritative_confirmation = (
+        lambda surfaces, **kwargs: bot.confirmations.append(set(surfaces))
+    )
+    bot._current_planning_snapshot = SimpleNamespace(account_invalidation_generation=0)
+    desired = _order("panic", execution_type="market", panic=True)
+
+    async def market_refresh(_bot, orders):
+        reconciler.mark_account_critical_state_dirty(
+            bot, reason="order_ws_fill", symbols=[desired["symbol"]], source="order_ws"
+        )
+        return orders
+
+    monkeypatch.setattr(Passivbot, "_filter_fresh_market_snapshot_creations", market_refresh)
+    await executor.execute_order_plan(bot, [], [desired], configure_creations=False)
+    assert bot.created == [desired]

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -7575,10 +7575,12 @@ def test_protective_planning_snapshot_requires_balance_not_fills_or_candles():
         )
     }
 
+    bot._account_invalidation_generation = 7
     snapshot = pb_mod.planning_gates.build_protective_planning_snapshot(
         bot, [symbol], snapshots
     )
 
+    assert snapshot.account_invalidation_generation == 7
     assert set(snapshot.required_surfaces) == {
         "balance",
         "positions",
@@ -9161,7 +9163,11 @@ def test_build_staged_planning_snapshot_captures_exact_surface_contract():
     bot._record_authoritative_surface("completed_candles", candle_signature)
     bot._record_market_snapshot_surface([symbol], snapshots)
 
+    bot._account_invalidation_generation = 7
     planning_snapshot = bot._build_staged_planning_snapshot([symbol], snapshots)
+    bot._account_invalidation_generation = 8
+
+    assert planning_snapshot.account_invalidation_generation == 7
 
     assert planning_snapshot is not None
     assert planning_snapshot.symbols == (symbol,)

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -13427,3 +13427,57 @@ def test_shared_ccxt_partial_fill_self_echo_invalidates_account(
     assert set(bot._authoritative_pending_confirmations) == (
         {"balance", "positions", "open_orders", "fills"} if has_fill else set()
     )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "progress",
+    [
+        {"filled": 0.25},
+        {"filled": 0.0, "remaining": 0.75},
+        {"filled": 0.0, "remaining": 1.0},
+    ],
+)
+async def test_hyperliquid_normal_partial_fill_self_echo_invalidates_account(
+    monkeypatch, progress
+):
+    from types import SimpleNamespace
+    from exchanges.hyperliquid import HyperliquidBot
+
+    bot = HyperliquidBot.__new__(HyperliquidBot)
+    bot.execution_scheduled = False
+    bot.stop_websocket = False
+    bot._authoritative_pending_confirmations = {}
+    _set_authoritative_epoch_state(bot, epoch=7)
+    bot.state_change_detected_by_symbol = set()
+    bot._hl_note_ws_symbols_for_dex_scope = lambda _orders: None
+    now_ms = 1_000_000
+    monkeypatch.setattr(passivbot_module, "utc_ms", lambda: now_ms)
+    order = {
+        "symbol": "BTC/USDC:USDC",
+        "side": "buy",
+        "amount": 1.0,
+        "price": 100.0,
+        "status": "open",
+        "reduceOnly": False,
+        "info": {"reduceOnly": False},
+        **progress,
+    }
+    bot.recent_order_executions = [
+        {**order, "position_side": "long", "qty": 1.0, "execution_timestamp": now_ms}
+    ]
+
+    async def watch_orders():
+        bot.stop_websocket = True
+        return [order]
+
+    bot.ccp = SimpleNamespace(watch_orders=watch_orders)
+    await bot.watch_orders()
+
+    assert order["position_side"] == "long"
+    assert "_pb_order_semantics_source" not in order
+    has_fill = progress.get("remaining") != 1.0
+    assert getattr(bot, "_account_invalidation_generation", 0) == int(has_fill)
+    assert set(bot._authoritative_pending_confirmations) == (
+        {"balance", "positions", "open_orders", "fills"} if has_fill else set()
+    )

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -13364,3 +13364,66 @@ def test_raw_only_balance_apply_replaces_stale_composition_with_unavailable():
     assert bot._balance_composition["reason"] == "raw_only_refresh"
     assert bot._balance_composition["asset_balances"] == []
     assert bot._balance_composition is not composition
+
+
+@pytest.mark.parametrize(
+    "progress",
+    [
+        {"filled": 0.25},
+        {"filled": None, "remaining": 0.75},
+        {"filled": 0.0, "remaining": 1.0},
+    ],
+)
+@pytest.mark.parametrize(
+    "venue, class_name",
+    [
+        ("ccxt_bot", "CCXTBot"),
+        ("bybit", "BybitBot"),
+        ("gateio", "GateIOBot"),
+        ("okx", "OKXBot"),
+        ("bitunix", "BitunixBot"),
+        ("weex", "WeexBot"),
+        ("binance", "BinanceBot"),
+        ("kucoin", "KucoinBot"),
+    ],
+)
+def test_shared_ccxt_partial_fill_self_echo_invalidates_account(
+    monkeypatch, progress, venue, class_name
+):
+    from importlib import import_module
+
+    bot_class = getattr(import_module(f"exchanges.{venue}"), class_name)
+    bot = bot_class.__new__(bot_class)
+    bot.execution_scheduled = False
+    bot._authoritative_pending_confirmations = {}
+    _set_authoritative_epoch_state(bot, epoch=7)
+    bot.state_change_detected_by_symbol = set()
+    now_ms = 1_000_000
+    monkeypatch.setattr(passivbot_module, "utc_ms", lambda: now_ms)
+    order = {
+        "symbol": "BTC/USDT:USDT",
+        "side": "buy",
+        "amount": 1.0,
+        "price": 100.0,
+        "status": "open",
+        "reduceOnly": False,
+        "info": {
+            "positionSide": "LONG",
+            "posSide": "long",
+            "positionIdx": 1,
+            "reduceOnly": False,
+        },
+        **progress,
+    }
+    normalized = bot._normalize_order_update(order)
+    bot.recent_order_executions = [{**normalized, "execution_timestamp": now_ms}]
+    bot.handle_order_update([normalized])
+
+    has_fill = progress.get("remaining") != 1.0
+    assert getattr(bot, "_account_invalidation_generation", 0) == int(has_fill)
+    assert bot.state_change_detected_by_symbol == (
+        {order["symbol"]} if has_fill else set()
+    )
+    assert set(bot._authoritative_pending_confirmations) == (
+        {"balance", "positions", "open_orders", "fills"} if has_fill else set()
+    )

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -5129,12 +5129,22 @@ async def test_execute_orders_parent_records_order_opened_event():
         def _log_order_action_summary(self, *args, **kwargs):
             return None
 
+        def _build_order_params(self, _order):
+            return {}
+
+        def _emit_execution_connector_call_started_event(self, **_kwargs):
+            return None
+
         async def execute_orders(self, orders):
             context = self._execution_connector_call_context
             assert context["action"] == "create"
             assert context["orders"][0] is orders[0]
             assert context["wave"] is self._order_wave_in_progress
-            return [{"id": "abc123", **orders[0]}]
+            async def create_order(**_params):
+                return {"id": "abc123"}
+
+            self.cca = SimpleNamespace(create_order=create_order)
+            return [await pb_mod.Passivbot.execute_order(self, order) for order in orders]
 
         def did_create_order(self, executed):
             return True

--- a/tests/test_run_fake_live.py
+++ b/tests/test_run_fake_live.py
@@ -321,6 +321,7 @@ async def test_fake_client_request_log_counts_order_writes():
     bot.user = "fake_01"
     bot.bot_id = "fake_bot"
     bot.cca = client
+    bot.open_orders = {}
     bot._build_order_params = lambda _order: {
         "positionSide": "LONG",
         "clientOrderId": "pb-test",
@@ -348,6 +349,7 @@ async def test_fake_client_request_log_counts_order_writes():
     assert summary["by_method"]["cancel_order"] == 1
     assert summary["by_category"]["order_write"] == 2
     assert [event_type for event_type, _kwargs in emitted] == [
+        "execution.create_sent",
         "execution.create_connector_call_started",
         "execution.cancel_connector_call_started",
     ]


### PR DESCRIPTION
A private fill arriving during exchange configuration, quote refresh, or batch task scheduling could allow orders based on superseded account state to reach the exchange. Planning snapshots now capture an account invalidation generation, and every planned creation rechecks that generation immediately before entering its connector call. Open partial-fill updates also invalidate account state when they match a recent local creation.

Ordinary creates defer until refresh and replanning. Dedicated protective market-panic orders retain their existing exception, and intentional cancel-first confirmation requests remain distinct. Locally deferred orders neither consume churn-attempt allowance nor register as submitted or ambiguous writes.

Validation: 1008 offline tests passed across account/planning, order execution and cancellation, fresh-entry eligibility, foreign-order detection, monitoring, exchange adapters, and exchange configuration. Regressions cover invalidation before executor entry, during configuration and quote awaits, after parent batch entry, between sibling connector calls, unrelated-symbol fills, refresh/replan recovery, and real partial-fill normalization/self-echo handling across eight shared adapter classes plus Hyperliquid's custom watcher. AI documentation and generated-registry checks passed (two existing documentation size warnings); git diff --check passed.

Submission and initial-entry eligibility telemetry are recorded only for orders admitted at the connector boundary; local deferrals do not create unmatched submission milestones.
