### PR TITLE
Harden external candle loading and archive extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ All notable user-facing changes will be documented in this file.
 - OKX now reads all pending-order pages before reconciling the account, preventing duplicate
   orders when more than 100 orders are open. Failed or stalled pagination rejects the snapshot.
 
+- External NumPy candle files no longer permit pickle objects, and local archive extraction
+  explicitly filters unsafe paths and links on every supported Python version.
+
 - Added `fills_gap_time_weighted_mean_hours` as an exact backtest and CPU/GPU optimizer metric.
   It minimizes `sum(gap_hours^2) / sum(gap_hours)` over unique portfolio fill timestamps and the
   analysis boundaries, providing smoother selection pressure against long no-fill periods than a

--- a/src/ohlcv_utils.py
+++ b/src/ohlcv_utils.py
@@ -169,7 +169,7 @@ def load_ohlcv_data(filepath: str) -> pd.DataFrame:
         df = df.drop_duplicates(subset=["timestamp"], keep="last")
         return ensure_millis_df(df)
 
-    arr = np.load(filepath, allow_pickle=True)
+    arr = np.load(filepath, allow_pickle=False)
     columns = ["timestamp", "open", "high", "low", "close", "volume"]
     arr_deduplicated = deduplicate_rows(arr)
     if len(arr) != len(arr_deduplicated):

--- a/sync_tar.py
+++ b/sync_tar.py
@@ -89,7 +89,7 @@ def extract_archive(archive_path: Path, destination: Path) -> None:
     destination.mkdir(parents=True, exist_ok=True)
     print(f"Extracting {archive_path} into {destination} ...")
     with tarfile.open(archive_path, "r:gz") as tf:
-        tf.extractall(destination)
+        tf.extractall(destination, filter="data")
     print("Extraction complete.")
 
 

--- a/sync_tar.py
+++ b/sync_tar.py
@@ -89,6 +89,10 @@ def extract_archive(archive_path: Path, destination: Path) -> None:
     destination.mkdir(parents=True, exist_ok=True)
     print(f"Extracting {archive_path} into {destination} ...")
     with tarfile.open(archive_path, "r:gz") as tf:
+        # Reject a later unsafe member before earlier members can overwrite an
+        # existing destination. Keep the extraction-time filter as well.
+        for member in tf.getmembers():
+            tarfile.data_filter(member, str(destination))
         tf.extractall(destination, filter="data")
     print("Extraction complete.")
 

--- a/tests/test_ohlcv_data_loading.py
+++ b/tests/test_ohlcv_data_loading.py
@@ -1,0 +1,41 @@
+import os
+
+import numpy as np
+import pytest
+
+from ohlcv_utils import load_ohlcv_data
+
+
+class _PickleMarker:
+    def __init__(self, path):
+        self.path = str(path)
+
+    def __reduce__(self):
+        return os.mkdir, (self.path,)
+
+
+def test_candle_object_array_is_rejected_without_executing_pickle(tmp_path):
+    marker = tmp_path / "pickle-executed"
+    path = tmp_path / "candles.npy"
+    np.save(path, np.array([_PickleMarker(marker)], dtype=object))
+
+    with pytest.raises(ValueError, match="allow_pickle=False"):
+        load_ohlcv_data(str(path))
+
+    assert not marker.exists()
+
+
+def test_numeric_candle_array_still_loads_and_deduplicates(tmp_path):
+    path = tmp_path / "candles.npy"
+    rows = np.array([
+        [1700000040000, 100, 102, 99, 101, 10],
+        [1700000040000, 100, 102, 99, 101, 10],
+        [1700000100000, 101, 103, 100, 102, 20],
+    ], dtype=np.float64)
+    np.save(path, rows)
+
+    loaded = load_ohlcv_data(str(path))
+
+    assert list(loaded.columns) == ["timestamp", "open", "high", "low", "close", "volume"]
+    np.testing.assert_array_equal(loaded.to_numpy(), rows[[0, 2]])
+    np.testing.assert_array_equal(np.load(path, allow_pickle=False), rows[[0, 2]])

--- a/tests/test_sync_tar.py
+++ b/tests/test_sync_tar.py
@@ -14,8 +14,14 @@ import sync_tar
 def test_extract_archive_rejects_members_escaping_destination(tmp_path, kind):
     archive = tmp_path / "input.tar.gz"
     destination = tmp_path / "output"
+    destination.mkdir()
+    (destination / "existing.txt").write_text("keep this")
     escaped = tmp_path / "escaped"
     with tarfile.open(archive, "w:gz") as output:
+        for name in ("existing.txt", "new.txt"):
+            regular = tarfile.TarInfo(name)
+            regular.size = 7
+            output.addfile(regular, io.BytesIO(b"changed"))
         member = tarfile.TarInfo("../escaped" if kind == "parent_path" else "link")
         if kind == "parent_path":
             member.size = 7
@@ -29,6 +35,8 @@ def test_extract_archive_rejects_members_escaping_destination(tmp_path, kind):
         sync_tar.extract_archive(archive, destination)
 
     assert not escaped.exists()
+    assert (destination / "existing.txt").read_text() == "keep this"
+    assert not (destination / "new.txt").exists()
     assert not (destination / "link").is_symlink()
 
 

--- a/tests/test_sync_tar.py
+++ b/tests/test_sync_tar.py
@@ -1,9 +1,47 @@
 from __future__ import annotations
 
 import argparse
+import io
+import tarfile
 from pathlib import Path
 
+import pytest
+
 import sync_tar
+
+
+@pytest.mark.parametrize("kind", ["parent_path", "symlink", "hardlink"])
+def test_extract_archive_rejects_members_escaping_destination(tmp_path, kind):
+    archive = tmp_path / "input.tar.gz"
+    destination = tmp_path / "output"
+    escaped = tmp_path / "escaped"
+    with tarfile.open(archive, "w:gz") as output:
+        member = tarfile.TarInfo("../escaped" if kind == "parent_path" else "link")
+        if kind == "parent_path":
+            member.size = 7
+            output.addfile(member, io.BytesIO(b"payload"))
+        else:
+            member.type = tarfile.SYMTYPE if kind == "symlink" else tarfile.LNKTYPE
+            member.linkname = "../escaped"
+            output.addfile(member)
+
+    with pytest.raises(tarfile.FilterError):
+        sync_tar.extract_archive(archive, destination)
+
+    assert not escaped.exists()
+    assert not (destination / "link").is_symlink()
+
+
+def test_extract_archive_roundtrips_regular_data(tmp_path):
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "data.txt").write_text("sample data")
+    archive = tmp_path / "input.tar.gz"
+    sync_tar.create_archive(source, archive)
+
+    sync_tar.extract_archive(archive, tmp_path / "output")
+
+    assert (tmp_path / "output" / "source" / "data.txt").read_text() == "sample data"
 
 
 def test_resolve_pull_destination_uses_parent_for_globbed_destination(tmp_path):


### PR DESCRIPTION
External NumPy candle files were loaded with pickle enabled, allowing object arrays to execute code before numeric validation. Local tar extraction also relied on the interpreter's extraction defaults, permitting destination escapes on Python 3.12. Candle loading now disables pickle, and archive extraction explicitly uses the restrictive data filter on every supported Python version.

Regression tests verify rejection before a pickle side effect, normal numeric loading/deduplication, traversal and escaping link rejection, and normal archive roundtrips.

Validation: 50 tests passed across candle loading, archive utilities, OHLCV foundation, and fake exchange; `git diff --check` passed. The security regressions failed before the fix. All inputs were synthetic local fixtures.
