### PR TITLE
Preserve reported zero fees and refresh fee conversion quotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,10 @@ All notable user-facing changes will be documented in this file.
 
 - Fill accounting now preserves explicitly reported zero fees and fully resolved zero-sum fee
   lists while retaining missing or malformed amounts for fallback accounting, including after
-  fill coalescing. Non-quote fee conversion refreshes expired ticker quotes and retries temporary lookup
-  failures, preventing stale conversion rates or permanent fallback fees during long-running bots.
+  fill coalescing and reload of older cached fallback fees. Non-quote fee conversion refreshes
+  expired ticker quotes and retries temporary lookup failures without discarding a fresh quote
+  because another fill cannot use it. Legacy Hyperliquid aggregates with unknown component fees
+  require cache repair instead of silently omitting those fees from reconciliation.
 
 - The monitor relay rejects foreign or malformed browser WebSocket origins before reading or
   sending account snapshots, while preserving the dashboard and originless native clients.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,10 @@ All notable user-facing changes will be documented in this file.
 
 - External NumPy candle files no longer permit pickle objects, and local archive extraction
   explicitly filters unsafe paths and links on every supported Python version.
+
 - Fill accounting now preserves explicitly reported zero fees and fully resolved zero-sum fee
-  lists. Non-quote fee conversion refreshes expired ticker quotes and retries temporary lookup
+  lists while retaining missing or malformed amounts for fallback accounting, including after
+  fill coalescing. Non-quote fee conversion refreshes expired ticker quotes and retries temporary lookup
   failures, preventing stale conversion rates or permanent fallback fees during long-running bots.
 
 - The monitor relay rejects foreign or malformed browser WebSocket origins before reading or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ All notable user-facing changes will be documented in this file.
 
 - Fill accounting now preserves explicitly reported zero fees and fully resolved zero-sum fee
   lists while retaining missing or malformed amounts for fallback accounting, including after
-  fill coalescing and reload of older cached fallback fees. Non-quote fee conversion refreshes
+  fill coalescing and reload of older cached fee estimates. Non-quote fee conversion refreshes
   expired ticker quotes and retries temporary lookup failures without discarding a fresh quote
   because another fill cannot use it. Legacy Hyperliquid aggregates with unknown component fees
   require cache repair instead of silently omitting those fees from reconciliation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ All notable user-facing changes will be documented in this file.
 
 - External NumPy candle files no longer permit pickle objects, and local archive extraction
   explicitly filters unsafe paths and links on every supported Python version.
+- Fill accounting now preserves explicitly reported zero fees and fully resolved zero-sum fee
+  lists. Non-quote fee conversion refreshes expired ticker quotes and retries temporary lookup
+  failures, preventing stale conversion rates or permanent fallback fees during long-running bots.
 
 - The monitor relay rejects foreign or malformed browser WebSocket origins before reading or
   sending account snapshots, while preserving the dashboard and originless native clients.

--- a/docs/ai/features/fill_events_manager.md
+++ b/docs/ai/features/fill_events_manager.md
@@ -14,8 +14,8 @@
    `live.fee_pct_fallback`. Every fill is sanity-checked by fee/notional ratio
    against `live.fee_pct_sanity_abs_max`; outliers use the fallback percentage.
    Explicit finite zero fees and fully resolved zero-sum fee lists are authoritative amounts.
-   Loading a cached fallback rechecks retained reported amounts and persists a newly resolved fee;
-   unresolved historical fallback amounts retain their original policy. Same-currency offsetting
+   Loading a cached fallback or rate estimate rechecks retained amounts and persists a resolved fee;
+   unresolved historical estimates retain their original policy. Same-currency offsetting
    fees need no ticker when their net amount is zero.
    Coalescing preserves missing or malformed fee amounts for fallback resolution.
    A zero non-quote fee needs no ticker and records `fee_conversion_source=zero_amount`.

--- a/docs/ai/features/fill_events_manager.md
+++ b/docs/ai/features/fill_events_manager.md
@@ -14,6 +14,9 @@
    `live.fee_pct_fallback`. Every fill is sanity-checked by fee/notional ratio
    against `live.fee_pct_sanity_abs_max`; outliers use the fallback percentage.
    Explicit finite zero fees and fully resolved zero-sum fee lists are authoritative amounts.
+   Loading a cached fallback rechecks retained reported amounts and persists a newly resolved fee;
+   unresolved historical fallback amounts retain their original policy. Same-currency offsetting
+   fees need no ticker when their net amount is zero.
    Coalescing preserves missing or malformed fee amounts for fallback resolution.
    A zero non-quote fee needs no ticker and records `fee_conversion_source=zero_amount`.
    Cached conversion quotes remain subject to `live.fee_conversion_max_age_ms` against the

--- a/docs/ai/features/fill_events_manager.md
+++ b/docs/ai/features/fill_events_manager.md
@@ -14,11 +14,13 @@
    `live.fee_pct_fallback`. Every fill is sanity-checked by fee/notional ratio
    against `live.fee_pct_sanity_abs_max`; outliers use the fallback percentage.
    Explicit finite zero fees and fully resolved zero-sum fee lists are authoritative amounts.
+   Coalescing preserves missing or malformed fee amounts for fallback resolution.
    A zero non-quote fee needs no ticker and records `fee_conversion_source=zero_amount`.
    Cached conversion quotes remain subject to `live.fee_conversion_max_age_ms` against the
    current time, fetch time, and each fill timestamp. Failed conversion lookups retry after
    at most one minute, bounded further by that same configured age. A batch reuses an identical
-   pair/fill-time lookup, including an unavailable result.
+   pair/fill-time lookup, including an unavailable result. A quote rejected only for one fill
+   timestamp must not create a pair-wide failed lookup.
 6. Do not mix legacy/missing-contract cache rows with current rows. Repair or
    rebuild legacy fill-event caches before using trading-critical accounting.
 7. Newly discovered fills may carry immutable `provenance` with attribution

--- a/docs/ai/features/fill_events_manager.md
+++ b/docs/ai/features/fill_events_manager.md
@@ -13,6 +13,12 @@
    non-quote fee converted by a fresh ticker, reported fee rate, then
    `live.fee_pct_fallback`. Every fill is sanity-checked by fee/notional ratio
    against `live.fee_pct_sanity_abs_max`; outliers use the fallback percentage.
+   Explicit finite zero fees and fully resolved zero-sum fee lists are authoritative amounts.
+   A zero non-quote fee needs no ticker and records `fee_conversion_source=zero_amount`.
+   Cached conversion quotes remain subject to `live.fee_conversion_max_age_ms` against the
+   current time, fetch time, and each fill timestamp. Failed conversion lookups retry after
+   at most one minute, bounded further by that same configured age. A batch reuses an identical
+   pair/fill-time lookup, including an unavailable result.
 6. Do not mix legacy/missing-contract cache rows with current rows. Repair or
    rebuild legacy fill-event caches before using trading-critical accounting.
 7. Newly discovered fills may carry immutable `provenance` with attribution

--- a/scenarios/fake_live/hsl_long_red_restart.hjson
+++ b/scenarios/fake_live/hsl_long_red_restart.hjson
@@ -90,13 +90,15 @@
       long.halted: false
       long.no_restart_latched: false
       long.last_stop_event.auto_restart_eligible: true
-      long.last_stop_event.drawdown_raw: {min: 0.001, max: 0.002}
+      // Zero exchange fees leave no fallback-fee residual in the finalized flat snapshot.
+      long.last_stop_event.drawdown_raw: 0.0
     }
     summary_paths: {
       step_count: 4
       last.step_index: 5
     }
     log_contains: [
+      "drawdown_raw=0.075000 drawdown_ema=0.075000 drawdown_score=0.075000"
       "RED stop finalized (auto-restart eligible)"
       "RED cooldown elapsed; trading resumed"
     ]

--- a/src/fill_events_manager.py
+++ b/src/fill_events_manager.py
@@ -134,21 +134,10 @@ def _day_key(timestamp_ms: int) -> str:
     return datetime.fromtimestamp(timestamp_ms / 1000, tz=timezone.utc).strftime("%Y-%m-%d")
 
 
-def _merge_fee_lists(
-    fees_a: Optional[Sequence], fees_b: Optional[Sequence]
-) -> Optional[List[Dict[str, object]]]:
-    def to_list(fees):
-        if not fees:
-            return []
-        if isinstance(fees, dict):
-            return [fees]
-        return list(fees)
-
+def _merge_fee_lists(fees_a: object, fees_b: object) -> Optional[List[Dict[str, object]]]:
     merged: Dict[str, Dict[str, object]] = {}
-    unresolved: List[Dict[str, object]] = []
-    for entry in to_list(fees_a) + to_list(fees_b):
-        if not isinstance(entry, dict):
-            continue
+    preserved: List[Dict[str, object]] = []
+    for entry in _fee_entries(fees_a) + _fee_entries(fees_b):
         # Do not turn missing or malformed amounts into an authoritative zero.
         # Keep these entries visible to the fee policy, including when other
         # same-currency components have usable amounts.
@@ -163,35 +152,37 @@ def _merge_fee_lists(
             or not math.isfinite(cost)
             or not _fee_entry_has_reported_amount(entry)
         ):
-            unresolved.append(dict(entry))
+            preserved.append(dict(entry))
             continue
-        currency = str(entry.get("currency") or entry.get("code") or "")
+        if set(entry) - {"cost", "currency", "code"}:
+            # Signed fields, rebates and rates determine cashflow independently
+            # of cost. Retain those components instead of inheriting only the
+            # first component's sign metadata after summing costs.
+            preserved.append(dict(entry))
+            continue
+        currency = _fee_entry_currency(entry)
         if currency not in merged:
             merged[currency] = dict(entry)
             merged[currency]["cost"] = cost
         else:
             merged[currency]["cost"] += cost
-    result = [dict(value) for value in merged.values()] + unresolved
+    result = [dict(value) for value in merged.values()] + preserved
     return result or None
 
 
 def _fee_entries(fees: object) -> List[Dict[str, object]]:
-    if fees is None or isinstance(fees, bool):
+    if fees is None:
         return []
     if isinstance(fees, dict):
         return [fees] if fees else []
-    if isinstance(fees, (int, float, str)) and not isinstance(fees, bool):
-        try:
-            cost = float(fees)
-        except (TypeError, ValueError):
-            return []
-        if math.isfinite(cost):
-            return [{"cost": cost}]
-        return []
+    if isinstance(fees, (int, float, str, bool)):
+        # Preserve both explicit zero and unusable scalar evidence. The amount
+        # validator decides whether this is reported accounting or a fallback.
+        return [{"cost": fees}]
     try:
-        return [entry for entry in list(fees) if isinstance(entry, dict)]
-    except Exception:
-        return []
+        return [entry if isinstance(entry, dict) else {"cost": entry} for entry in fees]
+    except TypeError:
+        return [{"cost": fees}]
 
 
 def _fee_cost(fees: Optional[Sequence]) -> float:
@@ -255,6 +246,23 @@ def _fee_entry_has_reported_amount(fee: Dict[str, object]) -> bool:
             except (TypeError, ValueError, OverflowError):
                 return False
     return False
+
+
+def _reported_fee_amounts_by_currency(
+    entries: Sequence[Dict[str, object]],
+) -> Tuple[Dict[str, float], bool]:
+    """Net only finite reported cashflows; retain whether any component is unknown."""
+    amounts = defaultdict(float)
+    unresolved = False
+    for entry in entries:
+        if not _fee_entry_has_reported_amount(entry):
+            unresolved = True
+            continue
+        currency = _fee_entry_currency(entry)
+        amounts[currency] += _fee_entry_signed_fee_paid(entry)
+        if not math.isfinite(amounts[currency]):
+            unresolved = True
+    return amounts, unresolved
 
 
 def _quote_currency_from_symbol(symbol: object) -> str:
@@ -358,6 +366,24 @@ def _normalize_fee_paid_from_payload(
 
     payload_fee_source = str(payload.get("fee_source") or "")
     payload_fee_quality = str(payload.get("fee_quality") or "")
+    if payload_fee_source == FEE_SOURCE_FALLBACK_PCT and entries:
+        # Current-contract caches can contain a fallback chosen before explicit
+        # zero amounts were recognized. Upgrade only newly resolved evidence;
+        # preserve an unresolved historical fallback and its original policy.
+        candidate = dict(payload)
+        for key in ("fee_paid", "fee_source", "fee_quality", "pnl_contract"):
+            candidate.pop(key, None)
+        resolved_paid, resolved_meta = _normalize_fee_paid_from_payload(
+            candidate,
+            fee_pct_fallback=fee_pct_fallback,
+            fee_pct_sanity_abs_max=fee_pct_sanity_abs_max,
+            quote_currency=quote,
+            conversion_rates=conversion_rates,
+        )
+        if resolved_meta["fee_source"] in (
+            FEE_SOURCE_REPORTED_QUOTE, FEE_SOURCE_REPORTED_CONVERTED
+        ):
+            return resolved_paid, resolved_meta
     recheck_existing_fee = payload_fee_quality == FEE_QUALITY_SANITY_REPLACED and bool(entries)
     trusted_fee_paid = (
         "fee_paid" in payload
@@ -379,13 +405,8 @@ def _normalize_fee_paid_from_payload(
         saw_quote = False
         saw_converted = False
         saw_ticker_conversion = False
-        unresolved_amount = False
-        for entry in entries:
-            if not _fee_entry_has_reported_amount(entry):
-                unresolved_amount = True
-                continue
-            signed = _fee_entry_signed_fee_paid(entry)
-            currency = _fee_entry_currency(entry)
+        amounts, unresolved_amount = _reported_fee_amounts_by_currency(entries)
+        for currency, signed in amounts.items():
             if not fee_currency and currency:
                 fee_currency = currency
             if not currency or (quote and currency == quote):
@@ -1147,6 +1168,15 @@ def _hyperliquid_coalesced_reconciliation_failure(
     if parent_qty is None or any(qty is None for qty in child_qtys):
         return "signed_qty"
 
+    for component in (event, *children):
+        entries = _fee_entries(component.get("fees")) + _fee_entries(component.get("fee"))
+        # The general extractor is deliberately provisional for ingestion; an
+        # aggregate proof instead requires every reported component to be known.
+        if any(not _fee_entry_has_reported_amount(entry) for entry in entries):
+            return "accounting"
+        if not entries and not _fee_entry_has_reported_amount(component):
+            return "accounting"
+
     try:
         parent_pnl = float(event.get("pnl") or 0.0)
         child_pnl = sum(float(child.get("pnl") or 0.0) for child in children)
@@ -1412,7 +1442,9 @@ def _coalesce_events(events: List[Dict[str, object]]) -> List[Dict[str, object]]
             aggregated[key]["pnl_status"] = _payload_pnl_status(ev)
             aggregated[key]["pnl_source"] = _payload_pnl_source(ev)
             aggregated[key]["pnl_synthetic_reason"] = str(ev.get("pnl_synthetic_reason") or "")
-            aggregated[key]["fees"] = _merge_fee_lists(ev.get("fees"), None)
+            aggregated[key]["fees"] = _merge_fee_lists(
+                _fee_entries(ev.get("fees")) or [{"cost": None}], None
+            )
             aggregated[key]["raw"] = _normalize_raw_field(ev.get("raw"))
             aggregated[key]["_price_numerator"] = float(ev.get("price", 0.0)) * float(
                 ev.get("qty", 0.0)
@@ -1436,7 +1468,9 @@ def _coalesce_events(events: List[Dict[str, object]]) -> List[Dict[str, object]]
                 agg["pnl_source"] = _payload_pnl_source(ev)
                 if ev.get("pnl_synthetic_reason"):
                     agg["pnl_synthetic_reason"] = str(ev.get("pnl_synthetic_reason"))
-            agg["fees"] = _merge_fee_lists(agg.get("fees"), ev.get("fees"))
+            agg["fees"] = _merge_fee_lists(
+                agg.get("fees"), _fee_entries(ev.get("fees")) or [{"cost": None}]
+            )
             agg["raw"] = _normalize_raw_field(agg.get("raw")) + _normalize_raw_field(ev.get("raw"))
             agg["_price_numerator"] = float(agg.get("_price_numerator", 0.0)) + float(
                 ev.get("price", 0.0)
@@ -3594,17 +3628,21 @@ class FillEventsManager:
                 retry_ms = min(self.fee_conversion_max_age_ms, 60_000)
                 if 0 <= age_ms < retry_ms:
                     return None
+                self._fee_conversion_cache.pop(cache_key, None)
             elif (
                 0 <= age_ms <= self.fee_conversion_max_age_ms
                 and abs(now_ms - quote_ts) <= self.fee_conversion_max_age_ms
-                and (fill_ts <= 0 or abs(quote_ts - int(fill_ts)) <= self.fee_conversion_max_age_ms)
             ):
-                return rate
-            self._fee_conversion_cache.pop(cache_key, None)
+                if fill_ts <= 0 or abs(quote_ts - int(fill_ts)) <= self.fee_conversion_max_age_ms:
+                    return rate
+                # This quote is still useful for other fills. A failed attempt
+                # to find one suitable for this timestamp must not evict it.
+            else:
+                self._fee_conversion_cache.pop(cache_key, None)
         api = getattr(self.fetcher, "api", None)
         fetch_ticker = getattr(api, "fetch_ticker", None)
         if fetch_ticker is None:
-            self._fee_conversion_cache[cache_key] = (None, now_ms, 0)
+            self._fee_conversion_cache.setdefault(cache_key, (None, now_ms, 0))
             return None
         symbols = [
             f"{fee_currency}/{quote_currency}",
@@ -3677,11 +3715,11 @@ class FillEventsManager:
         for raw in batch:
             quote = _quote_currency_from_symbol(raw.get("symbol"))
             conversion_rates: Dict[str, float] = {}
-            for entry in _fee_entries(raw.get("fees")) + _fee_entries(raw.get("fee")):
-                currency = _fee_entry_currency(entry)
-                if not currency or currency == quote:
-                    continue
-                if _fee_entry_has_reported_amount(entry) and _fee_entry_signed_fee_paid(entry) == 0.0:
+            amounts, _ = _reported_fee_amounts_by_currency(
+                _fee_entries(raw.get("fees")) + _fee_entries(raw.get("fee"))
+            )
+            for currency, signed in amounts.items():
+                if not currency or currency == quote or signed == 0.0:
                     continue
                 key = (currency, quote, int(raw.get("timestamp") or 0))
                 if key not in batch_rates:
@@ -6379,7 +6417,9 @@ class HyperliquidFetcher(BaseFetcher):
         qty = abs(float(trade.get("amount") or info.get("sz") or 0.0))
         price = float(trade.get("price") or info.get("px") or 0.0)
         pnl = float(trade.get("pnl") or info.get("closedPnl") or 0.0)
-        fee = trade.get("fee") or {"currency": info.get("feeToken"), "cost": info.get("fee")}
+        fee = trade.get("fee")
+        if fee is None:
+            fee = {"currency": info.get("feeToken"), "cost": info.get("fee")}
         client_order_id = trade.get("clientOrderId") or info.get("cloid") or info.get("clOrdId") or ""
         direction = str(info.get("dir", "")).lower()
         if "short" in direction:

--- a/src/fill_events_manager.py
+++ b/src/fill_events_manager.py
@@ -145,24 +145,34 @@ def _merge_fee_lists(
         return list(fees)
 
     merged: Dict[str, Dict[str, object]] = {}
+    unresolved: List[Dict[str, object]] = []
     for entry in to_list(fees_a) + to_list(fees_b):
         if not isinstance(entry, dict):
+            continue
+        # Do not turn missing or malformed amounts into an authoritative zero.
+        # Keep these entries visible to the fee policy, including when other
+        # same-currency components have usable amounts.
+        raw_cost = entry.get("cost")
+        try:
+            cost = float(raw_cost)
+        except (TypeError, ValueError, OverflowError):
+            cost = None
+        if (
+            isinstance(raw_cost, bool)
+            or cost is None
+            or not math.isfinite(cost)
+            or not _fee_entry_has_reported_amount(entry)
+        ):
+            unresolved.append(dict(entry))
             continue
         currency = str(entry.get("currency") or entry.get("code") or "")
         if currency not in merged:
             merged[currency] = dict(entry)
-            try:
-                merged[currency]["cost"] = float(entry.get("cost", 0.0))
-            except Exception:
-                merged[currency]["cost"] = 0.0
+            merged[currency]["cost"] = cost
         else:
-            try:
-                merged[currency]["cost"] += float(entry.get("cost", 0.0))
-            except Exception:
-                pass
-    if not merged:
-        return None
-    return [dict(value) for value in merged.values()]
+            merged[currency]["cost"] += cost
+    result = [dict(value) for value in merged.values()] + unresolved
+    return result or None
 
 
 def _fee_entries(fees: object) -> List[Dict[str, object]]:
@@ -465,7 +475,14 @@ def _normalize_fee_paid_from_payload(
 
 def signed_fee_paid_from_fees(fees: object) -> float:
     """Return canonical signed fee cashflow from CCXT-style fee payloads."""
-    return sum(_fee_entry_signed_fee_paid(entry) for entry in _fee_entries(fees))
+    # Coalescing keeps unusable entries in the raw fee list. They cannot
+    # contribute a numeric amount here; the fee policy resolves the whole list
+    # (or applies its documented fallback) before publication.
+    return sum(
+        _fee_entry_signed_fee_paid(entry)
+        for entry in _fee_entries(fees)
+        if _fee_entry_has_reported_amount(entry)
+    )
 
 
 def signed_fee_paid_from_payload(payload: Dict[str, object]) -> float:
@@ -3623,9 +3640,7 @@ class FillEventsManager:
                 continue
             ticker_ts = int(ticker.get("timestamp") or 0)
             quote_ts = ticker_ts if ticker_ts > 0 else now_ms
-            if abs(now_ms - quote_ts) > self.fee_conversion_max_age_ms or (
-                fill_ts > 0 and abs(quote_ts - int(fill_ts)) > self.fee_conversion_max_age_ms
-            ):
+            if abs(now_ms - quote_ts) > self.fee_conversion_max_age_ms:
                 continue
             for key in ("last", "close", "mark", "bid", "ask"):
                 try:
@@ -3633,9 +3648,18 @@ class FillEventsManager:
                 except Exception:
                     rate = 0.0
                 if math.isfinite(rate) and rate > 0.0:
+                    # Quote freshness is pair-wide; suitability for this fill
+                    # is not. Retain a usable quote even when this fill is too
+                    # distant, so it cannot poison later fills' conversion.
                     self._fee_conversion_cache[cache_key] = (rate, now_ms, quote_ts)
-                    return rate
-        self._fee_conversion_cache[cache_key] = (None, now_ms, 0)
+                    if (
+                        fill_ts <= 0
+                        or abs(quote_ts - int(fill_ts)) <= self.fee_conversion_max_age_ms
+                    ):
+                        return rate
+                    break
+        if cache_key not in self._fee_conversion_cache:
+            self._fee_conversion_cache[cache_key] = (None, now_ms, 0)
         return None
 
     async def _apply_fee_policy_to_batch(self, batch: List[Dict[str, object]]) -> None:
@@ -4229,10 +4253,16 @@ class FillEventsManager:
         currency = fee.get("currency") or fee.get("code")
         if currency:
             out["currency"] = str(currency)
+        raw_cost = fee.get("cost")
         try:
-            out["cost"] = float(fee.get("cost", 0.0))
-        except Exception:
-            out["cost"] = 0.0
+            cost = float(raw_cost)
+        except (TypeError, ValueError, OverflowError):
+            cost = None
+        out["cost"] = (
+            cost
+            if cost is not None and math.isfinite(cost) and not isinstance(raw_cost, bool)
+            else None
+        )
         if fee.get("rate") is not None:
             try:
                 out["rate"] = float(fee.get("rate"))
@@ -8028,13 +8058,19 @@ class OkxFetcher(BaseFetcher):
 
         client_order_id = str(raw.get("clOrdId") or "")
         fee_ccy = str(raw.get("feeCcy") or "")
-        fee_amt = float(raw.get("fee") or 0.0)
+        raw_fee = raw.get("fee")
+        try:
+            fee_amt = float(raw_fee)
+        except (TypeError, ValueError, OverflowError):
+            fee_amt = None
+        if isinstance(raw_fee, bool) or (fee_amt is not None and not math.isfinite(fee_amt)):
+            fee_amt = None
         fee = None
         if fee_ccy:
             fee = {
                 "currency": fee_ccy,
-                "cost": abs(fee_amt),
-                "type": "rebate" if fee_amt > 0.0 else "fee",
+                "cost": abs(fee_amt) if fee_amt is not None else None,
+                "type": "rebate" if fee_amt is not None and fee_amt > 0.0 else "fee",
             }
 
         return {

--- a/src/fill_events_manager.py
+++ b/src/fill_events_manager.py
@@ -6418,7 +6418,7 @@ class HyperliquidFetcher(BaseFetcher):
         price = float(trade.get("price") or info.get("px") or 0.0)
         pnl = float(trade.get("pnl") or info.get("closedPnl") or 0.0)
         fee = trade.get("fee")
-        if fee is None:
+        if fee is None or (isinstance(fee, (dict, list, tuple)) and not fee):
             fee = {"currency": info.get("feeToken"), "cost": info.get("fee")}
         client_order_id = trade.get("clientOrderId") or info.get("cloid") or info.get("clOrdId") or ""
         direction = str(info.get("dir", "")).lower()

--- a/src/fill_events_manager.py
+++ b/src/fill_events_manager.py
@@ -366,8 +366,8 @@ def _normalize_fee_paid_from_payload(
 
     payload_fee_source = str(payload.get("fee_source") or "")
     payload_fee_quality = str(payload.get("fee_quality") or "")
-    if payload_fee_source == FEE_SOURCE_FALLBACK_PCT and entries:
-        # Current-contract caches can contain a fallback chosen before explicit
+    if payload_fee_source in (FEE_SOURCE_FALLBACK_PCT, FEE_SOURCE_ESTIMATED_RATE) and entries:
+        # Current-contract caches can contain an estimate chosen before explicit
         # zero amounts were recognized. Upgrade only newly resolved evidence;
         # preserve an unresolved historical fallback and its original policy.
         candidate = dict(payload)

--- a/src/fill_events_manager.py
+++ b/src/fill_events_manager.py
@@ -166,16 +166,16 @@ def _merge_fee_lists(
 
 
 def _fee_entries(fees: object) -> List[Dict[str, object]]:
-    if not fees:
+    if fees is None or isinstance(fees, bool):
         return []
     if isinstance(fees, dict):
-        return [fees]
+        return [fees] if fees else []
     if isinstance(fees, (int, float, str)) and not isinstance(fees, bool):
         try:
             cost = float(fees)
         except (TypeError, ValueError):
             return []
-        if cost != 0.0:
+        if math.isfinite(cost):
             return [{"cost": cost}]
         return []
     try:
@@ -233,6 +233,18 @@ def _fee_entry_signed_fee_paid(fee: Dict[str, object]) -> float:
 
 def _fee_entry_currency(fee: Dict[str, object]) -> str:
     return str(fee.get("currency") or fee.get("code") or fee.get("feeCoin") or "").strip().upper()
+
+
+def _fee_entry_has_reported_amount(fee: Dict[str, object]) -> bool:
+    """Distinguish a finite reported amount, including zero, from a missing fee."""
+    for key in ("fee_paid", "totalFee", "fee", "totalDeductionFee", "cost"):
+        value = fee.get(key)
+        if (key == "fee_paid" and key in fee) or value not in (None, ""):
+            try:
+                return not isinstance(value, bool) and math.isfinite(float(value))
+            except (TypeError, ValueError, OverflowError):
+                return False
+    return False
 
 
 def _quote_currency_from_symbol(symbol: object) -> str:
@@ -356,10 +368,13 @@ def _normalize_fee_paid_from_payload(
         converted_total = 0.0
         saw_quote = False
         saw_converted = False
+        saw_ticker_conversion = False
+        unresolved_amount = False
         for entry in entries:
-            signed = _fee_entry_signed_fee_paid(entry)
-            if signed == 0.0:
+            if not _fee_entry_has_reported_amount(entry):
+                unresolved_amount = True
                 continue
+            signed = _fee_entry_signed_fee_paid(entry)
             currency = _fee_entry_currency(entry)
             if not fee_currency and currency:
                 fee_currency = currency
@@ -368,21 +383,22 @@ def _normalize_fee_paid_from_payload(
                 saw_quote = True
                 continue
             rate = conversion_rates.get(currency)
-            if rate is None:
+            if signed == 0.0:
+                # A zero balance impact needs no price conversion.
+                saw_converted = True
+                continue
+            if rate is None or not math.isfinite(float(rate)) or float(rate) <= 0.0:
                 unresolved_non_quote = True
                 continue
             converted_total += signed * float(rate)
             saw_converted = True
-        if converted_total != 0.0 and not unresolved_non_quote:
+            saw_ticker_conversion = True
+        if (saw_quote or saw_converted) and not (unresolved_amount or unresolved_non_quote):
             fee_paid = converted_total
-            if saw_converted and not saw_quote:
+            if saw_converted:
                 fee_source = FEE_SOURCE_REPORTED_CONVERTED
                 fee_quality = FEE_QUALITY_CONVERTED
-                conversion_source = "ticker"
-            elif saw_converted:
-                fee_source = FEE_SOURCE_REPORTED_CONVERTED
-                fee_quality = FEE_QUALITY_CONVERTED
-                conversion_source = "ticker"
+                conversion_source = "ticker" if saw_ticker_conversion else "zero_amount"
             else:
                 fee_source = FEE_SOURCE_REPORTED_QUOTE
                 fee_quality = FEE_QUALITY_EXACT
@@ -3512,7 +3528,8 @@ class FillEventsManager:
             if self.runtime_identity
             else {}
         )
-        self._fee_conversion_cache: Dict[Tuple[str, str], Optional[float]] = {}
+        # Pair -> (rate or failed lookup, fetch time, quote timestamp).
+        self._fee_conversion_cache: Dict[Tuple[str, str], Tuple[Optional[float], int, int]] = {}
         self._fee_warning_reported_ids: set[str] = set()
         self._events: List[FillEvent] = []
         self._loaded = False
@@ -3553,11 +3570,24 @@ class FillEventsManager:
             return None
         cache_key = (fee_currency, quote_currency)
         if cache_key in self._fee_conversion_cache:
-            return self._fee_conversion_cache[cache_key]
+            rate, fetched_at_ms, quote_ts = self._fee_conversion_cache[cache_key]
+            age_ms = now_ms - fetched_at_ms
+            if rate is None:
+                # Failed lookups should recover promptly without retrying every fill.
+                retry_ms = min(self.fee_conversion_max_age_ms, 60_000)
+                if 0 <= age_ms < retry_ms:
+                    return None
+            elif (
+                0 <= age_ms <= self.fee_conversion_max_age_ms
+                and abs(now_ms - quote_ts) <= self.fee_conversion_max_age_ms
+                and (fill_ts <= 0 or abs(quote_ts - int(fill_ts)) <= self.fee_conversion_max_age_ms)
+            ):
+                return rate
+            self._fee_conversion_cache.pop(cache_key, None)
         api = getattr(self.fetcher, "api", None)
         fetch_ticker = getattr(api, "fetch_ticker", None)
         if fetch_ticker is None:
-            self._fee_conversion_cache[cache_key] = None
+            self._fee_conversion_cache[cache_key] = (None, now_ms, 0)
             return None
         symbols = [
             f"{fee_currency}/{quote_currency}",
@@ -3592,10 +3622,9 @@ class FillEventsManager:
             if not isinstance(ticker, dict):
                 continue
             ticker_ts = int(ticker.get("timestamp") or 0)
-            if (
-                ticker_ts > 0
-                and fill_ts > 0
-                and abs(ticker_ts - int(fill_ts)) > self.fee_conversion_max_age_ms
+            quote_ts = ticker_ts if ticker_ts > 0 else now_ms
+            if abs(now_ms - quote_ts) > self.fee_conversion_max_age_ms or (
+                fill_ts > 0 and abs(quote_ts - int(fill_ts)) > self.fee_conversion_max_age_ms
             ):
                 continue
             for key in ("last", "close", "mark", "bid", "ask"):
@@ -3603,10 +3632,10 @@ class FillEventsManager:
                     rate = float(ticker.get(key) or 0.0)
                 except Exception:
                     rate = 0.0
-                if rate > 0.0:
-                    self._fee_conversion_cache[cache_key] = rate
+                if math.isfinite(rate) and rate > 0.0:
+                    self._fee_conversion_cache[cache_key] = (rate, now_ms, quote_ts)
                     return rate
-        self._fee_conversion_cache[cache_key] = None
+        self._fee_conversion_cache[cache_key] = (None, now_ms, 0)
         return None
 
     async def _apply_fee_policy_to_batch(self, batch: List[Dict[str, object]]) -> None:
@@ -3620,6 +3649,7 @@ class FillEventsManager:
         symbol_counts: Dict[str, int] = defaultdict(int)
         reason_counts: Dict[str, int] = defaultdict(int)
         examples = []
+        batch_rates: Dict[Tuple[str, str, int], Optional[float]] = {}
         for raw in batch:
             quote = _quote_currency_from_symbol(raw.get("symbol"))
             conversion_rates: Dict[str, float] = {}
@@ -3627,11 +3657,12 @@ class FillEventsManager:
                 currency = _fee_entry_currency(entry)
                 if not currency or currency == quote:
                     continue
-                rate = await self._fee_conversion_rate(
-                    currency,
-                    quote,
-                    int(raw.get("timestamp") or 0),
-                )
+                if _fee_entry_has_reported_amount(entry) and _fee_entry_signed_fee_paid(entry) == 0.0:
+                    continue
+                key = (currency, quote, int(raw.get("timestamp") or 0))
+                if key not in batch_rates:
+                    batch_rates[key] = await self._fee_conversion_rate(*key)
+                rate = batch_rates[key]
                 if rate is not None:
                     conversion_rates[currency] = rate
             meta = self._apply_fee_policy(raw, conversion_rates=conversion_rates)

--- a/tests/test_fill_events_manager.py
+++ b/tests/test_fill_events_manager.py
@@ -8624,6 +8624,7 @@ def _hyperliquid_same_millisecond_events() -> List[Dict[str, object]]:
             "qty": qty,
             "price": price,
             "pnl": -0.343558 if side == "sell" else 0.0,
+            "fees": {"currency": "USDC", "cost": 0.0},
             "raw": [
                 {
                     "source": "fetch_my_trades",
@@ -8634,6 +8635,7 @@ def _hyperliquid_same_millisecond_events() -> List[Dict[str, object]]:
                         "side": side,
                         "amount": qty,
                         "price": price,
+                        "fee": {"currency": "USDC", "cost": 0.0},
                         "info": {
                             "tid": trade_id,
                             "side": side,
@@ -8846,6 +8848,9 @@ def test_expand_hyperliquid_coalesced_event_restores_component_boundaries():
     "mismatch",
     [
         "component_ids",
+        "component_fee_nan",
+        "component_fee_invalid",
+        "component_fee_missing",
         "source_ids",
         "signed_qty",
         "pnl",
@@ -8893,6 +8898,12 @@ def test_expand_hyperliquid_coalesced_event_rejects_unreconciled_aggregate(
         aggregate["pnl"] = 1.0
     elif mismatch == "fees":
         aggregate["fee_paid"] = -1.0
+    elif mismatch.startswith("component_fee_"):
+        value = {"component_fee_nan": "nan", "component_fee_invalid": "bad", "component_fee_missing": None}[mismatch]
+        aggregate["raw"][0]["data"]["fee"]["cost"] = value
+        # Match the old permissive sum exactly: one unknown fee was omitted.
+        aggregate["fee_paid"] /= 2
+        mismatch = "accounting"
     elif mismatch == "malformed_component":
         aggregate["raw"][0]["data"]["amount"] = "invalid"
     elif mismatch == "component_price":
@@ -8995,3 +9006,27 @@ def test_order_same_timestamp_fills_keeps_distinct_timestamps_untouched():
     order_same_timestamp_fills(events)
 
     assert [ev["id"] for ev in events] == original
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("invalid_cost", [None, "bad", "NaN", "Infinity"])
+async def test_hyperliquid_unknown_component_fee_requires_cache_quarantine(tmp_path, invalid_cost):
+    first = deepcopy(_hyperliquid_same_millisecond_events()[0])
+    first["id"] = first["raw"][0]["data"]["id"] = "first"
+    first["raw"][0]["data"]["info"]["tid"] = "first"
+    second = deepcopy(first)
+    second["id"] = second["raw"][0]["data"]["id"] = "second"
+    second["raw"][0]["data"]["info"]["tid"] = "second"
+    first["client_order_id"] = second["client_order_id"] = ""
+    aggregate = fem._coalesce_events([first, second])[0]
+    aggregate["raw"][0]["data"]["fee"]["cost"] = invalid_cost
+    cache = FillEventCache(tmp_path)
+    cache.save([FillEvent.from_dict(aggregate)])
+    manager = FillEventsManager(exchange="hyperliquid", user="test",
+                               fetcher=_StaticFetcher([]), cache_path=tmp_path)
+    with pytest.raises(FillEventCacheContractError, match="quarantine and rebuild.*accounting"):
+        await manager.ensure_loaded()
+    quarantine = manager.quarantine_cache_for_rebuild(reason="unreconciled_hyperliquid_aggregate")
+    assert quarantine is not None
+    assert Path(quarantine).exists()
+    assert FillEventCache(tmp_path).load() == []

--- a/tests/test_fill_events_manager.py
+++ b/tests/test_fill_events_manager.py
@@ -9030,3 +9030,14 @@ async def test_hyperliquid_unknown_component_fee_requires_cache_quarantine(tmp_p
     assert quarantine is not None
     assert Path(quarantine).exists()
     assert FillEventCache(tmp_path).load() == []
+
+
+@pytest.mark.parametrize("wrapper,expected", [({}, -0.25), ([], -0.25), (None, -0.25), (0, 0.0), ({"currency": "USDC", "cost": 0}, 0.0)])
+def test_hyperliquid_empty_fee_wrapper_uses_native_amount_without_replacing_zero(wrapper, expected):
+    trade = {"id": "native-fee", "timestamp": 1700000000000,
+             "symbol": "BTC/USDC:USDC", "side": "buy", "amount": 1, "price": 1000,
+             "fee": wrapper, "info": {"feeToken": "USDC", "fee": "0.25", "dir": "Open Long"}}
+    event = HyperliquidFetcher._normalize_trade(trade)
+    paid, metadata = fem._normalize_fee_paid_from_payload(event, quote_currency="USDC")
+    assert paid == pytest.approx(expected)
+    assert metadata["fee_source"] == fem.FEE_SOURCE_REPORTED_QUOTE

--- a/tests/test_fill_fee_resolution.py
+++ b/tests/test_fill_fee_resolution.py
@@ -200,3 +200,129 @@ async def test_nonfinite_quote_does_not_become_a_converted_fee(tmp_path, clock, 
     api.price = price
     fills = manager(tmp_path, api)
     assert await fills._fee_conversion_rate("BNB", "USDT", clock.ms) is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("first_is_old", [True, False], ids=["old-fill-first", "new-fill-first"])
+async def test_fill_specific_quote_rejection_does_not_poison_pair_cache(
+    tmp_path, clock, first_is_old
+):
+    api = TickerApi(clock)
+    # Each timestamp is individually within the age limit relative to now;
+    # the old fill and the quote are too far apart from each other.
+    api.quote_age_ms = -2000
+    fills = manager(tmp_path, api, max_age_ms=10_000)
+    fee = {"currency": "BNB", "cost": 0.001}
+    old = fill(fee, clock.ms - 9000, "old")
+    recent = fill(fee, clock.ms, "recent")
+    batch = [old, recent] if first_is_old else [recent, old]
+    await fills._apply_fee_policy_to_batch(batch)
+
+    assert old["fee_source"] == fem.FEE_SOURCE_FALLBACK_PCT
+    assert recent["fee_source"] == fem.FEE_SOURCE_REPORTED_CONVERTED
+    assert recent["fee_paid"] == pytest.approx(-0.3)
+    # A following current fill still reuses the pair's positive quote.
+    subsequent = fill(fee, clock.ms, "subsequent")
+    await fills._apply_fee_policy_to_batch([subsequent])
+    assert subsequent["fee_paid"] == pytest.approx(-0.3)
+    assert api.calls == (1 if first_is_old else 2)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("invalid_cost", [None, "", "invalid", "nan", "inf", False])
+@pytest.mark.parametrize("valid_first", [True, False], ids=["valid-first", "invalid-first"])
+async def test_coalescing_preserves_unresolved_fee_through_refresh_and_reload(
+    tmp_path, clock, invalid_cost, valid_first
+):
+    invalid = fill({"currency": "USDT", "cost": invalid_cost}, clock.ms, "invalid")
+    valid = fill({"currency": "USDT", "cost": 0}, clock.ms, "valid")
+    rows = [valid, invalid] if valid_first else [invalid, valid]
+    coalesced = fem._coalesce_events(rows)
+    assert len(coalesced) == 1
+    api = TickerApi(clock)
+    fills = manager(tmp_path, api, coalesced)
+    await fills.refresh()
+    event = fills.get_events()[0]
+    assert event.fee_source == fem.FEE_SOURCE_FALLBACK_PCT
+    assert event.fee_paid == pytest.approx(-0.4)
+    assert fills.get_pnl_sum() == pytest.approx(3.6)
+    reloaded = manager(tmp_path, api)
+    await reloaded.ensure_loaded()
+    assert reloaded.get_events()[0].fee_source == fem.FEE_SOURCE_FALLBACK_PCT
+    assert reloaded.get_pnl_sum() == pytest.approx(3.6)
+
+
+@pytest.mark.asyncio
+async def test_coalescing_preserves_missing_cost_and_explicit_zero_distinction(tmp_path, clock):
+    api = TickerApi(clock)
+    rows = fem._coalesce_events(
+        [
+            fill({"currency": "USDT"}, clock.ms, "missing"),
+            fill({"currency": "USDT", "cost": 0}, clock.ms + 1, "zero"),
+        ]
+    )
+    fills = manager(tmp_path, api, rows)
+    await fills.refresh()
+    events = {event.id: event for event in fills.get_events()}
+    assert events["missing"].fee_source == fem.FEE_SOURCE_FALLBACK_PCT
+    assert events["missing"].fee_paid == pytest.approx(-0.2)
+    assert events["zero"].fee_source == fem.FEE_SOURCE_REPORTED_QUOTE
+    assert events["zero"].fee_paid == 0.0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("exchange", ["bybit", "okx"])
+@pytest.mark.parametrize("cost", [None, "", "invalid", "nan", "inf", False, 0.0])
+async def test_exchange_fee_producers_preserve_unknown_vs_zero_after_coalescing(
+    tmp_path, clock, exchange, cost
+):
+    api = TickerApi(clock)
+    if exchange == "bybit":
+        row = fem.BybitFetcher._normalize_trade(
+            {
+                "id": "trade",
+                "timestamp": clock.ms,
+                "symbol": "BTC/USDT:USDT",
+                "side": "sell",
+                "amount": 1.0,
+                "price": 1000.0,
+                "pnl": 2.0,
+                "fee": {"currency": "USDT", "cost": cost},
+                "info": {"closedSize": 1.0},
+            }
+        )
+    else:
+        row = fem.OkxFetcher(api)._normalize_fill(
+            {
+                "tradeId": "trade",
+                "ts": clock.ms,
+                "instId": "BTC-USDT-SWAP",
+                "side": "sell",
+                "fillSz": 1.0,
+                "fillPx": 1000.0,
+                "fillPnl": 2.0,
+                "posSide": "long",
+                "feeCcy": "USDT",
+                "fee": cost,
+            }
+        )
+    fills = manager(tmp_path, api, fem._coalesce_events([row]))
+    await fills.refresh()
+    event = fills.get_events()[0]
+    exact_zero = isinstance(cost, float) and cost == 0.0
+    assert event.fee_source == (
+        fem.FEE_SOURCE_REPORTED_QUOTE if exact_zero else fem.FEE_SOURCE_FALLBACK_PCT
+    )
+    assert event.fee_paid == pytest.approx(0.0 if exact_zero else -0.2)
+    assert fills.get_pnl_sum() == pytest.approx(2.0 if exact_zero else 1.8)
+
+
+@pytest.mark.parametrize("cost", [None, "", "invalid", "nan", "inf", False])
+def test_bybit_overlap_fee_normalization_does_not_fabricate_zero(cost):
+    fee = fem.FillEventsManager._extract_bybit_fee_from_trade_row(
+        {"fee": {"currency": "USDT", "cost": cost}}
+    )
+    coalesced = fem._coalesce_events([fill(fee, 1_700_000_000_000)])
+    fee_paid, metadata = fem._normalize_fee_paid_from_payload(coalesced[0])
+    assert fee_paid == pytest.approx(-0.2)
+    assert metadata["fee_source"] == fem.FEE_SOURCE_FALLBACK_PCT

--- a/tests/test_fill_fee_resolution.py
+++ b/tests/test_fill_fee_resolution.py
@@ -88,7 +88,7 @@ def manager(tmp_path, api, rows=(), max_age_ms=86_400_000):
         ),
         (
             [{"currency": "BNB", "cost": 0.001}, {"currency": "BNB", "cost": -0.001}],
-            1,
+            0,
             fem.FEE_SOURCE_REPORTED_CONVERTED,
         ),
         (
@@ -326,3 +326,100 @@ def test_bybit_overlap_fee_normalization_does_not_fabricate_zero(cost):
     fee_paid, metadata = fem._normalize_fee_paid_from_payload(coalesced[0])
     assert fee_paid == pytest.approx(-0.2)
     assert metadata["fee_source"] == fem.FEE_SOURCE_FALLBACK_PCT
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("scalar", [0, 0.0, "0"])
+async def test_scalar_zero_survives_coalescing_refresh_and_reload(tmp_path, clock, scalar):
+    rows = fem._coalesce_events([fill(scalar, clock.ms, str(i)) for i in range(2)])
+    api = TickerApi(clock)
+    fills = manager(tmp_path, api, rows)
+    await fills.refresh()
+    assert fills.get_events()[0].fee_source == fem.FEE_SOURCE_REPORTED_QUOTE
+    assert fills.get_pnl_sum() == pytest.approx(4.0)
+    reloaded = manager(tmp_path, api)
+    await reloaded.ensure_loaded()
+    assert reloaded.get_pnl_sum() == pytest.approx(4.0)
+    assert reloaded.get_events()[0].fee_paid == 0.0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("fees", [
+    0, {"currency": "USDT", "cost": 0},
+    [{"currency": "USDT", "cost": 0.1}, {"currency": "USDT", "cost": -0.1}],
+    {"currency": "BNB", "cost": 0},
+    [{"currency": "BNB", "cost": 0.1}, {"currency": "BNB", "cost": -0.1}],
+])
+async def test_loading_current_contract_repairs_old_zero_fee_fallback(tmp_path, clock, fees):
+    # A historical row outside ticker and recent-fill overlap must recover
+    # directly from its retained source amounts, without a network refetch.
+    payload = fill(fees, clock.ms - 365 * 86_400_000)
+    payload.update(fee_paid=-0.2, fee_source=fem.FEE_SOURCE_FALLBACK_PCT,
+                   fee_quality=fem.FEE_QUALITY_FALLBACK, pnl_contract=fem.PNL_CONTRACT_CURRENT,
+                   raw=[{"source": "fetch_my_trades", "data": {"id": "close"}}])
+    cache = fem.FillEventCache(tmp_path)
+    # Write the old representation directly: from_dict now repairs it itself.
+    import json
+    day = fem._day_key(payload["timestamp"])
+    (tmp_path / f"{day}.json").write_text(json.dumps([payload]))
+    cache.save_metadata({"pnl_contract": fem.PNL_CONTRACT_CURRENT})
+    api = TickerApi(clock)
+    loaded = manager(tmp_path, api)
+    await loaded.ensure_loaded()
+    assert loaded.get_pnl_sum() == pytest.approx(2.0)
+    assert loaded.get_events()[0].fee_paid == 0.0
+    persisted = cache.load()[0]
+    assert persisted.fee_source != fem.FEE_SOURCE_FALLBACK_PCT
+    assert persisted.fee_paid == 0.0
+    assert api.calls == 0
+
+
+def test_unresolved_historical_fallback_keeps_its_original_amount():
+    payload = fill({"currency": "BNB", "cost": 1.0}, 1)
+    payload.update(fee_paid=-0.7, fee_source=fem.FEE_SOURCE_FALLBACK_PCT,
+                   fee_quality=fem.FEE_QUALITY_FALLBACK, pnl_contract=fem.PNL_CONTRACT_CURRENT)
+    paid, meta = fem._normalize_fee_paid_from_payload(payload, fee_pct_fallback=0.0001)
+    assert paid == -0.7
+    assert meta["fee_source"] == fem.FEE_SOURCE_FALLBACK_PCT
+
+
+@pytest.mark.asyncio
+async def test_unsuitable_fill_failed_refetch_preserves_fresh_pair_quote(tmp_path, clock):
+    api = TickerApi(clock)
+    api.quote_age_ms = -2000
+    fills = manager(tmp_path, api, max_age_ms=10_000)
+    assert await fills._fee_conversion_rate("BNB", "USDT", clock.ms) == 300.0
+    api.failed = True
+    fee = {"currency": "BNB", "cost": 0.001}
+    old = fill(fee, clock.ms - 9000, "old")
+    recent = fill(fee, clock.ms, "recent")
+    await fills._apply_fee_policy_to_batch([old, recent])
+    assert old["fee_source"] == fem.FEE_SOURCE_FALLBACK_PCT
+    assert recent["fee_source"] == fem.FEE_SOURCE_REPORTED_CONVERTED
+    assert recent["fee_paid"] == pytest.approx(-0.3)
+    assert api.calls == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("missing", [None, {}, "bad", False, ["NaN"]])
+async def test_coalescing_retains_unknown_fee_beside_reported_zero(tmp_path, clock, missing):
+    rows = fem._coalesce_events([fill(missing, clock.ms, "unknown"), fill(0, clock.ms, "zero")])
+    fills = manager(tmp_path, TickerApi(clock), rows)
+    await fills.refresh()
+    assert fills.get_events()[0].fee_source == fem.FEE_SOURCE_FALLBACK_PCT
+    assert fills.get_pnl_sum() == pytest.approx(3.6)
+
+
+@pytest.mark.asyncio
+async def test_coalesced_offsetting_fee_rate_signs_need_no_conversion(tmp_path, clock):
+    rows = fem._coalesce_events([
+        fill({"currency": "BNB", "cost": 0.001, "rate": 0.0001}, clock.ms, "paid"),
+        fill({"currency": "BNB", "cost": 0.001, "rate": -0.0001}, clock.ms, "rebate"),
+    ])
+    api = TickerApi(clock)
+    fills = manager(tmp_path, api, rows)
+    await fills.refresh()
+    assert fills.get_events()[0].fee_paid == 0.0
+    assert fills.get_events()[0].fee_source == fem.FEE_SOURCE_REPORTED_CONVERTED
+    assert fills.get_pnl_sum() == 4.0
+    assert api.calls == 0

--- a/tests/test_fill_fee_resolution.py
+++ b/tests/test_fill_fee_resolution.py
@@ -1,0 +1,202 @@
+from copy import deepcopy
+from datetime import datetime, timezone
+
+import pytest
+
+import fill_events_manager as fem
+
+
+@pytest.fixture
+def clock(monkeypatch):
+    class Clock(datetime):
+        ms = 1_700_000_000_000
+
+        @classmethod
+        def now(cls, tz=None):
+            return datetime.fromtimestamp(cls.ms / 1000, tz=tz or timezone.utc)
+
+    monkeypatch.setattr(fem, "datetime", Clock)
+    return Clock
+
+
+class TickerApi:
+    markets = {"BNB/USDT": {}}
+
+    def __init__(self, clock):
+        self.clock = clock
+        self.calls = 0
+        self.price = 300.0
+        self.quote_age_ms = 0
+        self.failed = False
+
+    async def fetch_ticker(self, symbol):
+        self.calls += 1
+        if self.failed:
+            raise RuntimeError("ticker unavailable")
+        return {"last": self.price, "timestamp": self.clock.ms - self.quote_age_ms}
+
+
+class FillFetcher(fem.BaseFetcher):
+    def __init__(self, api, rows=()):
+        self.api = api
+        self.rows = list(rows)
+
+    async def fetch(self, since_ms, until_ms, detail_cache, on_batch=None):
+        return deepcopy(self.rows)
+
+
+def fill(fees, timestamp, event_id="close"):
+    return {
+        "id": event_id,
+        "timestamp": timestamp,
+        "symbol": "BTC/USDT:USDT",
+        "side": "sell",
+        "position_side": "long",
+        "qty": 1.0,
+        "price": 1000.0,
+        "pnl": 2.0,
+        "pb_order_type": "",
+        "client_order_id": "",
+        "fees": fees,
+    }
+
+
+def manager(tmp_path, api, rows=(), max_age_ms=86_400_000):
+    return fem.FillEventsManager(
+        exchange="fake",
+        user="test",
+        fetcher=FillFetcher(api, rows),
+        cache_path=tmp_path,
+        fee_conversion_max_age_ms=max_age_ms,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "fees,expected_calls,expected_source",
+    [
+        (0, 0, fem.FEE_SOURCE_REPORTED_QUOTE),
+        (0.0, 0, fem.FEE_SOURCE_REPORTED_QUOTE),
+        ("0", 0, fem.FEE_SOURCE_REPORTED_QUOTE),
+        ({"currency": "USDT", "cost": 0.0}, 0, fem.FEE_SOURCE_REPORTED_QUOTE),
+        ({"currency": "USDT", "totalFee": "0"}, 0, fem.FEE_SOURCE_REPORTED_QUOTE),
+        ({"currency": "BNB", "cost": 0.0}, 0, fem.FEE_SOURCE_REPORTED_CONVERTED),
+        (
+            [{"currency": "USDT", "cost": 0.1}, {"currency": "USDT", "cost": -0.1}],
+            0,
+            fem.FEE_SOURCE_REPORTED_QUOTE,
+        ),
+        (
+            [{"currency": "BNB", "cost": 0.001}, {"currency": "BNB", "cost": -0.001}],
+            1,
+            fem.FEE_SOURCE_REPORTED_CONVERTED,
+        ),
+        (
+            [{"currency": "BNB", "cost": 0.001}, {"currency": "USDT", "cost": -0.3}],
+            1,
+            fem.FEE_SOURCE_REPORTED_CONVERTED,
+        ),
+    ],
+)
+async def test_zero_fee_and_resolved_zero_sum_survive_refresh_and_reload(
+    tmp_path, clock, fees, expected_calls, expected_source
+):
+    api = TickerApi(clock)
+    fills = manager(tmp_path, api, [fill(fees, clock.ms)])
+
+    await fills.refresh()
+    event = fills.get_events()[0]
+    assert event.fee_paid == pytest.approx(0.0)
+    assert event.fee_source == expected_source
+    assert fills.get_pnl_sum() == pytest.approx(2.0)
+    assert api.calls == expected_calls
+
+    reloaded = manager(tmp_path, api)
+    await reloaded.ensure_loaded()
+    assert reloaded.get_events()[0].fee_source == expected_source
+    assert reloaded.get_pnl_sum() == pytest.approx(2.0)
+    assert api.calls == expected_calls
+
+
+@pytest.mark.parametrize(
+    "fees",
+    [None, {}]
+    + [{"currency": "USDT", "cost": value} for value in (None, "", "nan", "inf", False)],
+)
+def test_missing_or_unusable_fee_is_not_reported_zero(fees):
+    fee_paid, metadata = fem._normalize_fee_paid_from_payload(fill(fees, 1_700_000_000_000))
+    assert fee_paid == pytest.approx(-0.2)
+    assert metadata["fee_source"] == fem.FEE_SOURCE_FALLBACK_PCT
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("quote_age_ms,advance_ms", [(0, 10_001), (8000, 3000)])
+async def test_cached_conversion_expires_by_fetch_and_quote_age(
+    tmp_path, clock, quote_age_ms, advance_ms
+):
+    api = TickerApi(clock)
+    api.quote_age_ms = quote_age_ms
+    fills = manager(tmp_path, api, max_age_ms=10_000)
+    fees = {"currency": "BNB", "cost": 0.001}
+    fills.fetcher.rows = [fill(fees, clock.ms, "first")]
+    await fills.refresh()
+    assert fills.get_events()[0].fee_paid == pytest.approx(-0.3)
+    assert api.calls == 1
+
+    clock.ms += advance_ms
+    api.price = 600.0
+    api.quote_age_ms = 0
+    fills.fetcher.rows = [fill(fees, clock.ms, "second"), fill(fees, clock.ms, "third")]
+    await fills.refresh()
+    assert [event.fee_paid for event in fills.get_events()] == pytest.approx([-0.3, -0.6, -0.6])
+    assert api.calls == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("max_age_ms,retry_ms", [(10_000, 10_000), (120_000, 60_000), (0, 0)])
+async def test_failed_conversion_recovers_after_bounded_retry_without_batch_duplicates(
+    tmp_path, clock, max_age_ms, retry_ms
+):
+    api = TickerApi(clock)
+    api.failed = True
+    fills = manager(tmp_path, api, max_age_ms=max_age_ms)
+    fees = {"currency": "BNB", "cost": 0.001}
+    first_batch = [fill(fees, clock.ms, str(i)) for i in range(3)]
+    await fills._apply_fee_policy_to_batch(first_batch)
+    assert api.calls == 1
+    assert all(row["fee_source"] == fem.FEE_SOURCE_FALLBACK_PCT for row in first_batch)
+
+    api.failed = False
+    if retry_ms:
+        clock.ms += retry_ms - 1
+        assert await fills._fee_conversion_rate("BNB", "USDT", clock.ms) is None
+        assert api.calls == 1
+        clock.ms += 1
+
+    second_batch = [fill(fees, clock.ms, str(i)) for i in range(3)]
+    await fills._apply_fee_policy_to_batch(second_batch)
+    assert api.calls == 2
+    assert all(row["fee_source"] == fem.FEE_SOURCE_REPORTED_CONVERTED for row in second_batch)
+    assert [row["fee_paid"] for row in second_batch] == pytest.approx([-0.3] * 3)
+
+
+@pytest.mark.asyncio
+async def test_cached_quote_is_rechecked_against_each_fill_timestamp(tmp_path, clock):
+    api = TickerApi(clock)
+    api.quote_age_ms = 9000
+    fills = manager(tmp_path, api, max_age_ms=10_000)
+    assert await fills._fee_conversion_rate("BNB", "USDT", clock.ms) == 300.0
+    # Both the quote and fill are near now, but are too far apart from each other.
+    api.price = 600.0
+    api.quote_age_ms = 0
+    assert await fills._fee_conversion_rate("BNB", "USDT", clock.ms + 9000) == 600.0
+    assert api.calls == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("price", [float("inf"), float("nan")])
+async def test_nonfinite_quote_does_not_become_a_converted_fee(tmp_path, clock, price):
+    api = TickerApi(clock)
+    api.price = price
+    fills = manager(tmp_path, api)
+    assert await fills._fee_conversion_rate("BNB", "USDT", clock.ms) is None

--- a/tests/test_fill_fee_resolution.py
+++ b/tests/test_fill_fee_resolution.py
@@ -350,12 +350,16 @@ async def test_scalar_zero_survives_coalescing_refresh_and_reload(tmp_path, cloc
     {"currency": "BNB", "cost": 0},
     [{"currency": "BNB", "cost": 0.1}, {"currency": "BNB", "cost": -0.1}],
 ])
-async def test_loading_current_contract_repairs_old_zero_fee_fallback(tmp_path, clock, fees):
+@pytest.mark.parametrize("old_source", [fem.FEE_SOURCE_FALLBACK_PCT, fem.FEE_SOURCE_ESTIMATED_RATE])
+async def test_loading_current_contract_repairs_old_zero_fee_fallback(tmp_path, clock, fees, old_source):
     # A historical row outside ticker and recent-fill overlap must recover
     # directly from its retained source amounts, without a network refetch.
+    if old_source == fem.FEE_SOURCE_ESTIMATED_RATE:
+        fees = [dict(entry, rate=0.0002) for entry in fem._fee_entries(fees)]
     payload = fill(fees, clock.ms - 365 * 86_400_000)
-    payload.update(fee_paid=-0.2, fee_source=fem.FEE_SOURCE_FALLBACK_PCT,
-                   fee_quality=fem.FEE_QUALITY_FALLBACK, pnl_contract=fem.PNL_CONTRACT_CURRENT,
+    payload.update(fee_paid=-0.2, fee_source=old_source,
+                   fee_quality=(fem.FEE_QUALITY_FALLBACK if old_source == fem.FEE_SOURCE_FALLBACK_PCT
+                                else fem.FEE_QUALITY_ESTIMATED), pnl_contract=fem.PNL_CONTRACT_CURRENT,
                    raw=[{"source": "fetch_my_trades", "data": {"id": "close"}}])
     cache = fem.FillEventCache(tmp_path)
     # Write the old representation directly: from_dict now repairs it itself.
@@ -369,18 +373,19 @@ async def test_loading_current_contract_repairs_old_zero_fee_fallback(tmp_path, 
     assert loaded.get_pnl_sum() == pytest.approx(2.0)
     assert loaded.get_events()[0].fee_paid == 0.0
     persisted = cache.load()[0]
-    assert persisted.fee_source != fem.FEE_SOURCE_FALLBACK_PCT
+    assert persisted.fee_source in (fem.FEE_SOURCE_REPORTED_QUOTE, fem.FEE_SOURCE_REPORTED_CONVERTED)
     assert persisted.fee_paid == 0.0
     assert api.calls == 0
 
 
-def test_unresolved_historical_fallback_keeps_its_original_amount():
+@pytest.mark.parametrize("old_source", [fem.FEE_SOURCE_FALLBACK_PCT, fem.FEE_SOURCE_ESTIMATED_RATE])
+def test_unresolved_historical_fallback_keeps_its_original_amount(old_source):
     payload = fill({"currency": "BNB", "cost": 1.0}, 1)
-    payload.update(fee_paid=-0.7, fee_source=fem.FEE_SOURCE_FALLBACK_PCT,
+    payload.update(fee_paid=-0.7, fee_source=old_source,
                    fee_quality=fem.FEE_QUALITY_FALLBACK, pnl_contract=fem.PNL_CONTRACT_CURRENT)
     paid, meta = fem._normalize_fee_paid_from_payload(payload, fee_pct_fallback=0.0001)
     assert paid == -0.7
-    assert meta["fee_source"] == fem.FEE_SOURCE_FALLBACK_PCT
+    assert meta["fee_source"] == old_source
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Explicit zero fees and fully resolved zero-sum fees now retain their reported value through coalescing, refresh, and reload. Existing fallback and rate-estimated cache rows are re-evaluated from retained fee evidence; unresolved historical estimates remain unchanged. Fee components with missing amounts or independent sign metadata are preserved instead of becoming an authoritative zero or inheriting another component's fee sign.

Non-quote conversion quotes expire under the existing maximum-age policy. Failed lookups retry within one minute (or the shorter configured age), and a fill-specific failure cannot evict a quote that remains valid for other fills. Same-currency zero sums need no ticker. Legacy Hyperliquid aggregates with unknown component fees fail reconciliation and enter the existing quarantine/rebuild path.

Validation: 364 tests passed across fill accounting, Hyperliquid mapping, OKX configuration, fake exchange, and the complete offline fake-live harness with a rebuilt, source-verified Rust extension. The documented zero-fee HSL scenario retains its final balance/restart checks and explicitly checks its 7.5% RED trigger. AI documentation and generated-registry checks passed with existing documentation-size warnings; `git diff --check` passed.
