### PR TITLE
Fetch every OKX pending-order page before reconciliation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable user-facing changes will be documented in this file.
   partial or failed fetches as complete coverage for realized-PnL risk checks. A traversal that
   completes on its final allowed request remains valid.
 
+- OKX now reads all pending-order pages before reconciling the account, preventing duplicate
+  orders when more than 100 orders are open. Failed or stalled pagination rejects the snapshot.
+
 - Added `fills_gap_time_weighted_mean_hours` as an exact backtest and CPU/GPU optimizer metric.
   It minimizes `sum(gap_hours^2) / sum(gap_hours)` over unique portfolio fill timestamps and the
   analysis boundaries, providing smoother selection pressure against long no-fill periods than a

--- a/src/exchanges/okx.py
+++ b/src/exchanges/okx.py
@@ -61,6 +61,35 @@ class OKXBot(CCXTBot):
 
     # ═══════════════════ HOOK OVERRIDES ═══════════════════
 
+    async def _do_fetch_open_orders(self, symbol: str = None) -> list:
+        """Read every pending-order page before exposing an account snapshot."""
+        orders = {}
+        cursor = None
+        for _ in range(1000):
+            params = {"paginate": False}
+            if cursor is not None:
+                params["after"] = str(cursor)
+            page = await self.cca.fetch_open_orders(symbol=symbol, limit=100, params=params)
+            if not isinstance(page, list) or len(page) > 100:
+                raise ValueError("OKX returned an invalid open-order page")
+            page_ids = []
+            for order in page:
+                order_id = order.get("id") if isinstance(order, dict) else None
+                if not isinstance(order_id, str) or not order_id.isdecimal():
+                    raise ValueError("OKX open order missing a numeric pagination ID")
+                page_ids.append(int(order_id))
+                orders.setdefault(order_id, order)
+            # CCXT sorts parsed orders by timestamp, so list position does not
+            # identify the oldest order. OKX's `after` cursor uses order IDs.
+            if page_ids:
+                next_cursor = min(page_ids)
+                if cursor is not None and next_cursor >= cursor:
+                    raise RuntimeError("OKX open-order pagination did not advance")
+                cursor = next_cursor
+            if len(page) < 100:
+                return list(orders.values())
+        raise RuntimeError("OKX open-order pagination exhausted before completion")
+
     def _get_position_side_for_order(self, order: dict) -> str:
         """OKX provides posSide in info."""
         info = order.get("info") or {}

--- a/tests/test_okx_open_orders.py
+++ b/tests/test_okx_open_orders.py
@@ -1,0 +1,74 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from exchanges.okx import OKXBot
+
+
+def make_order(i):
+    return {"id": str(i), "timestamp": i, "amount": 1.0,
+            "symbol": "BTC/USDT:USDT", "side": "buy", "info": {"posSide": "long"}}
+
+
+def make_bot(pages):
+    bot = OKXBot.__new__(OKXBot)
+    bot.cca = SimpleNamespace(fetch_open_orders=AsyncMock(side_effect=pages))
+    bot._record_live_margin_mode_from_payload = lambda _: None
+    return bot
+
+
+@pytest.mark.asyncio
+async def test_all_pages_are_normalized_using_oldest_id_cursor():
+    # Parsed CCXT orders are ascending, despite the endpoint's descending order.
+    bot = make_bot([[make_order(i) for i in range(106, 206)],
+                    [make_order(i) for i in range(6, 106)],
+                    [make_order(i) for i in range(1, 6)]])
+    orders = await bot.fetch_open_orders()
+    assert [o["id"] for o in orders] == [str(i) for i in range(1, 206)]
+    assert all(o["position_side"] == "long" and o["qty"] == 1 for o in orders)
+    calls = bot.cca.fetch_open_orders.await_args_list
+    assert [c.kwargs["params"] for c in calls] == [
+        {"paginate": False}, {"paginate": False, "after": "106"},
+        {"paginate": False, "after": "6"}]
+    assert all(c.kwargs["limit"] == 100 for c in calls)
+
+
+@pytest.mark.asyncio
+async def test_exact_full_page_requires_terminal_empty_and_preserves_symbol_filter():
+    bot = make_bot([[make_order(i) for i in range(1, 101)], []])
+    raw, normalized = await bot.capture_open_orders_snapshot("BTC/USDT:USDT")
+    assert len(raw) == len(normalized) == 100
+    assert all(c.kwargs["symbol"] == "BTC/USDT:USDT"
+               for c in bot.cca.fetch_open_orders.await_args_list)
+
+
+@pytest.mark.asyncio
+async def test_later_page_failure_does_not_return_partial_snapshot():
+    bot = make_bot([[make_order(i) for i in range(1, 101)], RuntimeError("offline error")])
+    with pytest.raises(RuntimeError, match="offline error"):
+        await bot.fetch_open_orders()
+
+
+@pytest.mark.asyncio
+async def test_overlapping_page_deduplicates_ids_while_cursor_advances():
+    bot = make_bot([[make_order(i) for i in range(6, 106)],
+                    [make_order(i) for i in range(1, 7)]])
+    assert len(await bot.fetch_open_orders()) == 105
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("page", [[make_order(5)], [{"id": None}], None,
+                                 [make_order(i) for i in range(101)]])
+async def test_stalled_or_malformed_page_rejects_snapshot(page):
+    bot = make_bot([[make_order(i) for i in range(5, 105)], page])
+    with pytest.raises((ValueError, RuntimeError)):
+        await bot.fetch_open_orders()
+
+
+@pytest.mark.asyncio
+async def test_page_budget_exhaustion_rejects_partial_snapshot():
+    bot = make_bot([[make_order(i) for i in range(n, n + 100)]
+                    for n in range(100000, 0, -100)])
+    with pytest.raises(RuntimeError, match="exhausted"):
+        await bot.fetch_open_orders()


### PR DESCRIPTION
OKX open-order reconciliation previously consumed only the first 100 pending orders. The OKX adapter now follows order-ID cursors until a terminal page, deduplicates overlapping orders, and rejects failed, malformed, stalled, or exhausted traversals instead of exposing partial snapshots. Cursor selection accounts for CCXT sorting parsed orders by timestamp.

Validation: 17 offline OKX tests passed, including 205 orders, an exact full page with an empty terminal response, symbol filtering, overlapping pages, malformed responses, later-page failure, and pagination exhaustion; `git diff --check` passed.
