### PR TITLE
Restrict browser access to monitor WebSockets by origin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ All notable user-facing changes will be documented in this file.
 - External NumPy candle files no longer permit pickle objects, and local archive extraction
   explicitly filters unsafe paths and links on every supported Python version.
 
+- The monitor relay rejects foreign or malformed browser WebSocket origins before reading or
+  sending account snapshots, while preserving the dashboard and originless native clients.
+
 - Added `fills_gap_time_weighted_mean_hours` as an exact backtest and CPU/GPU optimizer metric.
   It minimizes `sum(gap_hours^2) / sum(gap_hours)` over unique portfolio fill timestamps and the
   analysis boundaries, providing smoother selection pressure against long no-fill periods than a

--- a/docs/ai/features/monitor_relay.md
+++ b/docs/ai/features/monitor_relay.md
@@ -6,6 +6,7 @@
 2. The monitor root on disk remains the source of truth; the relay is a network view over that data.
 3. WebSocket clients must receive a snapshot first, then live-forward event/history messages.
 4. Relay failures must stay contained to the relay process and must not require bot-process changes.
+5. Browser WebSocket requests must have the relay's own HTTP origin before any monitor data is loaded or sent. Originless native clients remain supported; this check is not authentication.
 
 ## Non-Obvious Details
 

--- a/docs/ai/features/monitor_relay.md
+++ b/docs/ai/features/monitor_relay.md
@@ -6,7 +6,7 @@
 2. The monitor root on disk remains the source of truth; the relay is a network view over that data.
 3. WebSocket clients must receive a snapshot first, then live-forward event/history messages.
 4. Relay failures must stay contained to the relay process and must not require bot-process changes.
-5. Browser WebSocket requests must have the relay's own HTTP origin before any monitor data is loaded or sent. Originless native clients remain supported; this check is not authentication.
+5. Browser WebSocket requests must have a configured allowed origin before any monitor data is loaded or sent. HTTP Host headers must match configured origin authorities, preventing DNS rebinding. Originless native clients remain supported; these checks are not authentication. Proxy origins are configured explicitly, without trusting forwarded headers.
 
 ## Non-Obvious Details
 

--- a/docs/monitor.md
+++ b/docs/monitor.md
@@ -19,10 +19,13 @@ python src/tools/monitor_relay.py --monitor-root monitor
 
 Default bind address is `127.0.0.1:8765`.
 
-Browser WebSocket connections must come from the relay's own origin (scheme, host, and port).
-Native clients without an `Origin` header remain supported. The relay does not authenticate
-clients; keep it on a trusted interface or behind authenticated access. A reverse proxy must
-preserve the browser-facing host and configure the application's scheme consistently.
+Browser WebSocket connections must use an allowed origin (scheme, host, and port). By default,
+the relay allows localhost, loopback addresses, and the configured bind host on its bind port.
+For an authenticated HTTPS reverse proxy, add `--allowed-origin https://monitor.example.com`
+and preserve the public `Host` header. Repeat this option for additional public origins.
+Forwarded headers do not grant trust. HTTP requests also require an allowed host to prevent
+DNS rebinding. Native clients without an `Origin` header remain supported on allowed hosts.
+The relay does not authenticate clients; keep it on a trusted interface or behind authenticated access.
 
 The relay is intended to be a single long-running process per repo checkout:
 

--- a/docs/monitor.md
+++ b/docs/monitor.md
@@ -19,6 +19,11 @@ python src/tools/monitor_relay.py --monitor-root monitor
 
 Default bind address is `127.0.0.1:8765`.
 
+Browser WebSocket connections must come from the relay's own origin (scheme, host, and port).
+Native clients without an `Origin` header remain supported. The relay does not authenticate
+clients; keep it on a trusted interface or behind authenticated access. A reverse proxy must
+preserve the browser-facing host and configure the application's scheme consistently.
+
 The relay is intended to be a single long-running process per repo checkout:
 
 1. Start it before or after any bot.

--- a/src/monitor_relay.py
+++ b/src/monitor_relay.py
@@ -611,6 +611,36 @@ class MonitorRelay:
 
 
 RELAY_APP_KEY = web.AppKey("monitor_relay", MonitorRelay)
+ORIGINS_APP_KEY = web.AppKey("monitor_allowed_origins", frozenset)
+
+
+def _monitor_origin(value: str) -> tuple[str, str, int]:
+    origin = urlsplit(value)
+    if (
+        value != value.strip() or any(ch in value for ch in "\r\n\t")
+        or origin.scheme not in {"http", "https"} or not origin.hostname
+        or origin.username is not None or origin.password is not None
+        or origin.path or origin.query or origin.fragment
+    ):
+        raise ValueError("expected an HTTP origin with no path or credentials")
+    port = origin.port
+    return origin.scheme, origin.hostname, port if port is not None else (443 if origin.scheme == "https" else 80)
+
+
+@web.middleware
+async def _validate_monitor_host(request: web.Request, handler):
+    # Also protect HTTP snapshots from DNS rebinding. Never derive trust from
+    # Host or forwarded headers; compare against configured origin authorities.
+    try:
+        if len(request.headers.getall("Host", [])) != 1 or not any(
+            _monitor_origin(f"{scheme}://{request.host}") in request.app[ORIGINS_APP_KEY]
+            for scheme in ("http", "https")
+        ):
+            raise ValueError("unapproved host")
+    except ValueError as exc:
+        raise web.HTTPForbidden(text="Monitor host is not allowed") from exc
+    return await handler(request)
+
 
 
 def _relay_from_app(app: web.Application) -> MonitorRelay:
@@ -668,29 +698,11 @@ async def _handle_dashboard_asset(request: web.Request) -> web.Response:
 
 
 async def _handle_ws(request: web.Request) -> web.StreamResponse:
-    # Browsers can open cross-origin WebSockets even when ordinary HTTP reads
-    # are blocked by same-origin policy. Check before loading account data.
     origins = request.headers.getall("Origin", [])
     if origins:
         try:
-            if len(origins) != 1:
-                raise ValueError("multiple origins")
-            origin = urlsplit(origins[0])
-            target = urlsplit(f"{request.scheme}://{request.host}")
-            if (
-                origin.scheme not in {"http", "https"}
-                or not origin.hostname
-                or origin.username is not None
-                or origin.password is not None
-                or origin.path
-                or origin.query
-                or origin.fragment
-                or origin.scheme != target.scheme
-                or origin.hostname != target.hostname
-                or (origin.port or (443 if origin.scheme == "https" else 80))
-                != (target.port or (443 if target.scheme == "https" else 80))
-            ):
-                raise ValueError("cross-origin websocket")
+            if len(origins) != 1 or _monitor_origin(origins[0]) not in request.app[ORIGINS_APP_KEY]:
+                raise ValueError("unapproved origin")
         except ValueError as exc:
             raise web.HTTPForbidden(text="WebSocket origin is not allowed") from exc
     relay = _relay_from_app(request.app)
@@ -749,6 +761,7 @@ def create_monitor_relay_app(
     poll_interval_ms: int = 250,
     subscriber_queue_size: int = 1000,
     ws_replay_limit: int = 50,
+    allowed_origins: list[str] | None = None,
 ) -> web.Application:
     relay = MonitorRelay(
         monitor_root=monitor_root,
@@ -756,7 +769,13 @@ def create_monitor_relay_app(
         subscriber_queue_size=subscriber_queue_size,
         ws_replay_limit=ws_replay_limit,
     )
-    app = web.Application()
+    if allowed_origins is None:
+        allowed_origins = ["http://127.0.0.1:8765", "http://localhost:8765", "http://[::1]:8765"]
+    origins = frozenset(_monitor_origin(origin) for origin in allowed_origins)
+    if not origins:
+        raise ValueError("at least one monitor origin must be allowed")
+    app = web.Application(middlewares=[_validate_monitor_host])
+    app[ORIGINS_APP_KEY] = origins
     app[RELAY_APP_KEY] = relay
     app.router.add_get("/health", _handle_health)
     app.router.add_get("/snapshot", _handle_snapshot)

--- a/src/monitor_relay.py
+++ b/src/monitor_relay.py
@@ -8,6 +8,7 @@ from collections import deque
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Optional
+from urllib.parse import urlsplit
 
 from aiohttp import web
 
@@ -667,6 +668,31 @@ async def _handle_dashboard_asset(request: web.Request) -> web.Response:
 
 
 async def _handle_ws(request: web.Request) -> web.StreamResponse:
+    # Browsers can open cross-origin WebSockets even when ordinary HTTP reads
+    # are blocked by same-origin policy. Check before loading account data.
+    origins = request.headers.getall("Origin", [])
+    if origins:
+        try:
+            if len(origins) != 1:
+                raise ValueError("multiple origins")
+            origin = urlsplit(origins[0])
+            target = urlsplit(f"{request.scheme}://{request.host}")
+            if (
+                origin.scheme not in {"http", "https"}
+                or not origin.hostname
+                or origin.username is not None
+                or origin.password is not None
+                or origin.path
+                or origin.query
+                or origin.fragment
+                or origin.scheme != target.scheme
+                or origin.hostname != target.hostname
+                or (origin.port or (443 if origin.scheme == "https" else 80))
+                != (target.port or (443 if target.scheme == "https" else 80))
+            ):
+                raise ValueError("cross-origin websocket")
+        except ValueError as exc:
+            raise web.HTTPForbidden(text="WebSocket origin is not allowed") from exc
     relay = _relay_from_app(request.app)
     exchange = request.query.get("exchange")
     user = request.query.get("user")

--- a/src/tools/monitor_relay.py
+++ b/src/tools/monitor_relay.py
@@ -41,6 +41,10 @@ def _parse_args() -> argparse.Namespace:
         help="Bind port for the relay server.",
     )
     parser.add_argument(
+        "--allowed-origin", action="append", default=[],
+        help="Additional browser-facing HTTP origin, e.g. https://monitor.example.com; repeatable.",
+    )
+    parser.add_argument(
         "--poll-interval-ms",
         type=int,
         default=250,
@@ -70,11 +74,16 @@ def _parse_args() -> argparse.Namespace:
 def main() -> None:
     args = _parse_args()
     configure_logging(args.log_level.upper())
+    hosts = {"127.0.0.1", "localhost", "[::1]"}
+    if args.host not in {"0.0.0.0", "::"}:
+        hosts.add(f"[{args.host}]" if ":" in args.host and not args.host.startswith("[") else args.host)
+    allowed_origins = [f"http://{host}:{args.port}" for host in sorted(hosts)] + args.allowed_origin
     app = create_monitor_relay_app(
         monitor_root=args.monitor_root,
         poll_interval_ms=args.poll_interval_ms,
         subscriber_queue_size=args.queue_size,
         ws_replay_limit=args.ws_replay_limit,
+        allowed_origins=allowed_origins,
     )
     logging.info(
         "[monitor-relay] serving monitor_root=%s host=%s port=%s poll_interval_ms=%s ws_replay_limit=%s",

--- a/tests/test_monitor_relay.py
+++ b/tests/test_monitor_relay.py
@@ -118,7 +118,8 @@ async def test_websocket_allows_same_origin_dashboard_and_originless_clients(
     tmp_path, monkeypatch, host, origin
 ):
     _make_monitor_root(tmp_path)
-    app = create_monitor_relay_app(monitor_root=str(tmp_path / "monitor"))
+    app = create_monitor_relay_app(monitor_root=str(tmp_path / "monitor"),
+                                   allowed_origins=[origin or f"http://{host}"])
     fake_ws = FakeWebSocket(close_after_messages=1)
     monkeypatch.setattr(monitor_relay.web, "WebSocketResponse", lambda **_: fake_ws)
     headers = {"Host": host}
@@ -127,6 +128,42 @@ async def test_websocket_allows_same_origin_dashboard_and_originless_clients(
     response = await _handle_ws(make_mocked_request("GET", "/ws", app=app, headers=headers))
     assert response is fake_ws
     assert fake_ws.messages[0]["type"] == "snapshot"
+
+
+@pytest.mark.asyncio
+async def test_dns_rebinding_host_and_origin_do_not_authorize_monitor_data(tmp_path):
+    app = create_monitor_relay_app(monitor_root=str(tmp_path))
+    request = make_mocked_request("GET", "/ws", app=app, headers={
+        "Host": "attacker.example:8765", "Origin": "http://attacker.example:8765"})
+    with pytest.raises(web.HTTPForbidden):
+        await _handle_ws(request)
+
+    async def must_not_read_data(request):
+        raise AssertionError("untrusted Host reached an HTTP data handler")
+
+    with pytest.raises(web.HTTPForbidden):
+        await monitor_relay._validate_monitor_host(request, must_not_read_data)
+
+
+@pytest.mark.asyncio
+async def test_configured_external_https_origin_works_through_http_proxy(tmp_path, monkeypatch):
+    _make_monitor_root(tmp_path)
+    app = create_monitor_relay_app(monitor_root=str(tmp_path / "monitor"),
+                                   allowed_origins=["https://monitor.example"])
+    fake_ws = FakeWebSocket(close_after_messages=1)
+    monkeypatch.setattr(monitor_relay.web, "WebSocketResponse", lambda **_: fake_ws)
+    request = make_mocked_request("GET", "/ws", app=app, headers={
+        "Host": "monitor.example", "Origin": "https://monitor.example"})
+    assert request.scheme == "http"
+    response = await monitor_relay._validate_monitor_host(request, _handle_ws)
+    assert response is fake_ws
+    assert fake_ws.messages[0]["type"] == "snapshot"
+
+
+@pytest.mark.parametrize("origin", ["*", "null", "http://host/path", "http://user@host", "http://host:bad"])
+def test_invalid_configured_origin_fails_startup(tmp_path, origin):
+    with pytest.raises(ValueError):
+        create_monitor_relay_app(monitor_root=str(tmp_path), allowed_origins=[origin])
 
 
 @pytest.mark.asyncio

--- a/tests/test_monitor_relay.py
+++ b/tests/test_monitor_relay.py
@@ -85,6 +85,51 @@ class FakeWebSocket:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("origin", [
+    "https://attacker.example", "http://localhost:9999", "null", "",
+    "http://localhost:8080@attacker.example", "http://localhost:8080/path",
+    "http://localhost:8080?query", "http://localhost:8080#fragment",
+    "http://localhost:bad", "http://user@localhost:8080", "https://localhost:8080",
+])
+async def test_websocket_rejects_foreign_or_invalid_origin_before_reading_data(tmp_path, origin):
+    app = create_monitor_relay_app(monitor_root=str(tmp_path / "missing"))
+    request = make_mocked_request("GET", "/ws", app=app,
+                                  headers={"Host": "localhost:8080", "Origin": origin})
+    with pytest.raises(web.HTTPForbidden):
+        await _handle_ws(request)
+
+
+@pytest.mark.asyncio
+async def test_websocket_rejects_multiple_origin_headers(tmp_path):
+    app = create_monitor_relay_app(monitor_root=str(tmp_path))
+    request = make_mocked_request("GET", "/ws", app=app, headers=[
+        ("Host", "localhost:8080"), ("Origin", "http://localhost:8080"),
+        ("Origin", "https://attacker.example")])
+    with pytest.raises(web.HTTPForbidden):
+        await _handle_ws(request)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("host,origin", [
+    ("localhost:8080", "http://localhost:8080"), ("localhost", "http://localhost:80"),
+    ("[::1]:8080", "http://[::1]:8080"), ("localhost:8080", None),
+])
+async def test_websocket_allows_same_origin_dashboard_and_originless_clients(
+    tmp_path, monkeypatch, host, origin
+):
+    _make_monitor_root(tmp_path)
+    app = create_monitor_relay_app(monitor_root=str(tmp_path / "monitor"))
+    fake_ws = FakeWebSocket(close_after_messages=1)
+    monkeypatch.setattr(monitor_relay.web, "WebSocketResponse", lambda **_: fake_ws)
+    headers = {"Host": host}
+    if origin is not None:
+        headers["Origin"] = origin
+    response = await _handle_ws(make_mocked_request("GET", "/ws", app=app, headers=headers))
+    assert response is fake_ws
+    assert fake_ws.messages[0]["type"] == "snapshot"
+
+
+@pytest.mark.asyncio
 async def test_monitor_relay_health_handler_reports_available_bots(tmp_path):
     monitor_root = _make_monitor_root(tmp_path)
     app = create_monitor_relay_app(monitor_root=str(monitor_root), poll_interval_ms=10)


### PR DESCRIPTION
A foreign website could connect to the monitor WebSocket and receive local account snapshots because browser WebSockets do not enforce the ordinary same-origin read policy. The relay now rejects foreign, opaque, malformed, or multiple Origin headers before loading account data or upgrading the connection. Same-origin dashboard connections and originless native clients remain supported.

The documentation explains the origin restriction and the existing unauthenticated relay boundary.

Validation: 29 monitor relay tests passed, covering foreign origins, scheme/port mismatches, malformed headers, valid dashboard origins including IPv6/default ports, and native clients; `git diff --check` passed.
