### PR TITLE
Include fill-free equity windows and unfinished recovery tails in metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ All notable user-facing changes will be documented in this file.
   plan when a private fill update arrives. Partial-fill updates also invalidate account state when
   they match a recently created order.
 
+- Backtest weighted equity metrics now include fill-free trailing windows and carry the last
+  actual balance into their equity-versus-balance calculations, preventing open losing positions
+  from receiving artificially favorable scores. Equity peak-recovery metrics now include an
+  unrecovered drawdown through the final sample.
+
 - Added `fills_gap_time_weighted_mean_hours` as an exact backtest and CPU/GPU optimizer metric.
   It minimizes `sum(gap_hours^2) / sum(gap_hours)` over unique portfolio fill timestamps and the
   analysis boundaries, providing smoother selection pressure against long no-fill periods than a

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -42,6 +42,9 @@ and more stable across collateral caps.
 - `exposure_mean_ratio`: `adg` divided by the mean absolute recorded wallet exposure.
 
 Weighted `_w` variants use the same trailing-slice averaging as the rest of the `_w` metrics.
+Equity-based metrics include every nonempty trailing equity slice even when no new fills occur;
+equity-versus-balance calculations carry the last actual fill balance into each slice. Fill-only
+statistics remain zero for a slice without fills. Short runs average the available nonempty slices.
 
 ## Drawdown and tail metrics
 - `drawdown_worst`: Maximum absolute drawdown over the equity curve.
@@ -68,7 +71,8 @@ Weighted `_w` variants use the same trailing-slice averaging as the rest of the 
   gaps `g`; the metric is `sum(g^2) / sum(g)`. A randomly selected moment is therefore weighted by
   the length of the gap containing it, so long droughts contribute more strongly than clustered
   fills. A zero-fill run equals the full analysis duration.
-- `peak_recovery_hours_equity`: Longest time to make a new high on the equity curve.
+- `peak_recovery_hours_equity`: Longest equity peak-to-recovery interval, including an unrecovered
+  tail from the last peak to the final equity sample.
 - `peak_recovery_days_equity`: Same equity recovery duration converted to days.
 - `peak_recovery_hours_pnl`: Same calculation on cumulative realized PnL.
 - `peak_recovery_days_pnl`: Same realized-PnL recovery duration converted to days.

--- a/passivbot-rust/src/analysis.rs
+++ b/passivbot-rust/src/analysis.rs
@@ -504,6 +504,8 @@ fn analyze_backtest_basic(
         timestamps_ms,
         exposures_series,
         first_fill.usd_total_balance,
+        first_fill.twe_net,
+        0,
     )
 }
 
@@ -513,6 +515,8 @@ fn analyze_backtest_basic_with_starting_balance(
     timestamps_ms: &[u64],
     exposures_series: &[f64],
     starting_balance: f64,
+    starting_exposure: f64,
+    index_offset: usize,
 ) -> Analysis {
     if equities.is_empty() {
         return Analysis::default();
@@ -716,7 +720,7 @@ fn analyze_backtest_basic_with_starting_balance(
             let fill_precedes_sample = if use_timestamps && fill.timestamp_ms > 0 {
                 fill.timestamp_ms <= timestamps_ms[i]
             } else {
-                fill.index <= i
+                fill.index <= index_offset + i
             };
             if fill_precedes_sample {
                 last_balance = fill.usd_total_balance;
@@ -762,6 +766,8 @@ fn analyze_backtest_basic_with_starting_balance(
             .filter(|value| value.is_finite())
             .map(f64::abs)
             .collect()
+    } else if fills.is_empty() {
+        vec![starting_exposure.abs()]
     } else {
         fills
             .iter()
@@ -1174,6 +1180,8 @@ pub fn analyze_backtest(
                 subset_timestamps,
                 subset_exposures,
                 fills.last().unwrap().usd_total_balance,
+                fills.last().unwrap().twe_net,
+                start_idx,
             ),
             FillSuffixSelection::Contiguous(fill_start_idx) => {
                 let balance = fills[fill_start_idx.saturating_sub(1)].usd_total_balance;
@@ -1183,6 +1191,8 @@ pub fn analyze_backtest(
                     subset_timestamps,
                     subset_exposures,
                     balance,
+                    fills[fill_start_idx.saturating_sub(1)].twe_net,
+                    start_idx,
                 )
             }
             FillSuffixSelection::NonContiguous => {
@@ -1193,20 +1203,21 @@ pub fn analyze_backtest(
                     })
                     .cloned()
                     .collect();
-                let balance = fills
+                let previous_fill = fills
                     .iter()
                     .rev()
                     .find(|fill| {
                         !fill_is_at_or_after_analysis_start(fill, subset_start_ts, start_idx)
                     })
-                    .unwrap_or(&fills[0])
-                    .usd_total_balance;
+                    .unwrap_or(&fills[0]);
                 analyze_backtest_basic_with_starting_balance(
                     &subset_fills,
                     subset_equities,
                     subset_timestamps,
                     subset_exposures,
-                    balance,
+                    previous_fill.usd_total_balance,
+                    previous_fill.twe_net,
+                    start_idx,
                 )
             }
         };
@@ -2284,16 +2295,7 @@ mod tests {
         let start = 1_740_000_000_000_u64;
         let fills = vec![
             make_trade_fill(100, start, "BTC", 0.0, 0.1, 0.1, 100.0, true),
-            make_trade_fill(
-                102,
-                start + 2 * 60_000,
-                "BTC",
-                -10.0,
-                -0.1,
-                0.0,
-                90.0,
-                true,
-            ),
+            make_trade_fill(102, start + 2 * 60_000, "BTC", -10.0, -0.1, 0.0, 90.0, true),
         ];
         let equities = vec![100.0, 90.0, 95.0];
         let timestamps = vec![start, start + 60_000, start + 2 * 60_000];
@@ -2593,12 +2595,44 @@ mod tests {
             &[0, MS_PER_DAY, 2 * MS_PER_DAY],
             &[0.4; 3],
             1000.0,
+            0.4,
+            0,
         );
         assert!((analysis.equity_balance_diff_neg_max - 0.3).abs() < 1e-12);
         assert!((analysis.paper_loss_ratio - analysis.adg / 0.3).abs() < 1e-12);
         assert!((analysis.exposure_ratio - analysis.adg / 0.4).abs() < 1e-12);
         assert_eq!(analysis.volume_pct_per_day_avg, 0.0);
         assert_eq!(analysis.win_rate, 0.0);
+    }
+
+    #[test]
+    fn suffix_index_fallback_applies_fills_at_their_original_offset() {
+        let mut fill = make_fill(15, 0.4);
+        fill.usd_total_balance = 1000.0;
+        let equities = [900.0; 15];
+        let analysis = analyze_backtest_basic_with_starting_balance(
+            &[fill],
+            &equities,
+            &[],
+            &[0.4; 15],
+            2000.0,
+            0.4,
+            15,
+        );
+        assert!((analysis.equity_balance_diff_neg_max - 0.1).abs() < 1e-12);
+    }
+
+    #[test]
+    fn weighted_fill_derived_exposure_is_carried_into_empty_suffixes() {
+        let fills = [make_fill(0, 0.4)];
+        let equities: Vec<f64> = (0..30).map(|i| 10000.0 - 100.0 * i as f64).collect();
+        let timestamps: Vec<u64> = (0..30).map(|i| i * MS_PER_DAY).collect();
+        let expected = analyze_backtest(&fills, &equities, &timestamps, &[0.4; 30]);
+        for exposures in [&[][..], &[0.4][..]] {
+            let actual = analyze_backtest(&fills, &equities, &timestamps, exposures);
+            assert!((actual.exposure_ratio_w - expected.exposure_ratio_w).abs() < 1e-12);
+            assert!((actual.exposure_mean_ratio_w - expected.exposure_mean_ratio_w).abs() < 1e-12);
+        }
     }
 
     #[test]
@@ -2625,5 +2659,4 @@ mod tests {
         assert_eq!(calc_peak_recovery_hours(&[], None, false), 0.0);
         assert_eq!(calc_peak_recovery_hours(&[100.0], None, false), 0.0);
     }
-
 }

--- a/passivbot-rust/src/analysis.rs
+++ b/passivbot-rust/src/analysis.rs
@@ -813,7 +813,11 @@ fn analyze_backtest_basic_with_starting_balance(
             (profit, loss + fill.pnl.abs())
         }
     });
-    let loss_profit_ratio = calc_loss_profit_ratio(total_loss, total_profit);
+    let loss_profit_ratio = if fills.is_empty() {
+        0.0
+    } else {
+        calc_loss_profit_ratio(total_loss, total_profit)
+    };
 
     let (long_profit, long_loss, short_profit, short_loss) =
         fills
@@ -2633,6 +2637,19 @@ mod tests {
             assert!((actual.exposure_ratio_w - expected.exposure_ratio_w).abs() < 1e-12);
             assert!((actual.exposure_mean_ratio_w - expected.exposure_mean_ratio_w).abs() < 1e-12);
         }
+    }
+
+    #[test]
+    fn profitable_run_keeps_zero_weighted_loss_ratio_with_fill_free_tails() {
+        let mut fills = [make_fill(0, 0.4), make_fill(1, 0.4)];
+        for fill in &mut fills {
+            fill.pnl = 10.0;
+        }
+        let equities: Vec<f64> = (0..30).map(|i| 10000.0 + 10.0 * i as f64).collect();
+        let timestamps: Vec<u64> = (0..30).map(|i| i * MS_PER_DAY).collect();
+        let result = analyze_backtest(&fills, &equities, &timestamps, &[0.4; 30]);
+        assert_eq!(result.loss_profit_ratio, 0.0);
+        assert_eq!(result.loss_profit_ratio_w, 0.0);
     }
 
     #[test]

--- a/passivbot-rust/src/analysis.rs
+++ b/passivbot-rust/src/analysis.rs
@@ -495,7 +495,26 @@ fn analyze_backtest_basic(
     timestamps_ms: &[u64],
     exposures_series: &[f64],
 ) -> Analysis {
-    if fills.is_empty() {
+    let Some(first_fill) = fills.first() else {
+        return Analysis::default();
+    };
+    analyze_backtest_basic_with_starting_balance(
+        fills,
+        equities,
+        timestamps_ms,
+        exposures_series,
+        first_fill.usd_total_balance,
+    )
+}
+
+fn analyze_backtest_basic_with_starting_balance(
+    fills: &[Fill],
+    equities: &[f64],
+    timestamps_ms: &[u64],
+    exposures_series: &[f64],
+    starting_balance: f64,
+) -> Analysis {
+    if equities.is_empty() {
         return Analysis::default();
     }
     // Calculate daily equities
@@ -690,7 +709,7 @@ fn analyze_backtest_basic(
     // Calculate equity-balance differences
     let mut bal_eq = Vec::with_capacity(equities.len());
     let mut fill_iter = fills.iter().peekable();
-    let mut last_balance = fills[0].usd_total_balance;
+    let mut last_balance = starting_balance;
 
     for (i, &equity) in equities.iter().enumerate() {
         while let Some(fill) = fill_iter.peek() {
@@ -1101,7 +1120,7 @@ pub fn analyze_backtest(
 ) -> Analysis {
     let mut analysis = analyze_backtest_basic(fills, equities, timestamps_ms, exposures_series);
 
-    if fills.len() <= 1 {
+    if fills.is_empty() || equities.is_empty() {
         return analysis;
     }
 
@@ -1144,15 +1163,28 @@ pub fn analyze_backtest(
             &[]
         };
 
+        // Equity continues changing even without another fill. Carry the
+        // last actual balance into the suffix; do not invent a trade merely
+        // to make equity/balance metrics evaluable.
         let subset_analysis = match select_contiguous_fill_suffix(fills, subset_start_ts, start_idx)
         {
-            FillSuffixSelection::Empty => break,
-            FillSuffixSelection::Contiguous(fill_start_idx) => analyze_backtest_basic(
-                &fills[fill_start_idx..],
+            FillSuffixSelection::Empty => analyze_backtest_basic_with_starting_balance(
+                &[],
                 subset_equities,
                 subset_timestamps,
                 subset_exposures,
+                fills.last().unwrap().usd_total_balance,
             ),
+            FillSuffixSelection::Contiguous(fill_start_idx) => {
+                let balance = fills[fill_start_idx.saturating_sub(1)].usd_total_balance;
+                analyze_backtest_basic_with_starting_balance(
+                    &fills[fill_start_idx..],
+                    subset_equities,
+                    subset_timestamps,
+                    subset_exposures,
+                    balance,
+                )
+            }
             FillSuffixSelection::NonContiguous => {
                 let subset_fills: Vec<Fill> = fills
                     .iter()
@@ -1161,14 +1193,20 @@ pub fn analyze_backtest(
                     })
                     .cloned()
                     .collect();
-                if subset_fills.is_empty() {
-                    break;
-                }
-                analyze_backtest_basic(
+                let balance = fills
+                    .iter()
+                    .rev()
+                    .find(|fill| {
+                        !fill_is_at_or_after_analysis_start(fill, subset_start_ts, start_idx)
+                    })
+                    .unwrap_or(&fills[0])
+                    .usd_total_balance;
+                analyze_backtest_basic_with_starting_balance(
                     &subset_fills,
                     subset_equities,
                     subset_timestamps,
                     subset_exposures,
+                    balance,
                 )
             }
         };
@@ -1176,81 +1214,86 @@ pub fn analyze_backtest(
     }
 
     // Compute weighted metrics as the mean of subset analyses
-    analysis.adg_w = subset_analyses.iter().map(|a| a.adg).sum::<f64>() / 10.0;
-    analysis.adg_pnl_w = subset_analyses.iter().map(|a| a.adg_pnl).sum::<f64>() / 10.0;
-    analysis.mdg_pnl_w = subset_analyses.iter().map(|a| a.mdg_pnl).sum::<f64>() / 10.0;
-    analysis.mdg_w = subset_analyses.iter().map(|a| a.mdg).sum::<f64>() / 10.0;
-    analysis.sharpe_ratio_w = subset_analyses.iter().map(|a| a.sharpe_ratio).sum::<f64>() / 10.0;
-    analysis.sortino_ratio_w = subset_analyses.iter().map(|a| a.sortino_ratio).sum::<f64>() / 10.0;
+    let subset_count = subset_analyses.len() as f64;
+    analysis.adg_w = subset_analyses.iter().map(|a| a.adg).sum::<f64>() / subset_count;
+    analysis.adg_pnl_w = subset_analyses.iter().map(|a| a.adg_pnl).sum::<f64>() / subset_count;
+    analysis.mdg_pnl_w = subset_analyses.iter().map(|a| a.mdg_pnl).sum::<f64>() / subset_count;
+    analysis.mdg_w = subset_analyses.iter().map(|a| a.mdg).sum::<f64>() / subset_count;
+    analysis.sharpe_ratio_w =
+        subset_analyses.iter().map(|a| a.sharpe_ratio).sum::<f64>() / subset_count;
+    analysis.sortino_ratio_w =
+        subset_analyses.iter().map(|a| a.sortino_ratio).sum::<f64>() / subset_count;
     analysis.sharpe_ratio_pnl_w = subset_analyses
         .iter()
         .map(|a| a.sharpe_ratio_pnl)
         .sum::<f64>()
-        / 10.0;
+        / subset_count;
     analysis.sortino_ratio_pnl_w = subset_analyses
         .iter()
         .map(|a| a.sortino_ratio_pnl)
         .sum::<f64>()
-        / 10.0;
-    analysis.omega_ratio_w = subset_analyses.iter().map(|a| a.omega_ratio).sum::<f64>() / 10.0;
-    analysis.calmar_ratio_w = subset_analyses.iter().map(|a| a.calmar_ratio).sum::<f64>() / 10.0;
+        / subset_count;
+    analysis.omega_ratio_w =
+        subset_analyses.iter().map(|a| a.omega_ratio).sum::<f64>() / subset_count;
+    analysis.calmar_ratio_w =
+        subset_analyses.iter().map(|a| a.calmar_ratio).sum::<f64>() / subset_count;
     analysis.sterling_ratio_w = subset_analyses
         .iter()
         .map(|a| a.sterling_ratio)
         .sum::<f64>()
-        / 10.0;
+        / subset_count;
     analysis.loss_profit_ratio_w = subset_analyses
         .iter()
         .map(|a| a.loss_profit_ratio)
         .sum::<f64>()
-        / 10.0;
+        / subset_count;
     analysis.paper_loss_ratio_w = subset_analyses
         .iter()
         .map(|a| a.paper_loss_ratio)
         .sum::<f64>()
-        / 10.0;
+        / subset_count;
     analysis.paper_loss_mean_ratio_w = subset_analyses
         .iter()
         .map(|a| a.paper_loss_mean_ratio)
         .sum::<f64>()
-        / 10.0;
+        / subset_count;
     analysis.exposure_ratio_w = subset_analyses
         .iter()
         .map(|a| a.exposure_ratio)
         .sum::<f64>()
-        / 10.0;
+        / subset_count;
     analysis.exposure_mean_ratio_w = subset_analyses
         .iter()
         .map(|a| a.exposure_mean_ratio)
         .sum::<f64>()
-        / 10.0;
+        / subset_count;
     analysis.equity_choppiness_w = subset_analyses
         .iter()
         .map(|a| a.equity_choppiness)
         .sum::<f64>()
-        / 10.0;
+        / subset_count;
     analysis.equity_jerkiness_w = subset_analyses
         .iter()
         .map(|a| a.equity_jerkiness)
         .sum::<f64>()
-        / 10.0;
+        / subset_count;
     analysis.exponential_fit_error_w = subset_analyses
         .iter()
         .map(|a| a.exponential_fit_error)
         .sum::<f64>()
-        / 10.0;
+        / subset_count;
     analysis.volume_pct_per_day_avg_w = subset_analyses
         .iter()
         .map(|a| a.volume_pct_per_day_avg)
         .sum::<f64>()
-        / 10.0;
+        / subset_count;
 
     analysis.positions_held_per_day_w = subset_analyses
         .iter()
         .map(|a| a.positions_held_per_day)
         .sum::<f64>()
-        / 10.0;
-    analysis.win_rate_w = subset_analyses.iter().map(|a| a.win_rate).sum::<f64>() / 10.0;
+        / subset_count;
+    analysis.win_rate_w = subset_analyses.iter().map(|a| a.win_rate).sum::<f64>() / subset_count;
 
     // Compute high-exposure duration metrics per side:
     // Mean and max continuous duration (hours) where twe exceeded the
@@ -1689,6 +1732,12 @@ fn calc_peak_recovery_hours(
             peak_ts = ts;
         }
     }
+    let final_ts = if use_timestamps {
+        *timestamps_ms.unwrap().last().unwrap()
+    } else {
+        fallback_timestamp_ms(series.len() - 1)
+    };
+    max_duration_ms = max_duration_ms.max(final_ts.saturating_sub(peak_ts));
     (max_duration_ms as f64) / MS_PER_HOUR as f64
 }
 
@@ -2507,4 +2556,74 @@ mod tests {
         assert!(analysis_usd.liquidated);
         assert!(analysis_btc.liquidated);
     }
+    #[test]
+    fn weighted_equity_metrics_include_fill_free_losing_suffixes() {
+        let timestamps: Vec<u64> = (0..30)
+            .map(|i| 1_704_067_200_000 + i * MS_PER_DAY)
+            .collect();
+        let equities: Vec<f64> = (0..30).map(|i| 10000.0 - 100.0 * i as f64).collect();
+        let mut first = make_fill(0, 0.1);
+        first.timestamp_ms = timestamps[0];
+        first.usd_total_balance = 10000.0;
+        let mut second = first.clone();
+        second.index = 1;
+        second.timestamp_ms = timestamps[1];
+        let analysis = analyze_backtest(&[first.clone(), second], &equities, &timestamps, &[]);
+        assert_eq!(analysis.equity_choppiness, 1.0);
+        assert_eq!(analysis.equity_choppiness_w, 1.0);
+        // Explicit daily-window reference: every suffix ends at the same
+        // three-day mean, but each has its own initial equity and duration.
+        let starts = [0, 15, 20, 23, 24, 25, 26, 26, 27, 27];
+        let expected = starts
+            .iter()
+            .map(|&start| (7200.0 / equities[start]).powf(1.0 / (30 - start) as f64) - 1.0)
+            .sum::<f64>()
+            / starts.len() as f64;
+        assert!((analysis.adg_w - expected).abs() < 1e-12);
+        let single_fill = analyze_backtest(&[first], &equities, &timestamps, &[]);
+        assert_eq!(single_fill.equity_choppiness_w, 1.0);
+        assert!((single_fill.adg_w - expected).abs() < 1e-12);
+    }
+
+    #[test]
+    fn fill_free_suffix_uses_last_actual_balance_without_inventing_fills() {
+        let analysis = analyze_backtest_basic_with_starting_balance(
+            &[],
+            &[900.0, 800.0, 700.0],
+            &[0, MS_PER_DAY, 2 * MS_PER_DAY],
+            &[0.4; 3],
+            1000.0,
+        );
+        assert!((analysis.equity_balance_diff_neg_max - 0.3).abs() < 1e-12);
+        assert!((analysis.paper_loss_ratio - analysis.adg / 0.3).abs() < 1e-12);
+        assert!((analysis.exposure_ratio - analysis.adg / 0.4).abs() < 1e-12);
+        assert_eq!(analysis.volume_pct_per_day_avg, 0.0);
+        assert_eq!(analysis.win_rate, 0.0);
+    }
+
+    #[test]
+    fn equity_peak_recovery_includes_unrecovered_tail_and_timestamp_fallback() {
+        let timestamps = [
+            0,
+            MS_PER_HOUR,
+            2 * MS_PER_HOUR,
+            3 * MS_PER_HOUR,
+            4 * MS_PER_HOUR,
+        ];
+        assert_eq!(
+            calc_peak_recovery_hours(&[100.0, 90.0, 80.0, 70.0, 60.0], Some(&timestamps), false),
+            4.0
+        );
+        assert_eq!(
+            calc_peak_recovery_hours(&[100.0, 110.0, 90.0, 80.0, 70.0], Some(&timestamps), false),
+            3.0
+        );
+        assert_eq!(
+            calc_peak_recovery_hours(&[100.0, 90.0, 80.0], None, false),
+            2.0 / 60.0
+        );
+        assert_eq!(calc_peak_recovery_hours(&[], None, false), 0.0);
+        assert_eq!(calc_peak_recovery_hours(&[100.0], None, false), 0.0);
+    }
+
 }

--- a/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
@@ -2316,6 +2316,11 @@ inline void passivbot_single_coin_impl(
     scalars[so + 54] = pnl_recovery_max_min * interval_ms;
     scalars[so + 55] = held_sum_min * interval_ms;
     scalars[so + 56] = held_count;
+    if (account_peak_k >= 0.0f && last_eq_k >= 0.0f) {
+        account_recovery_max_min = fmax(
+            account_recovery_max_min, last_eq_k - account_peak_k
+        );
+    }
     scalars[so + 57] = account_recovery_max_min * interval_ms;
     scalars[so + 58] = profit_sum_long;
     scalars[so + 59] = loss_sum_long;

--- a/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
@@ -3461,6 +3461,11 @@ inline void passivbot_ema_anchor_multicoin_impl(
     scalars[scalar_offset + 28] = pnl_recovery_max_min * interval_ms;
     scalars[scalar_offset + 29] = held_sum_min * interval_ms;
     scalars[scalar_offset + 30] = held_count;
+    if (account_peak_k >= 0.0f && last_eq_k >= 0.0f) {
+        account_recovery_max_min = fmax(
+            account_recovery_max_min, last_eq_k - account_peak_k
+        );
+    }
     scalars[scalar_offset + 31] = account_recovery_max_min * interval_ms;
     if (coin_hsl_mode) {
         write_one_side_coin_hsl_outputs(
@@ -4444,6 +4449,11 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
         fills.pnl_recovery_max_min * interval_ms;
     scalars[scalar_offset + 29] = fills.held_sum_min * interval_ms;
     scalars[scalar_offset + 30] = fills.held_count;
+    if (account_peak_k >= 0.0f && last_eq_k >= 0.0f) {
+        account_recovery_max_min = fmax(
+            account_recovery_max_min, last_eq_k - account_peak_k
+        );
+    }
     scalars[scalar_offset + 31] = account_recovery_max_min * interval_ms;
     if (long_config.coin_hsl_mode) {
         write_dual_side_coin_hsl_outputs(

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -4541,6 +4541,11 @@ inline void passivbot_single_coin_impl(
     scalars[so + 54] = pnl_recovery_max_min * interval_ms;
     scalars[so + 55] = held_sum_min * interval_ms;
     scalars[so + 56] = held_count;
+    if (account_peak_k >= 0.0f && last_eq_k >= 0.0f) {
+        account_recovery_max_min = fmax(
+            account_recovery_max_min, last_eq_k - account_peak_k
+        );
+    }
     scalars[so + 57] = account_recovery_max_min * interval_ms;
     scalars[so + 58] = profit_sum_long;
     scalars[so + 59] = loss_sum_long;

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
@@ -5594,6 +5594,11 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
         fills.pnl_recovery_max_min * interval_ms;
     scalars[scalar_offset + 29] = fills.held_sum_min * interval_ms;
     scalars[scalar_offset + 30] = fills.held_count;
+    if (account_peak_k >= 0.0f && last_eq_k >= 0.0f) {
+        account_recovery_max_min = fmax(
+            account_recovery_max_min, last_eq_k - account_peak_k
+        );
+    }
     scalars[scalar_offset + 31] = account_recovery_max_min * interval_ms;
     if (long_config.coin_hsl_mode) {
         write_dual_side_coin_hsl_outputs(
@@ -6355,6 +6360,11 @@ inline void passivbot_trailing_martingale_multicoin_impl(
     scalars[scalar_offset + 28] = pnl_recovery_max_min * interval_ms;
     scalars[scalar_offset + 29] = held_sum_min * interval_ms;
     scalars[scalar_offset + 30] = held_count;
+    if (account_peak_k >= 0.0f && last_eq_k >= 0.0f) {
+        account_recovery_max_min = fmax(
+            account_recovery_max_min, last_eq_k - account_peak_k
+        );
+    }
     scalars[scalar_offset + 31] = account_recovery_max_min * interval_ms;
     if (coin_hsl_mode) {
         write_one_side_coin_hsl_outputs(

--- a/src/optimization/gpu/metrics.py
+++ b/src/optimization/gpu/metrics.py
@@ -876,6 +876,7 @@ def _weighted_subset_context(
         )
         subsets.append(
             active & (day_ids.unsqueeze(0) >= subset_start_day.unsqueeze(1))
+            & (subset_start_step <= last_eq_steps).unsqueeze(1)
         )
         subset_start_steps.append(subset_start_step)
         subset_start_timestamps.append(subset_start_ts)
@@ -929,7 +930,8 @@ def _weighted_adg(
         total += torch.where(
             eligible, _smoothed_adg(day_eq, subset), torch.zeros_like(total)
         )
-    return total / 10.0
+    count = torch.stack([subset.any(dim=1) for subset in subsets]).sum(dim=0)
+    return total / count.clamp(min=1).to(total.dtype)
 
 
 WEIGHTED_STRATEGY_EQ_METRICS = {
@@ -981,7 +983,7 @@ def _weighted_daily_series_metrics(
         first_timestamp,
         interval_ms,
     )
-    fill_eligible = fill_count.to(torch.float64) > 1.0
+    fill_eligible = fill_count.to(torch.float64) > 0.0
     timestamp_origin = float(first_timestamp)
     finite_last_fill = torch.isfinite(last_fill_ts)
     relative_last_fill_ms = torch.where(
@@ -992,11 +994,9 @@ def _weighted_daily_series_metrics(
     last_fill_steps = torch.floor(
         relative_last_fill_ms / float(interval_ms) + 0.5
     ).to(torch.long)
-    # Unlike weighted equity-return metrics, Rust's weighted shape and volume
-    # analysis admits a one-sample equity run when it has multiple fills. The
-    # full-run analysis contributes one tenth, then the first empty suffix ends
-    # the loop. Only finite, ordered timestamps and one active sample are
-    # required here.
+    # Equity-only suffixes remain evaluable after the last fill. The full
+    # run still needs actual fill evidence, and empty sample windows do not
+    # contribute to the denominator.
     eligible = (
         fill_eligible
         & torch.isfinite(first_eq_ts)
@@ -1025,9 +1025,7 @@ def _weighted_daily_series_metrics(
     for subset_index, (subset, subset_start_step, subset_start_ts) in enumerate(
         zip(subsets, subset_start_steps, subset_start_timestamps)
     ):
-        subset_eligible = (
-            eligible & finite_last_fill & (last_fill_steps >= subset_start_step)
-        )
+        subset_eligible = eligible & subset.any(dim=1)
         if "volume_pct_per_day_avg_w" in requested:
             if subset_index == 0:
                 volume_fill_mask = day_has_fill & subset
@@ -1059,7 +1057,8 @@ def _weighted_daily_series_metrics(
                 torch.zeros_like(totals["volume_pct_per_day_avg_w"]),
             )
             totals["volume_pct_per_day_avg_w"] += torch.where(
-                subset_eligible & (fill_days > 0),
+                subset_eligible & finite_last_fill
+                & (last_fill_steps >= subset_start_step) & (fill_days > 0),
                 value,
                 torch.zeros_like(value),
             )
@@ -1070,10 +1069,9 @@ def _weighted_daily_series_metrics(
                 totals[name] += torch.where(
                     subset_eligible, value, torch.zeros_like(value)
                 )
-    result = {name: value / 10.0 for name, value in totals.items()}
-    # analyze_backtest returns early for zero or one fill. Preserve the custom
-    # Analysis defaults for weighted shape metrics; weighted volume defaults
-    # to zero.
+    count = torch.stack([subset.any(dim=1) for subset in subsets]).sum(dim=0)
+    result = {name: value / count.clamp(min=1).to(value.dtype) for name, value in totals.items()}
+    # Preserve the exact no-fill Analysis defaults.
     for name in shape_names:
         result[name] = torch.where(
             fill_eligible, result[name], torch.ones_like(result[name])
@@ -1159,7 +1157,8 @@ def _weighted_strategy_eq_metrics(
             totals[name] += torch.where(
                 eligible, value, torch.zeros_like(value)
             )
-    return {name: value / 10.0 for name, value in totals.items()}
+    count = torch.stack([subset.any(dim=1) for subset in subsets]).sum(dim=0)
+    return {name: value / count.clamp(min=1).to(value.dtype) for name, value in totals.items()}
 
 
 def _daily_pnl_stats(day_net_pnl, day_last_fill_balance, mask):
@@ -1323,7 +1322,7 @@ def _weighted_pnl_metrics(
     fill_count = torch.where(
         active, day_fill_count, torch.zeros_like(day_fill_count)
     )
-    eligible = fill_count.sum(dim=1) > 1.0
+    eligible = fill_count.sum(dim=1) > 0.0
     totals = {
         name: torch.zeros(
             day_net_pnl.shape[0],
@@ -1352,7 +1351,8 @@ def _weighted_pnl_metrics(
             totals[name] += torch.where(
                 include, values[name], torch.zeros_like(values[name])
             )
-    return {name: value / 10.0 for name, value in totals.items()}
+    count = torch.stack([subset.any(dim=1) for subset in subsets]).sum(dim=0)
+    return {name: value / count.clamp(min=1).to(value.dtype) for name, value in totals.items()}
 
 
 def _hard_stop_lifecycle_metrics(out: dict, run) -> dict:
@@ -1619,6 +1619,12 @@ def _daily_peak_recovery_ms(day_end_eq, active):
         peak = torch.where(new_high, value, peak)
         peak_day = torch.where(
             new_high, torch.full_like(peak_day, day), peak_day
+        )
+        # Count the still-unrecovered interval through every valid sample.
+        recovery_days = torch.where(
+            valid & started,
+            torch.maximum(recovery_days, (day - peak_day).to(day_end_eq.dtype)),
+            recovery_days,
         )
         started |= valid
     return torch.where(

--- a/src/optimization/gpu/metrics.py
+++ b/src/optimization/gpu/metrics.py
@@ -1856,7 +1856,7 @@ def _btc_account_metrics(out: dict, run, data: dict, requested) -> dict:
         "mdg_w_per_exposure_short_btc",
     }:
         wanted_safe_weighted_sources.add("mdg_strategy_eq_w")
-    enough_fills = out["fill_count"].to(torch.float64) > 1.0
+    enough_fills = out["fill_count"].to(torch.float64) > 0.0
     if wanted_safe_weighted_sources:
         safe_weighted = _weighted_strategy_eq_metrics(
             day_end_btc,

--- a/tests/optimization/test_gpu_metrics.py
+++ b/tests/optimization/test_gpu_metrics.py
@@ -75,7 +75,7 @@ def test_btc_daily_peak_recovery_matches_non_strict_rust_contract():
 
     recovery = _daily_peak_recovery_ms(day_end, active) / 86_400_000.0
 
-    assert recovery.tolist() == [2.0, 0.0]
+    assert recovery.tolist() == [2.0, 3.0]
 
 
 def test_fill_activity_ratio_recovers_integer_steps_at_whole_day_boundary():
@@ -856,7 +856,8 @@ def test_weighted_daily_series_metrics_match_rust_suffix_contract():
     )
 
 
-def test_weighted_daily_series_metrics_preserve_sparse_fill_rust_defaults():
+@pytest.mark.parametrize("fill_count", [0.0, 1.0])
+def test_weighted_daily_series_metrics_evaluate_single_fill_run(fill_count):
     day_end = torch.tensor([[100.0, 101.0]], dtype=torch.float64)
     requested = set(
         [
@@ -872,7 +873,7 @@ def test_weighted_daily_series_metrics_preserve_sparse_fill_rust_defaults():
         torch.tensor([[0.5, 0.0]], dtype=torch.float64),
         torch.tensor([[True, False]]),
         torch.ones_like(day_end, dtype=torch.bool),
-        torch.tensor([1.0]),
+        torch.tensor([fill_count]),
         torch.tensor([0.0]),
         torch.tensor([0.0]),
         torch.tensor([86_400_000.0]),
@@ -882,12 +883,19 @@ def test_weighted_daily_series_metrics_preserve_sparse_fill_rust_defaults():
     )
 
     assert set(metrics) == requested
-    assert metrics["volume_pct_per_day_avg_w"].item() == 0.0
-    for name in requested - {"volume_pct_per_day_avg_w"}:
-        assert metrics[name].item() == 1.0
+    if fill_count == 0:
+        assert metrics["volume_pct_per_day_avg_w"].item() == 0.0
+        for name in requested - {"volume_pct_per_day_avg_w"}:
+            assert metrics[name].item() == 1.0
+    else:
+        # Three nonempty windows: the full run and two one-sample suffixes.
+        assert metrics["volume_pct_per_day_avg_w"].item() == pytest.approx(0.5 / 3)
+        assert metrics["equity_choppiness_w_usd"].item() == pytest.approx(1.0 / 3)
+        assert metrics["equity_jerkiness_w_usd"].item() == 0.0
+        assert math.isinf(metrics["exponential_fit_error_w_usd"].item())
 
 
-def test_weighted_daily_series_metrics_keep_one_sample_full_run_tenth():
+def test_weighted_daily_series_metrics_average_only_nonempty_windows():
     requested = {
         "equity_choppiness_w_usd",
         "equity_jerkiness_w_usd",
@@ -912,8 +920,30 @@ def test_weighted_daily_series_metrics_keep_one_sample_full_run_tenth():
     assert metrics["equity_choppiness_w_usd"].item() == 0.0
     assert metrics["equity_jerkiness_w_usd"].item() == 0.0
     assert math.isinf(metrics["exponential_fit_error_w_usd"].item())
-    assert metrics["volume_pct_per_day_avg_w"].item() == pytest.approx(0.05)
+    assert metrics["volume_pct_per_day_avg_w"].item() == pytest.approx(0.5)
 
+
+
+def test_weighted_metrics_include_fill_free_losing_tail():
+    day_ms = 86_400_000
+    equities = torch.arange(10000.0, 7000.0, -100.0, dtype=torch.float64).unsqueeze(0)
+    active = torch.ones_like(equities, dtype=torch.bool)
+    first_ts = torch.tensor([0.0], dtype=torch.float64)
+    last_ts = torch.tensor([29.0 * day_ms], dtype=torch.float64)
+    adg = _weighted_adg(equities, active, first_ts, last_ts, 0.0, day_ms)
+    shape = _weighted_daily_series_metrics(
+        equities, torch.zeros_like(equities), torch.zeros_like(active), active,
+        torch.tensor([2.0]), torch.tensor([float(day_ms)]), first_ts, last_ts,
+        0.0, day_ms, {"equity_choppiness_w_usd"},
+    )
+    starts = [0, 15, 20, 23, 24, 25, 26, 26, 27, 27]
+    expected = np.mean([
+        (7200.0 / equities[0, start].item()) ** (1.0 / (30 - start)) - 1.0
+        for start in starts
+    ])
+    assert adg.item() == pytest.approx(expected, abs=1e-12)
+    assert shape["equity_choppiness_w_usd"].item() == 1.0
+    assert (_daily_peak_recovery_ms(equities, active) / 3_600_000).item() == 696.0
 
 def test_weighted_volume_excludes_ambiguous_intraday_cutoff_day():
     metrics = _weighted_daily_series_metrics(
@@ -982,9 +1012,8 @@ def test_weighted_suffix_admission_uses_integer_candle_steps():
         {"equity_choppiness_w_usd"},
     )
 
-    # Linear full and half-window daily series both have choppiness 1.0;
-    # Rust admits both and stops at the next suffix, for a weighted 0.2.
-    assert metrics["equity_choppiness_w_usd"].item() == pytest.approx(0.2)
+    # Every nonempty linear suffix contributes, including those after the last fill.
+    assert metrics["equity_choppiness_w_usd"].item() == pytest.approx(1.0)
 
 
 def test_weighted_subsets_normalize_relative_timestamps_to_unix_origin():

--- a/tests/optimization/test_gpu_metrics.py
+++ b/tests/optimization/test_gpu_metrics.py
@@ -1926,7 +1926,8 @@ def test_new_strategy_equity_metrics_reduce_existing_compact_surface():
     assert zero_exposure["gain_per_exposure_short_usd"].item() == 0.0
 
 
-def test_btc_account_metrics_use_prepared_daily_price_context():
+@pytest.mark.parametrize("fill_count", [1.0, 3.0])
+def test_btc_account_metrics_use_prepared_daily_price_context(fill_count):
     day_end = torch.tensor([[100.0, 110.0, 90.0]], dtype=torch.float64)
     out = {
         "day_end_eq": day_end,
@@ -1934,7 +1935,7 @@ def test_btc_account_metrics_use_prepared_daily_price_context():
         "day_max_dd": torch.zeros_like(day_end),
         "day_volume": torch.zeros_like(day_end),
         "day_has_fill": torch.ones_like(day_end, dtype=torch.bool),
-        "fill_count": torch.tensor([3.0]),
+        "fill_count": torch.tensor([fill_count]),
         "max_dd": torch.zeros(1),
         "held_max_ms": torch.zeros(1),
         "gap_hist": torch.zeros((1, 128), dtype=torch.int32),
@@ -1956,6 +1957,8 @@ def test_btc_account_metrics_use_prepared_daily_price_context():
         "gain_btc",
         "gain_per_exposure_long_btc",
         "peak_recovery_days_equity_btc",
+        "adg_w_btc",
+        "adg_w_per_exposure_long_btc",
     }
     btc_day_end = np.array([10.0, 10.0, 20.0])
 
@@ -1987,6 +1990,10 @@ def test_btc_account_metrics_use_prepared_daily_price_context():
         expected_gain.item() / 1.25
     )
     assert metrics["peak_recovery_days_equity_btc"].item() == 1.0
+    assert metrics["adg_w_btc"].item() < 0.0
+    assert metrics["adg_w_per_exposure_long_btc"].item() == pytest.approx(
+        metrics["adg_w_btc"].item() / 1.25
+    )
 
 
 def test_btc_account_metrics_fail_closed_without_price_context():

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -5892,6 +5892,34 @@ def _multicoin_exposure_fixture(
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
 @pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_mps_equity_recovery_includes_unrecovered_final_tail(strategy_kind, side):
+    count = 32
+    final_multiplier = 0.7 if side == "long" else 1.3
+    closes = np.column_stack([
+        np.linspace(initial, initial * final_multiplier, count)
+        for initial in (100.0, 120.0)
+    ])
+    runner, row = _multicoin_exposure_fixture(
+        strategy_kind, side, count=count, closes=closes,
+        highs=closes if side == "long" else closes * 1.01,
+        lows=closes * 0.99 if side == "long" else closes,
+    )
+    output = runner.run(np.asarray([row], dtype=np.float64))
+    torch.mps.synchronize()
+
+    assert output["fill_count"].item() > 0.0
+    # Every mark after the first is below the account's initial equity peak.
+    # The still-open drawdown must span the complete recorded equity interval.
+    duration = output["last_eq_ts"] - output["first_eq_ts"]
+    assert duration.item() > 0.0
+    assert output["account_recovery_max_ms"].item() == duration.item()
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+@pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
 def test_mps_runner_profile_distinguishes_cold_warm_and_disabled(strategy_kind):
     runner, row = _multicoin_exposure_fixture(strategy_kind, "long")
     second_runner, _row = _multicoin_exposure_fixture(strategy_kind, "long")
@@ -12499,6 +12527,9 @@ def test_mps_recovery_captures_early_post_fill_liquidation_endpoint():
         ],
     )
     assert recovery[0, 3].item() > 0.0
+    assert output["account_recovery_max_ms"][0].item() == (
+        output["last_eq_ts"][0] - output["first_eq_ts"][0]
+    ).item()
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
Backtest weighted metrics stopped at the first suffix without fills and still divided by ten, understating adverse equity tails. Weighted evaluation now includes fill-free equity windows with the carried account balance and averages the windows actually evaluated. Equity peak recovery also includes an unfinished drawdown through the last analysis sample. Exact Rust, GPU postprocessing, and Metal scalar outputs share these semantics.

Regression coverage exercises sparse fills, losing no-fill tails, short histories, balance carry, and open recovery tails. Documentation describes the updated metrics.

Validation: 279 Rust tests and default-feature test compilation; 104 Python tests using a rebuilt, source-verified extension; 8 existing Apple MPS cases and 5 new hardware recovery-tail regressions passed; `git diff --check` passed.
