### PR TITLE
Serialize OHLCV initialization and materialized cache ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable user-facing changes will be documented in this file.
 - Concurrent OHLCV writers now lock monthly initialization through catalog publication, preserving
   both candle bodies and validity masks. Materialized scratch allocation and pruning use a persistent
   advisory lock, preventing simultaneous owners while owner metadata is being initialized.
+  Stop older backtest/optimizer workers before sharing their cache with the new lock protocol;
+  ambiguous legacy locks require explicit cleanup after those workers have stopped.
 
 - Gate.io and KuCoin fill-history refreshes now reject unfinished pagination instead of marking
   partial or failed fetches as complete coverage for realized-PnL risk checks. A traversal that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Concurrent OHLCV writers now lock monthly initialization through catalog publication, preserving
+  both candle bodies and validity masks. Materialized scratch allocation and pruning use a persistent
+  advisory lock, preventing simultaneous owners while owner metadata is being initialized.
+
 - Gate.io and KuCoin fill-history refreshes now reject unfinished pagination instead of marking
   partial or failed fetches as complete coverage for realized-PnL risk checks. A traversal that
   completes on its final allowed request remains valid.

--- a/docs/backtesting.md
+++ b/docs/backtesting.md
@@ -259,3 +259,20 @@ explicitly in `backtest.exchanges` when you want them included.
 ## Exchange Name Conventions
 
 Cache paths and output directories use standard exchange names (e.g., `binance`, `bybit`, `gateio`, `kucoin`). CCXT-specific IDs such as `binanceusdm`, `bybitusdt`, and `kucoinfutures` are only used internally when communicating with exchange APIs. Always use the short names in your configuration files and external OHLCV source directories.
+
+## Materialized scratch cache locks
+
+Backtests and optimizers serialize scratch allocation and pruning with the persistent
+`.materialized.op.flock` file in their materialized cache directory. Do not delete this file:
+processes holding an older inode would otherwise stop excluding new owners. The operating system
+releases ownership when a worker exits, including after an abnormal exit.
+
+When upgrading from the previous `.materialized.op.lock` directory protocol, stop all older
+backtest and optimizer workers before starting the updated version against the same cache.
+Concurrent workers using different lock protocols are unsupported. A legacy lock with a confirmed
+dead local PID does not block the updated version. An active, foreign, missing, or malformed owner
+record is preserved and produces an actionable error. Missing metadata may belong to a worker
+paused while creating its lock, so an age limit cannot safely establish that ownership has ended.
+After confirming that every older worker has stopped, remove only the legacy
+`.materialized.op.lock` directory named in the error and retry. Keep the new `.materialized.op.flock`
+file and existing active run directories intact.

--- a/src/materialized_cache.py
+++ b/src/materialized_cache.py
@@ -136,17 +136,25 @@ def materialized_operation_lock(output_root: str | Path):
         if legacy.exists():
             owner = _read_lock(legacy / OP_LOCK_FILENAME) or {}
             pid = owner.get("pid")
-            if type(pid) is not int:
-                pid = 0
+            unknown_or_active = True
+            if type(pid) is int and pid > 0 and owner.get("hostname") == _hostname():
+                try:
+                    unknown_or_active = _process_exists(pid)
+                except OverflowError:
+                    # Unrepresentable PIDs cannot establish a dead owner.
+                    pass
             # Missing metadata can mean an older worker paused between mkdir
             # and publishing its PID. Elapsed time does not prove it is dead.
-            if pid <= 0 or owner.get("hostname") != _hostname() or _process_exists(pid):
+            if unknown_or_active:
                 raise RuntimeError(
                     f"legacy materialized cache operation ownership is unknown or active: {legacy}. "
                     "Stop all workers using the previous lock protocol; after confirming none "
                     "remain, remove only this legacy lock directory and retry. "
                     f"Do not remove {OP_LOCK_FILE}."
                 )
+            # Complete the confirmed-dead migration before a later PID reuse
+            # can make this obsolete record appear active again.
+            shutil.rmtree(legacy)
         yield
 
 

--- a/src/materialized_cache.py
+++ b/src/materialized_cache.py
@@ -11,11 +11,13 @@ from pathlib import Path
 from typing import Any
 
 import numpy as np
+import portalocker
 
 
 LOCK_FILENAME = ".materialized.lock.json"
 OP_LOCK_DIRNAME = ".materialized.op.lock"
 OP_LOCK_FILENAME = "lock.json"
+OP_LOCK_FILE = ".materialized.op.flock"
 OP_LOCK_TIMEOUT_SECONDS = 30.0
 OP_LOCK_POLL_SECONDS = 0.05
 
@@ -117,38 +119,26 @@ def materialized_lock_path(run_root: str | Path) -> Path:
 
 
 def materialized_operation_lock_path(output_root: str | Path) -> Path:
-    return Path(output_root) / OP_LOCK_DIRNAME
-
-
-def _operation_lock_is_active(lock_dir: Path) -> bool:
-    return _lock_is_active(lock_dir / OP_LOCK_FILENAME)
+    return Path(output_root) / OP_LOCK_FILE
 
 
 @contextmanager
 def materialized_operation_lock(output_root: str | Path):
     root = Path(output_root)
     root.mkdir(parents=True, exist_ok=True)
-    lock_dir = materialized_operation_lock_path(root)
-    deadline = time.monotonic() + OP_LOCK_TIMEOUT_SECONDS
-    acquired = False
-    while True:
-        try:
-            lock_dir.mkdir()
-            _write_lock(lock_dir / OP_LOCK_FILENAME)
-            acquired = True
-            break
-        except FileExistsError:
-            if not _operation_lock_is_active(lock_dir):
-                shutil.rmtree(lock_dir, ignore_errors=True)
-                continue
-            if time.monotonic() >= deadline:
-                raise TimeoutError(f"timed out waiting for materialized cache lock {lock_dir}")
-            time.sleep(OP_LOCK_POLL_SECONDS)
-    try:
+    # Keep the lock inode permanently: unlinking it can create simultaneous
+    # owners when another process has already opened the old inode.
+    with portalocker.Lock(
+        str(materialized_operation_lock_path(root)), mode="a",
+        timeout=OP_LOCK_TIMEOUT_SECONDS, check_interval=OP_LOCK_POLL_SECONDS,
+    ):
+        legacy = root / OP_LOCK_DIRNAME
+        if legacy.exists() and (
+            _read_lock(legacy / OP_LOCK_FILENAME) is None
+            or _lock_is_active(legacy / OP_LOCK_FILENAME)
+        ):
+            raise RuntimeError(f"legacy materialized cache operation may be active: {legacy}")
         yield
-    finally:
-        if acquired:
-            shutil.rmtree(lock_dir, ignore_errors=True)
 
 
 def create_materialized_lock(run_root: str | Path) -> Path:

--- a/src/materialized_cache.py
+++ b/src/materialized_cache.py
@@ -133,11 +133,21 @@ def materialized_operation_lock(output_root: str | Path):
         timeout=OP_LOCK_TIMEOUT_SECONDS, check_interval=OP_LOCK_POLL_SECONDS,
     ):
         legacy = root / OP_LOCK_DIRNAME
-        if legacy.exists() and (
-            _read_lock(legacy / OP_LOCK_FILENAME) is None
-            or _lock_is_active(legacy / OP_LOCK_FILENAME)
-        ):
-            raise RuntimeError(f"legacy materialized cache operation may be active: {legacy}")
+        if legacy.exists():
+            owner = _read_lock(legacy / OP_LOCK_FILENAME) or {}
+            try:
+                pid = int(owner.get("pid"))
+            except (TypeError, ValueError):
+                pid = 0
+            # Missing metadata can mean an older worker paused between mkdir
+            # and publishing its PID. Elapsed time does not prove it is dead.
+            if pid <= 0 or owner.get("hostname") != _hostname() or _process_exists(pid):
+                raise RuntimeError(
+                    f"legacy materialized cache operation ownership is unknown or active: {legacy}. "
+                    "Stop all workers using the previous lock protocol; after confirming none "
+                    "remain, remove only this legacy lock directory and retry. "
+                    f"Do not remove {OP_LOCK_FILE}."
+                )
         yield
 
 

--- a/src/materialized_cache.py
+++ b/src/materialized_cache.py
@@ -135,9 +135,8 @@ def materialized_operation_lock(output_root: str | Path):
         legacy = root / OP_LOCK_DIRNAME
         if legacy.exists():
             owner = _read_lock(legacy / OP_LOCK_FILENAME) or {}
-            try:
-                pid = int(owner.get("pid"))
-            except (TypeError, ValueError):
+            pid = owner.get("pid")
+            if type(pid) is not int:
                 pid = 0
             # Missing metadata can mean an older worker paused between mkdir
             # and publishing its PID. Elapsed time does not prove it is dead.

--- a/src/ohlcv_store.py
+++ b/src/ohlcv_store.py
@@ -113,6 +113,15 @@ class OhlcvStore:
         status: str = "open",
     ) -> MonthChunkPaths:
         paths = self.month_paths(exchange, timeframe, symbol, year, month)
+        with self._chunk_write_lock(paths):
+            return self._ensure_month_unlocked(exchange, timeframe, symbol, year, month, status=status)
+
+    def _ensure_month_unlocked(
+        self, exchange: str, timeframe: str, symbol: str, year: int, month: int,
+        *, status: str = "open",
+    ) -> MonthChunkPaths:
+        """Initialize and register a chunk while its write lock is held."""
+        paths = self.month_paths(exchange, timeframe, symbol, year, month)
         n_rows = rows_in_month(year, month, timeframe)
         if not paths.body_path.exists():
             body = np.lib.format.open_memmap(
@@ -238,8 +247,9 @@ class OhlcvStore:
             grouped.setdefault(month_key_for_ts(int(ts_ms)), []).append(idx)
 
         for (year, month), indices in grouped.items():
-            paths = self.ensure_month(exchange, timeframe, symbol, year, month, status=status)
+            paths = self.month_paths(exchange, timeframe, symbol, year, month)
             with self._chunk_write_lock(paths):
+                self._ensure_month_unlocked(exchange, timeframe, symbol, year, month, status=status)
                 self._invalidate_verified_checksum_cache(paths.body_path)
                 body = np.load(paths.body_path, mmap_mode="r+")
                 valid = np.load(paths.valid_path, mmap_mode="r+")

--- a/tests/test_cache_lock_races.py
+++ b/tests/test_cache_lock_races.py
@@ -1,0 +1,104 @@
+from concurrent.futures import ThreadPoolExecutor
+from threading import Event
+from pathlib import Path
+import os
+import subprocess
+import sys
+
+import numpy as np
+
+import materialized_cache as cache
+from ohlcv_catalog import OhlcvCatalog
+from ohlcv_store import OhlcvStore, month_start_ts
+
+
+def test_concurrent_first_month_writers_preserve_both_rows(tmp_path, monkeypatch):
+    root = tmp_path / "ohlcv"
+    stores = [OhlcvStore(root, OhlcvCatalog(root / "catalog.sqlite")) for _ in range(2)]
+    first_initializing, release_first, second_started, second_done = [Event() for _ in range(4)]
+    original = np.lib.format.open_memmap
+    paused = False
+
+    def pause_initialization(filename, *args, **kwargs):
+        nonlocal paused
+        if kwargs.get("mode") == "w+" and not paused:
+            paused = True
+            first_initializing.set()
+            assert release_first.wait(5)
+        return original(filename, *args, **kwargs)
+
+    monkeypatch.setattr(np.lib.format, "open_memmap", pause_initialization)
+    base = month_start_ts(2026, 4)
+    values = np.array([[101, 99, 100, 10], [102, 100, 101, 11]], dtype=np.float32)
+
+    def write(index):
+        if index:
+            second_started.set()
+        stores[index].write_rows("binance", "1m", "BTC/USDT", np.array([base + index * 60000]),
+                                 values[index:index + 1])
+        if index:
+            second_done.set()
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        first = pool.submit(write, 0)
+        try:
+            assert first_initializing.wait(5)
+            second = pool.submit(write, 1)
+            assert second_started.wait(5)
+            assert not second_done.wait(0.2)
+        finally:
+            release_first.set()
+        first.result(timeout=5)
+        second.result(timeout=5)
+    fresh = OhlcvStore(root, OhlcvCatalog(root / "catalog.sqlite"))
+    result = fresh.read_range("binance", "1m", "BTC/USDT", base, base + 60000)
+    np.testing.assert_array_equal(result.valid, [True, True])
+    np.testing.assert_array_equal(result.values, values)
+
+
+def test_prune_waits_for_allocation_before_owner_metadata_exists(tmp_path, monkeypatch):
+    writing_owner, release_owner, prune_started, prune_done = [Event() for _ in range(4)]
+    original = cache._write_lock
+    paused = False
+
+    def pause_owner(path):
+        nonlocal paused
+        if not paused:
+            paused = True
+            writing_owner.set()
+            assert release_owner.wait(5)
+        original(path)
+
+    monkeypatch.setattr(cache, "_write_lock", pause_owner)
+
+    def prune():
+        prune_started.set()
+        cache.prune_materialized_cache(tmp_path)
+        prune_done.set()
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        allocation = pool.submit(cache.prepare_materialized_run, tmp_path, "run")
+        try:
+            assert writing_owner.wait(5)
+            pruning = pool.submit(prune)
+            assert prune_started.wait(5)
+            assert not prune_done.wait(0.2)
+        finally:
+            release_owner.set()
+        run = allocation.result(timeout=5)
+        pruning.result(timeout=5)
+    assert run.is_dir()
+    assert cache.materialized_lock_path(run).is_file()
+
+
+def test_operation_lock_survives_owner_exit_without_replacing_inode(tmp_path):
+    env = dict(os.environ, PYTHONPATH=str(Path(cache.__file__).parent))
+    subprocess.run([sys.executable, "-c",
+                    "import os,sys; from materialized_cache import materialized_operation_lock; "
+                    "lock=materialized_operation_lock(sys.argv[1]); lock.__enter__(); os._exit(0)",
+                    str(tmp_path)], check=True, env=env, timeout=10)
+    path = cache.materialized_operation_lock_path(tmp_path)
+    inode = path.stat().st_ino
+    with cache.materialized_operation_lock(tmp_path):
+        assert path.stat().st_ino == inode
+    assert path.stat().st_ino == inode

--- a/tests/test_cache_lock_races.py
+++ b/tests/test_cache_lock_races.py
@@ -185,3 +185,18 @@ def test_confirmed_dead_local_legacy_owner_does_not_block(tmp_path, monkeypatch)
     (legacy / cache.OP_LOCK_FILENAME).write_text(json.dumps({"hostname": cache._hostname(), "pid": 12345}))
     monkeypatch.setattr(cache, "_process_exists", lambda _pid: False)
     assert cache.prepare_materialized_run(tmp_path, "new-run").is_dir()
+
+
+@pytest.mark.parametrize("pid", [999999999.5, 999999999.0, True, False, "999999999"])
+def test_non_integer_legacy_pid_cannot_prove_dead_owner(tmp_path, monkeypatch, pid):
+    legacy = tmp_path / cache.OP_LOCK_DIRNAME
+    legacy.mkdir()
+    owner = {"hostname": cache._hostname(), "pid": pid}
+    (legacy / cache.OP_LOCK_FILENAME).write_text(json.dumps(owner))
+    def unexpected_probe(_pid):
+        pytest.fail("Malformed owner PID must not be probed as a process")
+    monkeypatch.setattr(cache, "_process_exists", unexpected_probe)
+    with pytest.raises(RuntimeError, match="ownership is unknown or active"):
+        cache.prepare_materialized_run(tmp_path, "new-run")
+    assert json.loads((legacy / cache.OP_LOCK_FILENAME).read_text()) == owner
+    assert not (tmp_path / "new-run").exists()

--- a/tests/test_cache_lock_races.py
+++ b/tests/test_cache_lock_races.py
@@ -2,10 +2,15 @@ from concurrent.futures import ThreadPoolExecutor
 from threading import Event
 from pathlib import Path
 import os
+import json
+import multiprocessing
+import shutil
+import time
 import subprocess
 import sys
 
 import numpy as np
+import pytest
 
 import materialized_cache as cache
 from ohlcv_catalog import OhlcvCatalog
@@ -102,3 +107,81 @@ def test_operation_lock_survives_owner_exit_without_replacing_inode(tmp_path):
     with cache.materialized_operation_lock(tmp_path):
         assert path.stat().st_ino == inode
     assert path.stat().st_ino == inode
+
+
+def _contending_process(root, start, iterations):
+    # Separate processes must exclude each other even before run-owner metadata
+    # exists. O_EXCL makes overlapping critical sections an immediate failure.
+    start.wait(10)
+    root = Path(root)
+    marker = root / "critical-section"
+    for _ in range(iterations):
+        with cache.materialized_operation_lock(root):
+            fd = os.open(marker, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+            try:
+                with (root / "owners.log").open("a") as output:
+                    output.write(f"{os.getpid()}\n")
+                time.sleep(0.005)
+            finally:
+                os.close(fd)
+                marker.unlink()
+
+
+def test_spawned_operation_owners_exclude_each_other(tmp_path):
+    context = multiprocessing.get_context("spawn")
+    start = context.Event()
+    workers = [context.Process(target=_contending_process, args=(str(tmp_path), start, 8)) for _ in range(4)]
+    for worker in workers:
+        worker.start()
+    start.set()
+    try:
+        for worker in workers:
+            worker.join(15)
+            assert worker.exitcode == 0
+    finally:
+        for worker in workers:
+            if worker.is_alive():
+                worker.terminate()
+                worker.join(5)
+    owners = (tmp_path / "owners.log").read_text().splitlines()
+    assert len(owners) == 32
+    assert len(set(owners)) == 4
+    assert cache.materialized_operation_lock_path(tmp_path).is_file()
+
+
+@pytest.mark.parametrize("metadata", [None, "invalid-json", {}, {"pid": "invalid"}, {"pid": 0}])
+def test_unknown_legacy_owner_is_preserved_with_actionable_recovery(tmp_path, metadata):
+    legacy = tmp_path / cache.OP_LOCK_DIRNAME
+    legacy.mkdir()
+    if metadata is not None:
+        text = metadata if isinstance(metadata, str) else json.dumps(metadata)
+        (legacy / cache.OP_LOCK_FILENAME).write_text(text)
+    with pytest.raises(RuntimeError, match="Stop all workers using the previous lock protocol"):
+        cache.prepare_materialized_run(tmp_path, "new-run")
+    assert legacy.is_dir()
+    assert not (tmp_path / "new-run").exists()
+    # Explicit operator cleanup is safe only after all old workers have stopped.
+    shutil.rmtree(legacy)
+    assert cache.prepare_materialized_run(tmp_path, "new-run").is_dir()
+
+
+@pytest.mark.parametrize("host,pid", [("local", "live"), ("foreign-host", "dead")])
+def test_active_or_foreign_legacy_owner_is_never_reclaimed(tmp_path, host, pid, monkeypatch):
+    legacy = tmp_path / cache.OP_LOCK_DIRNAME
+    legacy.mkdir()
+    owner = {"hostname": cache._hostname() if host == "local" else host,
+             "pid": os.getpid() if pid == "live" else 12345}
+    (legacy / cache.OP_LOCK_FILENAME).write_text(json.dumps(owner))
+    if pid == "dead":
+        monkeypatch.setattr(cache, "_process_exists", lambda _pid: False)
+    with pytest.raises(RuntimeError, match="ownership is unknown or active"):
+        cache.prune_materialized_cache(tmp_path)
+    assert json.loads((legacy / cache.OP_LOCK_FILENAME).read_text()) == owner
+
+
+def test_confirmed_dead_local_legacy_owner_does_not_block(tmp_path, monkeypatch):
+    legacy = tmp_path / cache.OP_LOCK_DIRNAME
+    legacy.mkdir()
+    (legacy / cache.OP_LOCK_FILENAME).write_text(json.dumps({"hostname": cache._hostname(), "pid": 12345}))
+    monkeypatch.setattr(cache, "_process_exists", lambda _pid: False)
+    assert cache.prepare_materialized_run(tmp_path, "new-run").is_dir()

--- a/tests/test_cache_lock_races.py
+++ b/tests/test_cache_lock_races.py
@@ -200,3 +200,28 @@ def test_non_integer_legacy_pid_cannot_prove_dead_owner(tmp_path, monkeypatch, p
         cache.prepare_materialized_run(tmp_path, "new-run")
     assert json.loads((legacy / cache.OP_LOCK_FILENAME).read_text()) == owner
     assert not (tmp_path / "new-run").exists()
+
+
+def test_unrepresentable_legacy_pid_has_actionable_recovery(tmp_path):
+    legacy = tmp_path / cache.OP_LOCK_DIRNAME
+    legacy.mkdir()
+    owner = {"hostname": cache._hostname(), "pid": 10**100}
+    (legacy / cache.OP_LOCK_FILENAME).write_text(json.dumps(owner))
+    with pytest.raises(RuntimeError, match="Stop all workers using the previous lock protocol"):
+        cache.prepare_materialized_run(tmp_path, "new-run")
+    assert json.loads((legacy / cache.OP_LOCK_FILENAME).read_text()) == owner
+    assert not (tmp_path / "new-run").exists()
+
+
+def test_confirmed_dead_legacy_migration_survives_pid_reuse(tmp_path, monkeypatch):
+    legacy = tmp_path / cache.OP_LOCK_DIRNAME
+    legacy.mkdir()
+    owner = {"hostname": cache._hostname(), "pid": 12345}
+    (legacy / cache.OP_LOCK_FILENAME).write_text(json.dumps(owner))
+    monkeypatch.setattr(cache, "_process_exists", lambda _pid: False)
+    with cache.materialized_operation_lock(tmp_path):
+        assert not legacy.exists()
+    monkeypatch.setattr(cache, "_process_exists", lambda _pid: True)
+    with cache.materialized_operation_lock(tmp_path):
+        assert not legacy.exists()
+    assert cache.materialized_operation_lock_path(tmp_path).is_file()


### PR DESCRIPTION
Concurrent first writers could initialize the same OHLCV month before taking its write lock, truncating a completed candle while leaving its validity mask set. Initialization and catalog publication now occur under the chunk lock.

Materialized-cache operation locks also exposed a directory before owner metadata existed, allowing a contender to delete it and enter concurrently. Operations now use a persistent advisory-lock inode released by the OS on process exit. Stop older workers before using the new protocol with their cache. Active or ambiguous legacy locks fail with explicit recovery instructions; confirmed-dead local owners do not block.

Validation: 99 focused cache/data tests passed, including simultaneous spawned processes, initialization and allocation races, owner-exit recovery, legacy migration states, and checksum/preservation coverage. Python compilation and diff checks passed. AI documentation checks report zero errors and two existing size warnings.
