### PR TITLE
Reset HSL episodes at ordinary flatten fills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,9 @@ All notable user-facing changes will be documented in this file.
   drawdown, while preserving RED-triggered cooldowns and persistent no-restart limits. Closing
   fills that first trigger RED finalize before same-step re-entry. Ambiguous required episode
   evidence defers startup replay and ordinary planning while already-latched RED supervision and
-  panic protection for active cooldown positions remain available.
+  panic protection for active cooldown positions remain available. Resting cooldown entries are
+  cancelled according to the configured policy, preserving orders after a proven manual-policy
+  intervention and graceful-stop adds to held positions. Normal-policy restart overrides replay later exact episode boundaries.
 
 - Added `fills_gap_time_weighted_mean_hours` as an exact backtest and CPU/GPU optimizer metric.
   It minimizes `sum(gap_hours^2) / sum(gap_hours)` over unique portfolio fill timestamps and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,9 @@ All notable user-facing changes will be documented in this file.
 - Equity Hard Stop Loss now resets RED-free episodes at the fill that flattens the configured
   coin, position-side, or unified scope, including a re-entry in the same minute. Live replay,
   exact backtests, and Apple MPS screening retain closing PnL and fees before resetting episode
-  drawdown, while preserving RED-triggered cooldowns and persistent no-restart limits.
+  drawdown, while preserving RED-triggered cooldowns and persistent no-restart limits. Closing
+  fills that first trigger RED finalize before same-step re-entry. Ambiguous required episode
+  evidence defers ordinary planning while already-latched RED supervision remains available.
 
 - Added `fills_gap_time_weighted_mean_hours` as an exact backtest and CPU/GPU optimizer metric.
   It minimizes `sum(gap_hours^2) / sum(gap_hours)` over unique portfolio fill timestamps and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,11 @@ All notable user-facing changes will be documented in this file.
   from receiving artificially favorable scores. Equity peak-recovery metrics now include an
   unrecovered drawdown through the final sample.
 
+- Equity Hard Stop Loss now resets RED-free episodes at the fill that flattens the configured
+  coin, position-side, or unified scope, including a re-entry in the same minute. Live replay,
+  exact backtests, and Apple MPS screening retain closing PnL and fees before resetting episode
+  drawdown, while preserving RED-triggered cooldowns and persistent no-restart limits.
+
 - Added `fills_gap_time_weighted_mean_hours` as an exact backtest and CPU/GPU optimizer metric.
   It minimizes `sum(gap_hours^2) / sum(gap_hours)` over unique portfolio fill timestamps and the
   analysis boundaries, providing smoother selection pressure against long no-fill periods than a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,8 +70,8 @@ All notable user-facing changes will be documented in this file.
   exact backtests, and Apple MPS screening retain closing PnL and fees before resetting episode
   drawdown, while preserving RED-triggered cooldowns and persistent no-restart limits. Closing
   fills that first trigger RED finalize before same-step re-entry. Ambiguous required episode
-  evidence defers startup replay and ordinary planning while already-latched RED supervision remains
-  available.
+  evidence defers startup replay and ordinary planning while already-latched RED supervision and
+  panic protection for active cooldown positions remain available.
 
 - Added `fills_gap_time_weighted_mean_hours` as an exact backtest and CPU/GPU optimizer metric.
   It minimizes `sum(gap_hours^2) / sum(gap_hours)` over unique portfolio fill timestamps and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,8 @@ All notable user-facing changes will be documented in this file.
   exact backtests, and Apple MPS screening retain closing PnL and fees before resetting episode
   drawdown, while preserving RED-triggered cooldowns and persistent no-restart limits. Closing
   fills that first trigger RED finalize before same-step re-entry. Ambiguous required episode
-  evidence defers ordinary planning while already-latched RED supervision remains available.
+  evidence defers startup replay and ordinary planning while already-latched RED supervision remains
+  available.
 
 - Added `fills_gap_time_weighted_mean_hours` as an exact backtest and CPU/GPU optimizer metric.
   It minimizes `sum(gap_hours^2) / sum(gap_hours)` over unique portfolio fill timestamps and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,12 @@ All notable user-facing changes will be documented in this file.
   evidence defers startup replay and ordinary planning while already-latched RED supervision and
   panic protection for active cooldown positions remain available. Resting cooldown entries are
   cancelled according to the configured policy, preserving orders after a proven manual-policy
-  intervention and graceful-stop adds to held positions. Normal-policy restart overrides replay later exact episode boundaries.
+  intervention and graceful-stop adds to held positions. Terminal no-restart scopes also cancel
+  resting entries. Normal-policy restart overrides and cooldown expiry retain the new episode's
+  baseline and entry fees before replaying later exact boundaries; live and restart paths retain
+  losses incurred before the next observation. Proven ordinary RED closes and panic closes follow
+  the same restart rules, with terminal no-restart protection taking precedence. Offline fake-live
+  scenarios retain complete fill history when their simulated dates differ from wall time.
 
 - Added `fills_gap_time_weighted_mean_hours` as an exact backtest and CPU/GPU optimizer metric.
   It minimizes `sum(gap_hours^2) / sum(gap_hours)` over unique portfolio fill timestamps and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,7 +77,8 @@ All notable user-facing changes will be documented in this file.
   resting entries. Normal-policy restart overrides and cooldown expiry retain the new episode's
   baseline and entry fees before replaying later exact boundaries; live and restart paths retain
   losses incurred before the next observation. Proven ordinary RED closes and panic closes follow
-  the same restart rules, with terminal no-restart protection taking precedence. Offline fake-live
+  the same restart rules, including proven same-millisecond interventions, with terminal no-restart
+  protection taking precedence. Offline fake-live
   scenarios retain complete fill history when their simulated dates differ from wall time.
 
 - Added `fills_gap_time_weighted_mean_hours` as an exact backtest and CPU/GPU optimizer metric.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,7 +78,8 @@ All notable user-facing changes will be documented in this file.
   baseline and entry fees before replaying later exact boundaries; live and restart paths retain
   losses incurred before the next observation. Proven ordinary RED closes and panic closes follow
   the same restart rules, including proven same-millisecond interventions, with terminal no-restart
-  protection taking precedence. Offline fake-live
+  protection taking precedence. Coin replay uses the account balance at each boundary, excluding
+  later fills and fees on other symbols. Offline fake-live
   scenarios retain complete fill history when their simulated dates differ from wall time.
 
 - Added `fills_gap_time_weighted_mean_hours` as an exact backtest and CPU/GPU optimizer metric.

--- a/docs/ai/features/equity_hard_stop_loss.md
+++ b/docs/ai/features/equity_hard_stop_loss.md
@@ -70,7 +70,8 @@ HSL drawdown state is scoped by `live.hsl_signal_mode`:
 ## Failure Semantics
 
 Incomplete fill coverage follows `../error_contract.md`. A required episode boundary is unavailable
-until supported by fill evidence. The affected HSL scope remains protective and retries after an
+until supported by fill evidence. Startup replay validates all enabled scope tapes before replacing
+existing protective state. The affected HSL scope remains protective and retries after an
 authoritative refresh. Flat scopes pending startup price replay retain the existing per-pair
 create gate, leaving unrelated scopes available. Ambiguous required held-episode evidence defers
 ordinary shared-account planning: the startup gate runs after portfolio intent construction and

--- a/docs/ai/features/equity_hard_stop_loss.md
+++ b/docs/ai/features/equity_hard_stop_loss.md
@@ -20,6 +20,12 @@ HSL drawdown state is scoped by `live.hsl_signal_mode`:
    unrealized-PnL availability. Multiple boundaries inside one replay minute retain their exact
    fill order, realized PnL, fees, and account balance at each boundary. Missing price replay may
    defer drawdown evaluation, but it must not hide an episode boundary.
+   Mixed-action fills sharing a millisecond require an unambiguous exchange-provided position
+   chain; list order and locally reconstructed position annotations are not ordering evidence.
+   Each proven fill boundary evaluates its final risk sample. Distinct boundaries in the same
+   minute replace that minute's EMA sample from its prior baseline instead of advancing EMA time
+   again. Ordinary polling within the minute remains cached. A RED stop is recorded while flat,
+   before a later fill can reopen the scope; a RED-free reset seeds the next episode in that minute.
 5. Current flat state is not a timestamp. If the flattening fill is not yet available, live
    finalization and cooldown anchoring defer visibly while protective entry blocking remains active;
    they never substitute the current time. Cooldown re-panic finalization must replay fills from a
@@ -65,7 +71,11 @@ HSL drawdown state is scoped by `live.hsl_signal_mode`:
 
 Incomplete fill coverage follows `../error_contract.md`. A required episode boundary is unavailable
 until supported by fill evidence. The affected HSL scope remains protective and retries after an
-authoritative refresh; unrelated scopes remain available.
+authoritative refresh. Flat scopes pending startup price replay retain the existing per-pair
+create gate, leaving unrelated scopes available. Ambiguous required held-episode evidence defers
+ordinary shared-account planning: the startup gate runs after portfolio intent construction and
+cannot make a plan built from unknown HSL episode state authoritative. Independently ready,
+already-latched RED supervision still runs during that deferral.
 
 ## Code And Tests
 

--- a/docs/ai/features/equity_hard_stop_loss.md
+++ b/docs/ai/features/equity_hard_stop_loss.md
@@ -78,6 +78,11 @@ ordinary shared-account planning: the startup gate runs after portfolio intent c
 cannot make a plan built from unknown HSL episode state authoritative. Independently ready,
 already-latched RED supervision and required panic protection for active cooldown positions still
 run during that deferral, using fresh protective account state and the configured execution pacing.
+Cooldown cancellation-only waves also remove resting initials from flat scopes without constructing
+new intent. Manual ownership begins only after a proven cooldown intervention and persists through
+later flat observations; before that intervention, fresh initials remain blocked. If current fill
+evidence cannot distinguish those cases, the cancellation wave preserves manual orders. Graceful-stop
+adds to held positions retain their policy semantics.
 
 ## Code And Tests
 

--- a/docs/ai/features/equity_hard_stop_loss.md
+++ b/docs/ai/features/equity_hard_stop_loss.md
@@ -76,7 +76,8 @@ authoritative refresh. Flat scopes pending startup price replay retain the exist
 create gate, leaving unrelated scopes available. Ambiguous required held-episode evidence defers
 ordinary shared-account planning: the startup gate runs after portfolio intent construction and
 cannot make a plan built from unknown HSL episode state authoritative. Independently ready,
-already-latched RED supervision still runs during that deferral.
+already-latched RED supervision and required panic protection for active cooldown positions still
+run during that deferral, using fresh protective account state and the configured execution pacing.
 
 ## Code And Tests
 

--- a/docs/ai/features/equity_hard_stop_loss.md
+++ b/docs/ai/features/equity_hard_stop_loss.md
@@ -36,6 +36,8 @@ HSL drawdown state is scoped by `live.hsl_signal_mode`:
    Live normal interventions and cooldown expiry use that same reconstruction before releasing a
    halt, retaining entry fees and losses before the next observation. A proven RED stop follows the
    same restart rules regardless of closing order type; terminal no-restart takes precedence.
+   Same-millisecond normal interventions require the validated fill-chain order and use its
+   cumulative PnL prefix so closing losses are excluded while entry fees survive subsequent polls.
 7. `bot.{pside}.hsl.panic_close_order_type = "market"` is an explicit protective execution
    override when HSL is enabled. Rust may emit that side's `close_panic_*` as a market order even
    when `live.market_orders_allowed = false`; the live flag gates non-panic market execution and

--- a/docs/ai/features/equity_hard_stop_loss.md
+++ b/docs/ai/features/equity_hard_stop_loss.md
@@ -20,6 +20,9 @@ HSL drawdown state is scoped by `live.hsl_signal_mode`:
    unrealized-PnL availability. Multiple boundaries inside one replay minute retain their exact
    fill order, realized PnL, fees, and account balance at each boundary. Missing price replay may
    defer drawdown evaluation, but it must not hide an episode boundary.
+   Coin boundary balance reverses all account PnL/fees strictly after the boundary timestamp and
+   the proven same-pair fill tail within that timestamp. Other pairs at the same timestamp remain
+   included in the account timestamp cohort, matching the incremental live convention.
    Mixed-action fills sharing a millisecond require an unambiguous exchange-provided position
    chain; list order and locally reconstructed position annotations are not ordering evidence.
    Each proven fill boundary evaluates its final risk sample. Distinct boundaries in the same

--- a/docs/ai/features/equity_hard_stop_loss.md
+++ b/docs/ai/features/equity_hard_stop_loss.md
@@ -33,6 +33,9 @@ HSL drawdown state is scoped by `live.hsl_signal_mode`:
 6. Restart reconstruction uses exchange state, fill/PnL history, candles where required, config, and
    current time. Local latch files are diagnostics, not authority. Restart always reconstructs from
    authoritative exchange-derived inputs; no persisted replay state participates in the decision.
+   Live normal interventions and cooldown expiry use that same reconstruction before releasing a
+   halt, retaining entry fees and losses before the next observation. A proven RED stop follows the
+   same restart rules regardless of closing order type; terminal no-restart takes precedence.
 7. `bot.{pside}.hsl.panic_close_order_type = "market"` is an explicit protective execution
    override when HSL is enabled. Rust may emit that side's `close_panic_*` as a market order even
    when `live.market_orders_allowed = false`; the live flag gates non-panic market execution and
@@ -78,10 +81,12 @@ ordinary shared-account planning: the startup gate runs after portfolio intent c
 cannot make a plan built from unknown HSL episode state authoritative. Independently ready,
 already-latched RED supervision and required panic protection for active cooldown positions still
 run during that deferral, using fresh protective account state and the configured execution pacing.
-Cooldown cancellation-only waves also remove resting initials from flat scopes without constructing
-new intent. Manual ownership begins only after a proven cooldown intervention and persists through
+Cancellation-only waves remove entries from terminal no-restart scopes and resting initials from
+flat cooldown scopes without constructing new intent or changing terminal state. Manual ownership
+begins only after a proven cooldown intervention and persists through
 later flat observations; before that intervention, fresh initials remain blocked. If current fill
-evidence cannot distinguish those cases, the cancellation wave preserves manual orders. Graceful-stop
+evidence cannot distinguish those cases, the cancellation wave refreshes the fill tail after its
+account observation and preserves manual orders if proof remains unavailable. Graceful-stop
 adds to held positions retain their policy semantics.
 
 ## Code And Tests

--- a/docs/equity_hard_stop_loss.md
+++ b/docs/equity_hard_stop_loss.md
@@ -196,7 +196,8 @@ that is currently halted in RED cooldown.
    - treat the position as an explicit operator override
    - while that `pside` still has no open positions, the bot remains halted and will not open fresh initials on its own
    - clear the halt for that `pside`
-   - reset HSL drawdown tracking and rolling-peak state from the current live state
+   - reconstruct HSL drawdown and the rolling peak from the proven intervention entry, retaining its fees and subsequent losses
+   - retain the halt and required protection if the episode cannot yet be reconstructed from authoritative history
 3. `manual`
    - keep the original cooldown deadline
    - leave the position in `manual` mode and do not let the bot resume normal trading on that `pside`

--- a/passivbot-rust/src/backtest.rs
+++ b/passivbot-rust/src/backtest.rs
@@ -3600,19 +3600,38 @@ impl<'a> Backtest<'a> {
     }
 
     fn update_hard_stop_state_pside(&mut self, k: usize, pside: usize) -> Result<(), String> {
+        self.update_hard_stop_state_pside_at_boundary(k, pside, false)
+    }
+
+    fn update_hard_stop_state_pside_at_boundary(
+        &mut self, k: usize, pside: usize, at_fill_boundary: bool,
+    ) -> Result<(), String> {
         if !self.hard_stop_enabled_pside(pside) || self.hard_stop_pside[pside].halted {
             return Ok(());
         }
-        let Some(&timestamp_ms) = self.equities.timestamps_ms.last() else {
+        let timestamp_ms = if at_fill_boundary {
+            self.first_timestamp_ms + k as u64 * self.interval_ms
+        } else if let Some(&timestamp_ms) = self.equities.timestamps_ms.last() {
+            timestamp_ms
+        } else {
             return Ok(());
         };
-        let (realized_pnl, unrealized_pnl) =
+        let (realized_pnl, unrealized_pnl) = if at_fill_boundary {
+            // The scope is proven flat at the fill, before a new account-equity
+            // sample is recorded. Use exact realized PnL rather than stale marks.
+            (if self.hard_stop_signal_mode() == "unified" {
+                self.pnl_cumsum_running_net
+            } else {
+                self.pnl_cumsum_running_net_pside[pside]
+            }, 0.0)
+        } else {
             self.hard_stop_signal_values_pside(k, pside).map_err(|e| {
                 format!(
                     "hard-stop evaluation failed at k {} pside {} while deriving signal values: {}",
                     k, pside, e
                 )
-            })?;
+            })?
+        };
         let strategy_pnl = realized_pnl + unrealized_pnl;
         let baseline_balance = self.balance.usd_total_balance - self.pnl_cumsum_running_net;
         let lookback_ms = if self.backtest_params.pnls_max_lookback_days < 0.0 {
@@ -3656,7 +3675,7 @@ impl<'a> Backtest<'a> {
                 orange: hsl_tier_ratio_orange,
             },
         };
-        let step = ehsl::step_with_peak_strategy_equity(
+        let step = ehsl::step_with_peak_strategy_equity_at_boundary(
             self.hard_stop_pside[pside]
                 .state
                 .get_or_insert_with(ehsl::HardStopState::default),
@@ -3664,6 +3683,8 @@ impl<'a> Backtest<'a> {
             strategy_equity,
             peak_strategy_equity,
             timestamp_ms,
+            true,
+            at_fill_boundary,
         )
         .map_err(|e| {
             format!(
@@ -3672,12 +3693,13 @@ impl<'a> Backtest<'a> {
             )
         })?;
         let has_open_position = self.hard_stop_scope_has_open_position(pside);
-        let has_blocking_open_orders = self.hard_stop_scope_has_blocking_open_orders(pside);
+        let has_blocking_open_orders = !at_fill_boundary && self.hard_stop_scope_has_blocking_open_orders(pside);
         let drawdown_ema = self.hard_stop_pside[pside]
             .state
             .as_ref()
             .map(|state| state.drawdown_ema)
             .unwrap_or(step.drawdown_raw);
+        if !at_fill_boundary {
         self.strategy_equity_series_pside[pside].push(strategy_equity);
         self.strategy_equity_timestamps_ms_pside[pside].push(timestamp_ms);
         self.peak_strategy_equity_series_pside[pside].push(peak_strategy_equity);
@@ -3685,6 +3707,7 @@ impl<'a> Backtest<'a> {
         self.hard_stop_drawdown_samples_pside[pside].push(step.drawdown_raw);
         self.hard_stop_drawdown_ema_samples_pside[pside].push(drawdown_ema);
         self.hard_stop_drawdown_score_samples_pside[pside].push(step.drawdown_score);
+        }
         let mut finalize_panic_close_loss_drawdown_pct = false;
         let runtime = &mut self.hard_stop_pside[pside];
         let prev_tier = runtime.tier;
@@ -3710,7 +3733,14 @@ impl<'a> Backtest<'a> {
                 runtime.flat_confirmations = 0;
                 runtime.pending_stop = None;
             } else {
-                runtime.flat_confirmations = runtime.flat_confirmations.saturating_add(1);
+                if at_fill_boundary {
+                    // The closing fill is authoritative flatten evidence, even
+                    // with resting entries that may fill later in this bar.
+                    runtime.pending_stop = None;
+                    runtime.flat_confirmations = 2;
+                } else {
+                    runtime.flat_confirmations = runtime.flat_confirmations.saturating_add(1);
+                }
                 if runtime.flat_confirmations == 1 {
                     runtime.pending_stop = Some(HardStopStopSnapshot {
                         timestamp_ms,
@@ -3806,6 +3836,12 @@ impl<'a> Backtest<'a> {
         idx: usize,
         pside: usize,
     ) -> Result<(), String> {
+        self.update_hard_stop_state_coin_at_boundary(k, idx, pside, false)
+    }
+
+    fn update_hard_stop_state_coin_at_boundary(
+        &mut self, k: usize, idx: usize, pside: usize, at_fill_boundary: bool,
+    ) -> Result<(), String> {
         if !self.hard_stop_coin_should_update(pside, idx)? || self.hard_stop_coin[pside][idx].halted
         {
             return Ok(());
@@ -3813,7 +3849,11 @@ impl<'a> Backtest<'a> {
         if self.hard_stop_coin_slot_n_positions(pside) == 0 {
             return Ok(());
         }
-        let Some(&timestamp_ms) = self.equities.timestamps_ms.last() else {
+        let timestamp_ms = if at_fill_boundary {
+            self.first_timestamp_ms + k as u64 * self.interval_ms
+        } else if let Some(&timestamp_ms) = self.equities.timestamps_ms.last() {
+            timestamp_ms
+        } else {
             return Ok(());
         };
         let (drawdown_ratio, peak_realized, last_realized, current_upnl, slot_budget) = self
@@ -3852,7 +3892,7 @@ impl<'a> Backtest<'a> {
             },
         };
         let synthetic_equity = (1.0 - drawdown_ratio).max(f64::EPSILON);
-        let step = ehsl::step_with_peak_strategy_equity(
+        let step = ehsl::step_with_peak_strategy_equity_at_boundary(
             self.hard_stop_coin[pside][idx]
                 .state
                 .get_or_insert_with(ehsl::HardStopState::default),
@@ -3860,6 +3900,8 @@ impl<'a> Backtest<'a> {
             synthetic_equity,
             1.0,
             timestamp_ms,
+            true,
+            at_fill_boundary,
         )
         .map_err(|e| {
             format!(
@@ -3868,7 +3910,7 @@ impl<'a> Backtest<'a> {
             )
         })?;
         let has_open_position = self.has_open_position_coin_pside(idx, pside);
-        let has_blocking_open_orders = self.has_blocking_open_orders_coin_pside(idx, pside);
+        let has_blocking_open_orders = !at_fill_boundary && self.has_blocking_open_orders_coin_pside(idx, pside);
         let mut finalize_panic_close_loss_drawdown_pct = false;
         let mut reset_coin_pnl_window = false;
         let runtime = &mut self.hard_stop_coin[pside][idx];
@@ -3895,7 +3937,14 @@ impl<'a> Backtest<'a> {
                 runtime.flat_confirmations = 0;
                 runtime.pending_stop = None;
             } else {
-                runtime.flat_confirmations = runtime.flat_confirmations.saturating_add(1);
+                if at_fill_boundary {
+                    // The closing fill is authoritative flatten evidence, even
+                    // with resting entries that may fill later in this bar.
+                    runtime.pending_stop = None;
+                    runtime.flat_confirmations = 2;
+                } else {
+                    runtime.flat_confirmations = runtime.flat_confirmations.saturating_add(1);
+                }
                 if runtime.flat_confirmations == 1 {
                     runtime.pending_stop = Some(HardStopStopSnapshot {
                         timestamp_ms,
@@ -4304,8 +4353,8 @@ impl<'a> Backtest<'a> {
     }
 
     /// Consume an exact fill boundary before another fill can reopen its scope.
-    /// A RED-seen episode belongs to stop finalization; only RED-free episodes
-    /// reset here. Persistent no-restart and stop accounting are retained.
+    /// RED-seen episodes finalize immediately; RED-free episodes reset.
+    /// Persistent no-restart and stop accounting are retained.
     fn finish_hard_stop_episode_at_fill(
         &mut self,
         k: usize,
@@ -4318,7 +4367,6 @@ impl<'a> Backtest<'a> {
         if self.balance.usd_total_balance <= 0.0 {
             return Ok(()); // The account liquidation path owns depleted balances.
         }
-        let timestamp_ms = self.first_timestamp_ms + k as u64 * self.interval_ms;
         let coin_mode = self.hard_stop_signal_mode() == "coin";
         let unified = self.hard_stop_signal_mode() == "unified";
         for pside in [LONG, SHORT] {
@@ -4341,70 +4389,20 @@ impl<'a> Backtest<'a> {
             } else {
                 &self.hard_stop_pside[pside]
             };
-            if runtime.halted
-                || runtime.no_restart_latched
-                || runtime
-                    .state
-                    .as_ref()
-                    .is_some_and(|state| state.red_seen_in_episode)
-            {
+            if runtime.halted || runtime.no_restart_latched {
                 continue;
             }
-            let cfg = if coin_mode {
-                self.hard_stop_cfg_coin(pside, idx)
+            if coin_mode {
+                self.update_hard_stop_state_coin_at_boundary(k, idx, pside, true)?;
             } else {
-                self.hard_stop_cfg_pside(pside)
-            };
-            let hs_cfg = ehsl::HardStopConfig {
-                red_threshold: cfg.hsl_red_threshold,
-                ema_span_minutes: cfg.hsl_ema_span_minutes,
-                tier_ratios: ehsl::HardStopTierRatios {
-                    yellow: cfg.hsl_tier_ratio_yellow,
-                    orange: cfg.hsl_tier_ratio_orange,
-                },
-            };
-            // Evaluate the closing PnL/fees before discarding this episode:
-            // the flattening fill itself can cross RED.
-            let (equity, peak) = if coin_mode {
-                let (drawdown, _, _, _, _) = self.hard_stop_coin_drawdown_ratio(k, idx, pside)?;
-                ((1.0 - drawdown).max(f64::EPSILON), 1.0)
-            } else {
-                let realized = if unified {
-                    self.pnl_cumsum_running_net
-                } else {
-                    self.pnl_cumsum_running_net_pside[pside]
-                };
-                let baseline = self.balance.usd_total_balance - self.pnl_cumsum_running_net;
-                let lookback_ms = if self.backtest_params.pnls_max_lookback_days < 0.0 {
-                    u64::MAX
-                } else {
-                    ((self.backtest_params.pnls_max_lookback_days.max(0.0) * 86_400_000.0).round()
-                        as u64)
-                        .max(self.interval_ms)
-                };
-                let peak_pnl = Self::update_strategy_pnl_peak_queue(
-                    &mut self.hard_stop_pside[pside].rolling_peak_strategy_pnl,
-                    timestamp_ms,
-                    realized,
-                    lookback_ms,
-                );
-                (baseline + realized, baseline + peak_pnl.max(realized))
-            };
+                self.update_hard_stop_state_pside_at_boundary(k, pside, true)?;
+            }
             let runtime = if coin_mode {
                 &mut self.hard_stop_coin[pside][idx]
             } else {
                 &mut self.hard_stop_pside[pside]
             };
-            ehsl::step_with_peak_strategy_equity(
-                runtime
-                    .state
-                    .get_or_insert_with(ehsl::HardStopState::default),
-                hs_cfg,
-                equity,
-                peak,
-                timestamp_ms,
-            )?;
-            if runtime.state.as_ref().unwrap().red_seen_in_episode {
+            if runtime.state.as_ref().is_some_and(|state| state.red_seen_in_episode) {
                 continue;
             }
             runtime.state = None;
@@ -6799,6 +6797,26 @@ mod tests {
                 .red_seen_in_episode
         );
 
+        // A new episode can also flatten again within the same bar. Its
+        // closing loss must be evaluated rather than inheriting the flat cache.
+        let mut second_boundary = Backtest::new(
+            hlcvs.view(), btc_usd_prices.view(), bt.bot_params.clone(),
+            vec![ExchangeParams::default()], &backtest_params,
+        );
+        second_boundary.positions.long[0] = Position { size: 500.0, price: 1.0 };
+        second_boundary.update_equities(0);
+        second_boundary.update_hard_stop_state_coin(0, 0, LONG).unwrap();
+        let large_close = Order { qty: -500.0, ..close };
+        second_boundary.process_close_fill_long(1, 0, &large_close, exec).unwrap();
+        assert!(second_boundary.hard_stop_coin[LONG][0].state.is_none());
+        second_boundary.process_entry_fill_long(1, 0, &Order { qty: 500.0, ..entry }, exec);
+        second_boundary.process_close_fill_long(
+            1, 0, &large_close, OrderFillExecution { price: 0.5, ..exec },
+        ).unwrap();
+        assert!(second_boundary.hard_stop_coin[LONG][0].halted);
+        assert_eq!(second_boundary.hard_stop_n_triggers, 1);
+        assert_eq!(second_boundary.hard_stop_coin[LONG][0].last_stop.unwrap().timestamp_ms, 60_000);
+
         // A closing execution can itself cross RED (e.g. adverse slippage).
         // Its PnL must be sampled before deciding that the episode may reset.
         let mut closing_red = Backtest::new(
@@ -6830,8 +6848,18 @@ mod tests {
         );
         assert_eq!(
             closing_red.effective_coin_pnl_cumsum(1, 0, LONG),
-            (0.0, -175.0)
+            (0.0, 0.0)
         );
+        assert!(closing_red.hard_stop_coin[LONG][0].halted);
+        assert_eq!(closing_red.hard_stop_n_triggers, 1);
+        let stop = closing_red.hard_stop_coin[LONG][0].last_stop.unwrap();
+        assert_eq!(stop.timestamp_ms, 60_000);
+        assert!(stop.drawdown_raw >= 0.15);
+        closing_red.process_entry_fill_long(1, 0, &entry, exec);
+        assert!(closing_red.positions.long[0].size > 0.0);
+        assert!(closing_red.hard_stop_coin[LONG][0].halted);
+        assert_eq!(closing_red.hard_stop_coin[LONG][0].last_stop.unwrap().timestamp_ms, 60_000);
+        assert_eq!(closing_red.hard_stop_n_triggers, 1);
     }
 
     #[test]

--- a/passivbot-rust/src/backtest.rs
+++ b/passivbot-rust/src/backtest.rs
@@ -2350,7 +2350,7 @@ impl<'a> Backtest<'a> {
                     );
                 }
             }
-            self.check_for_fills(k);
+            self.check_for_fills(k)?;
             self.update_emas(k);
             self.update_rounded_balance(k);
             self.update_trailing_prices(k);
@@ -2376,7 +2376,7 @@ impl<'a> Backtest<'a> {
                 self.initialize_btc_collateral_if_needed(k);
                 self.update_open_orders_all(k)?;
             }
-            self.force_close_delisted_positions(k);
+            self.force_close_delisted_positions(k)?;
             if self.equity_tracking_active {
                 self.update_equities(k);
                 if self.check_and_apply_liquidation(k) {
@@ -4221,7 +4221,7 @@ impl<'a> Backtest<'a> {
         (twe_long, twe_short, twe_net)
     }
 
-    fn check_for_fills(&mut self, k: usize) {
+    fn check_for_fills(&mut self, k: usize) -> Result<(), String> {
         self.did_fill_long.fill(false);
         self.did_fill_short.fill(false);
         if self.trading_enabled.long {
@@ -4239,7 +4239,7 @@ impl<'a> Backtest<'a> {
                     for (order, exec) in closes_to_process {
                         if self.positions.long[idx].size != 0.0 {
                             self.did_fill_long[idx] = true;
-                            self.process_close_fill_long(k, idx, &order, exec);
+                            self.process_close_fill_long(k, idx, &order, exec)?;
                         }
                     }
                 }
@@ -4277,7 +4277,7 @@ impl<'a> Backtest<'a> {
                     for (order, exec) in closes_to_process {
                         if self.positions.short[idx].size != 0.0 {
                             self.did_fill_short[idx] = true;
-                            self.process_close_fill_short(k, idx, &order, exec);
+                            self.process_close_fill_short(k, idx, &order, exec)?;
                         }
                     }
                 }
@@ -4300,6 +4300,126 @@ impl<'a> Backtest<'a> {
                 }
             }
         }
+        Ok(())
+    }
+
+    /// Consume an exact fill boundary before another fill can reopen its scope.
+    /// A RED-seen episode belongs to stop finalization; only RED-free episodes
+    /// reset here. Persistent no-restart and stop accounting are retained.
+    fn finish_hard_stop_episode_at_fill(
+        &mut self,
+        k: usize,
+        idx: usize,
+        filled_pside: usize,
+    ) -> Result<(), String> {
+        if !self.balance.usd_total_balance.is_finite() {
+            return Err(format!("non-finite balance at HSL fill boundary: k {}", k));
+        }
+        if self.balance.usd_total_balance <= 0.0 {
+            return Ok(()); // The account liquidation path owns depleted balances.
+        }
+        let timestamp_ms = self.first_timestamp_ms + k as u64 * self.interval_ms;
+        let coin_mode = self.hard_stop_signal_mode() == "coin";
+        let unified = self.hard_stop_signal_mode() == "unified";
+        for pside in [LONG, SHORT] {
+            if !unified && pside != filled_pside {
+                continue;
+            }
+            if coin_mode {
+                if !self.hard_stop_coin_should_update(pside, idx)?
+                    || self.hard_stop_coin_slot_n_positions(pside) == 0
+                {
+                    continue;
+                }
+            } else if !self.hard_stop_enabled_pside(pside)
+                || self.hard_stop_scope_has_open_position(pside)
+            {
+                continue;
+            }
+            let runtime = if coin_mode {
+                &self.hard_stop_coin[pside][idx]
+            } else {
+                &self.hard_stop_pside[pside]
+            };
+            if runtime.halted
+                || runtime.no_restart_latched
+                || runtime
+                    .state
+                    .as_ref()
+                    .is_some_and(|state| state.red_seen_in_episode)
+            {
+                continue;
+            }
+            let cfg = if coin_mode {
+                self.hard_stop_cfg_coin(pside, idx)
+            } else {
+                self.hard_stop_cfg_pside(pside)
+            };
+            let hs_cfg = ehsl::HardStopConfig {
+                red_threshold: cfg.hsl_red_threshold,
+                ema_span_minutes: cfg.hsl_ema_span_minutes,
+                tier_ratios: ehsl::HardStopTierRatios {
+                    yellow: cfg.hsl_tier_ratio_yellow,
+                    orange: cfg.hsl_tier_ratio_orange,
+                },
+            };
+            // Evaluate the closing PnL/fees before discarding this episode:
+            // the flattening fill itself can cross RED.
+            let (equity, peak) = if coin_mode {
+                let (drawdown, _, _, _, _) = self.hard_stop_coin_drawdown_ratio(k, idx, pside)?;
+                ((1.0 - drawdown).max(f64::EPSILON), 1.0)
+            } else {
+                let realized = if unified {
+                    self.pnl_cumsum_running_net
+                } else {
+                    self.pnl_cumsum_running_net_pside[pside]
+                };
+                let baseline = self.balance.usd_total_balance - self.pnl_cumsum_running_net;
+                let lookback_ms = if self.backtest_params.pnls_max_lookback_days < 0.0 {
+                    u64::MAX
+                } else {
+                    ((self.backtest_params.pnls_max_lookback_days.max(0.0) * 86_400_000.0).round()
+                        as u64)
+                        .max(self.interval_ms)
+                };
+                let peak_pnl = Self::update_strategy_pnl_peak_queue(
+                    &mut self.hard_stop_pside[pside].rolling_peak_strategy_pnl,
+                    timestamp_ms,
+                    realized,
+                    lookback_ms,
+                );
+                (baseline + realized, baseline + peak_pnl.max(realized))
+            };
+            let runtime = if coin_mode {
+                &mut self.hard_stop_coin[pside][idx]
+            } else {
+                &mut self.hard_stop_pside[pside]
+            };
+            ehsl::step_with_peak_strategy_equity(
+                runtime
+                    .state
+                    .get_or_insert_with(ehsl::HardStopState::default),
+                hs_cfg,
+                equity,
+                peak,
+                timestamp_ms,
+            )?;
+            if runtime.state.as_ref().unwrap().red_seen_in_episode {
+                continue;
+            }
+            runtime.state = None;
+            runtime.tier = ehsl::HardStopTier::Green;
+            runtime.red_active_now = false;
+            runtime.rolling_peak_strategy_pnl.clear();
+            runtime.flat_confirmations = 0;
+            runtime.pending_stop = None;
+            runtime.current_red_start_ms = None;
+            if coin_mode {
+                self.reset_hard_stop_coin_pnl_window(idx, pside);
+            }
+        }
+        self.refresh_global_hard_stop_tier();
+        Ok(())
     }
 
     fn process_close_fill_long(
@@ -4308,7 +4428,7 @@ impl<'a> Backtest<'a> {
         idx: usize,
         close_fill: &Order,
         exec: OrderFillExecution,
-    ) {
+    ) -> Result<(), String> {
         let current_position = self.positions.long[idx];
         let mut new_psize = round_(
             current_position.size + close_fill.qty,
@@ -4400,6 +4520,10 @@ impl<'a> Backtest<'a> {
             twe_short,
             twe_net,
         });
+        if new_psize == 0.0 && current_position.size != 0.0 {
+            self.finish_hard_stop_episode_at_fill(k, idx, LONG)?;
+        }
+        Ok(())
     }
 
     fn process_close_fill_short(
@@ -4408,7 +4532,7 @@ impl<'a> Backtest<'a> {
         idx: usize,
         order: &Order,
         exec: OrderFillExecution,
-    ) {
+    ) -> Result<(), String> {
         let current_position = self.positions.short[idx];
         let mut new_psize = round_(
             current_position.size + order.qty,
@@ -4499,6 +4623,10 @@ impl<'a> Backtest<'a> {
             twe_short,
             twe_net,
         });
+        if new_psize == 0.0 && current_position.size != 0.0 {
+            self.finish_hard_stop_episode_at_fill(k, idx, SHORT)?;
+        }
+        Ok(())
     }
 
     fn process_entry_fill_long(
@@ -4717,7 +4845,7 @@ impl<'a> Backtest<'a> {
         }
     }
 
-    fn force_close_delisted_positions(&mut self, k: usize) {
+    fn force_close_delisted_positions(&mut self, k: usize) -> Result<(), String> {
         for idx in 0..self.n_coins {
             if self.last_valid_timestamps.get(idx).copied().flatten() != Some(k) {
                 continue;
@@ -4742,7 +4870,7 @@ impl<'a> Backtest<'a> {
                         liquidity: "taker",
                     };
                     self.did_fill_long[idx] = true;
-                    self.process_close_fill_long(k, idx, &order, exec);
+                    self.process_close_fill_long(k, idx, &order, exec)?;
                     closed_any = true;
                 }
             }
@@ -4762,7 +4890,7 @@ impl<'a> Backtest<'a> {
                         liquidity: "taker",
                     };
                     self.did_fill_short[idx] = true;
-                    self.process_close_fill_short(k, idx, &order, exec);
+                    self.process_close_fill_short(k, idx, &order, exec)?;
                     closed_any = true;
                 }
             }
@@ -4772,6 +4900,7 @@ impl<'a> Backtest<'a> {
                 self.open_orders.short[idx] = OpenOrderBundle::default();
             }
         }
+        Ok(())
     }
 
     #[inline(always)]
@@ -6551,6 +6680,280 @@ mod tests {
     }
 
     #[test]
+    fn ordinary_flatten_resets_coin_hsl_before_same_bar_reentry() {
+        let mut values = vec![1.0; 3 * 4];
+        values[8] = 0.5;
+        values[9] = 0.5;
+        values[10] = 0.5;
+        values[11] = 0.5;
+        let hlcvs = Array3::from_shape_vec((3, 1, 4), values).unwrap();
+        let btc_usd_prices = Array1::from_vec(vec![20_000.0; 3]);
+        let mut bp_pair = BotParamsPair::default();
+        bp_pair.long.n_positions = 1;
+        bp_pair.long.total_wallet_exposure_limit = 1.0;
+        bp_pair.long.wallet_exposure_limit = 1.0;
+        bp_pair.long.ema_span_0 = 10.0;
+        bp_pair.long.ema_span_1 = 20.0;
+        bp_pair.long.hsl_enabled = true;
+        bp_pair.long.hsl_red_threshold = 0.15;
+        bp_pair.long.hsl_ema_span_minutes = 1.0;
+        bp_pair.long.hsl_no_restart_drawdown_threshold = 1.0;
+        let mut hs = EquityHardStopLossConfig::default();
+        hs.signal_mode = "coin".to_string();
+        let backtest_params = BacktestParams {
+            starting_balance: 1000.0,
+            maker_fee: 0.0,
+            taker_fee: 0.00055,
+            coins: vec!["TEST".to_string()],
+            active_coin_indices: None,
+            first_timestamp_ms: 0,
+            requested_start_timestamp_ms: 0,
+            first_valid_indices: vec![0],
+            last_valid_indices: vec![2],
+            warmup_minutes: vec![0],
+            trade_start_indices: vec![0],
+            global_warmup_bars: 0,
+            btc_collateral_cap: 0.0,
+            btc_collateral_ltv_cap: None,
+            metrics_only: true,
+            skip_btc_analysis: false,
+            filter_by_min_effective_cost: false,
+            dynamic_wel_by_tradability: false,
+            hedge_mode: true,
+            forager_score_hysteresis_pct: 0.0,
+            max_realized_loss_pct: 1.0,
+            pnls_max_lookback_days: 30.0,
+            liquidation_threshold: 0.05,
+            equity_hard_stop_loss: hs,
+            market_orders_allowed: false,
+            market_order_near_touch_threshold: 0.001,
+            market_order_slippage_pct: 0.0005,
+            candle_interval_minutes: 1,
+        };
+        let mut bt = Backtest::new(
+            hlcvs.view(),
+            btc_usd_prices.view(),
+            vec![bp_pair],
+            vec![ExchangeParams::default()],
+            &backtest_params,
+        );
+
+        bt.positions.long[0] = Position {
+            size: 100.0,
+            price: 2.0,
+        };
+        bt.hard_stop_coin[LONG][0].no_restart_peak_strategy_equity = 1.2;
+        bt.update_equities(0);
+        bt.update_hard_stop_state_coin(0, 0, LONG).unwrap();
+        let close = Order {
+            qty: -100.0,
+            price: 1.0,
+            order_type: OrderType::CloseGridLong,
+        };
+        let exec = OrderFillExecution {
+            price: 1.0,
+            fee_rate: 0.0,
+            liquidity: "maker",
+        };
+        bt.process_close_fill_long(1, 0, &close, exec).unwrap();
+        assert_eq!(bt.positions.long[0].size, 0.0);
+        assert!(bt.hard_stop_coin[LONG][0].state.is_none());
+        assert_eq!(
+            bt.hard_stop_coin[LONG][0].no_restart_peak_strategy_equity,
+            1.2
+        );
+        assert_eq!(bt.effective_coin_pnl_cumsum(1, 0, LONG), (0.0, 0.0));
+        let entry = Order {
+            qty: 100.0,
+            price: 1.0,
+            order_type: OrderType::EntryInitialNormalLong,
+        };
+        bt.process_entry_fill_long(1, 0, &entry, exec);
+        bt.update_equities(1);
+        bt.update_hard_stop_state_coin(1, 0, LONG).unwrap();
+        bt.update_equities(2);
+        bt.update_hard_stop_state_coin(2, 0, LONG).unwrap();
+        let (raw, _, _, _, _) = bt.hard_stop_coin_drawdown_ratio(2, 0, LONG).unwrap();
+        assert!((raw - 50.0 / 900.0).abs() < 1e-12);
+        assert_eq!(bt.hard_stop_coin[LONG][0].tier, ehsl::HardStopTier::Green);
+        assert_eq!(bt.hard_stop_n_triggers, 0);
+
+        // RED-seen episodes belong to ordinary stop finalization, including
+        // an episode which has recovered before its final fill.
+        bt.hard_stop_coin[LONG][0]
+            .state
+            .as_mut()
+            .unwrap()
+            .red_seen_in_episode = true;
+        bt.hard_stop_coin[LONG][0]
+            .state
+            .as_mut()
+            .unwrap()
+            .red_latched = true;
+        bt.process_close_fill_long(2, 0, &close, exec).unwrap();
+        assert!(
+            bt.hard_stop_coin[LONG][0]
+                .state
+                .as_ref()
+                .unwrap()
+                .red_seen_in_episode
+        );
+
+        // A closing execution can itself cross RED (e.g. adverse slippage).
+        // Its PnL must be sampled before deciding that the episode may reset.
+        let mut closing_red = Backtest::new(
+            hlcvs.view(),
+            btc_usd_prices.view(),
+            bt.bot_params.clone(),
+            vec![ExchangeParams::default()],
+            &backtest_params,
+        );
+        closing_red.positions.long[0] = Position {
+            size: 100.0,
+            price: 2.0,
+        };
+        closing_red.update_equities(0);
+        closing_red.update_hard_stop_state_coin(0, 0, LONG).unwrap();
+        let adverse_exec = OrderFillExecution {
+            price: 0.25,
+            ..exec
+        };
+        closing_red
+            .process_close_fill_long(1, 0, &close, adverse_exec)
+            .unwrap();
+        assert!(
+            closing_red.hard_stop_coin[LONG][0]
+                .state
+                .as_ref()
+                .unwrap()
+                .red_seen_in_episode
+        );
+        assert_eq!(
+            closing_red.effective_coin_pnl_cumsum(1, 0, LONG),
+            (0.0, -175.0)
+        );
+    }
+
+    #[test]
+    fn ordinary_flatten_respects_pside_and_unified_scope() {
+        for mode in ["pside", "unified"] {
+            let hlcvs = Array3::from_shape_vec((3, 2, 4), vec![1.0; 3 * 2 * 4]).unwrap();
+            let btc_usd_prices = Array1::from_vec(vec![20_000.0; 3]);
+            let mut bp_pair = BotParamsPair::default();
+            bp_pair.long.n_positions = 1;
+            bp_pair.long.total_wallet_exposure_limit = 1.0;
+            bp_pair.long.wallet_exposure_limit = 1.0;
+            bp_pair.long.ema_span_0 = 10.0;
+            bp_pair.long.ema_span_1 = 20.0;
+            bp_pair.long.hsl_enabled = true;
+            bp_pair.long.hsl_red_threshold = 0.15;
+            bp_pair.long.hsl_ema_span_minutes = 1.0;
+            bp_pair.long.hsl_no_restart_drawdown_threshold = 1.0;
+            let mut hs = EquityHardStopLossConfig::default();
+            hs.signal_mode = mode.to_string();
+            bp_pair.short = bp_pair.long.clone();
+            let backtest_params = BacktestParams {
+                starting_balance: 1000.0,
+                maker_fee: 0.0,
+                taker_fee: 0.00055,
+                coins: vec!["A".to_string(), "B".to_string()],
+                active_coin_indices: None,
+                first_timestamp_ms: 0,
+                requested_start_timestamp_ms: 0,
+                first_valid_indices: vec![0, 0],
+                last_valid_indices: vec![2, 2],
+                warmup_minutes: vec![0, 0],
+                trade_start_indices: vec![0, 0],
+                global_warmup_bars: 0,
+                btc_collateral_cap: 0.0,
+                btc_collateral_ltv_cap: None,
+                metrics_only: true,
+                skip_btc_analysis: false,
+                filter_by_min_effective_cost: false,
+                dynamic_wel_by_tradability: false,
+                hedge_mode: true,
+                forager_score_hysteresis_pct: 0.0,
+                max_realized_loss_pct: 1.0,
+                pnls_max_lookback_days: 30.0,
+                liquidation_threshold: 0.05,
+                equity_hard_stop_loss: hs,
+                market_orders_allowed: false,
+                market_order_near_touch_threshold: 0.001,
+                market_order_slippage_pct: 0.0005,
+                candle_interval_minutes: 1,
+            };
+            let mut bt = Backtest::new(
+                hlcvs.view(),
+                btc_usd_prices.view(),
+                vec![bp_pair.clone(), bp_pair],
+                vec![ExchangeParams::default(); 2],
+                &backtest_params,
+            );
+
+            bt.positions.long[0] = Position {
+                size: 1.0,
+                price: 2.0,
+            };
+            bt.positions.long[1] = Position {
+                size: 1.0,
+                price: 2.0,
+            };
+            bt.positions.short[0] = Position {
+                size: -1.0,
+                price: 1.0,
+            };
+            bt.update_equities(0);
+            bt.update_hard_stop_state(0).unwrap();
+            for pside in [LONG, SHORT] {
+                bt.hard_stop_pside[pside].no_restart_peak_strategy_equity = 1200.0;
+            }
+            let close = Order {
+                qty: -1.0,
+                price: 1.0,
+                order_type: OrderType::CloseGridLong,
+            };
+            let exec = OrderFillExecution {
+                price: 1.0,
+                fee_rate: 0.0,
+                liquidity: "maker",
+            };
+            bt.process_close_fill_long(1, 0, &close, exec).unwrap();
+            assert!(
+                bt.hard_stop_pside[LONG].state.is_some(),
+                "remaining long position owns episode"
+            );
+            bt.process_close_fill_long(1, 1, &close, exec).unwrap();
+            if mode == "pside" {
+                assert!(bt.hard_stop_pside[LONG].state.is_none());
+            } else {
+                assert!(
+                    bt.hard_stop_pside[LONG].state.is_some(),
+                    "unified episode still has a short"
+                );
+            }
+            assert!(bt.hard_stop_pside[SHORT].state.is_some());
+            let close_short = Order {
+                qty: 1.0,
+                price: 1.0,
+                order_type: OrderType::CloseGridShort,
+            };
+            bt.process_close_fill_short(1, 0, &close_short, exec)
+                .unwrap();
+            for pside in [LONG, SHORT] {
+                assert!(bt.hard_stop_pside[pside].state.is_none());
+                assert!(bt.hard_stop_pside[pside]
+                    .rolling_peak_strategy_pnl
+                    .is_empty());
+                assert_eq!(
+                    bt.hard_stop_pside[pside].no_restart_peak_strategy_equity,
+                    1200.0
+                );
+            }
+            assert_eq!(bt.hard_stop_n_triggers, 0);
+        }
+    }
+
+    #[test]
     fn hard_stop_orange_overrides_to_graceful_stop() {
         let hlcvs = Array3::from_shape_vec((2, 1, 4), vec![1.0; 2 * 1 * 4]).unwrap();
         let btc_usd_prices = Array1::from_vec(vec![20_000.0, 20_000.0]);
@@ -6923,7 +7326,7 @@ mod tests {
             execution_type: orchestrator::ExecutionType::Market,
         });
 
-        bt.check_for_fills(1);
+        bt.check_for_fills(1).unwrap();
 
         assert_eq!(bt.positions.long[0].size, 0.0);
         assert_eq!(bt.fills.len(), 1);
@@ -7005,7 +7408,7 @@ mod tests {
             execution_type: orchestrator::ExecutionType::Limit,
         });
 
-        bt.check_for_fills(1);
+        bt.check_for_fills(1).unwrap();
 
         assert_ne!(bt.positions.long[0].size, 0.0);
         assert!(bt.fills.is_empty());
@@ -7175,7 +7578,7 @@ mod tests {
             execution_type: orchestrator::ExecutionType::Market,
         });
 
-        bt.check_for_fills(1);
+        bt.check_for_fills(1).unwrap();
 
         assert_ne!(bt.positions.long[0].size, 0.0);
         assert_eq!(bt.fills.len(), 1);
@@ -7253,7 +7656,7 @@ mod tests {
             execution_type: orchestrator::ExecutionType::Limit,
         });
 
-        bt.check_for_fills(1);
+        bt.check_for_fills(1).unwrap();
 
         assert_ne!(bt.positions.long[0].size, 0.0);
         assert_eq!(bt.fills.len(), 1);
@@ -7372,7 +7775,7 @@ mod tests {
             "expected the v7 grid leg to stage multiple entries, got {staged_entry_count}"
         );
 
-        bt.check_for_fills(1);
+        bt.check_for_fills(1).unwrap();
 
         let same_candle_entries: Vec<&Fill> = bt
             .fills
@@ -7502,7 +7905,7 @@ mod tests {
                 && (order.order.qty + 26.24).abs() < 1e-12
         }));
 
-        bt.check_for_fills(1);
+        bt.check_for_fills(1).unwrap();
 
         let same_candle_closes: Vec<&Fill> = bt
             .fills

--- a/passivbot-rust/src/backtest.rs
+++ b/passivbot-rust/src/backtest.rs
@@ -4397,6 +4397,11 @@ impl<'a> Backtest<'a> {
             } else {
                 self.update_hard_stop_state_pside_at_boundary(k, pside, true)?;
             }
+            let flat_strategy_pnl = if unified {
+                self.pnl_cumsum_running_net
+            } else {
+                self.pnl_cumsum_running_net_pside[pside]
+            };
             let runtime = if coin_mode {
                 &mut self.hard_stop_coin[pside][idx]
             } else {
@@ -4409,6 +4414,14 @@ impl<'a> Backtest<'a> {
             runtime.tier = ehsl::HardStopTier::Green;
             runtime.red_active_now = false;
             runtime.rolling_peak_strategy_pnl.clear();
+            if !coin_mode {
+                // Keep the proven flat baseline before any same-bar re-entry
+                // fees or closing loss can become the queue's first sample.
+                runtime.rolling_peak_strategy_pnl.push_back((
+                    self.first_timestamp_ms + k as u64 * self.interval_ms,
+                    flat_strategy_pnl,
+                ));
+            }
             runtime.flat_confirmations = 0;
             runtime.pending_stop = None;
             runtime.current_red_start_ms = None;
@@ -6864,7 +6877,10 @@ mod tests {
 
     #[test]
     fn ordinary_flatten_respects_pside_and_unified_scope() {
-        for mode in ["pside", "unified"] {
+        for (mode, closing_side) in [
+            ("pside", LONG), ("pside", SHORT),
+            ("unified", LONG), ("unified", SHORT),
+        ] {
             let hlcvs = Array3::from_shape_vec((3, 2, 4), vec![1.0; 3 * 2 * 4]).unwrap();
             let btc_usd_prices = Array1::from_vec(vec![20_000.0; 3]);
             let mut bp_pair = BotParamsPair::default();
@@ -6969,15 +6985,54 @@ mod tests {
                 .unwrap();
             for pside in [LONG, SHORT] {
                 assert!(bt.hard_stop_pside[pside].state.is_none());
-                assert!(bt.hard_stop_pside[pside]
-                    .rolling_peak_strategy_pnl
-                    .is_empty());
+                let expected_baseline = if mode == "unified" {
+                    bt.pnl_cumsum_running_net
+                } else {
+                    bt.pnl_cumsum_running_net_pside[pside]
+                };
+                assert_eq!(
+                    bt.hard_stop_pside[pside].rolling_peak_strategy_pnl,
+                    VecDeque::from([(60_000, expected_baseline)])
+                );
                 assert_eq!(
                     bt.hard_stop_pside[pside].no_restart_peak_strategy_equity,
                     1200.0
                 );
             }
             assert_eq!(bt.hard_stop_n_triggers, 0);
+
+            // A second complete episode in this bar must retain the first
+            // flatten's PnL baseline, including entry and closing fees.
+            let fee_exec = OrderFillExecution { fee_rate: 0.001, ..exec };
+            if closing_side == LONG {
+                let entry = Order {
+                    qty: 500.0, price: 1.0,
+                    order_type: OrderType::EntryInitialNormalLong,
+                };
+                bt.process_entry_fill_long(1, 0, &entry, fee_exec);
+                bt.process_close_fill_long(
+                    1, 0, &Order { qty: -500.0, ..close },
+                    OrderFillExecution { price: 0.5, ..fee_exec },
+                ).unwrap();
+            } else {
+                let entry = Order {
+                    qty: -500.0, price: 1.0,
+                    order_type: OrderType::EntryInitialNormalShort,
+                };
+                bt.process_entry_fill_short(1, 0, &entry, fee_exec);
+                bt.process_close_fill_short(
+                    1, 0, &Order { qty: 500.0, ..close_short },
+                    OrderFillExecution { price: 1.5, ..fee_exec },
+                ).unwrap();
+            }
+            let runtime = &bt.hard_stop_pside[closing_side];
+            assert!(runtime.halted, "second same-bar loss must trigger RED in {mode}");
+            let stop = runtime.last_stop.unwrap();
+            assert_eq!(stop.timestamp_ms, 60_000);
+            let episode_loss = if closing_side == LONG { 250.75 } else { 251.25 };
+            let peak_equity = if mode == "unified" || closing_side == LONG { 998.0 } else { 1000.0 };
+            assert!((stop.drawdown_raw - episode_loss / peak_equity).abs() < 1e-12);
+            assert_eq!(bt.hard_stop_n_triggers, if mode == "unified" { 2 } else { 1 });
         }
     }
 

--- a/passivbot-rust/src/equity_hard_stop_loss.rs
+++ b/passivbot-rust/src/equity_hard_stop_loss.rs
@@ -74,6 +74,9 @@ pub struct HardStopState {
     pub initialized: bool,
     pub last_minute: Option<u64>,
     pub cached_step: Option<HardStopStep>,
+    // Baseline for replacing this minute's sample at exact fill boundaries.
+    pub minute_start_ema: f64,
+    pub minute_elapsed: u64,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -380,6 +383,22 @@ pub fn step_with_peak_strategy_equity_latch(
     timestamp_ms: u64,
     latch_red: bool,
 ) -> Result<HardStopStep, String> {
+    step_with_peak_strategy_equity_at_boundary(
+        state, config, equity, peak_strategy_equity, timestamp_ms, latch_red, false,
+    )
+}
+
+/// Exact fill boundaries replace the current minute's sample without advancing
+/// the EMA clock twice. Ordinary polling retains its cached-minute semantics.
+pub fn step_with_peak_strategy_equity_at_boundary(
+    state: &mut HardStopState,
+    config: HardStopConfig,
+    equity: f64,
+    peak_strategy_equity: f64,
+    timestamp_ms: u64,
+    latch_red: bool,
+    at_fill_boundary: bool,
+) -> Result<HardStopStep, String> {
     config.validate()?;
     if !equity.is_finite() || equity <= 0.0 {
         return Err("equity must be finite and > 0".to_string());
@@ -418,7 +437,11 @@ pub fn step_with_peak_strategy_equity_latch(
             elapsed_minutes: 0,
         };
         state.cached_step = Some(step);
-        return Ok(step);
+        state.minute_start_ema = 0.0;
+        state.minute_elapsed = 0;
+        if !at_fill_boundary {
+            return Ok(step);
+        }
     }
 
     let last_minute = state
@@ -431,7 +454,7 @@ pub fn step_with_peak_strategy_equity_latch(
         ));
     }
     let elapsed_minutes = current_minute - last_minute;
-    if elapsed_minutes == 0 {
+    if elapsed_minutes == 0 && !at_fill_boundary {
         let mut step = state
             .cached_step
             .ok_or_else(|| "initialized hard-stop state missing cached_step".to_string())?;
@@ -448,8 +471,15 @@ pub fn step_with_peak_strategy_equity_latch(
 
     state.peak_strategy_equity = peak_strategy_equity;
     let drawdown_raw = (1.0 - (equity / state.peak_strategy_equity.max(f64::EPSILON))).max(0.0);
-    let decay = (1.0 - alpha).powf(elapsed_minutes as f64);
-    state.drawdown_ema = drawdown_raw + (state.drawdown_ema - drawdown_raw) * decay;
+    if elapsed_minutes > 0 {
+        state.minute_start_ema = state.drawdown_ema;
+        state.minute_elapsed = elapsed_minutes;
+    }
+    // A freshly primed episode has no elapsed bucket yet. Its first exact
+    // boundary supplies that bucket's signal; subsequent boundaries replace it.
+    let sample_minutes = state.minute_elapsed.max(1);
+    let decay = (1.0 - alpha).powf(sample_minutes as f64);
+    state.drawdown_ema = drawdown_raw + (state.minute_start_ema - drawdown_raw) * decay;
     // Effective trigger metric: min(raw, EMA).
     // Prevents false RED after recovery (stale EMA) and flash-crash bottom exits (raw spike).
     let drawdown_score = drawdown_raw.min(state.drawdown_ema);
@@ -498,6 +528,49 @@ pub fn step_with_peak_strategy_equity_latch(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn distinct_fill_boundaries_replace_one_minute_ema_sample() {
+        let config = HardStopConfig {
+            red_threshold: 0.15,
+            ema_span_minutes: 3.0,
+            tier_ratios: HardStopTierRatios::default(),
+        };
+        let mut state = HardStopState::default();
+        step_with_peak_strategy_equity_latch(&mut state, config, 1.0, 1.0, 60_000, false).unwrap();
+        let first = step_with_peak_strategy_equity_at_boundary(
+            &mut state, config, 0.8, 1.0, 90_000, false, true,
+        ).unwrap();
+        assert!((first.drawdown_ema - 0.1).abs() < 1e-12);
+        let second = step_with_peak_strategy_equity_at_boundary(
+            &mut state, config, 0.6, 1.0, 95_000, false, true,
+        ).unwrap();
+        // Replace alpha*raw (0.2), rather than compound another step (0.25).
+        assert!((second.drawdown_raw - 0.4).abs() < 1e-12);
+        assert!((second.drawdown_ema - 0.2).abs() < 1e-12);
+        assert_eq!(second.elapsed_minutes, 0);
+        assert!(second.red_active_now);
+        assert!(state.red_seen_in_episode);
+        let polling = step_with_peak_strategy_equity_latch(
+            &mut state, config, 1.0, 1.0, 96_000, false,
+        ).unwrap();
+        assert_eq!(polling.drawdown_raw, second.drawdown_raw);
+        assert_eq!(polling.drawdown_ema, second.drawdown_ema);
+        let recovered = step_with_peak_strategy_equity_at_boundary(
+            &mut state, config, 1.0, 1.0, 97_000, false, true,
+        ).unwrap();
+        assert_eq!(recovered.drawdown_ema, 0.0);
+        assert!(!recovered.red_active_now);
+        assert!(state.red_seen_in_episode);
+        let normal = step_with_peak_strategy_equity_latch(
+            &mut state, config, 0.8, 1.0, 120_000, false,
+        ).unwrap();
+        assert!((normal.drawdown_ema - 0.1).abs() < 1e-12);
+        let boundary = step_with_peak_strategy_equity_at_boundary(
+            &mut state, config, 0.6, 1.0, 125_000, false, true,
+        ).unwrap();
+        assert!((boundary.drawdown_ema - 0.2).abs() < 1e-12);
+    }
 
     #[test]
     fn red_active_now_splits_from_seen_and_latch() {

--- a/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
@@ -1436,6 +1436,19 @@ inline void passivbot_single_coin_impl(
             }
         }
 
+        if (long_close_fill && long_side.psize <= 0.0f) {
+            prepare_coin_hsl_rolling_signal(
+                long_hsl, long_rolling_pnl, rolling_pnl_values, rolling_pnl_indices,
+                long_rolling_base, rolling_capacity, int(kf), pnl_lookback_bars,
+                realized_pnl_cumsum_long
+            );
+            if (finish_hsl_scoped_episode_at_flat(
+                    long_hsl, &short_hsl, false, short_side.psize > 0.0f,
+                    balance, starting_balance, realized_pnl_cumsum_last,
+                    realized_pnl_cumsum_long, kf, interval_ms
+                )) reset_hsl_rolling_pnl_window(long_rolling_pnl);
+        }
+
         bool long_entry_fill = valid && alive && long_enabled
             && long_side.entry_qty > 0.0f
             && (long_side.entry_market
@@ -1559,6 +1572,19 @@ inline void passivbot_single_coin_impl(
             }
         }
 
+        if (short_close_fill && short_side.psize <= 0.0f) {
+            prepare_coin_hsl_rolling_signal(
+                short_hsl, short_rolling_pnl, rolling_pnl_values, rolling_pnl_indices,
+                short_rolling_base, rolling_capacity, int(kf), pnl_lookback_bars,
+                realized_pnl_cumsum_short
+            );
+            if (finish_hsl_scoped_episode_at_flat(
+                    short_hsl, &long_hsl, false, long_side.psize > 0.0f,
+                    balance, starting_balance, realized_pnl_cumsum_last,
+                    realized_pnl_cumsum_short, kf, interval_ms
+                )) reset_hsl_rolling_pnl_window(short_rolling_pnl);
+        }
+
         bool short_entry_fill = valid && alive && short_enabled
             && short_side.entry_qty > 0.0f
             && (short_side.entry_market
@@ -1622,6 +1648,19 @@ inline void passivbot_single_coin_impl(
                 long_coin_hsl_rolling, profit_sum, loss_sum, profit_sum_long,
                 loss_sum_long, held_max_min, held_sum_min, held_count, day_volume
             );
+            if (forced_long_close) {
+                prepare_coin_hsl_rolling_signal(
+                    long_hsl, long_rolling_pnl, rolling_pnl_values, rolling_pnl_indices,
+                    long_rolling_base, rolling_capacity, int(kf), pnl_lookback_bars,
+                    realized_pnl_cumsum_long
+                );
+                if (finish_hsl_scoped_episode_at_flat(
+                        long_hsl, &short_hsl, false, short_side.psize > 0.0f,
+                        balance, starting_balance, realized_pnl_cumsum_last,
+                        realized_pnl_cumsum_long, kf, interval_ms
+                    )) reset_hsl_rolling_pnl_window(long_rolling_pnl);
+            }
+
             float long_unrealized = long_side.psize > 0.0f
                 ? long_side.psize * c_mult * (close - long_side.pprice)
                 : 0.0f;
@@ -1638,6 +1677,19 @@ inline void passivbot_single_coin_impl(
                 short_coin_hsl_rolling, profit_sum, loss_sum, profit_sum_short,
                 loss_sum_short, held_max_min, held_sum_min, held_count, day_volume
             );
+            if (forced_short_close) {
+                prepare_coin_hsl_rolling_signal(
+                    short_hsl, short_rolling_pnl, rolling_pnl_values, rolling_pnl_indices,
+                    short_rolling_base, rolling_capacity, int(kf), pnl_lookback_bars,
+                    realized_pnl_cumsum_short
+                );
+                if (finish_hsl_scoped_episode_at_flat(
+                        short_hsl, &long_hsl, false, long_side.psize > 0.0f,
+                        balance, starting_balance, realized_pnl_cumsum_last,
+                        realized_pnl_cumsum_short, kf, interval_ms
+                    )) reset_hsl_rolling_pnl_window(short_rolling_pnl);
+            }
+
             long_close_fill = long_close_fill || forced_long_close;
             short_close_fill = short_close_fill || forced_short_close;
             forced_delist_closed_any = forced_long_close || forced_short_close;

--- a/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
@@ -259,7 +259,9 @@ inline void record_ema_multicoin_close_fill(
     bool short_side,
     bool is_hsl_panic,
     bool collect_coin_fill_counts,
-    thread float& hsl_equity_before_fills
+    thread float& hsl_equity_before_fills,
+    thread HslState* opposite_hsl = nullptr,
+    bool opposite_has_position = false
 ) {
     const bool coin_hsl_mode =
         side.hsl.signal_mode == HSL_SIGNAL_COIN;
@@ -295,6 +297,27 @@ inline void record_ema_multicoin_close_fill(
     }
     if (collect_coin_fill_counts) {
         coin_fill_counts[candidate_index * coin_count + coin] += 1.0f;
+    }
+
+    // The caller applies the position reduction immediately after accounting.
+    // Test the pre-fill size so a complete close ends the episode before reentry.
+    if (qty >= side.psize[coin]) {
+        bool scope_has_position = false;
+        if (!coin_hsl_mode) {
+            for (int other_coin = 0; other_coin < coin_count; ++other_coin) {
+                if (other_coin != coin && side.psize[other_coin] > 0.0f) {
+                    scope_has_position = true;
+                }
+            }
+        }
+        thread HslState& controller = coin_hsl_mode ? side.coin_hsl[coin] : side.hsl;
+        float realized_scope = coin_hsl_mode ? side.coin_realized_pnl[coin]
+            : (short_side ? account.realized_pnl_short : account.realized_pnl_long);
+        finish_hsl_scoped_episode_at_flat(
+            controller, opposite_hsl, scope_has_position, opposite_has_position,
+            account.balance, account.balance - account.realized_pnl_total,
+            account.realized_pnl_total, realized_scope, float(k), 0.0f
+        );
     }
 }
 
@@ -2479,7 +2502,9 @@ inline bool process_ema_multicoin_side_fills(
     bool collect_coin_fill_counts,
     float market_order_slippage_pct,
     bool hsl_panic_market,
-    float hsl_equity_before_fills
+    float hsl_equity_before_fills,
+    thread HslState* opposite_hsl = nullptr,
+    bool opposite_has_position = false
 ) {
     thread HslState& hsl = side.hsl;
     thread HslState* coin_hsl = side.coin_hsl;
@@ -2584,7 +2609,7 @@ inline bool process_ema_multicoin_side_fills(
                 candidate_index, coin_count, c, k, pnl, net_pnl,
                 adjusted, pprice[c], close, c_mult, short_side,
                 is_hsl_panic, collect_coin_fill_counts,
-                hsl_equity_before_fills
+                hsl_equity_before_fills, opposite_hsl, opposite_has_position
             );
             float new_size = fmax(
                 round_step(psize[c] - adjusted, qty_step), 0.0f
@@ -2717,7 +2742,9 @@ inline bool force_close_ema_multicoin_delisted_position(
     bool short_side,
     bool collect_coin_fill_counts,
     float market_order_slippage_pct,
-    thread float& hsl_equity_before_close
+    thread float& hsl_equity_before_close,
+    thread HslState* opposite_hsl = nullptr,
+    bool opposite_has_position = false
 ) {
     if (!(side.psize[coin] > 0.0f && side.pprice[coin] > 0.0f)) {
         return false;
@@ -2747,7 +2774,8 @@ inline bool force_close_ema_multicoin_delisted_position(
         side, account, fills, coin_fill_counts,
         candidate_index, coin_count, coin, k, pnl, net_pnl,
         close_qty, position_price, close, c_mult, short_side,
-        true, collect_coin_fill_counts, hsl_equity_before_close
+        true, collect_coin_fill_counts, hsl_equity_before_close,
+        opposite_hsl, opposite_has_position
     );
     if (!coin_hsl_mode) {
         advance_coin_hsl_equity_after_close_fill(
@@ -2828,17 +2856,25 @@ inline bool force_close_ema_multicoin_delisted_fused(
     for (int c = 0; c < coin_count; ++c) {
         const int last_valid = int(coin_settings[c * COIN_COLS + 7]);
         if (k != last_valid || last_valid + 1400 >= timestep_count) continue;
+        bool short_has_position = false;
+        for (int other_coin = 0; other_coin < coin_count; ++other_coin) {
+            short_has_position = short_has_position || short_side.psize[other_coin] > 0.0f;
+        }
         const bool long_closed = force_close_ema_multicoin_delisted_position(
             long_side, account, fills, bars, coin_settings, coin_fill_counts,
             candidate_index, k, coin_count, c, false,
             collect_coin_fill_counts, market_order_slippage_pct,
-            hsl_equity_before_close
+            hsl_equity_before_close, &short_side.hsl, short_has_position
         );
+        bool long_has_position = false;
+        for (int other_coin = 0; other_coin < coin_count; ++other_coin) {
+            long_has_position = long_has_position || long_side.psize[other_coin] > 0.0f;
+        }
         const bool short_closed = force_close_ema_multicoin_delisted_position(
             short_side, account, fills, bars, coin_settings, coin_fill_counts,
             candidate_index, k, coin_count, c, true,
             collect_coin_fill_counts, market_order_slippage_pct,
-            hsl_equity_before_close
+            hsl_equity_before_close, &long_side.hsl, long_has_position
         );
         if (long_closed || short_closed) {
             clear_ema_multicoin_coin_orders(long_side, c);
@@ -3915,7 +3951,8 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
             bars, fill_ticks, coin_settings, long_coin_overrides,
             coin_fill_counts, int(b), k, C, false, alive,
             collect_coin_fill_counts, market_order_slippage_pct,
-            long_hsl_panic_market, long_hsl_equity_before_fills
+            long_hsl_panic_market, long_hsl_equity_before_fills,
+            &short_side.hsl, ema_multicoin_side_has_position(short_side, C)
         );
         float short_hsl_equity_before_fills = account.balance;
         short_hsl_equity_before_fills =
@@ -3933,7 +3970,8 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
             bars, fill_ticks, coin_settings, short_coin_overrides,
             coin_fill_counts, int(b), k, C, true, alive,
             collect_coin_fill_counts, market_order_slippage_pct,
-            short_hsl_panic_market, short_hsl_equity_before_fills
+            short_hsl_panic_market, short_hsl_equity_before_fills,
+            &long_side.hsl, ema_multicoin_side_has_position(long_side, C)
         );
         bool any_fill = long_fill || short_fill;
 

--- a/passivbot-rust/src/gpu/mps_hsl_common.metal
+++ b/passivbot-rust/src/gpu/mps_hsl_common.metal
@@ -200,6 +200,8 @@ struct HslState {
     float slot_count;
     bool initialized;
     float drawdown_ema;
+    float last_sample_k;
+    float sampled_drawdown_raw;
 #if PASSIVBOT_HSL_DIAGNOSTICS_ENABLED
     float drawdown_ema_max;
 #endif
@@ -521,6 +523,8 @@ inline HslState load_hsl(
     h.slot_count = fmax(round(params[ho + 10]), 1.0f);
     h.initialized = false;
     h.drawdown_ema = 0.0f;
+    h.last_sample_k = -1.0f;
+    h.sampled_drawdown_raw = 0.0f;
 #if PASSIVBOT_HSL_DIAGNOSTICS_ENABLED
     h.drawdown_ema_max = 0.0f;
 #endif
@@ -701,13 +705,19 @@ inline void update_hsl_from_signal(
     float drawdown_raw = signal.drawdown_raw;
     float strategy_equity = signal.strategy_equity;
     float peak_strategy_equity = signal.peak_strategy_equity;
-    if (!h.initialized) {
-        h.initialized = true;
-        h.drawdown_ema = 0.0f;
-        h.tier = 0;
-        return;
+    if (h.last_sample_k != kf) {
+        h.last_sample_k = kf;
+        h.sampled_drawdown_raw = drawdown_raw;
+        if (!h.initialized) {
+            h.initialized = true;
+            h.drawdown_ema = 0.0f;
+            h.tier = 0;
+            return;
+        }
+        h.drawdown_ema = fma(h.alpha, drawdown_raw - h.drawdown_ema, h.drawdown_ema);
+    } else {
+        drawdown_raw = h.sampled_drawdown_raw;
     }
-    h.drawdown_ema = fma(h.alpha, drawdown_raw - h.drawdown_ema, h.drawdown_ema);
 #if PASSIVBOT_HSL_DIAGNOSTICS_ENABLED
     h.drawdown_ema_max = fmax(h.drawdown_ema_max, fabs(h.drawdown_ema));
 #endif
@@ -837,6 +847,63 @@ inline void update_hsl(
     );
 }
 
+// A real closing fill samples its final fee-inclusive drawdown before an ordinary
+// episode reset. RED finalization remains owned by the normal end-of-bar update.
+inline bool finish_hsl_episode_at_flat(
+    thread HslState& h,
+    float balance,
+    float starting_balance,
+    float realized_pnl,
+    float kf,
+    float interval_ms
+) {
+    if (!h.enabled || h.halted || h.no_restart_latched || h.red_latched) return false;
+    HslSignal signal;
+    if (!derive_hsl_signal(h, balance, starting_balance, realized_pnl, 0.0f, signal)) {
+        return false;
+    }
+    // Suppress flat confirmation here: the normal controller owns that transition.
+    update_hsl_from_signal(h, signal, realized_pnl, true, false, kf, interval_ms);
+    if (h.red_latched) return false;
+    h.initialized = false;
+    h.drawdown_ema = 0.0f;
+    h.last_sample_k = -1.0f;
+    h.sampled_drawdown_raw = 0.0f;
+    h.peak_strategy_pnl = -INFINITY;
+    h.coin_realized_baseline = realized_pnl;
+    h.coin_realized_peak = 0.0f;
+    h.tier = 0;
+    h.red_active_now = false;
+    h.flat_confirmations = 0;
+    h.current_red_start_k = -1.0f;
+    return true;
+}
+
+inline bool finish_hsl_scoped_episode_at_flat(
+    thread HslState& h,
+    thread HslState* opposite_hsl,
+    bool scope_has_position,
+    bool opposite_has_position,
+    float balance,
+    float starting_balance,
+    float realized_total,
+    float realized_scope,
+    float kf,
+    float interval_ms
+) {
+    const bool unified = h.signal_mode == HSL_SIGNAL_UNIFIED;
+    if (scope_has_position || (unified && opposite_has_position)) return false;
+    bool reset = finish_hsl_episode_at_flat(
+        h, balance, starting_balance, unified ? realized_total : realized_scope, kf, interval_ms
+    );
+    if (unified && opposite_hsl != nullptr) {
+        finish_hsl_episode_at_flat(
+            *opposite_hsl, balance, starting_balance, realized_total, kf, interval_ms
+        );
+    }
+    return reset;
+}
+
 inline void update_one_side_hsl(
     thread HslState& hsl,
     float balance,
@@ -922,6 +989,8 @@ inline void try_restart_hsl(thread HslState& h, float kf, float current_equity) 
 #endif
     h.initialized = false;
     h.drawdown_ema = 0.0f;
+    h.last_sample_k = -1.0f;
+    h.sampled_drawdown_raw = 0.0f;
     h.peak_strategy_pnl = -INFINITY;
     h.tier = 0;
     h.red_latched = false;

--- a/passivbot-rust/src/gpu/mps_hsl_common.metal
+++ b/passivbot-rust/src/gpu/mps_hsl_common.metal
@@ -202,6 +202,9 @@ struct HslState {
     float drawdown_ema;
     float last_sample_k;
     float sampled_drawdown_raw;
+    float sample_start_drawdown_ema;
+    float sample_elapsed_minutes;
+    float sample_interval_ms;
 #if PASSIVBOT_HSL_DIAGNOSTICS_ENABLED
     float drawdown_ema_max;
 #endif
@@ -525,6 +528,9 @@ inline HslState load_hsl(
     h.drawdown_ema = 0.0f;
     h.last_sample_k = -1.0f;
     h.sampled_drawdown_raw = 0.0f;
+    h.sample_start_drawdown_ema = 0.0f;
+    h.sample_elapsed_minutes = 0.0f;
+    h.sample_interval_ms = 60000.0f;
 #if PASSIVBOT_HSL_DIAGNOSTICS_ENABLED
     h.drawdown_ema_max = 0.0f;
 #endif
@@ -700,21 +706,36 @@ inline void update_hsl_from_signal(
     bool has_position,
     bool has_blocking_orders,
     float kf,
-    float interval_ms
+    float interval_ms,
+    bool at_fill_boundary = false
 ) {
     float drawdown_raw = signal.drawdown_raw;
     float strategy_equity = signal.strategy_equity;
     float peak_strategy_equity = signal.peak_strategy_equity;
-    if (h.last_sample_k != kf) {
+    if (h.halted) return;
+    if (interval_ms > 0.0f) h.sample_interval_ms = interval_ms;
+    interval_ms = h.sample_interval_ms;
+    const bool new_minute = h.last_sample_k != kf;
+    if (new_minute) {
+        h.sample_start_drawdown_ema = h.drawdown_ema;
+        h.sample_elapsed_minutes = h.last_sample_k < 0.0f ? 0.0f
+            : fmax((kf - h.last_sample_k) * interval_ms / 60000.0f, 0.0f);
         h.last_sample_k = kf;
-        h.sampled_drawdown_raw = drawdown_raw;
         if (!h.initialized) {
             h.initialized = true;
             h.drawdown_ema = 0.0f;
+            h.sample_start_drawdown_ema = 0.0f;
+            h.sampled_drawdown_raw = drawdown_raw;
             h.tier = 0;
-            return;
+            if (!at_fill_boundary) return;
         }
-        h.drawdown_ema = fma(h.alpha, drawdown_raw - h.drawdown_ema, h.drawdown_ema);
+    }
+    if (new_minute || at_fill_boundary) {
+        h.sampled_drawdown_raw = drawdown_raw;
+        // Distinct closing fills replace this minute's sample, without taking
+        // another EMA time step. Ordinary repeated reads remain cached.
+        float decay = pow(1.0f - h.alpha, fmax(h.sample_elapsed_minutes, 1.0f));
+        h.drawdown_ema = fma(h.sample_start_drawdown_ema - drawdown_raw, decay, drawdown_raw);
     } else {
         drawdown_raw = h.sampled_drawdown_raw;
     }
@@ -848,7 +869,7 @@ inline void update_hsl(
 }
 
 // A real closing fill samples its final fee-inclusive drawdown before an ordinary
-// episode reset. RED finalization remains owned by the normal end-of-bar update.
+// episode reset. Proven-flat RED boundaries finalize before later fills can reopen.
 inline bool finish_hsl_episode_at_flat(
     thread HslState& h,
     float balance,
@@ -857,19 +878,28 @@ inline bool finish_hsl_episode_at_flat(
     float kf,
     float interval_ms
 ) {
-    if (!h.enabled || h.halted || h.no_restart_latched || h.red_latched) return false;
+    if (!h.enabled || h.halted || h.no_restart_latched) return false;
     HslSignal signal;
     if (!derive_hsl_signal(h, balance, starting_balance, realized_pnl, 0.0f, signal)) {
         return false;
     }
-    // Suppress flat confirmation here: the normal controller owns that transition.
-    update_hsl_from_signal(h, signal, realized_pnl, true, false, kf, interval_ms);
-    if (h.red_latched) return false;
-    h.initialized = false;
+    // A complete closing fill is exact flat evidence. Record both confirmation
+    // transitions now so resting same-bar entries cannot erase the stop anchor.
+    h.flat_confirmations = 0;
+    update_hsl_from_signal(h, signal, realized_pnl, false, false, kf, interval_ms, true);
+    if (h.red_latched) {
+        update_hsl_from_signal(h, signal, realized_pnl, false, false, kf, interval_ms);
+        return false;
+    }
+    // Prime the next episode at the exact flat baseline. Another closing fill
+    // in this minute must include its entry fee and closing loss in its signal.
+    h.initialized = true;
     h.drawdown_ema = 0.0f;
-    h.last_sample_k = -1.0f;
+    h.last_sample_k = kf;
     h.sampled_drawdown_raw = 0.0f;
-    h.peak_strategy_pnl = -INFINITY;
+    h.sample_start_drawdown_ema = 0.0f;
+    h.sample_elapsed_minutes = 0.0f;
+    h.peak_strategy_pnl = realized_pnl;
     h.coin_realized_baseline = realized_pnl;
     h.coin_realized_peak = 0.0f;
     h.tier = 0;
@@ -991,6 +1021,8 @@ inline void try_restart_hsl(thread HslState& h, float kf, float current_equity) 
     h.drawdown_ema = 0.0f;
     h.last_sample_k = -1.0f;
     h.sampled_drawdown_raw = 0.0f;
+    h.sample_start_drawdown_ema = 0.0f;
+    h.sample_elapsed_minutes = 0.0f;
     h.peak_strategy_pnl = -INFINITY;
     h.tier = 0;
     h.red_latched = false;

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -2764,6 +2764,19 @@ inline void passivbot_single_coin_impl(
             long_side.secondary_close_qty = 0.0f;
         }
 
+        if (long_close_fill && long_side.psize <= 0.0f) {
+            prepare_coin_hsl_rolling_signal(
+                long_hsl, long_rolling_pnl, rolling_pnl_values, rolling_pnl_indices,
+                long_rolling_base, rolling_capacity, int(kf), pnl_lookback_bars,
+                realized_pnl_cumsum_long
+            );
+            if (finish_hsl_scoped_episode_at_flat(
+                    long_hsl, &short_hsl, false, short_side.psize > 0.0f,
+                    balance, starting_balance, realized_pnl_cumsum_last,
+                    realized_pnl_cumsum_long, kf, interval_ms
+                )) reset_hsl_rolling_pnl_window(long_rolling_pnl);
+        }
+
         bool long_entry_passive_reachable = long_side.entry_qty > 0.0f
             && long_side.entry_ticks > low_nonfill_max_tick;
         long_entry_fill = valid && alive && long_enabled
@@ -3547,6 +3560,19 @@ inline void passivbot_single_coin_impl(
             short_side.secondary_close_qty = 0.0f;
         }
 
+        if (short_close_fill && short_side.psize <= 0.0f) {
+            prepare_coin_hsl_rolling_signal(
+                short_hsl, short_rolling_pnl, rolling_pnl_values, rolling_pnl_indices,
+                short_rolling_base, rolling_capacity, int(kf), pnl_lookback_bars,
+                realized_pnl_cumsum_short
+            );
+            if (finish_hsl_scoped_episode_at_flat(
+                    short_hsl, &long_hsl, false, long_side.psize > 0.0f,
+                    balance, starting_balance, realized_pnl_cumsum_last,
+                    realized_pnl_cumsum_short, kf, interval_ms
+                )) reset_hsl_rolling_pnl_window(short_rolling_pnl);
+        }
+
         bool short_entry_passive_reachable = short_side.entry_qty > 0.0f
             && short_side.entry_ticks <= high_fill_max_tick;
         short_entry_fill = valid && alive && short_enabled
@@ -3736,6 +3762,19 @@ inline void passivbot_single_coin_impl(
                 long_coin_hsl_rolling, profit_sum, loss_sum, profit_sum_long,
                 loss_sum_long, held_max_min, held_sum_min, held_count, day_volume
             );
+            if (forced_long_close) {
+                prepare_coin_hsl_rolling_signal(
+                    long_hsl, long_rolling_pnl, rolling_pnl_values, rolling_pnl_indices,
+                    long_rolling_base, rolling_capacity, int(kf), pnl_lookback_bars,
+                    realized_pnl_cumsum_long
+                );
+                if (finish_hsl_scoped_episode_at_flat(
+                        long_hsl, &short_hsl, false, short_side.psize > 0.0f,
+                        balance, starting_balance, realized_pnl_cumsum_last,
+                        realized_pnl_cumsum_long, kf, interval_ms
+                    )) reset_hsl_rolling_pnl_window(long_rolling_pnl);
+            }
+
 #else
             bool forced_long_close = false;
 #endif
@@ -3760,6 +3799,19 @@ inline void passivbot_single_coin_impl(
                 short_coin_hsl_rolling, profit_sum, loss_sum, profit_sum_short,
                 loss_sum_short, held_max_min, held_sum_min, held_count, day_volume
             );
+            if (forced_short_close) {
+                prepare_coin_hsl_rolling_signal(
+                    short_hsl, short_rolling_pnl, rolling_pnl_values, rolling_pnl_indices,
+                    short_rolling_base, rolling_capacity, int(kf), pnl_lookback_bars,
+                    realized_pnl_cumsum_short
+                );
+                if (finish_hsl_scoped_episode_at_flat(
+                        short_hsl, &long_hsl, false, long_side.psize > 0.0f,
+                        balance, starting_balance, realized_pnl_cumsum_last,
+                        realized_pnl_cumsum_short, kf, interval_ms
+                    )) reset_hsl_rolling_pnl_window(short_rolling_pnl);
+            }
+
 #else
             bool forced_short_close = false;
 #endif

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
@@ -1135,7 +1135,9 @@ inline void record_tm_multicoin_close_fill(
     bool short_side,
     bool is_hsl_panic,
     bool collect_coin_fill_counts,
-    thread float& hsl_equity_before_fills
+    thread float& hsl_equity_before_fills,
+    thread HslState* opposite_hsl = nullptr,
+    bool opposite_has_position = false
 ) {
     const bool coin_hsl_mode =
         side.hsl.signal_mode == HSL_SIGNAL_COIN;
@@ -1171,6 +1173,27 @@ inline void record_tm_multicoin_close_fill(
     }
     if (collect_coin_fill_counts) {
         coin_fill_counts[candidate_index * coin_count + coin] += 1.0f;
+    }
+
+    // The caller applies the position reduction immediately after accounting.
+    // Test the pre-fill size so a complete close ends the episode before reentry.
+    if (qty >= side.psize[coin]) {
+        bool scope_has_position = false;
+        if (!coin_hsl_mode) {
+            for (int other_coin = 0; other_coin < coin_count; ++other_coin) {
+                if (other_coin != coin && side.psize[other_coin] > 0.0f) {
+                    scope_has_position = true;
+                }
+            }
+        }
+        thread HslState& controller = coin_hsl_mode ? side.coin_hsl[coin] : side.hsl;
+        float realized_scope = coin_hsl_mode ? side.coin_realized_pnl[coin]
+            : (short_side ? account.realized_pnl_short : account.realized_pnl_long);
+        finish_hsl_scoped_episode_at_flat(
+            controller, opposite_hsl, scope_has_position, opposite_has_position,
+            account.balance, account.balance - account.realized_pnl_total,
+            account.realized_pnl_total, realized_scope, float(k), 0.0f
+        );
     }
 }
 
@@ -1348,7 +1371,9 @@ inline bool force_close_tm_multicoin_delisted_position(
     bool short_side,
     bool collect_coin_fill_counts,
     float market_order_slippage_pct,
-    thread float& hsl_equity_before_close
+    thread float& hsl_equity_before_close,
+    thread HslState* opposite_hsl = nullptr,
+    bool opposite_has_position = false
 ) {
     if (!(side.psize[coin] > 0.0f && side.pprice[coin] > 0.0f)) {
         return false;
@@ -1378,7 +1403,8 @@ inline bool force_close_tm_multicoin_delisted_position(
         side, account, fills, coin_fill_counts,
         candidate_index, coin_count, coin, k, pnl, net_pnl,
         close_qty, position_price, close, c_mult, short_side,
-        true, collect_coin_fill_counts, hsl_equity_before_close
+        true, collect_coin_fill_counts, hsl_equity_before_close,
+        opposite_hsl, opposite_has_position
     );
     if (!coin_hsl_mode) {
         advance_coin_hsl_equity_after_close_fill(
@@ -1446,17 +1472,25 @@ inline bool force_close_tm_multicoin_delisted_fused(
     for (int c = 0; c < coin_count; ++c) {
         const int last_valid = int(coin_settings[c * COIN_COLS + 7]);
         if (k != last_valid || last_valid + 1400 >= timestep_count) continue;
+        bool short_has_position = false;
+        for (int other_coin = 0; other_coin < coin_count; ++other_coin) {
+            short_has_position = short_has_position || short_side.psize[other_coin] > 0.0f;
+        }
         const bool long_closed = force_close_tm_multicoin_delisted_position(
             long_side, account, fills, bars, coin_settings, coin_fill_counts,
             candidate_index, k, coin_count, c, false,
             collect_coin_fill_counts, market_order_slippage_pct,
-            hsl_equity_before_close
+            hsl_equity_before_close, &short_side.hsl, short_has_position
         );
+        bool long_has_position = false;
+        for (int other_coin = 0; other_coin < coin_count; ++other_coin) {
+            long_has_position = long_has_position || long_side.psize[other_coin] > 0.0f;
+        }
         const bool short_closed = force_close_tm_multicoin_delisted_position(
             short_side, account, fills, bars, coin_settings, coin_fill_counts,
             candidate_index, k, coin_count, c, true,
             collect_coin_fill_counts, market_order_slippage_pct,
-            hsl_equity_before_close
+            hsl_equity_before_close, &long_side.hsl, long_has_position
         );
         if (long_closed || short_closed) {
             clear_tm_multicoin_coin_orders(long_side, c);
@@ -1496,7 +1530,9 @@ inline bool process_tm_multicoin_side_fills(
     float market_order_slippage_pct,
     float market_order_near_touch_threshold,
     bool hsl_panic_market,
-    thread float& hsl_equity_before_fills
+    thread float& hsl_equity_before_fills,
+    thread HslState* opposite_hsl = nullptr,
+    bool opposite_has_position = false
 ) {
     const bool coin_hsl_mode = config.coin_hsl_mode;
     const float close_qty_pct = config.close_qty_pct;
@@ -1917,7 +1953,7 @@ inline bool process_tm_multicoin_side_fills(
                             int(b), C, c, k, pnl, net_pnl, qty,
                             pprice[c], close, c_mult, short_side,
                             false, collect_coin_fill_counts,
-                            hsl_equity_before_fills
+                            hsl_equity_before_fills, opposite_hsl, opposite_has_position
                         );
                         psize[c] = fmax(
                             round_step(psize[c] - qty, qty_step), 0.0f
@@ -1959,7 +1995,7 @@ inline bool process_tm_multicoin_side_fills(
                     int(b), C, c, k, grid_pnl, grid_net_pnl,
                     grid_qty, pprice[c], close, c_mult, short_side,
                     false, collect_coin_fill_counts,
-                    hsl_equity_before_fills
+                    hsl_equity_before_fills, opposite_hsl, opposite_has_position
                 );
                 psize[c] = fmax(
                     round_step(psize[c] - grid_qty, qty_step), 0.0f
@@ -2017,7 +2053,7 @@ inline bool process_tm_multicoin_side_fills(
                     int(b), C, c, k, pnl, net_pnl, qty,
                     pprice[c], close, c_mult, short_side,
                     is_hsl_panic, collect_coin_fill_counts,
-                    hsl_equity_before_fills
+                    hsl_equity_before_fills, opposite_hsl, opposite_has_position
                 );
                 psize[c] = fmax(
                     round_step(psize[c] - qty, qty_step), 0.0f
@@ -5047,7 +5083,8 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
             collect_coin_fill_counts, loss_gate_enabled,
             max_realized_loss_pct, market_order_slippage_pct,
             market_order_near_touch_threshold,
-            long_hsl_panic_market, long_hsl_equity_before_fills
+            long_hsl_panic_market, long_hsl_equity_before_fills,
+            &short_side.hsl, tm_multicoin_side_has_position(short_side, C)
         );
         float short_hsl_equity_before_fills = account.balance;
         short_hsl_equity_before_fills =
@@ -5073,7 +5110,8 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
             collect_coin_fill_counts, loss_gate_enabled,
             max_realized_loss_pct, market_order_slippage_pct,
             market_order_near_touch_threshold,
-            short_hsl_panic_market, short_hsl_equity_before_fills
+            short_hsl_panic_market, short_hsl_equity_before_fills,
+            &long_side.hsl, tm_multicoin_side_has_position(long_side, C)
         );
         bool any_fill = long_fill || short_fill;
 

--- a/passivbot-rust/src/python.rs
+++ b/passivbot-rust/src/python.rs
@@ -309,7 +309,8 @@ impl EquityHardStopRuntimePy {
         ema_span_minutes,
         tier_ratio_yellow,
         tier_ratio_orange,
-        latch_red = true
+        latch_red = true,
+        at_fill_boundary = false
     ))]
     pub fn apply_sample(
         &mut self,
@@ -322,6 +323,7 @@ impl EquityHardStopRuntimePy {
         tier_ratio_yellow: f64,
         tier_ratio_orange: f64,
         latch_red: bool,
+        at_fill_boundary: bool,
     ) -> PyResult<Py<PyDict>> {
         self.last_rolling_peak = peak_strategy_equity;
         let cfg = ehsl::HardStopConfig {
@@ -332,13 +334,14 @@ impl EquityHardStopRuntimePy {
                 orange: tier_ratio_orange,
             },
         };
-        let step = ehsl::step_with_peak_strategy_equity_latch(
+        let step = ehsl::step_with_peak_strategy_equity_at_boundary(
             &mut self.state,
             cfg,
             equity,
             peak_strategy_equity,
             timestamp_ms,
             latch_red,
+            at_fill_boundary,
         )
         .map_err(PyValueError::new_err)?;
 

--- a/scenarios/fake_live/hsl_long_cooldown_manual_entry_graceful_stop.hjson
+++ b/scenarios/fake_live/hsl_long_cooldown_manual_entry_graceful_stop.hjson
@@ -40,6 +40,7 @@
         pnl: 100.0
         reduceOnly: true
         clientOrderId: initial_take_profit_boot
+        info: {startPosition: "5.0"}
       }
       {
         id: "12"
@@ -52,6 +53,7 @@
         price: 100.0
         pnl: 0.0
         clientOrderId: reentry_boot
+        info: {startPosition: "0.0"}
       }
     ]
   }

--- a/scenarios/fake_live/hsl_long_cooldown_manual_entry_manual.hjson
+++ b/scenarios/fake_live/hsl_long_cooldown_manual_entry_manual.hjson
@@ -40,6 +40,7 @@
         pnl: 100.0
         reduceOnly: true
         clientOrderId: initial_take_profit_boot
+        info: {startPosition: "5.0"}
       }
       {
         id: "12"
@@ -52,6 +53,7 @@
         price: 100.0
         pnl: 0.0
         clientOrderId: reentry_boot
+        info: {startPosition: "0.0"}
       }
     ]
   }

--- a/scenarios/fake_live/hsl_long_cooldown_manual_entry_manual_quarantine.hjson
+++ b/scenarios/fake_live/hsl_long_cooldown_manual_entry_manual_quarantine.hjson
@@ -40,6 +40,7 @@
         pnl: 100.0
         reduceOnly: true
         clientOrderId: initial_take_profit_boot
+        info: {startPosition: "5.0"}
       }
       {
         id: "12"
@@ -52,6 +53,7 @@
         price: 100.0
         pnl: 0.0
         clientOrderId: reentry_boot
+        info: {startPosition: "0.0"}
       }
     ]
   }

--- a/scenarios/fake_live/hsl_long_cooldown_manual_entry_normal.hjson
+++ b/scenarios/fake_live/hsl_long_cooldown_manual_entry_normal.hjson
@@ -40,6 +40,7 @@
         pnl: 100.0
         reduceOnly: true
         clientOrderId: initial_take_profit_boot
+        info: {startPosition: "5.0"}
       }
       {
         id: "12"
@@ -52,6 +53,7 @@
         price: 100.0
         pnl: 0.0
         clientOrderId: reentry_boot
+        info: {startPosition: "0.0"}
       }
     ]
   }

--- a/scenarios/fake_live/hsl_long_cooldown_manual_entry_panic.hjson
+++ b/scenarios/fake_live/hsl_long_cooldown_manual_entry_panic.hjson
@@ -40,6 +40,7 @@
         pnl: 100.0
         reduceOnly: true
         clientOrderId: initial_take_profit_boot
+        info: {startPosition: "5.0"}
       }
       {
         id: "12"
@@ -52,6 +53,7 @@
         price: 100.0
         pnl: 0.0
         clientOrderId: reentry_boot
+        info: {startPosition: "0.0"}
       }
     ]
   }

--- a/scenarios/fake_live/hsl_long_cooldown_manual_entry_repanic_keep_original.hjson
+++ b/scenarios/fake_live/hsl_long_cooldown_manual_entry_repanic_keep_original.hjson
@@ -40,6 +40,7 @@
         pnl: 100.0
         reduceOnly: true
         clientOrderId: initial_take_profit_boot
+        info: {startPosition: "5.0"}
       }
       {
         id: "12"
@@ -52,6 +53,7 @@
         price: 100.0
         pnl: 0.0
         clientOrderId: reentry_boot
+        info: {startPosition: "0.0"}
       }
     ]
   }

--- a/scenarios/fake_live/hsl_long_cooldown_manual_entry_repanic_reset.hjson
+++ b/scenarios/fake_live/hsl_long_cooldown_manual_entry_repanic_reset.hjson
@@ -40,6 +40,7 @@
         pnl: 100.0
         reduceOnly: true
         clientOrderId: initial_take_profit_boot
+        info: {startPosition: "5.0"}
       }
       {
         id: "12"
@@ -52,6 +53,7 @@
         price: 100.0
         pnl: 0.0
         clientOrderId: reentry_boot
+        info: {startPosition: "0.0"}
       }
     ]
   }

--- a/scenarios/fake_live/hsl_long_cooldown_manual_entry_resume_normal.hjson
+++ b/scenarios/fake_live/hsl_long_cooldown_manual_entry_resume_normal.hjson
@@ -40,6 +40,7 @@
         pnl: 100.0
         reduceOnly: true
         clientOrderId: initial_take_profit_boot
+        info: {startPosition: "5.0"}
       }
       {
         id: "12"
@@ -52,6 +53,7 @@
         price: 100.0
         pnl: 0.0
         clientOrderId: reentry_boot
+        info: {startPosition: "0.0"}
       }
     ]
   }

--- a/scenarios/fake_live/hsl_long_cooldown_manual_entry_tp_only.hjson
+++ b/scenarios/fake_live/hsl_long_cooldown_manual_entry_tp_only.hjson
@@ -40,6 +40,7 @@
         pnl: 100.0
         reduceOnly: true
         clientOrderId: initial_take_profit_boot
+        info: {startPosition: "5.0"}
       }
       {
         id: "12"
@@ -52,6 +53,7 @@
         price: 100.0
         pnl: 0.0
         clientOrderId: reentry_boot
+        info: {startPosition: "0.0"}
       }
     ]
   }

--- a/scenarios/fake_live/hsl_long_red_restart.hjson
+++ b/scenarios/fake_live/hsl_long_red_restart.hjson
@@ -29,7 +29,8 @@
       {
         id: "11"
         order: "11"
-        timestamp: "2026-01-01T00:01:00Z"
+        // Distinct timestamps prove the boot flatten/re-entry execution order.
+        timestamp: "2026-01-01T00:00:59.999Z"
         symbol: "BTC/USDT:USDT"
         position_side: long
         side: sell

--- a/scenarios/fake_live/hsl_long_red_restart.hjson
+++ b/scenarios/fake_live/hsl_long_red_restart.hjson
@@ -29,8 +29,7 @@
       {
         id: "11"
         order: "11"
-        // Distinct timestamps prove the boot flatten/re-entry execution order.
-        timestamp: "2026-01-01T00:00:59.999Z"
+        timestamp: "2026-01-01T00:01:00Z"
         symbol: "BTC/USDT:USDT"
         position_side: long
         side: sell
@@ -39,6 +38,7 @@
         pnl: 100.0
         reduceOnly: true
         clientOrderId: initial_take_profit_boot
+        info: {startPosition: "5.0"}
       }
       {
         id: "12"
@@ -51,6 +51,7 @@
         price: 100.0
         pnl: 0.0
         clientOrderId: reentry_boot
+        info: {startPosition: "0.0"}
       }
     ]
   }

--- a/scenarios/fake_live/hsl_long_terminal_no_restart.hjson
+++ b/scenarios/fake_live/hsl_long_terminal_no_restart.hjson
@@ -38,6 +38,7 @@
         pnl: 100.0
         reduceOnly: true
         clientOrderId: initial_take_profit_boot
+        info: {startPosition: "5.0"}
       }
       {
         id: "12"
@@ -50,6 +51,7 @@
         price: 100.0
         pnl: 0.0
         clientOrderId: reentry_boot
+        info: {startPosition: "0.0"}
       }
     ]
   }

--- a/src/exchanges/fake.py
+++ b/src/exchanges/fake.py
@@ -582,6 +582,8 @@ class FakeCCXTClient:
                 "contractMultiplier": self._c_mult(symbol),
             },
         }
+        if "startPosition" in info:
+            boot_fill["info"]["startPosition"] = info["startPosition"]
         self.realized_pnl += float(boot_fill["pnl"])
         self.realized_fees += fee_cost
         self.fills.append(boot_fill)

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -6113,6 +6113,77 @@ class Passivbot:
         await asyncio.sleep(1.0)
         return True
 
+    async def _run_halted_hsl_protection_if_active(self) -> bool:
+        """Protect proven cooldown scopes while unrelated episode evidence is unavailable."""
+        coin_mode = self._equity_hard_stop_signal_mode() == "coin"
+        scopes = []
+        if coin_mode:
+            initialized = bool(getattr(self, "_equity_hard_stop_coin_initialized", False))
+            ready_pairs = getattr(self, "_equity_hard_stop_coin_replay_ready_pairs", set())
+            for pside, states in getattr(self, "_equity_hard_stop_coin", {}).items():
+                for symbol, state in states.items():
+                    if (
+                        state["halted"]
+                        and self._equity_hard_stop_enabled(pside, symbol=symbol)
+                        and (initialized or (pside, symbol) in ready_pairs)
+                    ):
+                        scopes.append((pside, symbol, state))
+        else:
+            scopes = [
+                (pside, None, self._hsl_state(pside))
+                for pside in self._hsl_psides()
+                if self._equity_hard_stop_enabled(pside) and self._hsl_state(pside)["halted"]
+            ]
+        if not scopes:
+            return False
+        if not await self.refresh_protective_authoritative_state():
+            return False
+        now_ms = int(self.get_exchange_time())
+        panic_needed = False
+        for pside, symbol, state in scopes:
+            cooldown_until_ms = state["cooldown_until_ms"]
+            if state["no_restart_latched"] or (
+                not state["cooldown_repanic_reset_pending"]
+                and (cooldown_until_ms is None or now_ms >= cooldown_until_ms)
+            ):
+                continue
+            symbols = [symbol] if coin_mode else self._equity_hard_stop_position_symbols(pside)
+            symbols = [
+                candidate
+                for candidate in symbols
+                if self._equity_hard_stop_has_open_position_symbol(pside, candidate)
+            ]
+            if not symbols:
+                # Fill-confirmed cooldown finalization retains its existing owner.
+                continue
+            if coin_mode:
+                await self._equity_hard_stop_handle_coin_position_during_cooldown(
+                    pside, symbol, now_ms
+                )
+                panic_needed |= bool(
+                    state["halted"]
+                    and self._runtime_forced_modes.get(pside, {}).get(symbol) == "panic"
+                )
+            else:
+                await self._equity_hard_stop_handle_position_during_cooldown(pside, now_ms)
+                panic_needed |= bool(
+                    state["halted"]
+                    and any(
+                        self._equity_hard_stop_halted_mode(pside, item) == "panic"
+                        for item in symbols
+                    )
+                )
+        if not panic_needed:
+            return False
+        # The existing protective planner admits only panic cancels/reduce-only
+        # closes, with its own fresh-account and submit-boundary checks.
+        to_cancel, to_create = await self.calc_protective_panic_orders_to_cancel_and_create()
+        await self.execute_order_plan_to_exchange(to_cancel, to_create, configure_creations=False)
+        await self._sleep_unless_shutdown(
+            float(self.live_value("execution_delay_seconds")), stage="hsl_cooldown_protection"
+        )
+        return True
+
     async def _run_latched_hsl_supervisor_if_active(
         self, *, cycle_id: object, loop_timings_ms: dict[str, int]
     ) -> bool:
@@ -6366,9 +6437,12 @@ class Passivbot:
                             reason_code="hsl_episode_boundaries_unavailable",
                             data={"reason": exc.reason},
                         )
-                        if not await self._run_latched_hsl_supervisor_if_active(
-                            cycle_id=cycle_id,
-                            loop_timings_ms=loop_timings_ms,
+                        if not (
+                            await self._run_halted_hsl_protection_if_active()
+                            or await self._run_latched_hsl_supervisor_if_active(
+                                cycle_id=cycle_id,
+                                loop_timings_ms=loop_timings_ms,
+                            )
                         ):
                             await self._sleep_unless_shutdown(
                                 0.5, stage="hsl_episode_boundaries_retry"

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -6356,7 +6356,24 @@ class Passivbot:
                     )
                     break
                 if self._equity_hard_stop_enabled():
-                    await self._equity_hard_stop_check()
+                    try:
+                        await self._equity_hard_stop_check()
+                    except state_refresh.AuthoritativeSurfaceUnavailable as exc:
+                        if exc.surface != "hsl_episode_boundaries":
+                            raise
+                        self._emit_live_cycle_degraded(
+                            cycle_id=cycle_id,
+                            reason_code="hsl_episode_boundaries_unavailable",
+                            data={"reason": exc.reason},
+                        )
+                        if not await self._run_latched_hsl_supervisor_if_active(
+                            cycle_id=cycle_id,
+                            loop_timings_ms=loop_timings_ms,
+                        ):
+                            await self._sleep_unless_shutdown(
+                                0.5, stage="hsl_episode_boundaries_retry"
+                            )
+                        continue
                     if await self._run_latched_hsl_supervisor_if_active(
                         cycle_id=cycle_id,
                         loop_timings_ms=loop_timings_ms,

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -14439,6 +14439,10 @@ class Passivbot:
                     "c_mult": float(self.c_mults.get(symbol, 1.0)),
                 }
             )
+            if fill.get("raw"):
+                # Exact tied-fill replay requires the exchange's position-chain
+                # evidence, not the locally reconstructed position annotation.
+                out[-1]["raw"] = fill["raw"]
         return sorted(out, key=lambda x: x["timestamp"])
 
     async def get_balance_equity_history(

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -2262,9 +2262,6 @@ class Passivbot:
         pb_hsl._equity_hard_stop_handle_position_during_cooldown
     )
     _equity_hard_stop_reset_after_restart = pb_hsl._equity_hard_stop_reset_after_restart
-    _equity_hard_stop_replay_from_boundary = (
-        pb_hsl._equity_hard_stop_replay_from_boundary
-    )
     _equity_hard_stop_refresh_halted_runtime_forced_modes = (
         pb_hsl._equity_hard_stop_refresh_halted_runtime_forced_modes
     )
@@ -6140,6 +6137,8 @@ class Passivbot:
             return False
         now_ms = int(self.get_exchange_time())
         panic_needed = False
+        cooldown_entry_cancels = []
+        policy = self._equity_hard_stop_cooldown_position_policy()
         for pside, symbol, state in scopes:
             cooldown_until_ms = state["cooldown_until_ms"]
             if state["no_restart_latched"] or (
@@ -6153,10 +6152,7 @@ class Passivbot:
                 for candidate in symbols
                 if self._equity_hard_stop_has_open_position_symbol(pside, candidate)
             ]
-            if not symbols:
-                # Fill-confirmed cooldown finalization retains its existing owner.
-                continue
-            if coin_mode:
+            if symbols and coin_mode:
                 await self._equity_hard_stop_handle_coin_position_during_cooldown(
                     pside, symbol, now_ms
                 )
@@ -6164,7 +6160,7 @@ class Passivbot:
                     state["halted"]
                     and self._runtime_forced_modes.get(pside, {}).get(symbol) == "panic"
                 )
-            else:
+            elif symbols:
                 await self._equity_hard_stop_handle_position_during_cooldown(pside, now_ms)
                 panic_needed |= bool(
                     state["halted"]
@@ -6173,11 +6169,46 @@ class Passivbot:
                         for item in symbols
                     )
                 )
-        if not panic_needed:
+            # Flat cooldown scopes still prohibit initials. Held normal scopes
+            # may have resumed above; graceful_stop preserves their existing adds.
+            if not state["halted"]:
+                continue
+            if policy == "manual" and pb_hsl._equity_hard_stop_manual_cooldown_intervention(
+                self, pside, symbol=symbol
+            ) is not False:
+                # Only complete fill evidence proving no intervention permits
+                # cancellation; manual ownership or unavailable evidence preserves orders.
+                continue
+            for order_symbol, orders in self.open_orders.items():
+                if coin_mode and order_symbol != symbol:
+                    continue
+                if (
+                    policy in {"normal", "graceful_stop"}
+                    and not state["cooldown_unresolved_residue"]
+                    and self._equity_hard_stop_has_open_position_symbol(pside, order_symbol)
+                ):
+                    continue
+                cooldown_entry_cancels.extend(
+                    dict(order)
+                    for order in orders
+                    if order.get("position_side") == pside
+                    and self._canonical_open_order_reduce_only(order) is False
+                )
+        if not panic_needed and not cooldown_entry_cancels:
             return False
-        # The existing protective planner admits only panic cancels/reduce-only
-        # closes, with its own fresh-account and submit-boundary checks.
-        to_cancel, to_create = await self.calc_protective_panic_orders_to_cancel_and_create()
+        # Only the existing panic planner can produce protective closes. A
+        # cancellation-only wave must not construct or freshen ordinary intent.
+        to_cancel, to_create = (
+            await self.calc_protective_panic_orders_to_cancel_and_create()
+            if panic_needed
+            else ([], [])
+        )
+        cancel_keys = {(order["symbol"], order["id"]) for order in to_cancel}
+        for order in cooldown_entry_cancels:
+            key = (order["symbol"], order["id"])
+            if key not in cancel_keys:
+                to_cancel.append(order)
+                cancel_keys.add(key)
         await self.execute_order_plan_to_exchange(to_cancel, to_create, configure_creations=False)
         await self._sleep_unless_shutdown(
             float(self.live_value("execution_delay_seconds")), stage="hsl_cooldown_protection"

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -6139,9 +6139,44 @@ class Passivbot:
         panic_needed = False
         cooldown_entry_cancels = []
         policy = self._equity_hard_stop_cooldown_position_policy()
+        if policy == "manual" and any(
+            not state["no_restart_latched"]
+            and (
+                state["cooldown_repanic_reset_pending"]
+                or (state["cooldown_until_ms"] is not None and now_ms < state["cooldown_until_ms"])
+            )
+            and any(
+                order.get("position_side") == pside
+                and self._canonical_open_order_reduce_only(order) is False
+                for order_symbol, orders in self.open_orders.items()
+                if symbol is None or order_symbol == symbol
+                for order in orders
+            )
+            and pb_hsl._equity_hard_stop_manual_cooldown_intervention(
+                self, pside, symbol=symbol
+            ) is None
+            for pside, symbol, state in scopes
+        ):
+            # Absence needs a successful fill tail after the account observation.
+            # A failed/degraded refresh leaves the proof unknown; it must not
+            # suppress independently ready protection in other scopes.
+            ledger = getattr(self, "freshness_ledger", None)
+            epoch = int(getattr(ledger, "epoch", 0))
+            generation = int(getattr(self, "_account_invalidation_generation", 0) or 0)
+            await self.update_pnls(source="hsl_cooldown_protection")
+            pending = getattr(self, "_authoritative_pending_confirmations", {})
+            if (
+                int(getattr(ledger, "epoch", 0)) != epoch
+                or int(getattr(self, "_account_invalidation_generation", 0) or 0) != generation
+                or any(int(pending.get(surface, 0)) > epoch for surface in ACCOUNT_SURFACES)
+            ):
+                if not await self.refresh_protective_authoritative_state():
+                    return False
+            now_ms = int(self.get_exchange_time())
         for pside, symbol, state in scopes:
             cooldown_until_ms = state["cooldown_until_ms"]
-            if state["no_restart_latched"] or (
+            terminal = bool(state["no_restart_latched"])
+            if not terminal and (
                 not state["cooldown_repanic_reset_pending"]
                 and (cooldown_until_ms is None or now_ms >= cooldown_until_ms)
             ):
@@ -6152,7 +6187,7 @@ class Passivbot:
                 for candidate in symbols
                 if self._equity_hard_stop_has_open_position_symbol(pside, candidate)
             ]
-            if symbols and coin_mode:
+            if symbols and coin_mode and not terminal:
                 await self._equity_hard_stop_handle_coin_position_during_cooldown(
                     pside, symbol, now_ms
                 )
@@ -6160,7 +6195,7 @@ class Passivbot:
                     state["halted"]
                     and self._runtime_forced_modes.get(pside, {}).get(symbol) == "panic"
                 )
-            elif symbols:
+            elif symbols and not terminal:
                 await self._equity_hard_stop_handle_position_during_cooldown(pside, now_ms)
                 panic_needed |= bool(
                     state["halted"]
@@ -6172,10 +6207,22 @@ class Passivbot:
             # Flat cooldown scopes still prohibit initials. Held normal scopes
             # may have resumed above; graceful_stop preserves their existing adds.
             if not state["halted"]:
+                # Canonical restart may already prove RED in the new episode.
+                # Keep that current risk in this wave even when another scope
+                # supplies cancellation-only work.
+                panic_needed |= bool(
+                    symbols
+                    and state["runtime"].red_latched()
+                    and (state["last_metrics"] or {}).get("red_active_now", False)
+                )
                 continue
-            if policy == "manual" and pb_hsl._equity_hard_stop_manual_cooldown_intervention(
-                self, pside, symbol=symbol
-            ) is not False:
+            if (
+                not terminal
+                and policy == "manual"
+                and pb_hsl._equity_hard_stop_manual_cooldown_intervention(
+                    self, pside, symbol=symbol
+                ) is not False
+            ):
                 # Only complete fill evidence proving no intervention permits
                 # cancellation; manual ownership or unavailable evidence preserves orders.
                 continue
@@ -6183,7 +6230,8 @@ class Passivbot:
                 if coin_mode and order_symbol != symbol:
                     continue
                 if (
-                    policy in {"normal", "graceful_stop"}
+                    not terminal
+                    and policy in {"normal", "graceful_stop"}
                     and not state["cooldown_unresolved_residue"]
                     and self._equity_hard_stop_has_open_position_symbol(pside, order_symbol)
                 ):

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -799,6 +799,127 @@ def _equity_hard_stop_replay_marker_confirms_red(metrics: dict) -> bool:
     )
 
 
+def _equity_hard_stop_intervention_entry_timestamp(
+    fill_events: Iterable[Any],
+    *,
+    psides: set[str],
+    stop_ms: int,
+    cooldown_until_ms: Optional[int],
+    symbol: Optional[str] = None,
+) -> Optional[int]:
+    """Find the first canonical non-panic increase after a particular stop."""
+    timestamps = []
+    for event in fill_events:
+        if _equity_hard_stop_fill_pside_optional(event) not in psides:
+            continue
+        if symbol is not None and _equity_hard_stop_fill_symbol(event) != symbol:
+            continue
+        timestamp = _equity_hard_stop_fill_timestamp_ms(event)
+        if timestamp <= stop_ms or (
+            cooldown_until_ms is not None and timestamp >= cooldown_until_ms
+        ):
+            continue
+        if _equity_hard_stop_fill_action(event) == "increase" and "panic" not in str(
+            _equity_hard_stop_event_value(event, "pb_order_type", "")
+        ):
+            timestamps.append(timestamp)
+    return min(timestamps, default=None)
+
+
+def _equity_hard_stop_manual_cooldown_intervention(
+    self,
+    pside: str,
+    symbol: Optional[str] = None,
+) -> Optional[bool]:
+    """Prove manual ownership from the current stop's fills, or return unknown.
+
+    A positive entry survives subsequent flattening and stale recent history.
+    Absence requires complete history through the protective account observation;
+    historical lookback coverage alone does not prove the recent fill tail.
+    """
+    state = self._hsl_coin_state(pside, symbol) if symbol is not None else self._hsl_state(pside)
+    stop = state.get("last_stop_event")
+    if not isinstance(stop, dict):
+        return None
+    try:
+        stop_ms = int(stop["stop_event_timestamp_ms"])
+        end_ms = int(state["cooldown_until_ms"])
+    except (KeyError, TypeError, ValueError, OverflowError):
+        return None
+    now_ms = int(self.get_exchange_time())
+    if stop_ms <= 0 or not stop_ms < now_ms < end_ms:
+        return None
+    manager = getattr(self, "_pnls_manager", None)
+    get_events = getattr(manager, "get_events", None)
+    if not callable(get_events):
+        return None
+    psides = {"long", "short"} if _equity_hard_stop_signal_mode(self) == "unified" else {pside}
+    scoped = []
+    ambiguous = False
+    stop_fill_seen = False
+    for event in get_events():
+        event_pside = _equity_hard_stop_fill_pside_optional(event)
+        event_symbol = _equity_hard_stop_fill_symbol(event)
+        if event_pside is not None and event_pside not in psides:
+            continue
+        if symbol is not None and event_symbol and event_symbol != symbol:
+            continue
+        try:
+            timestamp = _equity_hard_stop_fill_timestamp_ms(event)
+        except (TypeError, ValueError, OverflowError):
+            ambiguous = True
+            continue
+        if timestamp <= 0:
+            ambiguous = True
+            continue
+        if timestamp < stop_ms or timestamp > now_ms or timestamp >= end_ms:
+            continue
+        action = _equity_hard_stop_fill_action(event)
+        qty = _equity_hard_stop_fill_replay_qty(event)
+        if event_pside is None or not event_symbol or action == "" or qty is None or qty <= 0.0:
+            ambiguous = True
+            continue
+        if timestamp == stop_ms:
+            # A timestamp-only stop cannot order an increase tied with its close.
+            ambiguous |= action == "increase"
+            stop_fill_seen |= action == "decrease"
+            continue
+        scoped.append(event)
+    if not stop_fill_seen:
+        return None
+    if (
+        _equity_hard_stop_intervention_entry_timestamp(
+            scoped,
+            psides=psides,
+            stop_ms=stop_ms,
+            cooldown_until_ms=end_ms,
+            symbol=symbol,
+        )
+        is not None
+    ):
+        return True
+    if ambiguous:
+        return None
+    coverage = getattr(manager, "get_coverage_status", None)
+    if not callable(coverage) or not coverage(start_ms=stop_ms, end_ms=now_ms).get("ready", False):
+        return None
+    ledger = getattr(self, "freshness_ledger", None)
+    if ledger is None or not {"positions", "open_orders"}.issubset(ledger.surfaces_at_epoch()):
+        return None
+    observation_ms = max(ledger.surface_updated_ms(name) for name in ("positions", "open_orders"))
+    cache = getattr(manager, "cache", None)
+    load_metadata = getattr(cache, "load_metadata", None)
+    if observation_ms <= 0 or not callable(load_metadata):
+        return None
+    # Both values use the local clock. The cache watermark records only a
+    # successful open-ended exchange refresh, never loading/local enrichment.
+    try:
+        refreshed_ms = int(load_metadata().get("last_refresh_ms", 0) or 0)
+    except (TypeError, ValueError, OverflowError):
+        return None
+    return False if refreshed_ms >= observation_ms else None
+
+
 def _equity_hard_stop_infer_replay_contract(
     self, pside: str, fill_events: list[dict], now_ms: int
 ) -> dict[str, Any]:
@@ -820,21 +941,12 @@ def _equity_hard_stop_infer_replay_contract(
         if latest_panic_ts is None or cooldown_ms <= 0
         else int(latest_panic_ts + cooldown_ms)
     )
-    intervention_entry_ts = None
-    if latest_panic_ts is not None:
-        for evt in fill_events:
-            if not isinstance(evt, dict):
-                continue
-            if str(evt.get("pside") or "").lower() != pside:
-                continue
-            evt_ts = int(evt["timestamp"])
-            if evt_ts <= latest_panic_ts:
-                continue
-            if cooldown_until_ms is not None and evt_ts >= cooldown_until_ms:
-                break
-            if evt.get("action") == "increase" and "panic" not in str(evt.get("pb_order_type") or ""):
-                intervention_entry_ts = evt_ts
-                break
+    intervention_entry_ts = (
+        None if latest_panic_ts is None else _equity_hard_stop_intervention_entry_timestamp(
+            fill_events, psides={pside}, stop_ms=latest_panic_ts,
+            cooldown_until_ms=cooldown_until_ms,
+        )
+    )
     active_cooldown_now = cooldown_until_ms is not None and now_ms < cooldown_until_ms
     unresolved_residue = bool(active_cooldown_now and pos_now and intervention_entry_ts is None)
     intervention_active = bool(active_cooldown_now and pos_now and intervention_entry_ts is not None)
@@ -880,23 +992,12 @@ def _equity_hard_stop_infer_coin_replay_contract(
         if latest_panic_ts is None or cooldown_ms <= 0
         else int(latest_panic_ts + cooldown_ms)
     )
-    intervention_entry_ts = None
-    if latest_panic_ts is not None:
-        for evt in fill_events:
-            if not isinstance(evt, dict):
-                continue
-            if str(evt.get("pside") or evt.get("position_side") or "").lower() != pside:
-                continue
-            if _equity_hard_stop_fill_symbol(evt) != symbol:
-                continue
-            evt_ts = int(evt["timestamp"])
-            if evt_ts <= latest_panic_ts:
-                continue
-            if cooldown_until_ms is not None and evt_ts >= cooldown_until_ms:
-                break
-            if evt.get("action") == "increase" and "panic" not in str(evt.get("pb_order_type") or ""):
-                intervention_entry_ts = evt_ts
-                break
+    intervention_entry_ts = (
+        None if latest_panic_ts is None else _equity_hard_stop_intervention_entry_timestamp(
+            fill_events, psides={pside}, stop_ms=latest_panic_ts,
+            cooldown_until_ms=cooldown_until_ms, symbol=symbol,
+        )
+    )
     active_cooldown_now = cooldown_until_ms is not None and now_ms < cooldown_until_ms
     unresolved_residue = bool(active_cooldown_now and pos_now and intervention_entry_ts is None)
     intervention_active = bool(active_cooldown_now and pos_now and intervention_entry_ts is not None)
@@ -3188,49 +3289,6 @@ def _equity_hard_stop_reset_after_restart(self, pside: str) -> None:
     self._equity_hard_stop_clear_runtime_forced_modes(pside)
 
 
-def _equity_hard_stop_replay_from_boundary(
-    self, pside: str, timeline: list[dict], signal_mode: str, boundary_ts: int, end_ts: int
-) -> int:
-    n_rows = 0
-    boundary_minute_ts = int(math.floor(int(boundary_ts) / 60_000.0) * 60_000)
-    for row in timeline:
-        if not isinstance(row, dict):
-            continue
-        required = ("timestamp", "balance", "realized_pnl")
-        if signal_mode == "pside":
-            required += (f"realized_pnl_{pside}", f"unrealized_pnl_{pside}")
-        else:
-            required += ("unrealized_pnl_long", "unrealized_pnl_short")
-        if any(key not in row for key in required):
-            continue
-        ts = int(row["timestamp"])
-        if ts < boundary_minute_ts:
-            continue
-        if ts > int(end_ts):
-            break
-        row_upnl_total = (
-            float(row["unrealized_pnl_long"]) + float(row["unrealized_pnl_short"])
-            if signal_mode == "unified"
-            else None
-        )
-        row_realized_pside = float(row[f"realized_pnl_{pside}"]) if signal_mode == "pside" else 0.0
-        row_unrealized_pside = (
-            float(row[f"unrealized_pnl_{pside}"]) if signal_mode == "pside" else 0.0
-        )
-        self._equity_hard_stop_apply_sample(
-            pside,
-            ts,
-            float(row["balance"]),
-            float(row["realized_pnl"]),
-            row_realized_pside,
-            row_unrealized_pside,
-            unrealized_pnl_total=row_upnl_total,
-            latch_red=False,
-        )
-        n_rows += 1
-    return n_rows
-
-
 def _equity_hard_stop_refresh_halted_runtime_forced_modes(self) -> None:
     symbols = set(self.positions.keys()) | set(self.open_orders.keys()) | set(self.active_symbols)
     for pside in self._hsl_psides():
@@ -3613,46 +3671,38 @@ async def _equity_hard_stop_initialize_from_history(self) -> None:
                 continue
             state = self._hsl_state(pside)
             contract = replay_contracts[pside]
+            replay_timeline = timeline
+            scope_boundaries = scope_boundaries_by_pside[pside]
+            ignored_panic_marker_timestamps: set[int] = set()
             if contract["intervention_entry_ts"] is not None and contract["policy"] == "normal":
+                entry_ts = int(contract["intervention_entry_ts"])
                 self._equity_hard_stop_reset_after_restart(pside)
-                n_rows[pside] = self._equity_hard_stop_replay_from_boundary(
-                    pside,
-                    timeline,
-                    signal_mode,
-                    int(contract["intervention_entry_ts"]),
-                    now_ms,
+                # Normal intervention starts a new replay window, but every
+                # later exact flatten still uses the canonical episode loop.
+                # Minute rows represent the minute's final state; pre-entry
+                # fill boundaries and panic markers must not enter that window.
+                replay_timeline = [
+                    row for row in timeline
+                    if isinstance(row, dict)
+                    and "timestamp" in row
+                    and int(row["timestamp"]) >= entry_ts // 60_000 * 60_000
+                ]
+                scope_boundaries = [
+                    row for row in scope_boundaries if int(row["timestamp"]) >= entry_ts
+                ]
+                ignored_panic_marker_timestamps.update(
+                    int(marker["timestamp"])
+                    for (marker_pside, _), marker in panic_flatten_events_by_key.items()
+                    if marker_pside == pside and int(marker["timestamp"]) < entry_ts
                 )
+                if contract["latest_panic_ts"] is not None:
+                    ignored_panic_marker_timestamps.add(int(contract["latest_panic_ts"]))
                 self._equity_hard_stop_remove_latch_file(pside)
                 logging.critical(
                     "[risk] HSL[%s] reconstructed operator override during RED cooldown from exchange-derived history | entry_ts=%s policy=normal",
                     pside,
-                    int(contract["intervention_entry_ts"]),
+                    entry_ts,
                 )
-                current_metrics = self._equity_hard_stop_apply_sample(
-                    pside,
-                    now_ms,
-                    current_balance,
-                    current_realized_total,
-                    float(self._equity_hard_stop_realized_pnl_now(pside)),
-                    current_upnl_by_pside[pside],
-                    unrealized_pnl_total=current_upnl_total,
-                )
-                logging.info(
-                    "[risk] HSL[%s] initialized from equity history | rows=%d tier=%s strategy_equity=%.6f peak_strategy_equity=%.6f rolling_peak_strategy_equity=%.6f drawdown_raw=%.6f drawdown_ema=%.6f drawdown_score=%.6f",
-                    pside,
-                    n_rows[pside],
-                    current_metrics["tier"],
-                    current_metrics["strategy_equity"],
-                    current_metrics["peak_strategy_equity"],
-                    current_metrics["rolling_peak_strategy_equity"],
-                    current_metrics["drawdown_raw"],
-                    current_metrics["drawdown_ema"],
-                    current_metrics["drawdown_score"],
-                )
-                if current_metrics["tier"] == "red":
-                    state["pending_red_since_ms"] = int(current_metrics["timestamp_ms"])
-                continue
-            ignored_panic_marker_timestamps: set[int] = set()
             scope_flat_key = "is_flat" if signal_mode == "unified" else f"is_flat_{pside}"
             scope_fill_ts = sorted(
                 _equity_hard_stop_fill_timestamp_ms(fill)
@@ -3660,10 +3710,9 @@ async def _equity_hard_stop_initialize_from_history(self) -> None:
                 if signal_mode == "unified"
                 or _equity_hard_stop_fill_pside(fill) == pside
             )
-            scope_boundaries = scope_boundaries_by_pside[pside]
             scope_was_nonflat = False
             prev_recorded_ts: Optional[int] = None
-            for row in _equity_hard_stop_scope_replay_rows(timeline, scope_boundaries):
+            for row in _equity_hard_stop_scope_replay_rows(replay_timeline, scope_boundaries):
                 if not isinstance(row, dict):
                     continue
                 required = ("timestamp", "balance", "realized_pnl")

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -9,6 +9,7 @@ import os
 import time
 import traceback
 from collections import deque
+from itertools import groupby
 from typing import Any, Iterable, Optional
 
 import passivbot_rust as pbr
@@ -25,7 +26,12 @@ from config.coerce import (
     normalize_hsl_signal_mode,
 )
 from config.pnl_lookback import parse_pnls_max_lookback_days
-from fill_events_manager import signed_fee_paid_from_payload
+from fill_events_manager import (
+    signed_fee_paid_from_payload,
+    _hyperliquid_fill_position_chain,
+    _unique_position_chain_order,
+)
+from live.state_refresh import AuthoritativeSurfaceUnavailable
 from live.diagnostic_safety import bounded_exception_type as _bounded_hsl_exception_type
 from live.event_bus import EventTypes, ReasonCodes, live_event_debug_profile_enabled
 from passivbot_exceptions import FatalBotException, RestartBotException
@@ -1532,6 +1538,7 @@ def _equity_hard_stop_apply_sample(
     unrealized_pnl_total: Optional[float] = None,
     *,
     latch_red: bool = True,
+    at_fill_boundary: bool = False,
 ) -> dict:
     if not math.isfinite(balance) or balance <= 0.0:
         raise ValueError(f"balance must be finite and > 0, got {balance}")
@@ -1566,7 +1573,7 @@ def _equity_hard_stop_apply_sample(
             and str(last_metrics.get("tier")) == "red"
             and not self._equity_hard_stop_runtime_red_latched(pside)
         )
-        if same_inputs and not needs_latching_replay_red:
+        if same_inputs and not needs_latching_replay_red and not at_fill_boundary:
             cached = dict(last_metrics)
             cached["changed"] = False
             cached["elapsed_minutes"] = 0
@@ -1602,6 +1609,7 @@ def _equity_hard_stop_apply_sample(
         tier_ratio_yellow=ratio_yellow,
         tier_ratio_orange=ratio_orange,
         latch_red=bool(latch_red),
+        at_fill_boundary=bool(at_fill_boundary),
     )
     if not isinstance(step, dict):
         raise TypeError(
@@ -1648,6 +1656,7 @@ def _equity_hard_stop_apply_coin_sample(
     current_upnl: float,
     *,
     latch_red: bool = True,
+    at_fill_boundary: bool = False,
 ) -> dict:
     peak_realized, last_realized = self._equity_hard_stop_coin_realized_pnl_peak_last(
         pside,
@@ -1664,6 +1673,7 @@ def _equity_hard_stop_apply_coin_sample(
         last_realized,
         current_upnl,
         latch_red=latch_red,
+        at_fill_boundary=at_fill_boundary,
     )
 
 
@@ -1678,6 +1688,7 @@ def _equity_hard_stop_apply_coin_metrics_sample(
     current_upnl: float,
     *,
     latch_red: bool = True,
+    at_fill_boundary: bool = False,
 ) -> dict:
     if not math.isfinite(balance) or balance <= 0.0:
         raise ValueError(f"balance must be finite and > 0, got {balance}")
@@ -1735,7 +1746,7 @@ def _equity_hard_stop_apply_coin_metrics_sample(
             and str(last_metrics.get("tier")) == "red"
             and not bool(state["runtime"].red_latched())
         )
-        if same_inputs and not needs_latching_replay_red:
+        if same_inputs and not needs_latching_replay_red and not at_fill_boundary:
             cached = dict(last_metrics)
             cached["changed"] = False
             cached["elapsed_minutes"] = 0
@@ -1752,6 +1763,7 @@ def _equity_hard_stop_apply_coin_metrics_sample(
         tier_ratio_yellow=ratio_yellow,
         tier_ratio_orange=ratio_orange,
         latch_red=bool(latch_red),
+        at_fill_boundary=bool(at_fill_boundary),
     )
     if not isinstance(step, dict):
         raise TypeError(
@@ -1984,11 +1996,75 @@ def _hsl_compact_sparse_replay_indices(
     return np.flatnonzero(selected).astype(np.int64)
 
 
+def _equity_hard_stop_order_fill_cohorts(fill_events):
+    """Order tied mixed-action fills only with exchange-provided position chains."""
+    ordered = []
+    ambiguous = False
+    known_sizes = {}
+    for _ts, cohort_iter in groupby(
+        sorted(fill_events, key=_equity_hard_stop_fill_timestamp_ms),
+        key=_equity_hard_stop_fill_timestamp_ms,
+    ):
+        cohort = list(cohort_iter)
+        actions = {_equity_hard_stop_fill_action(event) for event in cohort}
+        if len(cohort) > 1 and actions == {"increase", "decrease"}:
+            pairs = {
+                (_equity_hard_stop_fill_pside_optional(event), _equity_hard_stop_fill_symbol(event))
+                for event in cohort
+            }
+            chains = [
+                _hyperliquid_fill_position_chain(event if isinstance(event, dict) else vars(event))
+                for event in cohort
+            ]
+            chain_order = (
+                _unique_position_chain_order(chains)
+                if len(pairs) == 1 and all(chain is not None for chain in chains)
+                else None
+            )
+            if (
+                chain_order is None
+                and len(pairs) == 1
+                and all(chain is not None for chain in chains)
+            ):
+                pair = next(iter(pairs))
+                if pair in known_sizes:
+                    # An extra graph edge anchors a cycle to the independently
+                    # reconstructed pre-cohort size; it is not a synthetic fill.
+                    anchored = _unique_position_chain_order([(-1.0, known_sizes[pair]), *chains])
+                    if anchored is not None and anchored[0] == 0:
+                        chain_order = [index - 1 for index in anchored[1:]]
+            if chain_order is None:
+                ambiguous = True
+            else:
+                cohort = [cohort[index] for index in chain_order]
+        ordered.extend(cohort)
+        for event in cohort:
+            pair = (
+                _equity_hard_stop_fill_pside_optional(event),
+                _equity_hard_stop_fill_symbol(event),
+            )
+            action = _equity_hard_stop_fill_action(event)
+            qty = _equity_hard_stop_fill_replay_qty(event)
+            if qty is None or action not in {"increase", "decrease"}:
+                known_sizes.pop(pair, None)
+                continue
+            size = known_sizes.get(pair, 0.0)
+            if action == "decrease" and qty > size:
+                known_sizes.pop(pair, None)
+            else:
+                known_sizes[pair] = size + qty if action == "increase" else size - qty
+    return ordered, ambiguous
+
+
 def _equity_hard_stop_coin_replay_events(
     fill_events: list[Any], pside: str, symbol: str, *, qty_step: float = 0.0
 ) -> tuple[list[tuple[int, str, float, float]], bool]:
     replay_events: list[tuple[int, str, float, float]] = []
-    ambiguous = False
+    fill_events, ambiguous = _equity_hard_stop_order_fill_cohorts([
+        event for event in fill_events
+        if _equity_hard_stop_fill_pside(event) == pside
+        and _equity_hard_stop_fill_symbol(event) == symbol
+    ])
     replay_size = 0.0
     flat_epsilon = _hsl_flat_epsilon(qty_step)
     for event in fill_events:
@@ -3161,15 +3237,27 @@ def _equity_hard_stop_scope_flatten_samples(
     balance,
     realized_total,
     realized_by_pside,
-) -> list[dict]:
+) -> Optional[list[dict]]:
     """Reconstruct exact scope-flat samples from a complete, position-matching fill tape."""
     events = sorted(
-        (
-            event
-            for event in fill_events
-            if _equity_hard_stop_fill_timestamp_ms(event) <= now_ms
-        ),
+        (event for event in fill_events if _equity_hard_stop_fill_timestamp_ms(event) <= now_ms),
         key=_equity_hard_stop_fill_timestamp_ms,
+    )
+    scoped_events = [
+        event
+        for event in events
+        if signal_mode == "unified" or _equity_hard_stop_fill_pside_optional(event) == pside
+    ]
+    ordered_scope, ambiguous = _equity_hard_stop_order_fill_cohorts(scoped_events)
+    if ambiguous:
+        return None
+    # Keep account-wide PnL ordering consistent with the proven scoped chain.
+    scope_order = {id(event): index for index, event in enumerate(ordered_scope)}
+    events.sort(
+        key=lambda event: (
+            _equity_hard_stop_fill_timestamp_ms(event),
+            scope_order.get(id(event), -1),
+        )
     )
     deltas = [
         float(_equity_hard_stop_event_value(event, "pnl", 0.0) or 0.0)
@@ -3207,13 +3295,13 @@ def _equity_hard_stop_scope_flatten_samples(
             or qty is None
             or qty <= 0.0
         ):
-            return []
+            return None
         pair = (side, symbol)
         epsilon = _hsl_flat_epsilon(_hsl_qty_step_for_symbol(self, symbol))
         size = sizes.get(pair, 0.0)
         was_nonflat = nonflat_pairs > 0
         if action == "decrease" and qty > size + epsilon:
-            return []
+            return None
         next_size = size + qty if action == "increase" else max(0.0, size - qty)
         sizes[pair] = 0.0 if next_size <= epsilon else next_size
         nonflat_pairs += int(sizes[pair] > 0.0) - int(size > 0.0)
@@ -3226,8 +3314,7 @@ def _equity_hard_stop_scope_flatten_samples(
             }
             for sample_side in self._hsl_psides():
                 sample[f"realized_pnl_{sample_side}"] = (
-                    float(realized_by_pside[sample_side])
-                    - remaining_by_pside[sample_side]
+                    float(realized_by_pside[sample_side]) - remaining_by_pside[sample_side]
                 )
                 if signal_mode == "unified" or sample_side == pside:
                     sample[f"unrealized_pnl_{sample_side}"] = 0.0
@@ -3242,22 +3329,18 @@ def _equity_hard_stop_scope_flatten_samples(
         epsilon = _hsl_flat_epsilon(_hsl_qty_step_for_symbol(self, pair[1]))
         actual = current_sizes.get(pair, 0.0)
         if abs(sizes.get(pair, 0.0) - actual) > max(epsilon, actual * 1e-12):
-            return []
+            return None
     return samples
 
 
 def _equity_hard_stop_scope_replay_rows(timeline, boundaries):
     """Place exact fill boundaries before their minute's final price sample."""
-    valid_rows = [
-        row for row in timeline if isinstance(row, dict) and "timestamp" in row
-    ]
+    valid_rows = [row for row in timeline if isinstance(row, dict) and "timestamp" in row]
     if not valid_rows:
         yield from timeline
         return
     first_minute = int(valid_rows[0]["timestamp"]) // 60_000
-    boundaries = [
-        row for row in boundaries if int(row["timestamp"]) // 60_000 >= first_minute
-    ]
+    boundaries = [row for row in boundaries if int(row["timestamp"]) // 60_000 >= first_minute]
     cursor = 0
     for row in timeline:
         if not isinstance(row, dict) or "timestamp" not in row:
@@ -3265,18 +3348,14 @@ def _equity_hard_stop_scope_replay_rows(timeline, boundaries):
             continue
         minute = int(row["timestamp"]) // 60_000
         last_boundary = None
-        while (
-            cursor < len(boundaries)
-            and int(boundaries[cursor]["timestamp"]) // 60_000 <= minute
-        ):
+        while cursor < len(boundaries) and int(boundaries[cursor]["timestamp"]) // 60_000 <= minute:
             last_boundary = boundaries[cursor]
             cursor += 1
             yield last_boundary
         if last_boundary is not None:
             row = dict(row)
-            row["timestamp"] = max(
-                int(row["timestamp"]), int(last_boundary["timestamp"]) + 1
-            )
+            row["_hsl_source_minute_timestamp"] = int(row["timestamp"])
+            row["timestamp"] = max(int(row["timestamp"]), int(last_boundary["timestamp"]) + 1)
         yield row
     yield from boundaries[cursor:]
 
@@ -3306,8 +3385,7 @@ async def _equity_hard_stop_refresh_live_scope_episode_boundaries(self, ts_ms, b
     signal_mode = self._equity_hard_stop_signal_mode()
     realized_total = self._equity_hard_stop_realized_pnl_now()
     realized_by_pside = {
-        side: self._equity_hard_stop_realized_pnl_now(side)
-        for side in self._hsl_psides()
+        side: self._equity_hard_stop_realized_pnl_now(side) for side in self._hsl_psides()
     }
     for pside in self._hsl_psides():
         state = self._hsl_state(pside)
@@ -3328,6 +3406,10 @@ async def _equity_hard_stop_refresh_live_scope_episode_boundaries(self, ts_ms, b
             realized_total,
             realized_by_pside,
         )
+        if boundaries is None:
+            raise AuthoritativeSurfaceUnavailable(
+                "hsl_episode_boundaries", f"{pside} fill tape cannot prove episode boundaries"
+            )
         reset_ts = state.get("pnl_reset_timestamp_ms")
         for row in boundaries:
             boundary_ts = int(row["timestamp"])
@@ -3344,6 +3426,7 @@ async def _equity_hard_stop_refresh_live_scope_episode_boundaries(self, ts_ms, b
                 float(row[f"realized_pnl_{pside}"]),
                 0.0,
                 unrealized_pnl_total=0.0 if signal_mode == "unified" else None,
+                at_fill_boundary=True,
             )
             if metrics["red_seen_in_episode"]:
                 await self._equity_hard_stop_initialize_from_history()
@@ -3505,7 +3588,7 @@ async def _equity_hard_stop_initialize_from_history(self) -> None:
             )
             scope_was_nonflat = False
             prev_recorded_ts: Optional[int] = None
-            for row in _equity_hard_stop_scope_replay_rows(timeline, scope_boundaries):
+            for row in _equity_hard_stop_scope_replay_rows(timeline, scope_boundaries or []):
                 if not isinstance(row, dict):
                     continue
                 required = ("timestamp", "balance", "realized_pnl")
@@ -3540,6 +3623,7 @@ async def _equity_hard_stop_initialize_from_history(self) -> None:
                     row_unrealized_pside,
                     unrealized_pnl_total=row_upnl_total,
                     latch_red=False,
+                    at_fill_boundary=bool(row.get("_hsl_scope_flatten_fill")),
                 )
                 n_rows[pside] += 1
                 row_flat = row.get(scope_flat_key)
@@ -3553,7 +3637,18 @@ async def _equity_hard_stop_initialize_from_history(self) -> None:
                     scope_was_nonflat = not row_flat
                 row_prev_recorded_ts = prev_recorded_ts
                 prev_recorded_ts = ts
-                panic_flatten_marker = panic_flatten_events_by_key.get((pside, ts))
+                panic_flatten_marker = panic_flatten_events_by_key.get(
+                    (
+                        pside,
+                        int(row.get(
+                            "_hsl_source_minute_timestamp",
+                            ts // 60_000 * 60_000 if row.get("_hsl_scope_flatten_fill") else ts,
+                        )),
+                    )
+                )
+                if row.get("_hsl_scope_flatten_fill") and panic_flatten_marker is not None:
+                    if int(panic_flatten_marker["timestamp"]) != ts:
+                        panic_flatten_marker = None
                 stop_ts: Optional[int] = None
                 stop_source = "panic_fill_flatten"
                 if panic_flatten_marker is not None:
@@ -3571,9 +3666,9 @@ async def _equity_hard_stop_initialize_from_history(self) -> None:
                             float(current_metrics["drawdown_score"]),
                             float(current_metrics["red_threshold"]),
                         )
-                        continue
-                    stop_ts = marker_ts
-                elif scope_flattened_this_row:
+                    else:
+                        stop_ts = marker_ts
+                if stop_ts is None and scope_flattened_this_row:
                     if bool(current_metrics.get("red_seen_in_episode")):
                         # B2.1: the episode crossed RED and ended by an ordinary
                         # (non-panic) scope-flattening fill; cooldown/no-restart
@@ -4732,6 +4827,7 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                                 window_last_realized,
                                 0.0,
                                 latch_red=False,
+                                at_fill_boundary=True,
                             )
                             applied_rows += 1
                             rows += 1
@@ -4781,6 +4877,10 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                             )
                             state = self._hsl_coin_state(pside, symbol)
                             reset_rolling_window()
+                            self._equity_hard_stop_apply_coin_metrics_sample(
+                                pside, symbol, flatten_ts, boundary_balance,
+                                0.0, 0.0, 0.0, latch_red=False,
+                            )
                             logging.info(
                                 "[risk] HSL[%s:%s] replay reset current episode after flat fill | flat_ts=%s",
                                 pside,
@@ -5611,7 +5711,9 @@ async def _equity_hard_stop_refresh_live_coin_episode_boundaries(
                 scope_events, pside, symbol, qty_step=qty_step
             )
             if ambiguous:
-                continue
+                raise AuthoritativeSurfaceUnavailable(
+                    "hsl_episode_boundaries", f"{pside}:{symbol} fill tape has ambiguous boundaries"
+                )
             epsilon = _hsl_flat_epsilon(qty_step)
             size = 0.0
             boundaries = []
@@ -5623,7 +5725,11 @@ async def _equity_hard_stop_refresh_live_coin_episode_boundaries(
             current_size = abs(
                 float((self.positions or {}).get(symbol, {}).get(pside, {}).get("size", 0.0))
             )
-            if not boundaries or abs(size - current_size) > max(epsilon, current_size * 1e-12):
+            if abs(size - current_size) > max(epsilon, current_size * 1e-12):
+                raise AuthoritativeSurfaceUnavailable(
+                    "hsl_episode_boundaries", f"{pside}:{symbol} fill tape does not match position"
+                )
+            if not boundaries:
                 continue
             for flatten_ts in boundaries:
                 last_sample_ts = int((state["last_metrics"] or {}).get("timestamp_ms", 0))
@@ -5653,7 +5759,7 @@ async def _equity_hard_stop_refresh_live_coin_episode_boundaries(
                     for event in later_events
                 )
                 metrics = self._equity_hard_stop_apply_coin_sample(
-                    pside, symbol, flatten_ts, boundary_balance, 0.0
+                    pside, symbol, flatten_ts, boundary_balance, 0.0, at_fill_boundary=True
                 )
                 if metrics["red_seen_in_episode"]:
                     await self._equity_hard_stop_initialize_coin_from_history()
@@ -5661,7 +5767,10 @@ async def _equity_hard_stop_refresh_live_coin_episode_boundaries(
                 state["pnl_reset_timestamp_ms"] = flatten_ts + 1
                 self._equity_hard_stop_reset_coin_after_restart(pside, symbol)
                 state = self._hsl_coin_state(pside, symbol)
-                self._equity_hard_stop_prime_coin_runtime_for_replay(pside, symbol, flatten_ts + 1)
+                self._equity_hard_stop_apply_coin_metrics_sample(
+                    pside, symbol, flatten_ts, boundary_balance, 0.0, 0.0, 0.0,
+                    latch_red=False,
+                )
                 logging.info(
                     "[risk] HSL[%s:%s] reset current episode after ordinary flat fill | flat_ts=%s",
                     pside,

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -3414,7 +3414,12 @@ def _equity_hard_stop_scope_replay_rows(timeline, boundaries):
         if last_boundary is not None:
             row = dict(row)
             row["_hsl_source_minute_timestamp"] = int(row["timestamp"])
-            row["timestamp"] = max(int(row["timestamp"]), int(last_boundary["timestamp"]) + 1)
+            # A boundary at :59.999 must not consume the following minute's
+            # cache slot before that minute's actual price sample arrives.
+            row["timestamp"] = max(
+                int(row["timestamp"]),
+                min(int(last_boundary["timestamp"]) + 1, (minute + 1) * 60_000 - 1),
+            )
         yield row
     yield from boundaries[cursor:]
 
@@ -3505,7 +3510,6 @@ async def _equity_hard_stop_initialize_from_history(self) -> None:
             phase=prev_phase, stage="equity_hard_stop_initialize_from_history"
         )
     try:
-        self._equity_hard_stop_reset_state()
         signal_mode = self._equity_hard_stop_signal_mode()
         if signal_mode not in ("unified", "pside"):
             raise ValueError(
@@ -3579,6 +3583,30 @@ async def _equity_hard_stop_initialize_from_history(self) -> None:
             pside: float(await self._calc_upnl_sum_strict(pside)) for pside in self._hsl_psides()
         }
         current_upnl_total = float(sum(current_upnl_by_pside.values()))
+        scope_boundaries_by_pside = {}
+        for pside in self._hsl_psides():
+            if not self._equity_hard_stop_enabled(pside):
+                continue
+            boundaries = _equity_hard_stop_scope_flatten_samples(
+                self,
+                fill_events,
+                pside,
+                signal_mode,
+                now_ms,
+                current_balance,
+                current_realized_total,
+                {
+                    side: self._equity_hard_stop_realized_pnl_now(side)
+                    for side in self._hsl_psides()
+                },
+            )
+            if boundaries is None:
+                raise AuthoritativeSurfaceUnavailable(
+                    "hsl_episode_boundaries", f"{pside} fill tape cannot prove episode boundaries"
+                )
+            scope_boundaries_by_pside[pside] = boundaries
+        # Validate every enabled scope before replacing existing protective state.
+        self._equity_hard_stop_reset_state()
         n_rows = {pside: 0 for pside in self._hsl_psides()}
         for pside in self._hsl_psides():
             if not self._equity_hard_stop_enabled(pside):
@@ -3632,22 +3660,10 @@ async def _equity_hard_stop_initialize_from_history(self) -> None:
                 if signal_mode == "unified"
                 or _equity_hard_stop_fill_pside(fill) == pside
             )
-            scope_boundaries = _equity_hard_stop_scope_flatten_samples(
-                self,
-                fill_events,
-                pside,
-                signal_mode,
-                now_ms,
-                current_balance,
-                current_realized_total,
-                {
-                    side: self._equity_hard_stop_realized_pnl_now(side)
-                    for side in self._hsl_psides()
-                },
-            )
+            scope_boundaries = scope_boundaries_by_pside[pside]
             scope_was_nonflat = False
             prev_recorded_ts: Optional[int] = None
-            for row in _equity_hard_stop_scope_replay_rows(timeline, scope_boundaries or []):
+            for row in _equity_hard_stop_scope_replay_rows(timeline, scope_boundaries):
                 if not isinstance(row, dict):
                     continue
                 required = ("timestamp", "balance", "realized_pnl")
@@ -3705,6 +3721,11 @@ async def _equity_hard_stop_initialize_from_history(self) -> None:
                         )),
                     )
                 )
+                if (
+                    panic_flatten_marker is not None
+                    and int(panic_flatten_marker["timestamp"]) in ignored_panic_marker_timestamps
+                ):
+                    panic_flatten_marker = None
                 if row.get("_hsl_scope_flatten_fill") and panic_flatten_marker is not None:
                     if int(panic_flatten_marker["timestamp"]) != ts:
                         panic_flatten_marker = None

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -1487,10 +1487,17 @@ def _equity_hard_stop_coin_realized_pnl_peak_last(
         return 0.0, 0.0
     lookback_ms = self._equity_hard_stop_lookback_ms()
     start_ms = None if lookback_ms is None else int(timestamp_ms) - int(lookback_ms)
+    reset_events = _equity_hard_stop_coin_events_after_reset(
+        self._pnls_manager.get_events(), pside, symbol, reset_timestamp_ms,
+        qty_step=_hsl_qty_step_for_symbol(self, symbol),
+    )
     if reset_timestamp_ms is not None:
-        start_ms = int(reset_timestamp_ms) if start_ms is None else max(start_ms, int(reset_timestamp_ms))
+        reset_start = min(
+            [int(reset_timestamp_ms), *map(_equity_hard_stop_fill_timestamp_ms, reset_events)]
+        )
+        start_ms = reset_start if start_ms is None else max(start_ms, reset_start)
     events = []
-    for event in self._pnls_manager.get_events():
+    for event in reset_events:
         if _equity_hard_stop_fill_pside(event) != pside:
             continue
         if _equity_hard_stop_fill_symbol(event) != symbol:
@@ -2054,6 +2061,58 @@ def _equity_hard_stop_order_fill_cohorts(fill_events):
             else:
                 known_sizes[pair] = size + qty if action == "increase" else size - qty
     return ordered, ambiguous
+
+
+def _equity_hard_stop_coin_events_after_reset(
+    fill_events, pside, symbol, reset_timestamp_ms, *, qty_step=0.0
+):
+    """Retain the proven tail after a flatten, including same-millisecond re-entry."""
+    events = [
+        event
+        for event in fill_events
+        if _equity_hard_stop_fill_pside(event) == pside
+        and _equity_hard_stop_fill_symbol(event) == symbol
+    ]
+    if reset_timestamp_ms is None:
+        return events
+    reset_ts = int(reset_timestamp_ms)
+    boundary_ts = reset_ts - 1
+    cohort = [
+        event for event in events if _equity_hard_stop_fill_timestamp_ms(event) == boundary_ts
+    ]
+    if len(cohort) > 1 and {_equity_hard_stop_fill_action(event) for event in cohort} == {
+        "increase",
+        "decrease",
+    }:
+        ordered, ambiguous = _equity_hard_stop_order_fill_cohorts(events)
+        if ambiguous:
+            raise AuthoritativeSurfaceUnavailable(
+                "hsl_episode_boundaries", f"{pside}:{symbol} reset fill cohort is ambiguous"
+            )
+        size = 0.0
+        last_boundary_index = None
+        epsilon = _hsl_flat_epsilon(qty_step)
+        for index, event in enumerate(ordered):
+            event_ts = _equity_hard_stop_fill_timestamp_ms(event)
+            if event_ts > boundary_ts:
+                break
+            qty = _equity_hard_stop_fill_replay_qty(event)
+            action = _equity_hard_stop_fill_action(event)
+            if qty is None or action not in {"increase", "decrease"}:
+                break
+            previous_size = size
+            if action == "decrease" and qty > size + epsilon:
+                break
+            size = size + qty if action == "increase" else max(0.0, size - qty)
+            if event_ts == boundary_ts and previous_size > epsilon and size <= epsilon:
+                last_boundary_index = index
+        if last_boundary_index is None:
+            raise AuthoritativeSurfaceUnavailable(
+                "hsl_episode_boundaries",
+                f"{pside}:{symbol} reset fill cohort cannot prove flatten",
+            )
+        return ordered[last_boundary_index + 1 :]
+    return [event for event in events if _equity_hard_stop_fill_timestamp_ms(event) >= reset_ts]
 
 
 def _equity_hard_stop_coin_replay_events(
@@ -5701,12 +5760,10 @@ async def _equity_hard_stop_refresh_live_coin_episode_boundaries(
             ):
                 continue
             reset_ts = state.get("pnl_reset_timestamp_ms")
-            scope_events = [
-                event
-                for event in events
-                if reset_ts is None or _equity_hard_stop_fill_timestamp_ms(event) >= int(reset_ts)
-            ]
             qty_step = _hsl_qty_step_for_symbol(self, symbol)
+            scope_events = _equity_hard_stop_coin_events_after_reset(
+                events, pside, symbol, reset_ts, qty_step=qty_step
+            )
             replay, ambiguous = _equity_hard_stop_coin_replay_events(
                 scope_events, pside, symbol, qty_step=qty_step
             )

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -1490,6 +1490,8 @@ def _equity_hard_stop_coin_realized_pnl_peak_last(
         if _equity_hard_stop_fill_symbol(event) != symbol:
             continue
         event_ts = _equity_hard_stop_fill_timestamp_ms(event)
+        if event_ts > int(timestamp_ms):
+            continue
         if start_ms is not None and event_ts < start_ms:
             continue
         events.append(event)
@@ -3150,6 +3152,206 @@ def _hsl_coin_replay_candidate_batches(
     )
 
 
+def _equity_hard_stop_scope_flatten_samples(
+    self,
+    fill_events,
+    pside,
+    signal_mode,
+    now_ms,
+    balance,
+    realized_total,
+    realized_by_pside,
+) -> list[dict]:
+    """Reconstruct exact scope-flat samples from a complete, position-matching fill tape."""
+    events = sorted(
+        (
+            event
+            for event in fill_events
+            if _equity_hard_stop_fill_timestamp_ms(event) <= now_ms
+        ),
+        key=_equity_hard_stop_fill_timestamp_ms,
+    )
+    deltas = [
+        float(_equity_hard_stop_event_value(event, "pnl", 0.0) or 0.0)
+        + _equity_hard_stop_fee_cost(event)
+        for event in events
+    ]
+    if not all(math.isfinite(delta) for delta in deltas):
+        raise ValueError("HSL scope replay requires finite realized PnL and fees")
+    remaining_total = sum(deltas)
+    remaining_by_pside = {
+        side: sum(
+            delta
+            for event, delta in zip(events, deltas)
+            if _equity_hard_stop_fill_pside_optional(event) == side
+        )
+        for side in self._hsl_psides()
+    }
+    sizes = {}
+    nonflat_pairs = 0
+    samples = []
+    for event, delta in zip(events, deltas):
+        side = _equity_hard_stop_fill_pside_optional(event)
+        remaining_total -= delta
+        if side in remaining_by_pside:
+            remaining_by_pside[side] -= delta
+        if signal_mode == "pside" and side != pside:
+            continue
+        symbol = _equity_hard_stop_fill_symbol(event)
+        action = _equity_hard_stop_fill_action(event)
+        qty = _equity_hard_stop_fill_replay_qty(event)
+        if (
+            side is None
+            or not symbol
+            or action not in {"increase", "decrease"}
+            or qty is None
+            or qty <= 0.0
+        ):
+            return []
+        pair = (side, symbol)
+        epsilon = _hsl_flat_epsilon(_hsl_qty_step_for_symbol(self, symbol))
+        size = sizes.get(pair, 0.0)
+        was_nonflat = nonflat_pairs > 0
+        if action == "decrease" and qty > size + epsilon:
+            return []
+        next_size = size + qty if action == "increase" else max(0.0, size - qty)
+        sizes[pair] = 0.0 if next_size <= epsilon else next_size
+        nonflat_pairs += int(sizes[pair] > 0.0) - int(size > 0.0)
+        if was_nonflat and nonflat_pairs == 0:
+            sample = {
+                "timestamp": _equity_hard_stop_fill_timestamp_ms(event),
+                "balance": float(balance) - remaining_total,
+                "realized_pnl": float(realized_total) - remaining_total,
+                "_hsl_scope_flatten_fill": True,
+            }
+            for sample_side in self._hsl_psides():
+                sample[f"realized_pnl_{sample_side}"] = (
+                    float(realized_by_pside[sample_side])
+                    - remaining_by_pside[sample_side]
+                )
+                if signal_mode == "unified" or sample_side == pside:
+                    sample[f"unrealized_pnl_{sample_side}"] = 0.0
+            samples.append(sample)
+    current_sizes = {
+        (side, symbol): abs(float(slot.get("size", 0.0)))
+        for symbol, slots in (self.positions or {}).items()
+        for side, slot in slots.items()
+        if side in self._hsl_psides() and (signal_mode == "unified" or side == pside)
+    }
+    for pair in set(current_sizes) | set(sizes):
+        epsilon = _hsl_flat_epsilon(_hsl_qty_step_for_symbol(self, pair[1]))
+        actual = current_sizes.get(pair, 0.0)
+        if abs(sizes.get(pair, 0.0) - actual) > max(epsilon, actual * 1e-12):
+            return []
+    return samples
+
+
+def _equity_hard_stop_scope_replay_rows(timeline, boundaries):
+    """Place exact fill boundaries before their minute's final price sample."""
+    valid_rows = [
+        row for row in timeline if isinstance(row, dict) and "timestamp" in row
+    ]
+    if not valid_rows:
+        yield from timeline
+        return
+    first_minute = int(valid_rows[0]["timestamp"]) // 60_000
+    boundaries = [
+        row for row in boundaries if int(row["timestamp"]) // 60_000 >= first_minute
+    ]
+    cursor = 0
+    for row in timeline:
+        if not isinstance(row, dict) or "timestamp" not in row:
+            yield row
+            continue
+        minute = int(row["timestamp"]) // 60_000
+        last_boundary = None
+        while (
+            cursor < len(boundaries)
+            and int(boundaries[cursor]["timestamp"]) // 60_000 <= minute
+        ):
+            last_boundary = boundaries[cursor]
+            cursor += 1
+            yield last_boundary
+        if last_boundary is not None:
+            row = dict(row)
+            row["timestamp"] = max(
+                int(row["timestamp"]), int(last_boundary["timestamp"]) + 1
+            )
+        yield row
+    yield from boundaries[cursor:]
+
+
+def _equity_hard_stop_reset_scope_at_flat_sample(self, pside, row, signal_mode):
+    """Start the next episode with its proven flat balance and realized-PnL baseline."""
+    state = self._hsl_state(pside)
+    state["pnl_reset_timestamp_ms"] = int(row["timestamp"]) + 1
+    self._equity_hard_stop_reset_after_restart(pside)
+    self._equity_hard_stop_apply_sample(
+        pside,
+        int(row["timestamp"]),
+        float(row["balance"]),
+        float(row["realized_pnl"]),
+        float(row[f"realized_pnl_{pside}"]),
+        0.0,
+        unrealized_pnl_total=0.0 if signal_mode == "unified" else None,
+        latch_red=False,
+    )
+
+
+async def _equity_hard_stop_refresh_live_scope_episode_boundaries(self, ts_ms, balance):
+    manager = getattr(self, "_pnls_manager", None)
+    if manager is None:
+        return False
+    events = manager.get_events()
+    signal_mode = self._equity_hard_stop_signal_mode()
+    realized_total = self._equity_hard_stop_realized_pnl_now()
+    realized_by_pside = {
+        side: self._equity_hard_stop_realized_pnl_now(side)
+        for side in self._hsl_psides()
+    }
+    for pside in self._hsl_psides():
+        state = self._hsl_state(pside)
+        if (
+            not self._equity_hard_stop_enabled(pside)
+            or state["halted"]
+            or state["runtime"].red_latched()
+            or state["last_metrics"] is None
+        ):
+            continue
+        boundaries = _equity_hard_stop_scope_flatten_samples(
+            self,
+            events,
+            pside,
+            signal_mode,
+            ts_ms,
+            balance,
+            realized_total,
+            realized_by_pside,
+        )
+        reset_ts = state.get("pnl_reset_timestamp_ms")
+        for row in boundaries:
+            boundary_ts = int(row["timestamp"])
+            if reset_ts is not None and boundary_ts < reset_ts:
+                continue
+            if boundary_ts <= int(state["last_metrics"]["timestamp_ms"]):
+                await self._equity_hard_stop_initialize_from_history()
+                return True
+            metrics = self._equity_hard_stop_apply_sample(
+                pside,
+                boundary_ts,
+                float(row["balance"]),
+                float(row["realized_pnl"]),
+                float(row[f"realized_pnl_{pside}"]),
+                0.0,
+                unrealized_pnl_total=0.0 if signal_mode == "unified" else None,
+            )
+            if metrics["red_seen_in_episode"]:
+                await self._equity_hard_stop_initialize_from_history()
+                return True
+            _equity_hard_stop_reset_scope_at_flat_sample(self, pside, row, signal_mode)
+    return False
+
+
 async def _equity_hard_stop_initialize_from_history(self) -> None:
     if not self._equity_hard_stop_enabled():
         return
@@ -3288,9 +3490,22 @@ async def _equity_hard_stop_initialize_from_history(self) -> None:
                 if signal_mode == "unified"
                 or _equity_hard_stop_fill_pside(fill) == pside
             )
+            scope_boundaries = _equity_hard_stop_scope_flatten_samples(
+                self,
+                fill_events,
+                pside,
+                signal_mode,
+                now_ms,
+                current_balance,
+                current_realized_total,
+                {
+                    side: self._equity_hard_stop_realized_pnl_now(side)
+                    for side in self._hsl_psides()
+                },
+            )
             scope_was_nonflat = False
             prev_recorded_ts: Optional[int] = None
-            for row in timeline:
+            for row in _equity_hard_stop_scope_replay_rows(timeline, scope_boundaries):
                 if not isinstance(row, dict):
                     continue
                 required = ("timestamp", "balance", "realized_pnl")
@@ -3329,9 +3544,12 @@ async def _equity_hard_stop_initialize_from_history(self) -> None:
                 n_rows[pside] += 1
                 row_flat = row.get(scope_flat_key)
                 scope_flattened_this_row = (
-                    isinstance(row_flat, bool) and row_flat and scope_was_nonflat
+                    bool(row.get("_hsl_scope_flatten_fill"))
+                    or (isinstance(row_flat, bool) and row_flat and scope_was_nonflat)
                 )
-                if isinstance(row_flat, bool):
+                if row.get("_hsl_scope_flatten_fill"):
+                    scope_was_nonflat = False
+                elif isinstance(row_flat, bool):
                     scope_was_nonflat = not row_flat
                 row_prev_recorded_ts = prev_recorded_ts
                 prev_recorded_ts = ts
@@ -3372,12 +3590,21 @@ async def _equity_hard_stop_initialize_from_history(self) -> None:
                         anchor = None
                         if idx > 0 and scope_fill_ts[idx - 1] > window_start:
                             anchor = int(scope_fill_ts[idx - 1])
-                        stop_ts = anchor if anchor is not None else int(ts)
+                        stop_ts = (
+                            int(ts)
+                            if row.get("_hsl_scope_flatten_fill")
+                            else (anchor if anchor is not None else int(ts))
+                        )
                         stop_source = "red_episode_flatten"
                     else:
                         # Ordinary flatten of a RED-free episode: plain episode
                         # reset with no stop accounting.
-                        self._equity_hard_stop_reset_after_restart(pside)
+                        if row.get("_hsl_scope_flatten_fill"):
+                            _equity_hard_stop_reset_scope_at_flat_sample(
+                                self, pside, row, signal_mode
+                            )
+                        else:
+                            self._equity_hard_stop_reset_after_restart(pside)
                         state = self._hsl_state(pside)
                         logging.info(
                             "[risk] HSL[%s] replay reset current episode after flat row | ts=%s",
@@ -3427,6 +3654,7 @@ async def _equity_hard_stop_initialize_from_history(self) -> None:
                         no_restart_peak_strategy_equity=no_restart_peak_strategy_equity,
                         no_restart_drawdown_raw=no_restart_drawdown_raw,
                     )
+                    state["pnl_reset_timestamp_ms"] = int(stop_ts) + 1
                     state["last_stop_event"] = payload
                     state["halted"] = True
                     state["no_restart_latched"] = no_restart_latched
@@ -5094,6 +5322,8 @@ async def _equity_hard_stop_check(self) -> Optional[dict]:
         await self._equity_hard_stop_initialize_from_history()
     balance = self.get_raw_balance()
     ts_ms = int(self.get_exchange_time())
+    if await _equity_hard_stop_refresh_live_scope_episode_boundaries(self, ts_ms, balance):
+        return None
     signal_mode = self._equity_hard_stop_signal_mode()
     realized_pnl_total = self._equity_hard_stop_realized_pnl_now()
     unrealized_pnl_by_pside = {
@@ -5335,9 +5565,117 @@ def _equity_hard_stop_emit_coin_status(self, pside: str, symbol: str, metrics: d
         )
 
 
+async def _equity_hard_stop_refresh_live_coin_episode_boundaries(
+    self, timestamp_ms: int, balance: float
+) -> bool:
+    """Consume proven ordinary flatten fills before sampling a later live episode.
+
+    A delayed boundary cannot be inserted into an already advanced Rust EMA. Reuse
+    canonical history reconstruction in that case, and when a closing fill first
+    proves RED, so cooldown and no-restart decisions retain their replay contract.
+    """
+    replay_task = getattr(self, "_equity_hard_stop_coin_replay_task", None)
+    if not getattr(self, "_equity_hard_stop_coin_initialized", False) or (
+        replay_task is not None and not replay_task.done()
+    ):
+        # Held-pair management may run before background reconstruction finishes.
+        # That owner must finish before live sampling can rebuild shared state.
+        return False
+    manager = getattr(self, "_pnls_manager", None)
+    if manager is None:
+        return False
+    events = [
+        event
+        for event in manager.get_events()
+        if _equity_hard_stop_fill_timestamp_ms(event) <= timestamp_ms
+    ]
+    for pside in self._hsl_psides():
+        for symbol, state in list(
+            getattr(self, "_equity_hard_stop_coin", {}).get(pside, {}).items()
+        ):
+            if (
+                not self._equity_hard_stop_coin_active_pside(pside, symbol)
+                or state["halted"]
+                or state["runtime"].red_latched()
+                or state["last_metrics"] is None
+            ):
+                continue
+            reset_ts = state.get("pnl_reset_timestamp_ms")
+            scope_events = [
+                event
+                for event in events
+                if reset_ts is None or _equity_hard_stop_fill_timestamp_ms(event) >= int(reset_ts)
+            ]
+            qty_step = _hsl_qty_step_for_symbol(self, symbol)
+            replay, ambiguous = _equity_hard_stop_coin_replay_events(
+                scope_events, pside, symbol, qty_step=qty_step
+            )
+            if ambiguous:
+                continue
+            epsilon = _hsl_flat_epsilon(qty_step)
+            size = 0.0
+            boundaries = []
+            for event_ts, action, qty, _delta in replay:
+                previous_size = size
+                size = size + qty if action == "increase" else max(0.0, size - qty)
+                if previous_size > epsilon and size <= epsilon:
+                    boundaries.append(event_ts)
+            current_size = abs(
+                float((self.positions or {}).get(symbol, {}).get(pside, {}).get("size", 0.0))
+            )
+            if not boundaries or abs(size - current_size) > max(epsilon, current_size * 1e-12):
+                continue
+            for flatten_ts in boundaries:
+                last_sample_ts = int((state["last_metrics"] or {}).get("timestamp_ms", 0))
+                tied_boundary = sum(event_ts == flatten_ts for event_ts, *_ in replay) > 1
+                if flatten_ts <= last_sample_ts or tied_boundary:
+                    logging.info(
+                        "[risk] HSL[%s:%s] reconstructing ordinary flatten outside incremental sample order | flat_ts=%s",
+                        pside,
+                        symbol,
+                        flatten_ts,
+                    )
+                    await self._equity_hard_stop_initialize_coin_from_history()
+                    return True
+                # Later fills can already be present in this refresh, including a
+                # re-entry in the same minute. Undo their PnL/fees for boundary sizing.
+                later_events = [
+                    event
+                    for event in events
+                    if _equity_hard_stop_fill_timestamp_ms(event) > flatten_ts
+                ]
+                self._assert_pnl_history_safe_for_risk(
+                    later_events, context="coin HSL flatten balance", start_ms=flatten_ts + 1
+                )
+                boundary_balance = balance - sum(
+                    float(_equity_hard_stop_event_value(event, "pnl", 0.0) or 0.0)
+                    + _equity_hard_stop_fee_cost(event)
+                    for event in later_events
+                )
+                metrics = self._equity_hard_stop_apply_coin_sample(
+                    pside, symbol, flatten_ts, boundary_balance, 0.0
+                )
+                if metrics["red_seen_in_episode"]:
+                    await self._equity_hard_stop_initialize_coin_from_history()
+                    return True
+                state["pnl_reset_timestamp_ms"] = flatten_ts + 1
+                self._equity_hard_stop_reset_coin_after_restart(pside, symbol)
+                state = self._hsl_coin_state(pside, symbol)
+                self._equity_hard_stop_prime_coin_runtime_for_replay(pside, symbol, flatten_ts + 1)
+                logging.info(
+                    "[risk] HSL[%s:%s] reset current episode after ordinary flat fill | flat_ts=%s",
+                    pside,
+                    symbol,
+                    flatten_ts,
+                )
+    return False
+
+
 async def _equity_hard_stop_check_coin(self) -> Optional[dict]:
     balance = float(self.get_raw_balance())
     ts_ms = int(self.get_exchange_time())
+    if await _equity_hard_stop_refresh_live_coin_episode_boundaries(self, ts_ms, balance):
+        return None
     out = {}
     symbols = sorted(self._equity_hard_stop_coin_symbols())
     partial_replay = (

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -811,6 +811,8 @@ def _equity_hard_stop_intervention_entry_timestamp(
     symbol: Optional[str] = None,
 ) -> Optional[int]:
     """Find the first canonical non-panic increase after a particular stop."""
+    fill_events = list(fill_events)
+    has_tied_entry = False
     timestamps = []
     for event in fill_events:
         if _equity_hard_stop_fill_pside_optional(event) not in psides:
@@ -818,15 +820,100 @@ def _equity_hard_stop_intervention_entry_timestamp(
         if symbol is not None and _equity_hard_stop_fill_symbol(event) != symbol:
             continue
         timestamp = _equity_hard_stop_fill_timestamp_ms(event)
-        if timestamp <= stop_ms or (
+        if timestamp < stop_ms or (
             cooldown_until_ms is not None and timestamp >= cooldown_until_ms
         ):
             continue
         if _equity_hard_stop_fill_action(event) == "increase" and "panic" not in str(
             _equity_hard_stop_event_value(event, "pb_order_type", "")
         ):
-            timestamps.append(timestamp)
+            if timestamp == stop_ms:
+                has_tied_entry = True
+            else:
+                timestamps.append(timestamp)
+    if has_tied_entry:
+        evidence = _equity_hard_stop_intervention_entry_evidence(
+            fill_events,
+            psides=psides,
+            stop_ms=stop_ms,
+            cooldown_until_ms=cooldown_until_ms,
+            symbol=symbol,
+        )
+        if evidence is not None:
+            return evidence["entry_timestamp_ms"]
+    # Timestamp-separated entries retain the existing inference contract.
     return min(timestamps, default=None)
+
+
+def _equity_hard_stop_intervention_entry_evidence(
+    fill_events: Iterable[Any],
+    *,
+    psides: set[str],
+    stop_ms: int,
+    cooldown_until_ms: Optional[int],
+    symbol: Optional[str] = None,
+    stop_index: Optional[int] = None,
+) -> Optional[dict[str, Any]]:
+    """Locate entry after a proven scoped flatten, including a tied fill cohort.
+
+    Indices refer to the scoped canonical ordering. An explicit index selects
+    a particular proven flatten; timestamp-only callers require a unique
+    flatten at that timestamp. An index never bypasses ambiguous ordering.
+    """
+    scoped = [
+        event
+        for event in fill_events
+        if _equity_hard_stop_fill_pside_optional(event) in psides
+        and (symbol is None or _equity_hard_stop_fill_symbol(event) == symbol)
+        and (
+            cooldown_until_ms is None
+            or _equity_hard_stop_fill_timestamp_ms(event) < cooldown_until_ms
+        )
+    ]
+    ordered, ambiguous, flatten_indices = _equity_hard_stop_order_fill_cohorts(
+        scoped, include_flatten_indices=True
+    )
+    if ambiguous:
+        return None
+    candidates = [
+        index
+        for index in flatten_indices
+        if _equity_hard_stop_fill_timestamp_ms(ordered[index]) == stop_ms
+    ]
+    if stop_index is None:
+        if len(candidates) != 1:
+            return None
+        stop_index = candidates[0]
+    elif stop_index not in candidates:
+        return None
+    prefix = 0.0
+    stop_prefix = None
+    for index, event in enumerate(ordered):
+        if (
+            index > stop_index
+            and _equity_hard_stop_fill_action(event) == "increase"
+            and ("panic" not in str(_equity_hard_stop_event_value(event, "pb_order_type", "")))
+        ):
+            return {
+                "entry_timestamp_ms": _equity_hard_stop_fill_timestamp_ms(event),
+                "entry_event": event,
+                "entry_index": index,
+                "stop_event": ordered[stop_index],
+                "stop_index": stop_index,
+                "realized_before_entry": prefix,
+                "realized_at_stop": stop_prefix,
+                "ordered_events": ordered,
+            }
+        delta = float(_equity_hard_stop_event_value(event, "pnl", 0.0) or 0.0)
+        delta += _equity_hard_stop_fee_cost(event)
+        if not math.isfinite(delta):
+            raise ValueError("HSL intervention prefix requires finite realized PnL and fees")
+        prefix += delta
+        if not math.isfinite(prefix):
+            raise ValueError("HSL intervention prefix must remain finite")
+        if index == stop_index:
+            stop_prefix = prefix
+    return None
 
 
 def _equity_hard_stop_manual_cooldown_intervention(
@@ -2107,11 +2194,14 @@ def _hsl_compact_sparse_replay_indices(
     return np.flatnonzero(selected).astype(np.int64)
 
 
-def _equity_hard_stop_order_fill_cohorts(fill_events):
+def _equity_hard_stop_order_fill_cohorts(fill_events, *, include_flatten_indices=False):
     """Order tied mixed-action fills only with exchange-provided position chains."""
     ordered = []
     ambiguous = False
     known_sizes = {}
+    flatten_indices = []
+    sizes_complete = True
+    nonflat_pairs = 0
     for _ts, cohort_iter in groupby(
         sorted(fill_events, key=_equity_hard_stop_fill_timestamp_ms),
         key=_equity_hard_stop_fill_timestamp_ms,
@@ -2149,7 +2239,8 @@ def _equity_hard_stop_order_fill_cohorts(fill_events):
             else:
                 cohort = [cohort[index] for index in chain_order]
         ordered.extend(cohort)
-        for event in cohort:
+        for offset, event in enumerate(cohort):
+            was_nonflat = nonflat_pairs > 0
             pair = (
                 _equity_hard_stop_fill_pside_optional(event),
                 _equity_hard_stop_fill_symbol(event),
@@ -2158,12 +2249,25 @@ def _equity_hard_stop_order_fill_cohorts(fill_events):
             qty = _equity_hard_stop_fill_replay_qty(event)
             if qty is None or action not in {"increase", "decrease"}:
                 known_sizes.pop(pair, None)
+                sizes_complete = False
                 continue
             size = known_sizes.get(pair, 0.0)
             if action == "decrease" and qty > size:
                 known_sizes.pop(pair, None)
+                # Keep ordering's original size cache behavior; optional flat
+                # evidence uses the same arithmetic tolerance as HSL replay.
+                if qty - size > _hsl_flat_epsilon():
+                    sizes_complete = False
             else:
                 known_sizes[pair] = size + qty if action == "increase" else size - qty
+            if include_flatten_indices and sizes_complete:
+                nonflat_pairs += int(known_sizes.get(pair, 0.0) > _hsl_flat_epsilon()) - int(
+                    size > _hsl_flat_epsilon()
+                )
+                if was_nonflat and nonflat_pairs == 0:
+                    flatten_indices.append(len(ordered) - len(cohort) + offset)
+    if include_flatten_indices:
+        return ordered, ambiguous, flatten_indices
     return ordered, ambiguous
 
 
@@ -3826,6 +3930,8 @@ async def _equity_hard_stop_initialize_from_history(self) -> None:
                     entry_ts = int(row["timestamp"])
                     if entry_ts > now_ms:
                         break
+                    # These seeds follow exact fills in validated chain order;
+                    # equality means a proven post-stop entry in the same cohort.
                     replayed_normal_override = (
                         contract["policy"] == "normal"
                         and state["halted"]
@@ -3833,7 +3939,7 @@ async def _equity_hard_stop_initialize_from_history(self) -> None:
                         and state["last_stop_event"] is not None
                         and state["cooldown_until_ms"] is not None
                         and int(state["last_stop_event"]["stop_event_timestamp_ms"])
-                        < entry_ts < state["cooldown_until_ms"]
+                        <= entry_ts < state["cooldown_until_ms"]
                     )
                     expired_cooldown = (
                         state["halted"]
@@ -4832,11 +4938,11 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
 
                 def replay_transitions_at(
                     row_ts_ms: int,
-                ) -> tuple[float, list[tuple[int, float]], float]:
+                ) -> tuple[float, list[tuple[int, float, int]], float]:
                     nonlocal replay_event_idx, replay_size
                     boundary_ts_ms = int(row_ts_ms) + 60_000
                     realized_delta = 0.0
-                    flatten_boundaries: list[tuple[int, float]] = []
+                    flatten_boundaries: list[tuple[int, float, int]] = []
                     while replay_event_idx < len(replay_events):
                         event_ts, action, qty, event_realized_delta = replay_events[
                             replay_event_idx
@@ -4855,7 +4961,7 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                                 # aggregate realized value be split at the
                                 # exact episode boundary.
                                 flatten_boundaries.append(
-                                    (int(event_ts), float(realized_delta))
+                                    (int(event_ts), float(realized_delta), replay_event_idx)
                                 )
                         replay_event_idx += 1
                     return (
@@ -5181,7 +5287,7 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
 
                     if flatten_boundaries and not replay_ambiguous:
                         row_start_abs_realized = abs_realized - row_realized_delta
-                        for flatten_ts, realized_delta_at_flatten in flatten_boundaries:
+                        for flatten_ts, realized_delta_at_flatten, flatten_index in flatten_boundaries:
                             if replay_start_boundary_ts is not None and flatten_ts < replay_start_boundary_ts:
                                 continue
                             boundary_abs_realized = (
@@ -5251,21 +5357,24 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                                 stop_finalized = True
                                 if state["no_restart_latched"]:
                                     break
-                                entry_ts = _equity_hard_stop_intervention_entry_timestamp(
+                                entry = _equity_hard_stop_intervention_entry_evidence(
                                     pair_fill_events, psides={pside}, symbol=symbol,
                                     stop_ms=stop_ts, cooldown_until_ms=state["cooldown_until_ms"],
+                                    stop_index=flatten_index,
                                 )
-                                if entry_ts is None or entry_ts > now_ms:
+                                if entry is None or entry["entry_timestamp_ms"] > now_ms:
                                     break
+                                entry_ts = int(entry["entry_timestamp_ms"])
                                 # A normal intervention follows this proven RED
                                 # flatten regardless of its exchange order type.
                                 replay_start_boundary_ts = int(entry_ts)
                                 contract["intervention_entry_ts"] = int(entry_ts)
-                                state["pnl_reset_timestamp_ms"] = int(entry_ts)
-                                reset_baseline_realized = sum(
-                                    float(delta) for event_ts, _, _, delta in replay_events
-                                    if int(event_ts) < entry_ts
+                                # A tied entry uses the existing fill-derived
+                                # reset tail for subsequent live samples too.
+                                state["pnl_reset_timestamp_ms"] = (
+                                    stop_ts + 1 if entry_ts == stop_ts else entry_ts
                                 )
+                                reset_baseline_realized = float(entry["realized_before_entry"])
                                 self._equity_hard_stop_reset_coin_after_restart(pside, symbol)
                                 self._equity_hard_stop_remove_latch_file(pside, symbol=symbol)
                                 state = self._hsl_coin_state(pside, symbol)

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -4336,6 +4336,18 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                 f"get_balance_equity_history()['fill_events'] must be a list, got {type(fill_events).__name__}"
             )
         fill_events_by_pair = _equity_hard_stop_index_coin_fill_events(fill_events)
+        account_fill_events = sorted(fill_events, key=_equity_hard_stop_fill_timestamp_ms)
+        account_fill_timestamps = [
+            _equity_hard_stop_fill_timestamp_ms(event) for event in account_fill_events
+        ]
+        account_realized_prefix = [0.0]
+        for event in account_fill_events:
+            delta = float(_equity_hard_stop_event_value(event, "pnl", 0.0) or 0.0)
+            delta += _equity_hard_stop_fee_cost(event)
+            cumulative = account_realized_prefix[-1] + delta
+            if not math.isfinite(cumulative):
+                raise ValueError("coin HSL boundary account PnL and fees must be finite")
+            account_realized_prefix.append(cumulative)
 
         compact_replay = history.get("hsl_coin_compact_replay")
         timeline = history.get("timeline")
@@ -5300,11 +5312,29 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                             boundary_abs_realized = (
                                 row_start_abs_realized + realized_delta_at_flatten
                             )
-                            boundary_balance = (
-                                row_balance
-                                - row_realized_delta
-                                + realized_delta_at_flatten
+                            # Minute balance includes every account fill in that
+                            # minute. Undo all later timestamps, then the proven
+                            # same-pair tail after this exact flatten. Other pairs
+                            # at F remain in its timestamp cohort, as in live replay.
+                            account_after = bisect.bisect_right(
+                                account_fill_timestamps, flatten_ts
                             )
+                            account_row_end = bisect.bisect_left(
+                                account_fill_timestamps, source_sample_ts + 60_000
+                            )
+                            later_account_delta = (
+                                account_realized_prefix[account_row_end]
+                                - account_realized_prefix[account_after]
+                            )
+                            tied_pair_delta = 0.0
+                            tail_index = flatten_index + 1
+                            while (
+                                tail_index < len(replay_events)
+                                and replay_events[tail_index][0] == flatten_ts
+                            ):
+                                tied_pair_delta += replay_events[tail_index][3]
+                                tail_index += 1
+                            boundary_balance = row_balance - later_account_delta - tied_pair_delta
                             peak_realized, window_last_realized = rolling_realized_at(
                                 flatten_ts, boundary_abs_realized
                             )

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -4,12 +4,14 @@ import asyncio
 import json
 import logging
 import bisect
+import copy
 import math
 import os
 import time
 import traceback
 from collections import deque
 from itertools import groupby
+from types import MethodType
 from typing import Any, Iterable, Optional
 
 import passivbot_rust as pbr
@@ -32,6 +34,7 @@ from fill_events_manager import (
     _unique_position_chain_order,
 )
 from live.state_refresh import AuthoritativeSurfaceUnavailable
+from live.freshness import ACCOUNT_SURFACES
 from live.diagnostic_safety import bounded_exception_type as _bounded_hsl_exception_type
 from live.event_bus import EventTypes, ReasonCodes, live_event_debug_profile_enabled
 from passivbot_exceptions import FatalBotException, RestartBotException
@@ -2555,10 +2558,16 @@ def _equity_hard_stop_activate_coin_red_from_metrics(
 def _equity_hard_stop_prime_coin_runtime_for_replay(
     self, pside: str, symbol: str, first_sample_ts_ms: int
 ) -> None:
-    state = self._hsl_coin_state(pside, symbol)
+    _equity_hard_stop_prime_runtime_for_replay(self, pside, first_sample_ts_ms, symbol=symbol)
+
+
+def _equity_hard_stop_prime_runtime_for_replay(
+    self, pside: str, first_sample_ts_ms: int, *, symbol: Optional[str] = None
+) -> None:
+    state = self._hsl_coin_state(pside, symbol) if symbol is not None else self._hsl_state(pside)
     if state["runtime"].initialized():
         return
-    cfg = _equity_hard_stop_config(self, pside, symbol)
+    cfg = _equity_hard_stop_config(self, pside, symbol) if symbol is not None else self.hsl[pside]
     baseline_ts_ms = max(0, int(first_sample_ts_ms) - 60_000)
     step = state["runtime"].apply_sample(
         timestamp_ms=baseline_ts_ms,
@@ -3087,6 +3096,135 @@ async def _equity_hard_stop_refresh_coin_cooldown_after_repanic(
     return True
 
 
+async def _equity_hard_stop_replay_live_restart(
+    self, pside: str, symbol: Optional[str] = None
+) -> bool:
+    """Publish a completed canonical replay without clearing live protection while awaiting it."""
+    background = getattr(self, "_equity_hard_stop_coin_replay_task", None)
+    if getattr(self, "_hsl_live_restart_replay_active", False) or (
+        background is not None and not background.done()
+    ):
+        return False
+    mode = self._equity_hard_stop_signal_mode()
+    sides = self._hsl_psides() if mode == "unified" else (pside,)
+    ledger = getattr(self, "freshness_ledger", None)
+    observation = (
+        int(getattr(ledger, "epoch", 0)),
+        int(getattr(self, "_account_invalidation_generation", 0) or 0),
+    )
+    staged = copy.copy(self)
+    # Production methods bind to the staged receiver. Preserve that property
+    # for injected instance methods as well (including the offline harness).
+    rebound_methods = []
+    for name, value in vars(self).items():
+        if isinstance(value, MethodType) and value.__self__ is self:
+            setattr(staged, name, MethodType(value.__func__, staged))
+            rebound_methods.append(name)
+    staged.positions = copy.deepcopy(self.positions)
+    staged.open_orders = copy.deepcopy(self.open_orders)
+    staged._equity_hard_stop = {
+        side: staged._equity_hard_stop_make_state() for side in self._hsl_psides()
+    }
+    staged._equity_hard_stop_coin = {side: {} for side in self._hsl_psides()}
+    staged._runtime_forced_modes = {side: {} for side in self._hsl_psides()}
+    staged._equity_hard_stop_coin_initialized = False
+    staged._equity_hard_stop_coin_replay_ready_event = asyncio.Event()
+    staged._equity_hard_stop_coin_replay_task = None
+    staged._live_event_pipeline = None
+    staged._emit_live_event = lambda *args, **kwargs: None
+    staged._set_log_silence_watchdog_context = lambda *args, **kwargs: None
+    latch_operations = []
+    staged._equity_hard_stop_write_latch = (
+        lambda side, payload, symbol=None: latch_operations.append(
+            ("write", side, symbol, dict(payload))
+        )
+    )
+    staged._equity_hard_stop_remove_latch_file = lambda side, symbol=None: latch_operations.append(
+        ("remove", side, symbol, None)
+    )
+    self._hsl_live_restart_replay_active = True
+    try:
+        try:
+            if mode == "coin":
+                result = await staged._equity_hard_stop_initialize_coin_from_history()
+            else:
+                result = await staged._equity_hard_stop_initialize_from_history()
+            if result is False:
+                return False
+        except AuthoritativeSurfaceUnavailable:
+            return False
+        background = getattr(self, "_equity_hard_stop_coin_replay_task", None)
+        if observation != (
+            int(getattr(getattr(self, "freshness_ledger", None), "epoch", 0)),
+            int(getattr(self, "_account_invalidation_generation", 0) or 0),
+        ) or (background is not None and not background.done()):
+            return False
+        pending = getattr(self, "_authoritative_pending_confirmations", {}) or {}
+        if any(int(pending.get(surface, 0)) > observation[0] for surface in ACCOUNT_SURFACES):
+            return False
+        if mode == "coin":
+            if not getattr(staged, "_equity_hard_stop_coin_initialized", False) or (
+                (pside, symbol)
+                not in getattr(staged, "_equity_hard_stop_coin_replay_ready_pairs", set())
+            ):
+                return False
+            replacements = [(pside, staged._hsl_coin_state(pside, symbol))]
+        else:
+            replacements = [(side, staged._hsl_state(side)) for side in sides]
+        for side, replacement in replacements:
+            old = self._hsl_coin_state(side, symbol) if mode == "coin" else self._hsl_state(side)
+            if old["no_restart_latched"] and not replacement["no_restart_latched"]:
+                return False
+            if (
+                self._equity_hard_stop_enabled(side)
+                and not replacement["halted"]
+                and (
+                    not replacement["runtime"].initialized()
+                    or not isinstance(replacement["last_metrics"], dict)
+                )
+            ):
+                return False
+        # No awaits below: existing scope references and independent scopes
+        # remain valid when the ready replacement becomes visible.
+        for side, replacement in replacements:
+            old = self._hsl_coin_state(side, symbol) if mode == "coin" else self._hsl_state(side)
+            replacement["no_restart_peak_strategy_equity"] = max(
+                float(old.get("no_restart_peak_strategy_equity", 0.0) or 0.0),
+                float(replacement.get("no_restart_peak_strategy_equity", 0.0) or 0.0),
+            )
+            # A bounded replay may begin after the preceding stop. Absence
+            # from that window does not erase its already-confirmed diagnostic.
+            if replacement["last_stop_event"] is None:
+                replacement["last_stop_event"] = old.get("last_stop_event")
+            old.clear()
+            old.update(replacement)
+            if mode == "coin":
+                forced = self._runtime_forced_modes.setdefault(side, {})
+                forced.pop(symbol, None)
+                if symbol in staged._runtime_forced_modes.get(side, {}):
+                    forced[symbol] = staged._runtime_forced_modes[side][symbol]
+                ready = set(
+                    getattr(self, "_equity_hard_stop_coin_replay_ready_pairs", set()) or set()
+                )
+                self._equity_hard_stop_coin_replay_ready_pairs = ready | {(side, symbol)}
+            else:
+                self._runtime_forced_modes[side] = dict(staged._runtime_forced_modes.get(side, {}))
+        for operation, side, coin, payload in latch_operations:
+            if side not in sides or (mode == "coin" and coin != symbol):
+                continue
+            if operation == "write":
+                self._equity_hard_stop_write_latch(side, payload, symbol=coin)
+            else:
+                self._equity_hard_stop_remove_latch_file(side, symbol=coin)
+        return True
+    finally:
+        self._hsl_live_restart_replay_active = False
+        # Bound test/harness methods form cycles. Release staging on this
+        # thread; Rust HSL objects must not be collected by a worker thread.
+        for name in rebound_methods:
+            vars(staged).pop(name, None)
+
+
 async def _equity_hard_stop_handle_position_during_cooldown(self, pside: str, now_ms: int) -> bool:
     state = self._hsl_state(pside)
     if not state["halted"] or state["no_restart_latched"]:
@@ -3138,13 +3276,7 @@ async def _equity_hard_stop_handle_position_during_cooldown(self, pside: str, no
     state["cooldown_intervention_active"] = True
 
     if policy == "normal":
-        self._equity_hard_stop_reset_after_restart(pside)
-        self._equity_hard_stop_remove_latch_file(pside)
-        logging.critical(
-            "[risk] HSL[%s] operator override during RED cooldown: resumed normal operation and reset drawdown tracker",
-            pside,
-        )
-        return True
+        return await _equity_hard_stop_replay_live_restart(self, pside)
 
     if policy == "panic":
         if not state["cooldown_repanic_reset_pending"]:
@@ -3224,15 +3356,7 @@ async def _equity_hard_stop_handle_coin_position_during_cooldown(
     state["cooldown_intervention_active"] = True
 
     if policy == "normal":
-        self._equity_hard_stop_reset_coin_after_restart(pside, symbol)
-        self._equity_hard_stop_remove_latch_file(pside, symbol=symbol)
-        logging.critical(
-            "[risk] HSL[%s:%s] operator override during RED cooldown: resumed normal operation "
-            "and reset drawdown tracker",
-            pside,
-            symbol,
-        )
-        return True
+        return await _equity_hard_stop_replay_live_restart(self, pside, symbol)
 
     if policy == "panic":
         if not state["cooldown_repanic_reset_pending"]:
@@ -3354,8 +3478,10 @@ def _equity_hard_stop_scope_flatten_samples(
     balance,
     realized_total,
     realized_by_pside,
+    *,
+    include_entry_seeds: bool = False,
 ) -> Optional[list[dict]]:
-    """Reconstruct exact scope-flat samples from a complete, position-matching fill tape."""
+    """Reconstruct exact flat/override baselines from a position-matching fill tape."""
     events = sorted(
         (event for event in fill_events if _equity_hard_stop_fill_timestamp_ms(event) <= now_ms),
         key=_equity_hard_stop_fill_timestamp_ms,
@@ -3422,16 +3548,22 @@ def _equity_hard_stop_scope_flatten_samples(
         next_size = size + qty if action == "increase" else max(0.0, size - qty)
         sizes[pair] = 0.0 if next_size <= epsilon else next_size
         nonflat_pairs += int(sizes[pair] > 0.0) - int(size > 0.0)
-        if was_nonflat and nonflat_pairs == 0:
+        entry_seed = not was_nonflat and action == "increase" and include_entry_seeds
+        if (was_nonflat and nonflat_pairs == 0) or entry_seed:
+            # Prime a restarted episode from its flat state before the entry's
+            # fees, so a close later in this same minute retains its loss.
+            entry_delta = delta if entry_seed else 0.0
             sample = {
                 "timestamp": _equity_hard_stop_fill_timestamp_ms(event),
-                "balance": float(balance) - remaining_total,
-                "realized_pnl": float(realized_total) - remaining_total,
-                "_hsl_scope_flatten_fill": True,
+                "balance": float(balance) - remaining_total - entry_delta,
+                "realized_pnl": float(realized_total) - remaining_total - entry_delta,
+                "_hsl_scope_entry_seed" if entry_seed else "_hsl_scope_flatten_fill": True,
             }
             for sample_side in self._hsl_psides():
                 sample[f"realized_pnl_{sample_side}"] = (
-                    float(realized_by_pside[sample_side]) - remaining_by_pside[sample_side]
+                    float(realized_by_pside[sample_side])
+                    - remaining_by_pside[sample_side]
+                    - (entry_delta if sample_side == side else 0.0)
                 )
                 if signal_mode == "unified" or sample_side == pside:
                     sample[f"unrealized_pnl_{sample_side}"] = 0.0
@@ -3466,9 +3598,11 @@ def _equity_hard_stop_scope_replay_rows(timeline, boundaries):
         minute = int(row["timestamp"]) // 60_000
         last_boundary = None
         while cursor < len(boundaries) and int(boundaries[cursor]["timestamp"]) // 60_000 <= minute:
-            last_boundary = boundaries[cursor]
+            boundary = boundaries[cursor]
             cursor += 1
-            yield last_boundary
+            if not boundary.get("_hsl_scope_entry_seed"):
+                last_boundary = boundary
+            yield boundary
         if last_boundary is not None:
             row = dict(row)
             row["_hsl_source_minute_timestamp"] = int(row["timestamp"])
@@ -3657,6 +3791,7 @@ async def _equity_hard_stop_initialize_from_history(self) -> None:
                     side: self._equity_hard_stop_realized_pnl_now(side)
                     for side in self._hsl_psides()
                 },
+                include_entry_seeds=True,
             )
             if boundaries is None:
                 raise AuthoritativeSurfaceUnavailable(
@@ -3674,35 +3809,6 @@ async def _equity_hard_stop_initialize_from_history(self) -> None:
             replay_timeline = timeline
             scope_boundaries = scope_boundaries_by_pside[pside]
             ignored_panic_marker_timestamps: set[int] = set()
-            if contract["intervention_entry_ts"] is not None and contract["policy"] == "normal":
-                entry_ts = int(contract["intervention_entry_ts"])
-                self._equity_hard_stop_reset_after_restart(pside)
-                # Normal intervention starts a new replay window, but every
-                # later exact flatten still uses the canonical episode loop.
-                # Minute rows represent the minute's final state; pre-entry
-                # fill boundaries and panic markers must not enter that window.
-                replay_timeline = [
-                    row for row in timeline
-                    if isinstance(row, dict)
-                    and "timestamp" in row
-                    and int(row["timestamp"]) >= entry_ts // 60_000 * 60_000
-                ]
-                scope_boundaries = [
-                    row for row in scope_boundaries if int(row["timestamp"]) >= entry_ts
-                ]
-                ignored_panic_marker_timestamps.update(
-                    int(marker["timestamp"])
-                    for (marker_pside, _), marker in panic_flatten_events_by_key.items()
-                    if marker_pside == pside and int(marker["timestamp"]) < entry_ts
-                )
-                if contract["latest_panic_ts"] is not None:
-                    ignored_panic_marker_timestamps.add(int(contract["latest_panic_ts"]))
-                self._equity_hard_stop_remove_latch_file(pside)
-                logging.critical(
-                    "[risk] HSL[%s] reconstructed operator override during RED cooldown from exchange-derived history | entry_ts=%s policy=normal",
-                    pside,
-                    entry_ts,
-                )
             scope_flat_key = "is_flat" if signal_mode == "unified" else f"is_flat_{pside}"
             scope_fill_ts = sorted(
                 _equity_hard_stop_fill_timestamp_ms(fill)
@@ -3712,9 +3818,63 @@ async def _equity_hard_stop_initialize_from_history(self) -> None:
             )
             scope_was_nonflat = False
             prev_recorded_ts: Optional[int] = None
+            seeded_entry_ts: Optional[int] = None
             for row in _equity_hard_stop_scope_replay_rows(replay_timeline, scope_boundaries):
                 if not isinstance(row, dict):
                     continue
+                if row.get("_hsl_scope_entry_seed"):
+                    entry_ts = int(row["timestamp"])
+                    if entry_ts > now_ms:
+                        break
+                    replayed_normal_override = (
+                        contract["policy"] == "normal"
+                        and state["halted"]
+                        and not state["no_restart_latched"]
+                        and state["last_stop_event"] is not None
+                        and state["cooldown_until_ms"] is not None
+                        and int(state["last_stop_event"]["stop_event_timestamp_ms"])
+                        < entry_ts < state["cooldown_until_ms"]
+                    )
+                    expired_cooldown = (
+                        state["halted"]
+                        and not state["no_restart_latched"]
+                        and state["cooldown_until_ms"] is not None
+                        and entry_ts >= state["cooldown_until_ms"]
+                    )
+                    if expired_cooldown or replayed_normal_override:
+                        if replayed_normal_override:
+                            ignored_panic_marker_timestamps.add(
+                                int(state["last_stop_event"]["stop_event_timestamp_ms"])
+                            )
+                        self._equity_hard_stop_reset_after_restart(pside)
+                    else:
+                        continue
+                    # Seed the rolling baseline at entry, and prime Rust in
+                    # the preceding bucket. Entry is not an extra EMA sample.
+                    strategy_pnl = float(
+                        row["realized_pnl"] if signal_mode == "unified"
+                        else row[f"realized_pnl_{pside}"]
+                    )
+                    lookback_ms = self._equity_hard_stop_lookback_ms()
+                    state["strategy_pnl_peak"].update(
+                        int(row["timestamp"]),
+                        strategy_pnl,
+                        int(lookback_ms) if lookback_ms is not None else (2**64 - 1),
+                    )
+                    _equity_hard_stop_prime_runtime_for_replay(self, pside, int(row["timestamp"]))
+                    seeded_entry_ts = entry_ts
+                    continue
+                if (
+                    seeded_entry_ts is not None
+                    and "timestamp" in row
+                    and int(row["timestamp"]) < seeded_entry_ts
+                    and int(row["timestamp"]) // 60_000 == seeded_entry_ts // 60_000
+                ):
+                    row = dict(row)
+                    row["_hsl_source_minute_timestamp"] = int(row["timestamp"])
+                    row["timestamp"] = min(
+                        seeded_entry_ts + 1, (seeded_entry_ts // 60_000 + 1) * 60_000 - 1
+                    )
                 required = ("timestamp", "balance", "realized_pnl")
                 if signal_mode == "pside":
                     required += (f"realized_pnl_{pside}", f"unrealized_pnl_{pside}")
@@ -4538,23 +4698,6 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                 replay_start_boundary_ts = bounded_held_replay_starts.get(
                     (pside, symbol)
                 )
-                if contract["intervention_entry_ts"] is not None and contract["policy"] == "normal":
-                    intervention_boundary_ts = int(contract["intervention_entry_ts"])
-                    replay_start_boundary_ts = (
-                        intervention_boundary_ts
-                        if replay_start_boundary_ts is None
-                        else max(replay_start_boundary_ts, intervention_boundary_ts)
-                    )
-                    self._equity_hard_stop_reset_coin_after_restart(pside, symbol)
-                    self._equity_hard_stop_remove_latch_file(pside, symbol=symbol)
-                    state = self._hsl_coin_state(pside, symbol)
-                    logging.critical(
-                        "[risk] HSL[%s:%s] reconstructed operator override during RED cooldown "
-                        "from exchange-derived history | entry_ts=%s policy=normal",
-                        pside,
-                        symbol,
-                        replay_start_boundary_ts,
-                    )
                 window_points: deque[tuple[int, float]] = deque()
                 window_max_points: deque[tuple[int, float]] = deque()
                 window_base_realized = 0.0
@@ -4570,10 +4713,10 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                     symbol,
                     qty_step=qty_step,
                 )
-                if (
-                    replay_start_boundary_ts is not None
-                    and (pside, symbol) in bounded_held_replay_starts
-                ):
+                if replay_start_boundary_ts is not None:
+                    # The current/live sample must use the same fill boundary
+                    # as retained replay rows, including the entry's fees.
+                    state["pnl_reset_timestamp_ms"] = int(replay_start_boundary_ts)
                     # Pair realized values are cumulative across the replay
                     # record window. Discarded closed episodes must therefore
                     # become the current episode's baseline rather than leaking
@@ -4679,6 +4822,13 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                 replay_size = 0.0
                 flat_epsilon = _hsl_flat_epsilon(qty_step)
                 ignored_panic_marker_timestamps: set[int] = set()
+                if replay_start_boundary_ts is not None:
+                    ignored_panic_marker_timestamps.update(
+                        int(marker["timestamp"])
+                        for (marker_side, marker_symbol, _), marker in latest_panic_by_coin_minute.items()
+                        if marker_side == pside and marker_symbol == symbol
+                        and int(marker["timestamp"]) < replay_start_boundary_ts
+                    )
 
                 def replay_transitions_at(
                     row_ts_ms: int,
@@ -4837,6 +4987,92 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                 background_replay = bool(
                     self._equity_hard_stop_coin_protective_ready
                 )
+                def finalize_replay_stop(metrics, stop_ts, stop_source, stop_abs_realized, realized_pnl_total):
+                    nonlocal state, reset_baseline_realized
+                    stop_drawdown_raw = float(metrics["drawdown_raw"])
+                    finalization = self._equity_hard_stop_red_episode_finalization(
+                        pside,
+                        {
+                            "equity": float(metrics["equity"]),
+                            "peak_strategy_equity": float(metrics["peak_strategy_equity"]),
+                            "drawdown_ema": float(metrics["drawdown_ema"]),
+                        },
+                        stop_ts,
+                        symbol=symbol,
+                    )
+                    no_restart_latched = bool(finalization["no_restart_latched"])
+                    cooldown_until_ms = finalization["cooldown_until_ms"]
+                    state["last_stop_event"] = self._equity_hard_stop_build_latch_payload(
+                        pside,
+                        symbol=symbol,
+                        stop_event_timestamp_ms=stop_ts,
+                        balance=float(metrics["balance"]),
+                        realized_pnl_total=realized_pnl_total,
+                        realized_pnl=float(metrics["realized_pnl"]),
+                        unrealized_pnl=float(metrics["unrealized_pnl"]),
+                        strategy_pnl=float(metrics["strategy_pnl"]),
+                        peak_strategy_pnl=float(metrics["peak_strategy_pnl"]),
+                        strategy_equity=float(metrics["strategy_equity"]),
+                        peak_strategy_equity=float(metrics["peak_strategy_equity"]),
+                        trigger_peak_strategy_equity=float(metrics["peak_strategy_equity"]),
+                        drawdown_raw=stop_drawdown_raw,
+                        drawdown_ema=float(metrics["drawdown_ema"]),
+                        drawdown_score=float(metrics["drawdown_score"]),
+                        no_restart_latched=no_restart_latched,
+                        cooldown_until_ms=cooldown_until_ms,
+                        no_restart_peak_strategy_equity=float(
+                            finalization["no_restart_peak_strategy_equity"]
+                        ),
+                        no_restart_drawdown_raw=float(
+                            finalization["no_restart_drawdown_raw"]
+                        ),
+                    )
+                    state["pnl_reset_timestamp_ms"] = stop_ts + 1
+                    state["pending_red_since_ms"] = None
+                    reset_baseline_realized = stop_abs_realized
+                    reset_rolling_window()
+                    if no_restart_latched:
+                        state["halted"] = True
+                        state["no_restart_latched"] = True
+                        state["cooldown_until_ms"] = None
+                        self._equity_hard_stop_write_latch(
+                            pside, state["last_stop_event"], symbol=symbol
+                        )
+                        self._equity_hard_stop_set_coin_runtime_forced_mode(
+                            pside, symbol, "graceful_stop"
+                        )
+                        logging.critical(
+                            "[risk] HSL[%s:%s] reconstructed terminal coin RED stop from exchange-derived history | "
+                            "stop_ts=%s drawdown_raw=%.6f source=%s",
+                            pside,
+                            symbol,
+                            stop_ts,
+                            stop_drawdown_raw,
+                            stop_source,
+                        )
+                        return
+                    state["halted"] = True
+                    state["no_restart_latched"] = False
+                    state["cooldown_until_ms"] = cooldown_until_ms
+                    self._equity_hard_stop_write_latch(
+                        pside, state["last_stop_event"], symbol=symbol
+                    )
+                    if cooldown_until_ms is not None and now_ms < cooldown_until_ms:
+                        self._equity_hard_stop_set_coin_runtime_forced_mode(
+                            pside, symbol, "graceful_stop"
+                        )
+                        logging.critical(
+                            "[risk] HSL[%s:%s] reconstructed active coin RED cooldown from exchange-derived history | "
+                            "remaining_time=%s source=%s",
+                            pside,
+                            symbol,
+                            _equity_hard_stop_format_remaining_time(
+                                (cooldown_until_ms - now_ms) / 1000.0
+                            ),
+                            stop_source,
+                        )
+                        return
+
                 yield_rows = (
                     _HSL_COIN_REPLAY_BACKGROUND_YIELD_ROWS
                     if background_replay
@@ -4871,11 +5107,15 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                             scanned_rows,
                             pair_started_s,
                         )
+                    source_sample_ts = ts
                     if replay_start_boundary_ts is not None and ts < replay_start_boundary_ts:
-                        # Advance fill-derived size state while intentionally
-                        # discarding pre-boundary episode transitions.
-                        replay_transitions_at(ts)
-                        continue
+                        if ts + _HSL_REPLAY_INTERVAL_MS <= replay_start_boundary_ts:
+                            # Advance size through discarded complete minutes.
+                            replay_transitions_at(ts)
+                            continue
+                        # Keep the intervention minute's later fills and price
+                        # sample while excluding earlier episode boundaries.
+                        ts = int(replay_start_boundary_ts)
                     if state["halted"]:
                         cooldown_until_ms = state["cooldown_until_ms"]
                         if (
@@ -4905,7 +5145,12 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                         replay_position_size,
                         flatten_boundaries,
                         row_realized_delta,
-                    ) = replay_transitions_at(ts)
+                    ) = replay_transitions_at(source_sample_ts)
+                    if replay_start_boundary_ts is not None:
+                        flatten_boundaries = [
+                            boundary for boundary in flatten_boundaries
+                            if int(boundary[0]) >= replay_start_boundary_ts
+                        ]
                     replay_is_nonflat = replay_position_size > flat_epsilon
                     if not has_realized:
                         if source_row is not None:
@@ -4924,15 +5169,21 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                         )
                     abs_realized = float(realized_value)
                     seen_coin_timeline_fields = True
-                    marker = latest_panic_by_coin_minute.get((pside, symbol, ts))
+                    marker = latest_panic_by_coin_minute.get((pside, symbol, source_sample_ts))
+                    if marker is not None and int(marker["timestamp"]) in ignored_panic_marker_timestamps:
+                        marker = None
                     metrics = None
                     stop_ts = None
                     stop_source = None
                     stop_abs_realized = abs_realized
+                    stop_finalized = False
+                    row_resumed_normal = False
 
                     if flatten_boundaries and not replay_ambiguous:
                         row_start_abs_realized = abs_realized - row_realized_delta
                         for flatten_ts, realized_delta_at_flatten in flatten_boundaries:
+                            if replay_start_boundary_ts is not None and flatten_ts < replay_start_boundary_ts:
+                                continue
                             boundary_abs_realized = (
                                 row_start_abs_realized + realized_delta_at_flatten
                             )
@@ -4994,7 +5245,38 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                                     else "red_episode_flatten"
                                 )
                                 stop_abs_realized = boundary_abs_realized
-                                break
+                                if contract["policy"] != "normal":
+                                    break
+                                finalize_replay_stop(metrics, stop_ts, stop_source, stop_abs_realized, row_realized_pnl)
+                                stop_finalized = True
+                                if state["no_restart_latched"]:
+                                    break
+                                entry_ts = _equity_hard_stop_intervention_entry_timestamp(
+                                    pair_fill_events, psides={pside}, symbol=symbol,
+                                    stop_ms=stop_ts, cooldown_until_ms=state["cooldown_until_ms"],
+                                )
+                                if entry_ts is None or entry_ts > now_ms:
+                                    break
+                                # A normal intervention follows this proven RED
+                                # flatten regardless of its exchange order type.
+                                replay_start_boundary_ts = int(entry_ts)
+                                contract["intervention_entry_ts"] = int(entry_ts)
+                                state["pnl_reset_timestamp_ms"] = int(entry_ts)
+                                reset_baseline_realized = sum(
+                                    float(delta) for event_ts, _, _, delta in replay_events
+                                    if int(event_ts) < entry_ts
+                                )
+                                self._equity_hard_stop_reset_coin_after_restart(pside, symbol)
+                                self._equity_hard_stop_remove_latch_file(pside, symbol=symbol)
+                                state = self._hsl_coin_state(pside, symbol)
+                                reset_rolling_window()
+                                self._equity_hard_stop_prime_coin_runtime_for_replay(pside, symbol, entry_ts)
+                                ignored_panic_marker_timestamps.add(stop_ts)
+                                marker = None
+                                stop_ts = None
+                                stop_finalized = False
+                                row_resumed_normal = True
+                                continue
 
                             # RED-free episodes still end at every zero
                             # crossing. Reset before evaluating a later
@@ -5017,7 +5299,10 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                                 int(flatten_ts),
                             )
                         if stop_ts is None:
-                            continue
+                            if not row_resumed_normal or source_sample_ts + _HSL_REPLAY_INTERVAL_MS <= replay_start_boundary_ts:
+                                continue
+                            ts = max(ts, replay_start_boundary_ts)
+                            peak_realized, window_last_realized = rolling_realized_at(ts, abs_realized)
                     else:
                         peak_realized, window_last_realized = rolling_realized_at(
                             ts, abs_realized
@@ -5079,88 +5364,11 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                                 float(metrics["red_threshold"]),
                             )
                             continue
-                    stop_drawdown_raw = float(metrics["drawdown_raw"])
-                    finalization = self._equity_hard_stop_red_episode_finalization(
-                        pside,
-                        {
-                            "equity": float(metrics["equity"]),
-                            "peak_strategy_equity": float(metrics["peak_strategy_equity"]),
-                            "drawdown_ema": float(metrics["drawdown_ema"]),
-                        },
-                        stop_ts,
-                        symbol=symbol,
-                    )
-                    no_restart_latched = bool(finalization["no_restart_latched"])
-                    cooldown_until_ms = finalization["cooldown_until_ms"]
-                    state["last_stop_event"] = self._equity_hard_stop_build_latch_payload(
-                        pside,
-                        symbol=symbol,
-                        stop_event_timestamp_ms=stop_ts,
-                        balance=float(metrics["balance"]),
-                        realized_pnl_total=row_realized_pnl,
-                        realized_pnl=float(metrics["realized_pnl"]),
-                        unrealized_pnl=float(metrics["unrealized_pnl"]),
-                        strategy_pnl=float(metrics["strategy_pnl"]),
-                        peak_strategy_pnl=float(metrics["peak_strategy_pnl"]),
-                        strategy_equity=float(metrics["strategy_equity"]),
-                        peak_strategy_equity=float(metrics["peak_strategy_equity"]),
-                        trigger_peak_strategy_equity=float(metrics["peak_strategy_equity"]),
-                        drawdown_raw=stop_drawdown_raw,
-                        drawdown_ema=float(metrics["drawdown_ema"]),
-                        drawdown_score=float(metrics["drawdown_score"]),
-                        no_restart_latched=no_restart_latched,
-                        cooldown_until_ms=cooldown_until_ms,
-                        no_restart_peak_strategy_equity=float(
-                            finalization["no_restart_peak_strategy_equity"]
-                        ),
-                        no_restart_drawdown_raw=float(
-                            finalization["no_restart_drawdown_raw"]
-                        ),
-                    )
-                    state["pnl_reset_timestamp_ms"] = stop_ts + 1
-                    state["pending_red_since_ms"] = None
-                    reset_baseline_realized = stop_abs_realized
-                    reset_rolling_window()
-                    if no_restart_latched:
-                        state["halted"] = True
-                        state["no_restart_latched"] = True
-                        state["cooldown_until_ms"] = None
-                        self._equity_hard_stop_write_latch(
-                            pside, state["last_stop_event"], symbol=symbol
-                        )
-                        self._equity_hard_stop_set_coin_runtime_forced_mode(
-                            pside, symbol, "graceful_stop"
-                        )
-                        logging.critical(
-                            "[risk] HSL[%s:%s] reconstructed terminal coin RED stop from exchange-derived history | "
-                            "stop_ts=%s drawdown_raw=%.6f source=%s",
-                            pside,
-                            symbol,
-                            stop_ts,
-                            stop_drawdown_raw,
-                            stop_source,
-                        )
+                    if not stop_finalized:
+                        finalize_replay_stop(metrics, stop_ts, stop_source, stop_abs_realized, row_realized_pnl)
+                    if state["no_restart_latched"]:
                         break
-                    state["halted"] = True
-                    state["no_restart_latched"] = False
-                    state["cooldown_until_ms"] = cooldown_until_ms
-                    self._equity_hard_stop_write_latch(
-                        pside, state["last_stop_event"], symbol=symbol
-                    )
-                    if cooldown_until_ms is not None and now_ms < cooldown_until_ms:
-                        self._equity_hard_stop_set_coin_runtime_forced_mode(
-                            pside, symbol, "graceful_stop"
-                        )
-                        logging.critical(
-                            "[risk] HSL[%s:%s] reconstructed active coin RED cooldown from exchange-derived history | "
-                            "remaining_time=%s source=%s",
-                            pside,
-                            symbol,
-                            _equity_hard_stop_format_remaining_time(
-                                (cooldown_until_ms - now_ms) / 1000.0
-                            ),
-                            stop_source,
-                        )
+                    if state["cooldown_until_ms"] is not None and now_ms < state["cooldown_until_ms"]:
                         continue
                     self._equity_hard_stop_reset_coin_after_restart(pside, symbol)
                     self._equity_hard_stop_remove_latch_file(pside, symbol=symbol)
@@ -5568,9 +5776,11 @@ async def _equity_hard_stop_check(self) -> Optional[dict]:
         if not self._equity_hard_stop_enabled(pside):
             continue
         state = self._hsl_state(pside)
+        replay_complete = False
         if state["halted"]:
             if await self._equity_hard_stop_handle_position_during_cooldown(pside, ts_ms):
                 state = self._hsl_state(pside)
+                replay_complete = True
             if state["halted"]:
                 cooldown_until_ms = state["cooldown_until_ms"]
                 if (
@@ -5579,8 +5789,12 @@ async def _equity_hard_stop_check(self) -> Optional[dict]:
                     and cooldown_until_ms is not None
                     and ts_ms >= cooldown_until_ms
                 ):
-                    self._equity_hard_stop_reset_after_restart(pside)
-                    self._equity_hard_stop_remove_latch_file(pside)
+                    if not await _equity_hard_stop_replay_live_restart(self, pside):
+                        continue
+                    state = self._hsl_state(pside)
+                    replay_complete = True
+                    if state["halted"]:
+                        continue
                     logging.info("[risk] HSL[%s] RED cooldown elapsed; trading resumed", pside)
                     _emit_hsl_event(
                         self,
@@ -5596,9 +5810,11 @@ async def _equity_hard_stop_check(self) -> Optional[dict]:
                 else:
                     self._equity_hard_stop_log_cooldown_status(pside, ts_ms)
                     continue
-        prev_latched = self._equity_hard_stop_runtime_red_latched(pside)
+        prev_latched = False if replay_complete else self._equity_hard_stop_runtime_red_latched(pside)
         prev_tier = self._equity_hard_stop_runtime_tier(pside)
-        metrics = self._equity_hard_stop_apply_sample(
+        # The replay already sampled its current account observation. Do not
+        # overwrite that result with the older pre-await check inputs.
+        metrics = state["last_metrics"] if replay_complete else self._equity_hard_stop_apply_sample(
             pside,
             ts_ms,
             float(balance),
@@ -5945,11 +6161,13 @@ async def _equity_hard_stop_check_coin(self) -> Optional[dict]:
             if partial_replay and (pside, symbol) not in ready_pairs:
                 continue
             state = self._hsl_coin_state(pside, symbol)
+            replay_complete = False
             if state["halted"]:
                 if await self._equity_hard_stop_handle_coin_position_during_cooldown(
                     pside, symbol, ts_ms
                 ):
                     state = self._hsl_coin_state(pside, symbol)
+                    replay_complete = True
                 if state["halted"]:
                     cooldown_until_ms = state["cooldown_until_ms"]
                     if (
@@ -5958,8 +6176,12 @@ async def _equity_hard_stop_check_coin(self) -> Optional[dict]:
                         and cooldown_until_ms is not None
                         and ts_ms >= cooldown_until_ms
                     ):
-                        self._equity_hard_stop_reset_coin_after_restart(pside, symbol)
-                        self._equity_hard_stop_remove_latch_file(pside, symbol=symbol)
+                        if not await _equity_hard_stop_replay_live_restart(self, pside, symbol):
+                            continue
+                        state = self._hsl_coin_state(pside, symbol)
+                        replay_complete = True
+                        if state["halted"]:
+                            continue
                         logging.info(
                             "[risk] HSL[%s:%s] RED cooldown elapsed; trading resumed",
                             pside,
@@ -5986,9 +6208,9 @@ async def _equity_hard_stop_check_coin(self) -> Optional[dict]:
                                     pside, symbol, "graceful_stop"
                                 )
                         continue
-            prev_latched = bool(state["runtime"].red_latched())
+            prev_latched = False if replay_complete else bool(state["runtime"].red_latched())
             prev_tier = str(state["runtime"].tier())
-            metrics = self._equity_hard_stop_apply_coin_sample(
+            metrics = state["last_metrics"] if replay_complete else self._equity_hard_stop_apply_coin_sample(
                 pside,
                 symbol,
                 ts_ms,

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -809,6 +809,7 @@ def _equity_hard_stop_intervention_entry_timestamp(
     stop_ms: int,
     cooldown_until_ms: Optional[int],
     symbol: Optional[str] = None,
+    qty_step: float = 0.0,
 ) -> Optional[int]:
     """Find the first canonical non-panic increase after a particular stop."""
     fill_events = list(fill_events)
@@ -838,6 +839,7 @@ def _equity_hard_stop_intervention_entry_timestamp(
             stop_ms=stop_ms,
             cooldown_until_ms=cooldown_until_ms,
             symbol=symbol,
+            qty_step=qty_step,
         )
         if evidence is not None:
             return evidence["entry_timestamp_ms"]
@@ -853,6 +855,7 @@ def _equity_hard_stop_intervention_entry_evidence(
     cooldown_until_ms: Optional[int],
     symbol: Optional[str] = None,
     stop_index: Optional[int] = None,
+    qty_step: float = 0.0,
 ) -> Optional[dict[str, Any]]:
     """Locate entry after a proven scoped flatten, including a tied fill cohort.
 
@@ -871,7 +874,7 @@ def _equity_hard_stop_intervention_entry_evidence(
         )
     ]
     ordered, ambiguous, flatten_indices = _equity_hard_stop_order_fill_cohorts(
-        scoped, include_flatten_indices=True
+        scoped, include_flatten_indices=True, qty_step=qty_step
     )
     if ambiguous:
         return None
@@ -1086,6 +1089,7 @@ def _equity_hard_stop_infer_coin_replay_contract(
         None if latest_panic_ts is None else _equity_hard_stop_intervention_entry_timestamp(
             fill_events, psides={pside}, stop_ms=latest_panic_ts,
             cooldown_until_ms=cooldown_until_ms, symbol=symbol,
+            qty_step=_hsl_qty_step_for_symbol(self, symbol),
         )
     )
     active_cooldown_now = cooldown_until_ms is not None and now_ms < cooldown_until_ms
@@ -2194,7 +2198,9 @@ def _hsl_compact_sparse_replay_indices(
     return np.flatnonzero(selected).astype(np.int64)
 
 
-def _equity_hard_stop_order_fill_cohorts(fill_events, *, include_flatten_indices=False):
+def _equity_hard_stop_order_fill_cohorts(
+    fill_events, *, include_flatten_indices=False, qty_step=0.0
+):
     """Order tied mixed-action fills only with exchange-provided position chains."""
     ordered = []
     ambiguous = False
@@ -2202,6 +2208,7 @@ def _equity_hard_stop_order_fill_cohorts(fill_events, *, include_flatten_indices
     flatten_indices = []
     sizes_complete = True
     nonflat_pairs = 0
+    proof_epsilon = _hsl_flat_epsilon(qty_step)
     for _ts, cohort_iter in groupby(
         sorted(fill_events, key=_equity_hard_stop_fill_timestamp_ms),
         key=_equity_hard_stop_fill_timestamp_ms,
@@ -2256,13 +2263,13 @@ def _equity_hard_stop_order_fill_cohorts(fill_events, *, include_flatten_indices
                 known_sizes.pop(pair, None)
                 # Keep ordering's original size cache behavior; optional flat
                 # evidence uses the same arithmetic tolerance as HSL replay.
-                if qty - size > _hsl_flat_epsilon():
+                if qty - size > proof_epsilon:
                     sizes_complete = False
             else:
                 known_sizes[pair] = size + qty if action == "increase" else size - qty
             if include_flatten_indices and sizes_complete:
-                nonflat_pairs += int(known_sizes.get(pair, 0.0) > _hsl_flat_epsilon()) - int(
-                    size > _hsl_flat_epsilon()
+                nonflat_pairs += int(known_sizes.get(pair, 0.0) > proof_epsilon) - int(
+                    size > proof_epsilon
                 )
                 if was_nonflat and nonflat_pairs == 0:
                     flatten_indices.append(len(ordered) - len(cohort) + offset)
@@ -5360,7 +5367,7 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                                 entry = _equity_hard_stop_intervention_entry_evidence(
                                     pair_fill_events, psides={pside}, symbol=symbol,
                                     stop_ms=stop_ts, cooldown_until_ms=state["cooldown_until_ms"],
-                                    stop_index=flatten_index,
+                                    stop_index=flatten_index, qty_step=qty_step,
                                 )
                                 if entry is None or entry["entry_timestamp_ms"] > now_ms:
                                     break

--- a/src/tools/run_fake_live.py
+++ b/src/tools/run_fake_live.py
@@ -23,6 +23,7 @@ from config.runtime_compile import compile_runtime_config
 from exchanges.fake import FakeCCXTClient, load_fake_scenario
 from fill_events_manager import FillEvent, FillEventCache
 from live.event_bus import LiveEvent, LiveEventContext, LiveEventPipeline
+from live.state_refresh import AuthoritativeSurfaceUnavailable
 from logging_setup import configure_logging
 import passivbot as passivbot_mod
 from passivbot import setup_bot, shutdown_bot
@@ -677,6 +678,23 @@ async def _run_fake_bot(
 
 
 async def _run_fake_cycle(bot):
+    try:
+        return await _run_fake_cycle_ready(bot)
+    except AuthoritativeSurfaceUnavailable as exc:
+        if exc.surface != "hsl_episode_boundaries":
+            raise
+        # Match the live loop: unknown held-episode evidence defers shared ordinary
+        # planning, while an independently latched RED scope keeps supervision.
+        if bot._equity_hard_stop_signal_mode() == "coin":
+            if bot._equity_hard_stop_coin_red_active():
+                await bot._equity_hard_stop_run_coin_red_supervisor()
+                return {"red_supervisor": True, "mode": "coin"}
+        elif _fake_active_red_psides(bot):
+            return await _run_fake_red_supervisor_step(bot)
+        return {"updated": False, "hsl_ready": False}
+
+
+async def _run_fake_cycle_ready(bot):
     if not await bot.update_pos_oos_pnls_ohlcvs():
         return {"updated": False}
     if bot._equity_hard_stop_enabled():

--- a/src/tools/run_fake_live.py
+++ b/src/tools/run_fake_live.py
@@ -685,6 +685,8 @@ async def _run_fake_cycle(bot):
             raise
         # Match the live loop: unknown held-episode evidence defers shared ordinary
         # planning, while an independently latched RED scope keeps supervision.
+        if await bot._run_halted_hsl_protection_if_active():
+            return {"cooldown_supervisor": True}
         if bot._equity_hard_stop_signal_mode() == "coin":
             if bot._equity_hard_stop_coin_red_active():
                 await bot._equity_hard_stop_run_coin_red_supervisor()

--- a/src/tools/run_fake_live.py
+++ b/src/tools/run_fake_live.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os
 import sys
+from types import MethodType
 from collections import deque
 from datetime import datetime, timezone
 from pathlib import Path
@@ -468,6 +469,19 @@ def _install_runtime_overrides(bot, scenario: dict) -> None:
     if hasattr(bot, "cca") and isinstance(bot.cca, FakeCCXTClient):
         fake_client = bot.cca
         bot.get_exchange_time = lambda: int(fake_client.now_ms)
+        update_pnls = getattr(bot, "update_pnls", None)
+        if isinstance(update_pnls, MethodType):
+            original_update_pnls = update_pnls.__func__
+
+            async def update_fake_pnls(self, *, source="direct", since_ms=None):
+                # Cache refresh watermarks use wall time, while scenarios can
+                # replay any date. Fetch the finite fake tape explicitly so a
+                # wall-clock overlap cannot skip scenario closing fills.
+                return await original_update_pnls(
+                    self, source=source, since_ms=0 if since_ms is None else since_ms
+                )
+
+            bot.update_pnls = MethodType(update_fake_pnls, bot)
         if hasattr(bot, "cm"):
             bot.cm._now_ms_callback = lambda: int(fake_client.now_ms)
 

--- a/tests/optimization/test_gpu_hsl_episode_boundaries.py
+++ b/tests/optimization/test_gpu_hsl_episode_boundaries.py
@@ -1,0 +1,219 @@
+"""Exercise the checked-in Metal episode boundary code on Apple MPS."""
+
+from functools import lru_cache
+from pathlib import Path
+
+import pytest
+
+
+torch = pytest.importorskip("torch")
+pytestmark = pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
+)
+
+_GPU = Path(__file__).resolve().parents[2] / "passivbot-rust" / "src" / "gpu"
+_KERNELS = (
+    "mps_ema_anchor_directional.metal",
+    "mps_trailing_martingale_directional.metal",
+    "mps_ema_anchor_multicoin_long.metal",
+    "mps_trailing_martingale_multicoin.metal",
+)
+
+
+def _source(name):
+    source = (_GPU / name).read_text()
+    for marker, filename in (
+        ("HSL", "mps_hsl_common.metal"),
+        ("BTC_RISK", "mps_btc_risk_common.metal"),
+        ("EQUITY_BALANCE_DIFF", "mps_equity_balance_diff_common.metal"),
+        ("ENTRY_INTERVAL", "mps_entry_interval_common.metal"),
+        ("MULTICOIN", "mps_multicoin_common.metal"),
+    ):
+        source = source.replace(f"// PASSIVBOT_{marker}_COMMON", (_GPU / filename).read_text())
+    return source
+
+
+def _params(mode=2, red_threshold=0.2):
+    return torch.tensor(
+        [1, red_threshold, 3, 60, 0.8, 0, 0.5, 0.8, 0, mode, 1],
+        dtype=torch.float32,
+        device="mps",
+    )
+
+
+_SHARED_PROBE = r"""
+kernel void episode_boundary_probe(
+    constant float* params,
+    device float* output,
+    constant int& scope_held,
+    constant int& opposite_held,
+    uint b [[thread_position_in_grid]]
+) {
+    HslState h = load_hsl(params, 0, 0);
+    h.initialized = true;
+    h.peak_strategy_pnl = 0.0f;
+    h.no_restart_peak_strategy_equity = 1234.0f;
+    HslState opposite = h;
+    bool reset = finish_hsl_scoped_episode_at_flat(
+        h, &opposite, scope_held != 0, opposite_held != 0,
+        900.0f, 1000.0f, -100.0f, -100.0f, 10.0f, 60000.0f
+    );
+    output[0] = reset;
+    output[1] = h.initialized;
+    output[2] = h.coin_realized_baseline;
+    output[3] = h.no_restart_peak_strategy_equity;
+    output[4] = h.red_latched;
+    output[5] = h.flat_confirmations;
+    output[6] = h.drawdown_ema;
+    output[7] = opposite.initialized;
+    // The controller still confirms flat exactly once during the normal bar pass.
+    update_hsl(h, 900.0f, 1000.0f, -100.0f, 0.0f,
+               false, false, 10.0f, 60000.0f);
+    output[8] = h.flat_confirmations;
+    output[9] = h.drawdown_ema;
+    // The next entry is in the same bar, after the actual flatten boundary.
+    HslSignal signal;
+    derive_hsl_signal(h, 900.0f, 1000.0f, -100.0f, -50.0f, signal);
+    output[10] = signal.drawdown_raw;
+}
+"""
+
+
+@lru_cache(maxsize=None)
+def _shared_library(name):
+    return torch.mps.compile_shader(_source(name) + _SHARED_PROBE)
+
+
+def _run_shared(name, mode=2, threshold=0.2, scope_held=False, opposite_held=False):
+    output = torch.zeros(11, dtype=torch.float32, device="mps")
+    _shared_library(name).episode_boundary_probe(
+        _params(mode, threshold), output, int(scope_held), int(opposite_held),
+        threads=(1, 1, 1),
+    )
+    torch.mps.synchronize()
+    return output.cpu().tolist()
+
+
+@pytest.mark.parametrize("name", _KERNELS)
+@pytest.mark.parametrize("mode", [0, 1, 2], ids=["unified", "pside", "coin"])
+def test_ordinary_episode_reset_preserves_persistent_peak_and_same_bar_reentry(name, mode):
+    values = _run_shared(name, mode)
+    assert values[:4] == [1, 0, -100, 1234]
+    assert values[4:7] == [0, 0, 0]
+    assert values[7] == (0 if mode == 0 else 1)
+    assert values[10] == pytest.approx(50 / 900, abs=1e-6)
+
+
+@pytest.mark.parametrize("name", _KERNELS)
+def test_closing_loss_can_first_trigger_red_without_double_sampling(name):
+    values = _run_shared(name, threshold=0.05)
+    assert values[0] == 0
+    assert values[1] == 1
+    assert values[2] == 0
+    assert values[4:6] == [1, 0]
+    assert values[6] == pytest.approx(0.5 * 100 / 900, abs=1e-6)
+    assert values[8] == 1
+    assert values[9] == values[6]
+
+
+@pytest.mark.parametrize("mode,scope_held,opposite_held,reset", [
+    (0, False, True, False),
+    (0, True, False, False),
+    (1, True, False, False),
+    (1, False, True, True),
+    (2, False, True, True),
+])
+def test_episode_resets_only_when_configured_scope_is_flat(mode, scope_held, opposite_held, reset):
+    values = _run_shared(_KERNELS[0], mode, scope_held=scope_held, opposite_held=opposite_held)
+    assert values[0] == int(reset)
+
+
+@pytest.mark.parametrize("direction", ["LONG", "SHORT"])
+@pytest.mark.parametrize("hsl_disabled", [False, True])
+def test_trailing_directional_specializations_compile(direction, hsl_disabled):
+    prefix = f"#define PASSIVBOT_TRAILING_{direction}_ONLY\n"
+    if hsl_disabled:
+        prefix += "#define PASSIVBOT_TRAILING_HSL_DISABLED\n"
+    torch.mps.compile_shader(prefix + _source(_KERNELS[1]))
+
+
+_MULTICOIN_PROBE = r"""
+kernel void multicoin_close_episode_probe(
+    constant float* params,
+    device float* output,
+    constant int& other_coin_held,
+    constant int& opposite_held,
+    constant int& short_side_raw,
+    uint b [[thread_position_in_grid]]
+) {
+    SIDE_STATE side;
+    side.hsl = load_hsl(params, 0, 0);
+    side.hsl.initialized = true;
+    side.hsl.peak_strategy_pnl = 0.0f;
+    side.psize[0] = 1.0f;
+    side.psize[1] = float(other_coin_held);
+    side.coin_realized_pnl[0] = 0.0f;
+    side.coin_realized_pnl[1] = 0.0f;
+    side.coin_hsl[0] = side.hsl;
+    side.coin_hsl[1] = side.hsl;
+    HslState opposite = side.hsl;
+    JointPortfolioAccount account = init_joint_portfolio_account(1000.0f);
+    FILL_STATE fills = INIT_FILLS();
+    float equity = 901.0f;
+    RECORD_FILL(side, account, fills, output, 0, 2, 0, 10,
+        -99.0f, -100.0f, 1.0f, 1000.0f, 901.0f, 1.0f,
+        short_side_raw != 0, false, false, equity, &opposite, opposite_held != 0);
+    thread HslState& h = side.hsl.signal_mode == HSL_SIGNAL_COIN
+        ? side.coin_hsl[0] : side.hsl;
+    output[0] = h.initialized;
+    output[1] = h.coin_realized_baseline;
+    output[2] = h.red_latched;
+    output[3] = account.balance;
+    output[4] = side.coin_realized_pnl[0];
+    output[5] = opposite.initialized;
+}
+"""
+
+
+@lru_cache(maxsize=None)
+def _multicoin_library(strategy):
+    if strategy == "ema":
+        name, side, fills, init, record = (
+            _KERNELS[2], "EmaMulticoinSideState", "EmaMulticoinFillState",
+            "init_ema_multicoin_fill_state", "record_ema_multicoin_close_fill",
+        )
+    else:
+        name, side, fills, init, record = (
+            _KERNELS[3], "TrailingMartingaleMulticoinSideState",
+            "TrailingMartingaleMulticoinFillState", "init_trailing_martingale_multicoin_fill_state",
+            "record_tm_multicoin_close_fill",
+        )
+    probe = _MULTICOIN_PROBE
+    for key, value in (("SIDE_STATE", side), ("FILL_STATE", fills), ("INIT_FILLS", init), ("RECORD_FILL", record)):
+        probe = probe.replace(key, value)
+    return torch.mps.compile_shader(_source(name) + probe)
+
+
+@pytest.mark.parametrize("strategy", ["ema", "trailing"])
+@pytest.mark.parametrize("short_side", [False, True], ids=["long", "short"])
+@pytest.mark.parametrize("mode,other_coin_held,opposite_held,reset", [
+    (2, True, True, True),
+    (1, True, False, False),
+    (1, False, True, True),
+    (0, False, True, False),
+    (0, False, False, True),
+])
+def test_multicoin_closing_fill_resets_scoped_state_after_accounting_for_fee(
+    strategy, short_side, mode, other_coin_held, opposite_held, reset
+):
+    output = torch.zeros(6, dtype=torch.float32, device="mps")
+    _multicoin_library(strategy).multicoin_close_episode_probe(
+        _params(mode), output, int(other_coin_held), int(opposite_held), int(short_side),
+        threads=(1, 1, 1),
+    )
+    torch.mps.synchronize()
+    values = output.cpu().tolist()
+    assert values[0] == int(not reset)
+    assert values[1] == (-100 if reset else 0)
+    assert values[2:5] == [0, 900, -100]
+    assert values[5] == (0 if mode == 0 and reset else 1)

--- a/tests/optimization/test_gpu_hsl_episode_boundaries.py
+++ b/tests/optimization/test_gpu_hsl_episode_boundaries.py
@@ -47,12 +47,15 @@ kernel void episode_boundary_probe(
     device float* output,
     constant int& scope_held,
     constant int& opposite_held,
+    constant int& prior_red,
     uint b [[thread_position_in_grid]]
 ) {
     HslState h = load_hsl(params, 0, 0);
     h.initialized = true;
     h.peak_strategy_pnl = 0.0f;
     h.no_restart_peak_strategy_equity = 1234.0f;
+    h.red_latched = prior_red != 0;
+    h.tier = prior_red != 0 ? 3 : 0;
     HslState opposite = h;
     bool reset = finish_hsl_scoped_episode_at_flat(
         h, &opposite, scope_held != 0, opposite_held != 0,
@@ -65,29 +68,38 @@ kernel void episode_boundary_probe(
     output[4] = h.red_latched;
     output[5] = h.flat_confirmations;
     output[6] = h.drawdown_ema;
-    output[7] = opposite.initialized;
-    // The controller still confirms flat exactly once during the normal bar pass.
+    output[7] = opposite.coin_realized_baseline;
+    // An ordinary bar read must not refinalize an already recorded stop.
     update_hsl(h, 900.0f, 1000.0f, -100.0f, 0.0f,
                false, false, 10.0f, 60000.0f);
     output[8] = h.flat_confirmations;
     output[9] = h.drawdown_ema;
     // The next entry is in the same bar, after the actual flatten boundary.
     HslSignal signal;
+    signal.drawdown_raw = -1.0f;
     derive_hsl_signal(h, 900.0f, 1000.0f, -100.0f, -50.0f, signal);
     output[10] = signal.drawdown_raw;
+    output[11] = h.halted;
+    output[12] = h.cooldown_until_k;
+    output[13] = h.triggers;
+    // A resting entry after this boundary cannot erase the finalized stop.
+    update_hsl(h, 900.0f, 1000.0f, -100.0f, -50.0f,
+               true, false, 10.0f, 60000.0f);
+    output[14] = h.pending_stop_k;
+    output[15] = h.triggers;
 }
 """
 
 
 @lru_cache(maxsize=None)
 def _shared_library(name):
-    return torch.mps.compile_shader(_source(name) + _SHARED_PROBE)
+    return torch.mps.compile_shader(_source(name) + _SHARED_PROBE + _SAME_MINUTE_PROBE + _EMA_REPLACEMENT_PROBE)
 
 
-def _run_shared(name, mode=2, threshold=0.2, scope_held=False, opposite_held=False):
-    output = torch.zeros(11, dtype=torch.float32, device="mps")
+def _run_shared(name, mode=2, threshold=0.2, scope_held=False, opposite_held=False, prior_red=False):
+    output = torch.zeros(16, dtype=torch.float32, device="mps")
     _shared_library(name).episode_boundary_probe(
-        _params(mode, threshold), output, int(scope_held), int(opposite_held),
+        _params(mode, threshold), output, int(scope_held), int(opposite_held), int(prior_red),
         threads=(1, 1, 1),
     )
     torch.mps.synchronize()
@@ -98,22 +110,24 @@ def _run_shared(name, mode=2, threshold=0.2, scope_held=False, opposite_held=Fal
 @pytest.mark.parametrize("mode", [0, 1, 2], ids=["unified", "pside", "coin"])
 def test_ordinary_episode_reset_preserves_persistent_peak_and_same_bar_reentry(name, mode):
     values = _run_shared(name, mode)
-    assert values[:4] == [1, 0, -100, 1234]
+    assert values[:4] == [1, 1, -100, 1234]
     assert values[4:7] == [0, 0, 0]
-    assert values[7] == (0 if mode == 0 else 1)
+    assert values[7] == (-100 if mode == 0 else 0)
     assert values[10] == pytest.approx(50 / 900, abs=1e-6)
 
 
 @pytest.mark.parametrize("name", _KERNELS)
-def test_closing_loss_can_first_trigger_red_without_double_sampling(name):
-    values = _run_shared(name, threshold=0.05)
+@pytest.mark.parametrize("prior_red", [False, True], ids=["first-red-on-close", "already-red"])
+def test_closing_loss_can_first_trigger_red_without_double_sampling(name, prior_red):
+    values = _run_shared(name, threshold=0.2 if prior_red else 0.05, prior_red=prior_red)
     assert values[0] == 0
     assert values[1] == 1
-    assert values[2] == 0
-    assert values[4:6] == [1, 0]
+    assert values[2] == -100
+    assert values[4:6] == [1, 2]
     assert values[6] == pytest.approx(0.5 * 100 / 900, abs=1e-6)
-    assert values[8] == 1
+    assert values[8] == 2
     assert values[9] == values[6]
+    assert values[11:] == [1, 70, 1, 10, 1]
 
 
 @pytest.mark.parametrize("mode,scope_held,opposite_held,reset", [
@@ -165,12 +179,12 @@ kernel void multicoin_close_episode_probe(
         short_side_raw != 0, false, false, equity, &opposite, opposite_held != 0);
     thread HslState& h = side.hsl.signal_mode == HSL_SIGNAL_COIN
         ? side.coin_hsl[0] : side.hsl;
-    output[0] = h.initialized;
+    output[0] = h.coin_realized_baseline == -100.0f;
     output[1] = h.coin_realized_baseline;
     output[2] = h.red_latched;
     output[3] = account.balance;
     output[4] = side.coin_realized_pnl[0];
-    output[5] = opposite.initialized;
+    output[5] = opposite.coin_realized_baseline;
 }
 """
 
@@ -213,7 +227,87 @@ def test_multicoin_closing_fill_resets_scoped_state_after_accounting_for_fee(
     )
     torch.mps.synchronize()
     values = output.cpu().tolist()
-    assert values[0] == int(not reset)
+    assert values[0] == int(reset)
     assert values[1] == (-100 if reset else 0)
     assert values[2:5] == [0, 900, -100]
-    assert values[5] == (0 if mode == 0 and reset else 1)
+    assert values[5] == (-100 if mode == 0 and reset else 0)
+
+
+_SAME_MINUTE_PROBE = r"""
+kernel void same_minute_boundary_probe(
+    constant float* params, device float* output,
+    uint b [[thread_position_in_grid]]
+) {
+    HslState h = load_hsl(params, 0, 0);
+    h.initialized = true;
+    h.peak_strategy_pnl = 0.0f;
+    // Prime the minute's normal sample before two separate position episodes.
+    update_hsl(h, 1000.0f, 1000.0f, 0.0f, 0.0f, true, false, 10.0f, 60000.0f);
+    output[0] = finish_hsl_episode_at_flat(h, 990.0f, 1000.0f, -10.0f, 10.0f, 60000.0f);
+    output[1] = h.drawdown_ema;
+    // Another entry and close in this minute lose a further 100 including fees.
+    output[2] = finish_hsl_episode_at_flat(h, 890.0f, 1000.0f, -110.0f, 10.0f, 60000.0f);
+    output[3] = h.sampled_drawdown_raw;
+    output[4] = h.drawdown_ema;
+    output[5] = h.halted;
+    output[6] = h.pending_stop_k;
+    output[7] = h.cooldown_until_k;
+    output[8] = h.triggers;
+    output[9] = h.no_restart_latched;
+    update_hsl(h, 890.0f, 1000.0f, -110.0f, -50.0f, true, false, 10.0f, 60000.0f);
+    output[10] = h.drawdown_ema;
+    output[11] = h.triggers;
+}
+"""
+
+
+@pytest.mark.parametrize("name", _KERNELS)
+@pytest.mark.parametrize("mode", [0, 1, 2], ids=["unified", "pside", "coin"])
+@pytest.mark.parametrize("terminal", [False, True])
+def test_second_same_minute_closing_loss_finalizes_red_before_reentry(name, mode, terminal):
+    params = _params(mode, 0.02)
+    if terminal:
+        params[4] = 0.04
+        params[5] = 1
+    output = torch.zeros(12, dtype=torch.float32, device="mps")
+    _shared_library(name).same_minute_boundary_probe(params, output, threads=(1, 1, 1))
+    torch.mps.synchronize()
+    values = output.cpu().tolist()
+    raw = 100 / (890 if mode == 2 else 990)
+    assert values[:3] == [1, 0, 0]
+    assert values[3:5] == pytest.approx([raw, 0.5 * raw], abs=1e-6)
+    assert values[5:10] == [1, 10, -1 if terminal else 70, 1, int(terminal)]
+    assert values[10] == values[4]
+    assert values[11] == 1
+
+
+_EMA_REPLACEMENT_PROBE = r"""
+kernel void boundary_ema_replacement_probe(constant float* params, device float* output,
+    uint b [[thread_position_in_grid]]) {
+    HslState h = load_hsl(params, 0, 0);
+    h.initialized = true;
+    h.drawdown_ema = 0.2f;
+    h.last_sample_k = 8.0f;
+    HslSignal signal;
+    signal.strategy_equity = 900.0f;
+    signal.peak_strategy_equity = 1000.0f;
+    signal.drawdown_raw = 0.1f;
+    update_hsl_from_signal(h, signal, 0.0f, true, false, 10.0f, 60000.0f);
+    output[0] = h.drawdown_ema;
+    signal.drawdown_raw = 0.3f;
+    update_hsl_from_signal(h, signal, 0.0f, true, false, 10.0f, 60000.0f, true);
+    output[1] = h.drawdown_ema;
+    signal.drawdown_raw = 0.9f;
+    update_hsl_from_signal(h, signal, 0.0f, true, false, 10.0f, 60000.0f);
+    output[2] = h.drawdown_ema;
+    output[3] = h.sampled_drawdown_raw;
+}
+"""
+
+
+@pytest.mark.parametrize("name", _KERNELS)
+def test_distinct_boundary_replaces_cached_minute_without_compounding_ema(name):
+    output = torch.zeros(4, dtype=torch.float32, device="mps")
+    _shared_library(name).boundary_ema_replacement_probe(_params(red_threshold=0.9), output, threads=(1, 1, 1))
+    torch.mps.synchronize()
+    assert output.cpu().tolist() == pytest.approx([0.125, 0.275, 0.275, 0.3], abs=1e-6)

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -15464,14 +15464,16 @@ def test_mps_dual_side_single_coin_hsl_respects_signal_scope(
     ).run(rows)
     torch.mps.synchronize()
 
-    assert output["hsl_triggers_long"][0].item() == (
-        0.0 if signal_mode == "unified" else 1.0
+    # EMA closes can briefly flatten the entire account before a resting entry
+    # reopens the other side in the same bar. That exact boundary now finalizes
+    # the enabled controller even though the final position snapshot is held.
+    enabled_side_triggers = (
+        0.0 if signal_mode == "unified" and strategy_kind == "trailing_martingale" else 1.0
     )
+    assert output["hsl_triggers_long"][0].item() == enabled_side_triggers
     assert output["hsl_triggers_short"][0].item() == 0.0
     assert output["hsl_triggers_long"][1].item() == 0.0
-    assert output["hsl_triggers_short"][1].item() == (
-        0.0 if signal_mode == "unified" else 1.0
-    )
+    assert output["hsl_triggers_short"][1].item() == enabled_side_triggers
     assert output["hsl_triggers_long"][2].item() == 1.0
     assert output["hsl_triggers_short"][2].item() == 1.0
     assert output["hsl_trigger_drawdown_count"][2].item() == 2.0

--- a/tests/test_hsl_coin_boundary_balance.py
+++ b/tests/test_hsl_coin_boundary_balance.py
@@ -1,0 +1,174 @@
+"""Coin risk samples use the account balance at the exact closing fill."""
+
+from types import MethodType
+
+import pytest
+
+from passivbot import Passivbot
+from test_hsl_coin_mode import make_coin_bot, make_fake_pnls_manager
+
+
+def _two_coin_boundary_bot(
+    *, other_pnl, other_pside, threshold, other_ts=180_700, other_fee=0.0
+):
+    bot = make_coin_bot()
+    for name in (
+        "_equity_hard_stop_runtime_initialized",
+        "_equity_hard_stop_log_status",
+    ):
+        setattr(bot, name, MethodType(getattr(Passivbot, name), bot))
+    bot._equity_hard_stop_status_log_interval_ms = 60_000
+    bot.hsl["long"].update(red_threshold=threshold, ema_span_minutes=1.0)
+    # A single configured budget slot makes the closing risk denominator explicit.
+    bot.bot_value = lambda pside, key: 1.0
+    events = [
+        dict(
+            timestamp=60_000,
+            symbol="A",
+            pside="long",
+            action="increase",
+            qty=1.0,
+            pnl=0.0,
+        ),
+        dict(
+            timestamp=90_000,
+            symbol="B",
+            pside=other_pside,
+            action="increase",
+            qty=1.0,
+            pnl=0.0,
+        ),
+        dict(
+            timestamp=180_500,
+            symbol="A",
+            pside="long",
+            action="decrease",
+            qty=1.0,
+            pnl=-300.0,
+        ),
+        dict(
+            timestamp=other_ts,
+            symbol="B",
+            pside=other_pside,
+            action="decrease",
+            qty=1.0,
+            pnl=other_pnl,
+            fee_paid=other_fee,
+        ),
+    ]
+    bot.positions = {
+        symbol: {side: {"size": 0.0} for side in ("long", "short")}
+        for symbol in ("A", "B")
+    }
+    bot._pnls_manager = make_fake_pnls_manager(events)
+    bot.get_raw_balance = lambda: 700.0 + other_pnl + other_fee
+    bot.get_exchange_time = lambda: 240_900
+    bot._equity_hard_stop_realized_pnl_now = lambda pside=None: sum(
+        (e["pnl"] + e.get("fee_paid", 0.0))
+        for e in events
+        if pside is None or e["pside"] == pside
+    )
+
+    async def history(**kwargs):
+        timeline = []
+        for ts in (60_000, 120_000, 180_000, 240_000):
+            prior = [e for e in events if e["timestamp"] < ts + 60_000]
+            by_pair = {
+                symbol: {
+                    side: sum(
+                        e["pnl"] + e.get("fee_paid", 0.0)
+                        for e in prior
+                        if e["symbol"] == symbol and e["pside"] == side
+                    )
+                    for side in ("long", "short")
+                }
+                for symbol in ("A", "B")
+            }
+            realized = sum(e["pnl"] + e.get("fee_paid", 0.0) for e in prior)
+            timeline.append(
+                {
+                    "timestamp": ts,
+                    "balance": 1000.0 + realized,
+                    "realized_pnl": realized,
+                    "realized_pnl_by_coin_pside": by_pair,
+                    "unrealized_pnl_by_coin_pside": {
+                        symbol: {"long": 0.0, "short": 0.0} for symbol in ("A", "B")
+                    },
+                }
+            )
+        return {"timeline": timeline, "fill_events": events, "panic_flatten_events": []}
+
+    bot.get_balance_equity_history = history
+    samples = []
+    original = bot._equity_hard_stop_apply_coin_metrics_sample
+
+    def record_sample(self, pside, symbol, timestamp_ms, balance, *args, **kwargs):
+        result = original(pside, symbol, timestamp_ms, balance, *args, **kwargs)
+        if symbol == "A" and timestamp_ms == 180_500 and kwargs.get("at_fill_boundary"):
+            samples.append((balance, dict(result)))
+        return result
+
+    bot._equity_hard_stop_apply_coin_metrics_sample = MethodType(record_sample, bot)
+    return bot, samples
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("other_pside", ["long", "short"])
+@pytest.mark.parametrize(
+    "other_pnl,threshold,expected_red", [(1000.0, 0.4, True), (-100.0, 0.45, False)]
+)
+async def test_coin_closing_risk_uses_account_balance_before_other_later_fill(
+    other_pside, other_pnl, threshold, expected_red
+):
+    bot, samples = _two_coin_boundary_bot(
+        other_pnl=other_pnl, other_pside=other_pside, threshold=threshold
+    )
+    # Repeating startup must reconstruct the same historical decision from scratch.
+    for _ in range(2):
+        samples.clear()
+        await bot._equity_hard_stop_initialize_coin_from_history()
+        assert samples
+        balance, metrics = samples[0]
+        assert balance == pytest.approx(700.0)
+        assert metrics["realized_pnl"] == pytest.approx(-300.0)
+        assert metrics["drawdown_raw"] == pytest.approx(300.0 / 700.0)
+        assert (metrics["tier"] == "red") is expected_red
+        state = bot._hsl_coin_state("long", "A")
+        assert bool(state["halted"]) is expected_red
+        if expected_red:
+            assert state["last_stop_event"]["stop_event_timestamp_ms"] == 180_500
+            assert state["cooldown_until_ms"] == 480_500
+        else:
+            assert state["last_stop_event"] is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("other_pside", ["long", "short"])
+@pytest.mark.parametrize("other_pnl", [1000.0, -100.0])
+async def test_coin_boundary_includes_other_pair_same_timestamp_cohort(
+    other_pside, other_pnl
+):
+    bot, samples = _two_coin_boundary_bot(
+        other_pnl=other_pnl, other_pside=other_pside, threshold=0.4, other_ts=180_500
+    )
+    await bot._equity_hard_stop_initialize_coin_from_history()
+    balance, metrics = samples[0]
+    # Separate pairs at the same timestamp have no global execution order. The
+    # existing incremental convention includes the whole timestamp cohort.
+    assert balance == pytest.approx(700.0 + other_pnl)
+    assert metrics["realized_pnl"] == pytest.approx(-300.0)
+    assert metrics["drawdown_raw"] == pytest.approx(300.0 / (700.0 + other_pnl))
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("other_pside", ["long", "short"])
+async def test_coin_boundary_excludes_other_pair_later_fee(other_pside):
+    bot, samples = _two_coin_boundary_bot(
+        other_pnl=0.0, other_pside=other_pside, threshold=0.4293, other_fee=-2.0
+    )
+    await bot._equity_hard_stop_initialize_coin_from_history()
+    balance, metrics = samples[0]
+    assert balance == pytest.approx(700.0)
+    assert metrics["drawdown_raw"] == pytest.approx(300.0 / 700.0)
+    assert metrics["tier"] != "red"
+    assert not bot._hsl_coin_state("long", "A")["halted"]

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -4727,3 +4727,530 @@ async def test_coin_hsl_check_tp_only_orange_blocks_flat_initial_entries():
         bot._runtime_forced_modes["long"][flat_symbol]
         == "tp_only_with_active_entry_cancellation"
     )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("reentry,extra_episode", [(False, False), (True, False), (True, True)])
+async def test_live_coin_hsl_resets_red_free_fill_episode_before_next_sample(
+    reentry, extra_episode
+):
+    bot = make_coin_bot()
+    bot._equity_hard_stop_coin_initialized = True
+    symbol = "A"
+    bot.bot_value = lambda pside, key: 1 if key == "n_positions" else 1.0
+    bot.hsl["long"]["red_threshold"] = 0.15
+    bot.positions = {symbol: {"long": {"size": 1.0}, "short": {"size": 0.0}}}
+    events = [
+        {
+            "timestamp": 60_000,
+            "symbol": symbol,
+            "pside": "long",
+            "action": "increase",
+            "qty": 1.0,
+            "pnl": 0.0,
+        },
+    ]
+    bot._pnls_manager = make_fake_pnls_manager(events)
+    bot._equity_hard_stop_apply_coin_sample("long", symbol, 120_000, 1000.0, -50.0)
+    state = bot._hsl_coin_state("long", symbol)
+    state["no_restart_peak_strategy_equity"] = 1.25
+    events.append(
+        {
+            "timestamp": 180_500,
+            "symbol": symbol,
+            "pside": "long",
+            "action": "decrease",
+            "qty": 1.0,
+            "pnl": -100.0,
+        }
+    )
+    if reentry:
+        events.append(
+            {
+                "timestamp": 180_600,
+                "symbol": symbol,
+                "pside": "long",
+                "action": "increase",
+                "qty": 1.0,
+                "pnl": 0.0,
+            }
+        )
+    else:
+        bot.positions[symbol]["long"]["size"] = 0.0
+    if extra_episode:
+        events.extend(
+            [
+                {
+                    "timestamp": 180_700,
+                    "symbol": symbol,
+                    "pside": "long",
+                    "action": "decrease",
+                    "qty": 1.0,
+                    "pnl": -20.0,
+                },
+                {
+                    "timestamp": 180_800,
+                    "symbol": symbol,
+                    "pside": "long",
+                    "action": "increase",
+                    "qty": 1.0,
+                    "pnl": 0.0,
+                    "fee_paid": -1.0,
+                },
+            ]
+        )
+    final_balance = 879.0 if extra_episode else 900.0
+    bot.get_raw_balance = lambda: final_balance
+    bot.get_exchange_time = lambda: 240_000
+
+    async def upnl(*args):
+        return -50.0 if reentry else 0.0
+
+    bot._calc_upnl_sum_strict = upnl
+    metrics = (await bot._equity_hard_stop_check_coin())[f"long:{symbol}"]
+    assert state["pnl_reset_timestamp_ms"] == (180_701 if extra_episode else 180_501)
+    assert state["no_restart_peak_strategy_equity"] == 1.25
+    assert metrics["realized_pnl"] == (-1.0 if extra_episode else 0.0)
+    expected_drawdown = (51.0 if extra_episode else 50.0) / final_balance if reentry else 0.0
+    assert metrics["drawdown_raw"] == pytest.approx(expected_drawdown)
+    assert metrics["tier"] != "red"
+    assert not state["halted"]
+    runtime = state["runtime"]
+    assert not await hsl._equity_hard_stop_refresh_live_coin_episode_boundaries(
+        bot, 300_000, final_balance
+    )
+    assert state["runtime"] is runtime
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "delayed,closing_loss,tied", [(True, 100.0, False), (False, 300.0, False), (False, 100.0, True)]
+)
+async def test_live_coin_boundary_uses_canonical_replay_for_delayed_or_red_fill(
+    delayed, closing_loss, tied
+):
+    bot = make_coin_bot()
+    bot._equity_hard_stop_coin_initialized = True
+    symbol = "A"
+    bot.bot_value = lambda pside, key: 1 if key == "n_positions" else 1.0
+    bot.hsl["long"]["red_threshold"] = 0.15
+    bot.positions = {symbol: {"long": {"size": 0.0}, "short": {"size": 0.0}}}
+    events = [
+        {
+            "timestamp": 60_000,
+            "symbol": symbol,
+            "pside": "long",
+            "action": "increase",
+            "qty": 1.0,
+            "pnl": 0.0,
+        },
+    ]
+    bot._pnls_manager = make_fake_pnls_manager(events)
+    bot._equity_hard_stop_apply_coin_sample(
+        "long", symbol, 240_000 if delayed else 120_000, 1000.0, 0.0
+    )
+    events.append(
+        {
+            "timestamp": 180_500,
+            "symbol": symbol,
+            "pside": "long",
+            "action": "decrease",
+            "qty": 1.0,
+            "pnl": -closing_loss,
+        }
+    )
+    if tied:
+        events.append(
+            {
+                "timestamp": 180_500,
+                "symbol": symbol,
+                "pside": "long",
+                "action": "increase",
+                "qty": 1.0,
+                "pnl": 0.0,
+            }
+        )
+        bot.positions[symbol]["long"]["size"] = 1.0
+    replays = []
+
+    async def replay():
+        replays.append(True)
+
+    bot._equity_hard_stop_initialize_coin_from_history = replay
+    rebuilt = await hsl._equity_hard_stop_refresh_live_coin_episode_boundaries(
+        bot, 300_000, 1000.0 - closing_loss
+    )
+    assert rebuilt is True
+    assert replays == [True]
+    # Replay owns resetting/finalizing this episode, not the ordinary fast path.
+    assert bot._hsl_coin_state("long", symbol)["pnl_reset_timestamp_ms"] is None
+
+
+@pytest.mark.asyncio
+async def test_live_coin_boundary_does_not_guess_from_incomplete_fill_sizes():
+    bot = make_coin_bot()
+    bot._equity_hard_stop_coin_initialized = True
+    symbol = "A"
+    bot.positions = {symbol: {"long": {"size": 1.0}, "short": {"size": 0.0}}}
+    events = [
+        {
+            "timestamp": 60_000,
+            "symbol": symbol,
+            "pside": "long",
+            "action": "increase",
+            "qty": 1.0,
+            "pnl": 0.0,
+        },
+    ]
+    bot._pnls_manager = make_fake_pnls_manager(events)
+    bot._equity_hard_stop_apply_coin_sample("long", symbol, 120_000, 1000.0, 0.0)
+    events.append(
+        {
+            "timestamp": 180_500,
+            "symbol": symbol,
+            "pside": "long",
+            "action": "decrease",
+            "qty": 1.0,
+            "pnl": -10.0,
+        }
+    )
+    assert (
+        await hsl._equity_hard_stop_refresh_live_coin_episode_boundaries(bot, 240_000, 990.0)
+        is False
+    )
+    assert bot._hsl_coin_state("long", symbol)["pnl_reset_timestamp_ms"] is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("initialized", [False, True])
+async def test_live_coin_boundary_waits_for_background_replay_owner(initialized):
+    bot = make_coin_bot()
+    bot._equity_hard_stop_coin_initialized = initialized
+    bot._equity_hard_stop_coin_protective_ready = True
+    bot._equity_hard_stop_coin_replay_ready_pairs = {("long", "A")}
+    bot._equity_hard_stop_coin_replay_pending_pairs = {("long", "Z")}
+    bot.positions = {"A": {"long": {"size": 1.0}, "short": {"size": 0.0}}}
+    release = asyncio.Event()
+    bot._equity_hard_stop_coin_replay_task = asyncio.create_task(release.wait())
+    reads = []
+    bot._pnls_manager = make_fake_pnls_manager([])
+    bot._pnls_manager.get_events = lambda: reads.append(True) or []
+    try:
+        assert not await hsl._equity_hard_stop_refresh_live_coin_episode_boundaries(
+            bot, 300_000, 1000.0
+        )
+        assert reads == []
+        release.set()
+        await bot._equity_hard_stop_coin_replay_task
+        # A failed partial reconstruction must also retain its ownership barrier.
+        assert not await hsl._equity_hard_stop_refresh_live_coin_episode_boundaries(
+            bot, 300_000, 1000.0
+        )
+        assert reads == ([True] if initialized else [])
+    finally:
+        release.set()
+        await bot._equity_hard_stop_coin_replay_task
+
+
+@pytest.mark.asyncio
+async def test_delayed_live_coin_boundary_is_not_replayed_again_after_reconstruction():
+    bot = make_coin_bot()
+    bot._equity_hard_stop_coin_initialized = True
+    bot.bot_value = lambda pside, key: 1 if key == "n_positions" else 1.0
+    bot.hsl["long"]["red_threshold"] = 0.5
+    bot.positions = {"A": {"long": {"size": 0.0}, "short": {"size": 0.0}}}
+    events = [
+        {
+            "timestamp": 60_000,
+            "symbol": "A",
+            "pside": "long",
+            "action": "increase",
+            "qty": 1.0,
+            "pnl": 0.0,
+        },
+        {
+            "timestamp": 180_500,
+            "symbol": "A",
+            "pside": "long",
+            "action": "decrease",
+            "qty": 1.0,
+            "pnl": -100.0,
+        },
+    ]
+    bot._pnls_manager = make_fake_pnls_manager(events)
+    bot._equity_hard_stop_apply_coin_sample("long", "A", 240_000, 900.0, 0.0)
+    bot.get_raw_balance = lambda: 900.0
+    bot.get_exchange_time = lambda: 300_000
+    replays = []
+
+    async def history(current_balance=None, **kwargs):
+        replays.append(True)
+        return {
+            "timeline": [
+                {
+                    "timestamp": ts,
+                    "balance": 1000.0 + pnl,
+                    "realized_pnl": pnl,
+                    "realized_pnl_by_coin_pside": {"A": {"long": pnl, "short": 0.0}},
+                    "unrealized_pnl_by_coin_pside": {"A": {"long": 0.0, "short": 0.0}},
+                }
+                for ts, pnl in [
+                    (60_000, 0.0),
+                    (120_000, 0.0),
+                    (180_000, 0.0),
+                    (240_000, -100.0),
+                ]
+            ],
+            "panic_flatten_events": [],
+            "fill_events": events,
+        }
+
+    bot.get_balance_equity_history = history
+    assert await hsl._equity_hard_stop_refresh_live_coin_episode_boundaries(
+        bot, 300_000, 900.0
+    )
+    assert bot._hsl_coin_state("long", "A")["pnl_reset_timestamp_ms"] == 180_501
+    assert not await hsl._equity_hard_stop_refresh_live_coin_episode_boundaries(
+        bot, 360_000, 900.0
+    )
+    assert replays == [True]
+
+
+def _make_aggregate_episode_bot(
+    signal_mode, *, closing_loss=100.0, other_side_held=False
+):
+    bot = make_coin_bot()
+    bot.config["live"]["hsl_signal_mode"] = signal_mode
+    for name in (
+        "_equity_hard_stop_runtime_initialized",
+        "_equity_hard_stop_log_status",
+    ):
+        setattr(bot, name, MethodType(getattr(Passivbot, name), bot))
+    bot._equity_hard_stop_status_log_interval_ms = 60_000
+    bot.hsl["long"]["red_threshold"] = 0.15
+    events = [
+        {
+            "timestamp": 60_000,
+            "symbol": "A",
+            "pside": "long",
+            "action": "increase",
+            "qty": 1.0,
+            "pnl": 0.0,
+        },
+        {
+            "timestamp": 180_500,
+            "symbol": "A",
+            "pside": "long",
+            "action": "decrease",
+            "qty": 1.0,
+            "pnl": -closing_loss,
+        },
+        {
+            "timestamp": 180_600,
+            "symbol": "A",
+            "pside": "long",
+            "action": "increase",
+            "qty": 1.0,
+            "pnl": 0.0,
+            "fee_paid": -1.0,
+        },
+    ]
+    bot.positions = {"A": {"long": {"size": 1.0}, "short": {"size": 0.0}}}
+    if other_side_held:
+        events.append(
+            {
+                "timestamp": 90_000,
+                "symbol": "B",
+                "pside": "short",
+                "action": "increase",
+                "qty": 1.0,
+                "pnl": 0.0,
+            }
+        )
+        bot.positions["B"] = {"long": {"size": 0.0}, "short": {"size": 1.0}}
+    bot._pnls_manager = make_fake_pnls_manager(events)
+    bot.get_raw_balance = lambda: 1000.0 + sum(
+        event.get("pnl", 0.0) + event.get("fee_paid", 0.0) for event in events
+    )
+    bot.get_exchange_time = lambda: 300_000
+    bot._equity_hard_stop_realized_pnl_now = lambda pside=None: sum(
+        event.get("pnl", 0.0) + event.get("fee_paid", 0.0)
+        for event in events
+        if pside is None or event["pside"] == pside
+    )
+
+    async def upnl(pside=None, symbol=None):
+        return (
+            -50.0
+            if pside in (None, "long") and bot.positions["A"]["long"]["size"]
+            else 0.0
+        )
+
+    async def history(current_balance=None, **kwargs):
+        rows = []
+        for ts in (60_000, 120_000, 180_000, 240_000):
+            realized = sum(
+                event.get("pnl", 0.0) + event.get("fee_paid", 0.0)
+                for event in events
+                if event["timestamp"] < ts + 60_000
+            )
+            long_size = sum(
+                event["qty"] * (1 if event["action"] == "increase" else -1)
+                for event in events
+                if event["pside"] == "long" and event["timestamp"] < ts + 60_000
+            )
+            rows.append(
+                {
+                    "timestamp": ts,
+                    "balance": 1000.0 + realized,
+                    "realized_pnl": realized,
+                    "realized_pnl_long": realized,
+                    "realized_pnl_short": 0.0,
+                    "unrealized_pnl_long": (
+                        0.0 if ts == 60_000 or long_size == 0.0 else -50.0
+                    ),
+                    "unrealized_pnl_short": 0.0,
+                    "is_flat": long_size == 0.0 and not other_side_held,
+                    "is_flat_long": long_size == 0.0,
+                    "is_flat_short": not other_side_held,
+                }
+            )
+        return {"timeline": rows, "fill_events": events, "panic_flatten_events": []}
+
+    bot._calc_upnl_sum_strict = upnl
+    bot.get_balance_equity_history = history
+    return bot
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("signal_mode", ["pside", "unified"])
+@pytest.mark.parametrize("late", [False, True])
+async def test_live_aggregate_episode_resets_at_fill_before_same_minute_reentry(
+    signal_mode, late
+):
+    bot = _make_aggregate_episode_bot(signal_mode)
+    bot._equity_hard_stop_apply_sample(
+        "long", 60_000, 1000.0, 0.0, 0.0, 0.0, unrealized_pnl_total=0.0
+    )
+    bot._equity_hard_stop_apply_sample(
+        "long",
+        240_000 if late else 120_000,
+        1000.0,
+        0.0,
+        0.0,
+        -50.0,
+        unrealized_pnl_total=-50.0,
+    )
+    bot._hsl_state("long")["no_restart_peak_strategy_equity"] = 1234.0
+    result = await hsl._equity_hard_stop_check(bot)
+    if late:
+        assert result is None
+        result = await hsl._equity_hard_stop_check(bot)
+    state = bot._hsl_state("long")
+    assert state["pnl_reset_timestamp_ms"] == 180_501
+    if not late:
+        assert state["no_restart_peak_strategy_equity"] == 1234.0
+    assert result["long"]["drawdown_raw"] == pytest.approx(51.0 / 900.0)
+    assert result["long"]["tier"] != "red"
+    runtime = state["runtime"]
+    assert not await hsl._equity_hard_stop_refresh_live_scope_episode_boundaries(
+        bot, 360_000, 899.0
+    )
+    assert state["runtime"] is runtime
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("signal_mode", ["pside", "unified"])
+async def test_aggregate_replay_uses_whole_scope_for_fill_boundary(signal_mode):
+    bot = _make_aggregate_episode_bot(signal_mode, other_side_held=True)
+    bot.hsl["long"]["red_threshold"] = 0.5
+    await bot._equity_hard_stop_initialize_from_history()
+    state = bot._hsl_state("long")
+    if signal_mode == "pside":
+        assert state["pnl_reset_timestamp_ms"] == 180_501
+        assert state["last_metrics"]["drawdown_raw"] == pytest.approx(51.0 / 900.0)
+    else:
+        assert state["pnl_reset_timestamp_ms"] is None
+        assert state["last_metrics"]["drawdown_raw"] == pytest.approx(151.0 / 1000.0)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("signal_mode", ["pside", "unified"])
+async def test_aggregate_final_fill_red_enters_cooldown_before_reentry(signal_mode):
+    bot = _make_aggregate_episode_bot(signal_mode, closing_loss=300.0)
+    bot._equity_hard_stop_apply_sample(
+        "long", 60_000, 1000.0, 0.0, 0.0, 0.0, unrealized_pnl_total=0.0
+    )
+    assert await hsl._equity_hard_stop_check(bot) is None
+    state = bot._hsl_state("long")
+    assert state["halted"]
+    assert state["last_stop_event"]["stop_event_timestamp_ms"] == 180_500
+    assert state["cooldown_until_ms"] == 180_500 + 300_000
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("signal_mode", ["pside", "unified"])
+@pytest.mark.parametrize(
+    "layout", ["flat", "two_episodes", "tied_episodes", "gap", "tail"]
+)
+async def test_aggregate_replay_retains_each_fill_boundary_and_fee(signal_mode, layout):
+    bot = _make_aggregate_episode_bot(signal_mode)
+    events = bot._pnls_manager.get_events()
+    expected_reset = 180_501
+    expected_drawdown = 51.0 / 900.0
+    if layout == "flat":
+        events.pop()
+        bot.positions["A"]["long"]["size"] = 0.0
+        expected_drawdown = 0.0
+    elif layout in {"two_episodes", "tied_episodes"}:
+        events.extend(
+            [
+                {
+                    "timestamp": 180_700,
+                    "symbol": "A",
+                    "pside": "long",
+                    "action": "decrease",
+                    "qty": 1.0,
+                    "pnl": -20.0,
+                },
+                {
+                    "timestamp": 180_800,
+                    "symbol": "A",
+                    "pside": "long",
+                    "action": "increase",
+                    "qty": 1.0,
+                    "pnl": 0.0,
+                    "fee_paid": -1.0,
+                },
+            ]
+        )
+        expected_reset = 180_701
+        expected_drawdown = 51.0 / 879.0
+        if layout == "tied_episodes":
+            for event in events[1:]:
+                event["timestamp"] = 180_500
+            expected_reset = 180_501
+    if layout in {"gap", "tail"}:
+        original_history = bot.get_balance_equity_history
+
+        async def history(**kwargs):
+            result = await original_history(**kwargs)
+            result["timeline"] = [
+                row
+                for row in result["timeline"]
+                if row["timestamp"] != 180_000
+                and (layout != "tail" or row["timestamp"] != 240_000)
+            ]
+            return result
+
+        bot.get_balance_equity_history = history
+
+    await bot._equity_hard_stop_initialize_from_history()
+
+    state = bot._hsl_state("long")
+    assert state["pnl_reset_timestamp_ms"] == expected_reset
+    assert state["last_metrics"]["drawdown_raw"] == pytest.approx(expected_drawdown)
+    assert not state["halted"]
+    assert not await hsl._equity_hard_stop_refresh_live_scope_episode_boundaries(
+        bot, 360_000, bot.get_raw_balance()
+    )

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -5500,3 +5500,51 @@ def test_hsl_tied_cycle_requires_raw_chain_and_known_pre_cohort_size():
     ordered, ambiguous = hsl._equity_hard_stop_order_fill_cohorts([initial, *cohort])
     assert not ambiguous
     assert [event["action"] for event in ordered] == ["increase", "decrease", "increase"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("reverse_cohort", [False, True])
+async def test_coin_reset_retains_proven_same_millisecond_reentry_fee(reverse_cohort):
+    bot = make_coin_bot()
+    bot._equity_hard_stop_coin_initialized = True
+    bot.bot_value = lambda pside, key: 1 if key == "n_positions" else 1.0
+    bot.positions = {"A": {"long": {"size": 1.0}, "short": {"size": 0.0}}}
+    initial = dict(timestamp=60_000, symbol="A", pside="long", action="increase", qty=1.0, pnl=0.0)
+    cohort = []
+    for action, before, pnl, fee in [("decrease", 1.0, -10.0, 0.0), ("increase", 0.0, 0.0, -1.0)]:
+        event = dict(
+            timestamp=180_500,
+            symbol="A",
+            pside="long",
+            action=action,
+            qty=1.0,
+            pnl=pnl,
+            fee_paid=fee,
+        )
+        event["raw"] = [
+            {
+                "data": {
+                    "side": "sell" if action == "decrease" else "buy",
+                    "amount": 1.0,
+                    "price": 1.0,
+                    "info": {"startPosition": str(before)},
+                }
+            }
+        ]
+        cohort.append(event)
+    bot._pnls_manager = make_fake_pnls_manager(
+        [initial, *(reversed(cohort) if reverse_cohort else cohort)]
+    )
+    state = bot._hsl_coin_state("long", "A")
+    state["pnl_reset_timestamp_ms"] = 180_501
+    bot._equity_hard_stop_apply_coin_metrics_sample(
+        "long", "A", 180_500, 990.0, 0.0, 0.0, 0.0, latch_red=False
+    )
+    for _ in range(2):
+        assert not await hsl._equity_hard_stop_refresh_live_coin_episode_boundaries(
+            bot, 240_000, 989.0
+        )
+        assert state["pnl_reset_timestamp_ms"] == 180_501
+        assert bot._equity_hard_stop_coin_realized_pnl_peak_last(
+            "long", "A", 240_000, 180_501
+        ) == (0.0, -1.0)

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -5805,3 +5805,87 @@ async def test_deferred_cooldown_empty_protective_wave_is_paced():
     bot._sleep_unless_shutdown.assert_awaited_with(0.75, stage="hsl_cooldown_protection")
     assert state["cooldown_repanic_since_ms"] == 180_000
     assert state["cooldown_repanic_start_sizes"] == {"A": 1.0}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("signal_mode", ["coin", "pside", "unified"])
+@pytest.mark.parametrize(
+    "policy,prior_intervention",
+    [(policy, False) for policy in ["panic", "manual", "tp_only", "graceful_stop", "normal"]]
+    + [("manual", True), ("manual", None)],
+)
+@pytest.mark.parametrize("held", [False, True])
+async def test_deferred_cooldown_cancels_entries_by_scope_policy(
+    signal_mode, policy, prior_intervention, held, monkeypatch
+):
+    from unittest.mock import AsyncMock
+
+    bot = make_coin_bot(policy=policy)
+    bot.config["live"].update(hsl_signal_mode=signal_mode, execution_delay_seconds=0.25)
+    bot._equity_hard_stop_coin_initialized = True
+    bot._equity_hard_stop_cooldown_log_interval_ms = 60_000
+    bot._equity_hard_stop_handle_position_during_cooldown = MethodType(
+        hsl._equity_hard_stop_handle_position_during_cooldown, bot
+    )
+    bot._canonical_open_order_reduce_only = MethodType(
+        Passivbot._canonical_open_order_reduce_only, bot
+    )
+    bot.positions = {"A": {"long": {"size": 0.0}}, "B": {"long": {"size": float(held)}}}
+    for symbol in ("A", "B"):
+        state = bot._hsl_coin_state("long", symbol) if signal_mode == "coin" else bot._hsl_state("long")
+        state["halted"] = True
+        state["cooldown_until_ms"] = 600_000
+    def intervention_evidence(_bot, pside, symbol=None):
+        if prior_intervention is None:
+            return None
+        return prior_intervention or (held and (signal_mode != "coin" or symbol == "B"))
+
+    monkeypatch.setattr(hsl, "_equity_hard_stop_manual_cooldown_intervention", intervention_evidence)
+    bot.open_orders = {
+        symbol: [
+            {"id": f"{symbol}-entry", "symbol": symbol, "position_side": "long", "reduce_only": False},
+            {"id": f"{symbol}-close", "symbol": symbol, "position_side": "long", "reduce_only": True},
+            {"id": f"{symbol}-other", "symbol": symbol, "position_side": "short", "reduce_only": False},
+            {"id": f"{symbol}-unknown", "symbol": symbol, "position_side": "long"},
+        ]
+        for symbol in ("A", "B")
+    }
+    snapshot = object()
+    bot._current_planning_snapshot = snapshot
+    bot.refresh_protective_authoritative_state = AsyncMock(return_value=True)
+    # The panic planner may already select the held entry; the combined wave must deduplicate it.
+    panic_cancels = [bot.open_orders["B"][0]] if held and policy == "panic" else []
+    panic_creates = [{"symbol": "B", "position_side": "long", "reduce_only": True}] if panic_cancels else []
+    bot.calc_protective_panic_orders_to_cancel_and_create = AsyncMock(
+        return_value=(panic_cancels, panic_creates)
+    )
+    bot.execute_order_plan_to_exchange = AsyncMock()
+    bot._sleep_unless_shutdown = AsyncMock()
+    expected = set()
+    if policy == "manual":
+        if prior_intervention is False:
+            if not held or signal_mode == "coin":
+                expected.add("A-entry")
+            if not held:
+                expected.add("B-entry")
+    else:
+        if not (held and policy == "normal" and signal_mode != "coin"):
+            expected.add("A-entry")
+        if not held or policy in {"panic", "tp_only"}:
+            expected.add("B-entry")
+    did_work = await Passivbot._run_halted_hsl_protection_if_active(bot)
+    assert did_work is bool(expected)
+    if expected:
+        args = bot.execute_order_plan_to_exchange.await_args
+        cancels, creates = args.args
+        assert {order["id"] for order in cancels} == expected
+        assert len(cancels) == len(expected)
+        assert creates == panic_creates
+        assert args.kwargs == {"configure_creations": False}
+        bot._sleep_unless_shutdown.assert_awaited_once_with(0.25, stage="hsl_cooldown_protection")
+    else:
+        bot.execute_order_plan_to_exchange.assert_not_awaited()
+    if not panic_creates:
+        bot.calc_protective_panic_orders_to_cancel_and_create.assert_not_awaited()
+        assert bot._current_planning_snapshot is snapshot
+    assert bot.positions["B"]["long"]["size"] == float(held)

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -5548,3 +5548,104 @@ async def test_coin_reset_retains_proven_same_millisecond_reentry_fee(reverse_co
         assert bot._equity_hard_stop_coin_realized_pnl_peak_last(
             "long", "A", 240_000, 180_501
         ) == (0.0, -1.0)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("signal_mode", ["pside", "unified"])
+@pytest.mark.parametrize("latched", [False, True])
+async def test_aggregate_startup_unavailable_preserves_existing_protective_state(
+    signal_mode, latched
+):
+    bot = _make_aggregate_episode_bot(signal_mode)
+    bot._equity_hard_stop_apply_sample(
+        "long", 60_000, 1000.0, 0.0, 0.0, 0.0, unrealized_pnl_total=0.0
+    )
+    bot._equity_hard_stop_apply_sample(
+        "long",
+        120_000,
+        1000.0,
+        0.0,
+        0.0,
+        -300.0 if latched else 0.0,
+        unrealized_pnl_total=-300.0 if latched else 0.0,
+    )
+    state = bot._hsl_state("long")
+    previous_metrics = state["last_metrics"]
+    assert state["runtime"].red_latched() is latched
+    bot._pnls_manager.get_events().pop(0)
+    with pytest.raises(hsl.AuthoritativeSurfaceUnavailable, match="cannot prove"):
+        await bot._equity_hard_stop_initialize_from_history()
+    assert state["last_metrics"] is previous_metrics
+    assert state["runtime"].red_latched() is latched
+    assert state["last_stop_event"] is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("signal_mode", ["pside", "unified"])
+async def test_rejected_panic_marker_cannot_finalize_reopened_episode(signal_mode):
+    bot = _make_aggregate_episode_bot(signal_mode, closing_loss=0.0)
+    events = bot._pnls_manager.get_events()
+    events[1]["timestamp"] = 239_999
+    events[1]["pb_order_type"] = "close_panic_long"
+    events[2]["timestamp"] = 239_999
+    for event, before in [(events[1], 1.0), (events[2], 0.0)]:
+        event["raw"] = [
+            {
+                "data": {
+                    "side": "sell" if event["action"] == "decrease" else "buy",
+                    "amount": 1.0,
+                    "price": 1.0,
+                    "info": {"startPosition": str(before)},
+                }
+            }
+        ]
+    original_history = bot.get_balance_equity_history
+
+    async def history(**kwargs):
+        result = await original_history(**kwargs)
+        for row in result["timeline"]:
+            if row["timestamp"] == 180_000:
+                row["unrealized_pnl_long"] = -300.0
+        result["panic_flatten_events"] = [
+            {"timestamp": 239_999, "minute_timestamp": 180_000, "pside": "long", "symbol": "A"}
+        ]
+        return result
+
+    bot.get_balance_equity_history = history
+    await bot._equity_hard_stop_initialize_from_history()
+    state = bot._hsl_state("long")
+    assert state["last_stop_event"] is None
+    assert not state["halted"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("signal_mode", ["pside", "unified"])
+async def test_minute_end_flatten_does_not_mask_next_price_sample(signal_mode):
+    bot = _make_aggregate_episode_bot(signal_mode, closing_loss=0.0)
+    events = bot._pnls_manager.get_events()
+    events[1]["timestamp"] = 239_999
+    events[2]["timestamp"] = 240_001
+    original_history = bot.get_balance_equity_history
+
+    async def history(**kwargs):
+        result = await original_history(**kwargs)
+        for row in result["timeline"]:
+            if row["timestamp"] == 240_000:
+                row["unrealized_pnl_long"] = -300.0
+        return result
+
+    bot.get_balance_equity_history = history
+    samples = []
+    original_apply = bot._equity_hard_stop_apply_sample
+
+    def apply(*args, **kwargs):
+        result = original_apply(*args, **kwargs)
+        samples.append(result)
+        return result
+
+    bot._equity_hard_stop_apply_sample = apply
+    await bot._equity_hard_stop_initialize_from_history()
+    next_minute_samples = [row for row in samples if row["timestamp_ms"] == 240_000]
+    assert len(next_minute_samples) == 1
+    assert next_minute_samples[0]["tier"] == "red"
+    assert next_minute_samples[0]["drawdown_raw"] > 0.29

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -5649,3 +5649,159 @@ async def test_minute_end_flatten_does_not_mask_next_price_sample(signal_mode):
     assert len(next_minute_samples) == 1
     assert next_minute_samples[0]["tier"] == "red"
     assert next_minute_samples[0]["drawdown_raw"] > 0.29
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("signal_mode", ["coin", "pside", "unified"])
+@pytest.mark.parametrize("policy", ["panic", "manual", "tp_only", "graceful_stop", "normal"])
+async def test_boundary_deferral_supervises_new_cooldown_position_until_flat(signal_mode, policy):
+    from unittest.mock import AsyncMock, MagicMock
+
+    fixture = make_coin_bot(policy=policy)
+    bot = Passivbot.__new__(Passivbot)
+    bot.__dict__.update(vars(fixture))
+    for name, value in list(vars(bot).items()):
+        if isinstance(value, MethodType) and value.__self__ is fixture:
+            setattr(bot, name, MethodType(value.__func__, bot))
+    bot.config["live"]["hsl_signal_mode"] = signal_mode
+    bot.config["live"]["execution_delay_seconds"] = 0.25
+    bot.hsl["short"]["enabled"] = True
+    bot.positions = {"A": {"long": {"size": 0.0}, "short": {"size": 1.0}}}
+    state = bot._hsl_coin_state("short", "A") if signal_mode == "coin" else bot._hsl_state("short")
+    state["halted"] = True
+    state["cooldown_until_ms"] = 600_000
+    assert not state["cooldown_repanic_reset_pending"]
+    bot._equity_hard_stop_coin_initialized = True
+    bot._equity_hard_stop_runtime_initialized = lambda _pside: True
+    bot._equity_hard_stop_cooldown_log_interval_ms = 60_000
+    bot._equity_hard_stop_handle_position_during_cooldown = MethodType(
+        hsl._equity_hard_stop_handle_position_during_cooldown, bot
+    )
+    bot.stop_signal_received = False
+    bot.execution_scheduled = False
+    bot.state_change_detected_by_symbol = set()
+    bot.debug_mode = True
+    bot._set_log_silence_watchdog_context = lambda *args, **kwargs: None
+    bot._emit_live_cycle_degraded = MagicMock()
+    bot.refresh_authoritative_state = AsyncMock(return_value=True)
+    bot._equity_hard_stop_check = AsyncMock(
+        side_effect=hsl.AuthoritativeSurfaceUnavailable(
+            "hsl_episode_boundaries", "unrelated long scope tape is ambiguous"
+        )
+    )
+    bot.prepare_planning_universe = AsyncMock()
+    bot.execute_to_exchange = AsyncMock()
+    bot._run_latched_hsl_supervisor_if_active = MethodType(
+        Passivbot._run_latched_hsl_supervisor_if_active, bot
+    )
+    bot._run_halted_hsl_protection_if_active = MethodType(
+        Passivbot._run_halted_hsl_protection_if_active, bot
+    )
+    calls = []
+
+    async def refresh():
+        calls.append("refresh")
+        return True
+
+    async def protective_plan():
+        calls.append("plan")
+        return [], [
+            {
+                "symbol": "A",
+                "position_side": "short",
+                "side": "buy",
+                "reduce_only": True,
+                "qty": bot.positions["A"]["short"]["size"],
+            }
+        ]
+
+    async def execute(cancels, creates, *, configure_creations):
+        calls.append("execute")
+        assert not cancels and not configure_creations
+        assert creates[0]["reduce_only"] is True
+        assert state["cooldown_repanic_reset_pending"]
+        bot.positions["A"]["short"]["size"] -= 0.5
+        if bot.positions["A"]["short"]["size"] == 0.0:
+            bot.stop_signal_received = True
+
+    async def stop(seconds, *, stage):
+        if stage == "hsl_cooldown_protection":
+            calls.append("pace")
+            assert seconds == 0.25
+        else:
+            bot.stop_signal_received = True
+
+    bot.refresh_protective_authoritative_state = AsyncMock(side_effect=refresh)
+    bot.calc_protective_panic_orders_to_cancel_and_create = AsyncMock(side_effect=protective_plan)
+    bot.execute_order_plan_to_exchange = AsyncMock(side_effect=execute)
+    bot._sleep_unless_shutdown = AsyncMock(side_effect=stop)
+    await Passivbot.run_execution_loop(bot)
+    bot.prepare_planning_universe.assert_not_awaited()
+    bot.execute_to_exchange.assert_not_awaited()
+    if policy == "panic":
+        assert calls == [
+            "refresh",
+            "plan",
+            "execute",
+            "pace",
+            "refresh",
+            "plan",
+            "execute",
+            "pace",
+        ]
+        assert bot.positions["A"]["short"]["size"] == 0.0
+        assert state["cooldown_repanic_start_sizes"] == {"A": 1.0}
+        assert state["cooldown_repanic_since_ms"] == 180_000
+    else:
+        assert "execute" not in calls
+        assert not state["cooldown_repanic_reset_pending"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("blocked_by", ["pending_replay", "account_refresh", "expired_cooldown"])
+async def test_deferred_cooldown_protection_requires_ready_scope_and_fresh_account(blocked_by):
+    from unittest.mock import AsyncMock
+
+    bot = make_coin_bot(policy="panic")
+    bot.positions = {"A": {"long": {"size": 1.0}, "short": {"size": 0.0}}}
+    state = bot._hsl_coin_state("long", "A")
+    state["halted"] = True
+    state["cooldown_until_ms"] = 120_000 if blocked_by == "expired_cooldown" else 600_000
+    bot._equity_hard_stop_coin_initialized = False
+    bot._equity_hard_stop_coin_protective_ready = True
+    bot._equity_hard_stop_coin_replay_ready_pairs = (
+        set() if blocked_by == "pending_replay" else {("long", "A")}
+    )
+    bot.refresh_protective_authoritative_state = AsyncMock(
+        return_value=blocked_by != "account_refresh"
+    )
+    bot.calc_protective_panic_orders_to_cancel_and_create = AsyncMock()
+    bot.execute_order_plan_to_exchange = AsyncMock()
+    assert not await Passivbot._run_halted_hsl_protection_if_active(bot)
+    bot.calc_protective_panic_orders_to_cancel_and_create.assert_not_awaited()
+    bot.execute_order_plan_to_exchange.assert_not_awaited()
+    assert not state["cooldown_repanic_reset_pending"]
+
+
+@pytest.mark.asyncio
+async def test_deferred_cooldown_empty_protective_wave_is_paced():
+    from unittest.mock import AsyncMock
+
+    bot = make_coin_bot(policy="panic")
+    bot.config["live"]["execution_delay_seconds"] = 0.75
+    bot._equity_hard_stop_coin_initialized = True
+    bot._equity_hard_stop_cooldown_log_interval_ms = 60_000
+    bot.positions = {"A": {"long": {"size": 1.0}, "short": {"size": 0.0}}}
+    state = bot._hsl_coin_state("long", "A")
+    state["halted"] = True
+    state["cooldown_until_ms"] = 600_000
+    bot.refresh_protective_authoritative_state = AsyncMock(return_value=True)
+    bot.calc_protective_panic_orders_to_cancel_and_create = AsyncMock(return_value=([], []))
+    bot.execute_order_plan_to_exchange = AsyncMock()
+    bot._sleep_unless_shutdown = AsyncMock()
+    for _ in range(2):
+        assert await Passivbot._run_halted_hsl_protection_if_active(bot)
+    assert bot._sleep_unless_shutdown.await_count == 2
+    bot._sleep_unless_shutdown.assert_awaited_with(0.75, stage="hsl_cooldown_protection")
+    assert state["cooldown_repanic_since_ms"] == 180_000
+    assert state["cooldown_repanic_start_sizes"] == {"A": 1.0}

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -4877,6 +4877,13 @@ async def test_live_coin_boundary_uses_canonical_replay_for_delayed_or_red_fill(
         replays.append(True)
 
     bot._equity_hard_stop_initialize_coin_from_history = replay
+    if tied:
+        with pytest.raises(hsl.AuthoritativeSurfaceUnavailable, match="ambiguous boundaries"):
+            await hsl._equity_hard_stop_refresh_live_coin_episode_boundaries(
+                bot, 300_000, 1000.0 - closing_loss
+            )
+        assert not replays
+        return
     rebuilt = await hsl._equity_hard_stop_refresh_live_coin_episode_boundaries(
         bot, 300_000, 1000.0 - closing_loss
     )
@@ -4914,10 +4921,8 @@ async def test_live_coin_boundary_does_not_guess_from_incomplete_fill_sizes():
             "pnl": -10.0,
         }
     )
-    assert (
+    with pytest.raises(hsl.AuthoritativeSurfaceUnavailable, match="does not match position"):
         await hsl._equity_hard_stop_refresh_live_coin_episode_boundaries(bot, 240_000, 990.0)
-        is False
-    )
     assert bot._hsl_coin_state("long", symbol)["pnl_reset_timestamp_ms"] is None
 
 
@@ -5191,7 +5196,7 @@ async def test_aggregate_final_fill_red_enters_cooldown_before_reentry(signal_mo
 @pytest.mark.asyncio
 @pytest.mark.parametrize("signal_mode", ["pside", "unified"])
 @pytest.mark.parametrize(
-    "layout", ["flat", "two_episodes", "tied_episodes", "gap", "tail"]
+    "layout", ["flat", "two_episodes", "gap", "tail"]
 )
 async def test_aggregate_replay_retains_each_fill_boundary_and_fee(signal_mode, layout):
     bot = _make_aggregate_episode_bot(signal_mode)
@@ -5202,7 +5207,7 @@ async def test_aggregate_replay_retains_each_fill_boundary_and_fee(signal_mode, 
         events.pop()
         bot.positions["A"]["long"]["size"] = 0.0
         expected_drawdown = 0.0
-    elif layout in {"two_episodes", "tied_episodes"}:
+    elif layout == "two_episodes":
         events.extend(
             [
                 {
@@ -5226,10 +5231,6 @@ async def test_aggregate_replay_retains_each_fill_boundary_and_fee(signal_mode, 
         )
         expected_reset = 180_701
         expected_drawdown = 51.0 / 879.0
-        if layout == "tied_episodes":
-            for event in events[1:]:
-                event["timestamp"] = 180_500
-            expected_reset = 180_501
     if layout in {"gap", "tail"}:
         original_history = bot.get_balance_equity_history
 
@@ -5254,3 +5255,248 @@ async def test_aggregate_replay_retains_each_fill_boundary_and_fee(signal_mode, 
     assert not await hsl._equity_hard_stop_refresh_live_scope_episode_boundaries(
         bot, 360_000, bot.get_raw_balance()
     )
+
+
+@pytest.mark.parametrize("signal_mode", ["pside", "unified"])
+@pytest.mark.parametrize(
+    "actions",
+    [
+        ["increase", "decrease", "decrease"],
+        ["decrease", "increase", "decrease"],
+    ],
+)
+def test_hsl_unordered_cohort_cannot_fabricate_intermediate_flat(signal_mode, actions):
+    bot = _make_aggregate_episode_bot(signal_mode)
+    bot.positions["A"]["long"]["size"] = 0.0
+    events = [
+        {
+            "timestamp": 60_000,
+            "symbol": "A",
+            "pside": "long",
+            "action": "increase",
+            "qty": 1.0,
+            "pnl": 0.0,
+        }
+    ]
+    events.extend(
+        {
+            "timestamp": 180_500,
+            "symbol": "A",
+            "pside": "long",
+            "action": action,
+            "qty": 1.0,
+            "pnl": 0.0,
+        }
+        for action in actions
+    )
+    assert (
+        hsl._equity_hard_stop_scope_flatten_samples(
+            bot,
+            events,
+            "long",
+            signal_mode,
+            240_000,
+            1000.0,
+            0.0,
+            {"long": 0.0, "short": 0.0},
+        )
+        is None
+    )
+    _, ambiguous = hsl._equity_hard_stop_coin_replay_events(events, "long", "A")
+    assert ambiguous
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("signal_mode", ["pside", "unified"])
+async def test_aggregate_incomplete_fill_tape_defers_without_sampling_old_episode(signal_mode):
+    bot = _make_aggregate_episode_bot(signal_mode)
+    bot._equity_hard_stop_apply_sample(
+        "long", 120_000, 1000.0, 0.0, 0.0, 0.0, unrealized_pnl_total=0.0
+    )
+    state = bot._hsl_state("long")
+    original_metrics = state["last_metrics"]
+    bot._pnls_manager.get_events().pop(0)  # retained history begins with an over-close
+    with pytest.raises(hsl.AuthoritativeSurfaceUnavailable, match="cannot prove"):
+        await hsl._equity_hard_stop_check(bot)
+    assert state["last_metrics"] is original_metrics
+    assert state["pnl_reset_timestamp_ms"] is None
+    assert not state["runtime"].red_latched()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("signal_mode", ["pside", "unified"])
+async def test_aggregate_shifted_minute_rejects_unproven_panic_marker(signal_mode, caplog):
+    bot = _make_aggregate_episode_bot(signal_mode, closing_loss=0.0)
+    events = bot._pnls_manager.get_events()
+    events.pop()  # fully flat tape ending at its non-minute-aligned close
+    events[-1]["pb_order_type"] = "close_panic_long"
+    bot.positions["A"]["long"]["size"] = 0.0
+    original_history = bot.get_balance_equity_history
+
+    async def history(**kwargs):
+        result = await original_history(**kwargs)
+        result["panic_flatten_events"] = [
+            {
+                "timestamp": 180_500,
+                "minute_timestamp": 180_000,
+                "pside": "long",
+                "symbol": "A",
+            }
+        ]
+        return result
+
+    bot.get_balance_equity_history = history
+    await bot._equity_hard_stop_initialize_from_history()
+    state = bot._hsl_state("long")
+    assert not state["halted"]
+    assert state["last_stop_event"] is None
+    assert state["pnl_reset_timestamp_ms"] == 180_501
+    assert "ignored historical panic marker without reconstructed RED" in caplog.text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("signal_mode", ["pside", "unified"])
+async def test_second_distinct_same_minute_flatten_can_first_trigger_red(signal_mode):
+    bot = _make_aggregate_episode_bot(signal_mode, closing_loss=0.0)
+    events = bot._pnls_manager.get_events()
+    events.extend(
+        [
+            {
+                "timestamp": 180_700,
+                "symbol": "A",
+                "pside": "long",
+                "action": "decrease",
+                "qty": 1.0,
+                "pnl": -300.0,
+            },
+            {
+                "timestamp": 180_800,
+                "symbol": "A",
+                "pside": "long",
+                "action": "increase",
+                "qty": 1.0,
+                "pnl": 0.0,
+            },
+        ]
+    )
+    await bot._equity_hard_stop_initialize_from_history()
+    state = bot._hsl_state("long")
+    assert state["halted"]
+    assert state["last_stop_event"]["stop_event_timestamp_ms"] == 180_700
+    assert state["cooldown_until_ms"] == 480_700
+
+
+@pytest.mark.asyncio
+async def test_live_coin_reset_seeds_flat_minute_before_next_ema_step():
+    bot = make_coin_bot()
+    bot._equity_hard_stop_coin_initialized = True
+    bot.bot_value = lambda pside, key: 1 if key == "n_positions" else 1.0
+    bot.hsl["long"]["red_threshold"] = 0.5
+    bot.hsl["long"]["ema_span_minutes"] = 3.0
+    bot.positions = {"A": {"long": {"size": 1.0}, "short": {"size": 0.0}}}
+    events = [
+        {
+            "timestamp": 60_000,
+            "symbol": "A",
+            "pside": "long",
+            "action": "increase",
+            "qty": 1.0,
+            "pnl": 0.0,
+        },
+        {
+            "timestamp": 180_500,
+            "symbol": "A",
+            "pside": "long",
+            "action": "decrease",
+            "qty": 1.0,
+            "pnl": 0.0,
+        },
+        {
+            "timestamp": 180_600,
+            "symbol": "A",
+            "pside": "long",
+            "action": "increase",
+            "qty": 1.0,
+            "pnl": 0.0,
+        },
+    ]
+    bot._pnls_manager = make_fake_pnls_manager(events)
+    bot._equity_hard_stop_apply_coin_sample("long", "A", 120_000, 1000.0, 0.0)
+    assert not await hsl._equity_hard_stop_refresh_live_coin_episode_boundaries(
+        bot, 240_000, 1000.0
+    )
+    metrics = bot._equity_hard_stop_apply_coin_sample("long", "A", 240_000, 1000.0, -100.0)
+    assert metrics["elapsed_minutes"] == 1
+    assert metrics["drawdown_ema"] == pytest.approx(0.05)
+
+
+def test_hsl_tied_cohort_uses_raw_position_chain_instead_of_input_order():
+    cohort = []
+    for action, qty, before in [
+        ("decrease", 3.0, 3.0),
+        ("increase", 2.0, 1.0),
+        ("decrease", 1.0, 2.0),
+    ]:
+        side = "sell" if action == "decrease" else "buy"
+        cohort.append(
+            {
+                "timestamp": 180_500,
+                "symbol": "A",
+                "pside": "long",
+                "action": action,
+                "qty": qty,
+                "pnl": 0.0,
+                "raw": [
+                    {
+                        "data": {
+                            "side": side,
+                            "amount": qty,
+                            "price": 1.0,
+                            "info": {"startPosition": str(before)},
+                        }
+                    }
+                ],
+            }
+        )
+    ordered, ambiguous = hsl._equity_hard_stop_order_fill_cohorts(cohort)
+    assert not ambiguous
+    assert [event["qty"] for event in ordered] == [1.0, 2.0, 3.0]
+
+
+def test_hsl_tied_cycle_requires_raw_chain_and_known_pre_cohort_size():
+    initial = {
+        "timestamp": 60_000,
+        "symbol": "A",
+        "pside": "long",
+        "action": "increase",
+        "qty": 1.0,
+        "pnl": 0.0,
+    }
+    cohort = []
+    for action, before in [("increase", 0.0), ("decrease", 1.0)]:
+        side = "sell" if action == "decrease" else "buy"
+        cohort.append(
+            {
+                "timestamp": 180_500,
+                "symbol": "A",
+                "pside": "long",
+                "action": action,
+                "qty": 1.0,
+                "pnl": 0.0,
+                "raw": [
+                    {
+                        "data": {
+                            "side": side,
+                            "amount": 1.0,
+                            "price": 1.0,
+                            "info": {"startPosition": str(before)},
+                        }
+                    }
+                ],
+            }
+        )
+    _, ambiguous_without_initial = hsl._equity_hard_stop_order_fill_cohorts(cohort)
+    assert ambiguous_without_initial
+    ordered, ambiguous = hsl._equity_hard_stop_order_fill_cohorts([initial, *cohort])
+    assert not ambiguous
+    assert [event["action"] for event in ordered] == ["increase", "decrease", "increase"]

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -3066,7 +3066,7 @@ async def test_held_coin_replay_bounds_missing_prices_only_after_proven_cooldown
     assert state["last_metrics"]["realized_pnl"] == pytest.approx(0.0)
     assert state["last_metrics"]["unrealized_pnl"] == pytest.approx(-1.0)
     assert state["last_metrics"]["tier"] == "green"
-    assert state["pnl_reset_timestamp_ms"] is None
+    assert state["pnl_reset_timestamp_ms"] == current_entry_ts // 60_000 * 60_000
 
 
 @pytest.mark.asyncio
@@ -5654,9 +5654,11 @@ async def test_minute_end_flatten_does_not_mask_next_price_sample(signal_mode):
 @pytest.mark.asyncio
 @pytest.mark.parametrize("signal_mode", ["coin", "pside", "unified"])
 @pytest.mark.parametrize("policy", ["panic", "manual", "tp_only", "graceful_stop", "normal"])
-async def test_boundary_deferral_supervises_new_cooldown_position_until_flat(signal_mode, policy):
+async def test_boundary_deferral_supervises_new_cooldown_position_until_flat(signal_mode, policy, monkeypatch):
     from unittest.mock import AsyncMock, MagicMock
 
+    # This loop test models unavailable replay; the live-restart suite supplies history.
+    monkeypatch.setattr(hsl, "_equity_hard_stop_replay_live_restart", AsyncMock(return_value=False))
     fixture = make_coin_bot(policy=policy)
     bot = Passivbot.__new__(Passivbot)
     bot.__dict__.update(vars(fixture))
@@ -5820,6 +5822,15 @@ async def test_deferred_cooldown_cancels_entries_by_scope_policy(
 ):
     from unittest.mock import AsyncMock
 
+    async def ready_restart(target, pside, symbol=None):
+        if symbol is None:
+            target._equity_hard_stop_reset_after_restart(pside)
+        else:
+            target._equity_hard_stop_reset_coin_after_restart(pside, symbol)
+        return True
+
+    # Isolate cancellation admission from the separately tested canonical replay.
+    monkeypatch.setattr(hsl, "_equity_hard_stop_replay_live_restart", ready_restart)
     bot = make_coin_bot(policy=policy)
     bot.config["live"].update(hsl_signal_mode=signal_mode, execution_delay_seconds=0.25)
     bot._equity_hard_stop_coin_initialized = True
@@ -5853,6 +5864,7 @@ async def test_deferred_cooldown_cancels_entries_by_scope_policy(
     snapshot = object()
     bot._current_planning_snapshot = snapshot
     bot.refresh_protective_authoritative_state = AsyncMock(return_value=True)
+    bot.update_pnls = AsyncMock(return_value=False)
     # The panic planner may already select the held entry; the combined wave must deduplicate it.
     panic_cancels = [bot.open_orders["B"][0]] if held and policy == "panic" else []
     panic_creates = [{"symbol": "B", "position_side": "long", "reduce_only": True}] if panic_cancels else []

--- a/tests/test_hsl_coin_override_baseline.py
+++ b/tests/test_hsl_coin_override_baseline.py
@@ -1,0 +1,137 @@
+import pytest
+
+from test_hsl_cooldown_boundary_replay import _normal_override_history
+
+
+def _coin_normal_override_bot(*, upnl=0.0, fee=0.0, close_loss=None):
+    bot = _normal_override_history("pside", same_minute=True)
+    bot.config["live"]["hsl_signal_mode"] = "coin"
+    events = bot._pnls_manager.get_events()
+    del events[3:]
+    events[-1]["fee_paid"] = -fee
+    if close_loss is not None:
+        events.append(
+            dict(
+                timestamp=60_800,
+                symbol="A",
+                pside="long",
+                action="decrease",
+                qty=1.0,
+                pnl=-close_loss,
+            )
+        )
+        bot.positions["A"]["long"]["size"] = 0.0
+    bot.get_exchange_time = lambda: 180_900
+    bot.bot_value = lambda pside, key: 1.0
+
+    async def current_upnl(pside=None, symbol=None):
+        return -upnl
+
+    bot._calc_upnl_sum_strict = current_upnl
+    original_history = bot.get_balance_equity_history
+
+    async def history(**kwargs):
+        result = await original_history(**kwargs)
+        for row in result["timeline"]:
+            row["unrealized_pnl_long"] = -upnl if not row["is_flat_long"] else 0.0
+            row["realized_pnl_by_coin_pside"] = {
+                "A": {"long": row["realized_pnl_long"], "short": 0.0}
+            }
+            row["unrealized_pnl_by_coin_pside"] = {
+                "A": {"long": row["unrealized_pnl_long"], "short": 0.0}
+            }
+        return result
+
+    bot.get_balance_equity_history = history
+    return bot
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("upnl", [0.0, 50.0])
+@pytest.mark.parametrize("fee", [0.0, 2.0])
+@pytest.mark.parametrize("span", [1.0, 5.0])
+async def test_coin_normal_override_discards_prior_stop_loss_but_keeps_new_loss(
+    upnl, fee, span
+):
+    bot = _coin_normal_override_bot(upnl=upnl, fee=fee)
+    bot.hsl["long"].update(ema_span_minutes=span, red_threshold=0.1)
+    for _ in range(2):
+        await bot._equity_hard_stop_initialize_coin_from_history()
+        state = bot._hsl_coin_state("long", "A")
+        assert state["pnl_reset_timestamp_ms"] == 60_600
+        assert not state["halted"]
+        metrics = state["last_metrics"]
+        assert metrics["realized_pnl"] == pytest.approx(-fee)
+        assert metrics["drawdown_raw"] == pytest.approx((fee + upnl) / (700.0 - fee))
+        # Current live samples must retain the same reset after reconstruction.
+        current = bot._equity_hard_stop_apply_coin_sample(
+            "long", "A", 240_900, 700.0 - fee, -upnl
+        )
+        assert current["realized_pnl"] == pytest.approx(-fee)
+        assert current["drawdown_raw"] == pytest.approx(metrics["drawdown_raw"])
+
+
+@pytest.mark.asyncio
+async def test_coin_normal_override_retains_later_flatten_in_intervention_minute():
+    bot = _coin_normal_override_bot(fee=2.0, close_loss=300.0)
+    await bot._equity_hard_stop_initialize_coin_from_history()
+    state = bot._hsl_coin_state("long", "A")
+    assert state["halted"]
+    assert state["last_stop_event"]["stop_event_timestamp_ms"] == 60_800
+    assert state["cooldown_until_ms"] == 360_800
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("restart_policy", ["always", "threshold"])
+@pytest.mark.parametrize("upnl", [0.0, 50.0])
+@pytest.mark.parametrize("fee", [0.0, 2.0])
+async def test_coin_expired_episode_replay_and_current_sample_share_baseline(
+    restart_policy, upnl, fee
+):
+    from test_hsl_coin_mode import _make_aggregate_episode_bot
+
+    bot = _make_aggregate_episode_bot("coin", closing_loss=300.0)
+    bot.hsl["long"].update(
+        cooldown_minutes_after_red=1.0, restart_after_red_policy=restart_policy
+    )
+    events = bot._pnls_manager.get_events()
+    events[-1].update(timestamp=240_600, fee_paid=-fee)
+    bot.get_exchange_time = lambda: 300_900
+    bot.bot_value = lambda pside, key: 1.0
+
+    async def current_upnl(pside=None, symbol=None):
+        return -upnl
+
+    bot._calc_upnl_sum_strict = current_upnl
+    original_history = bot.get_balance_equity_history
+
+    async def history(**kwargs):
+        result = await original_history(**kwargs)
+        for row in result["timeline"]:
+            row["unrealized_pnl_long"] = -upnl if row["timestamp"] >= 240_000 else 0.0
+            row["realized_pnl_by_coin_pside"] = {
+                "A": {"long": row["realized_pnl_long"], "short": 0.0}
+            }
+            row["unrealized_pnl_by_coin_pside"] = {
+                "A": {"long": row["unrealized_pnl_long"], "short": 0.0}
+            }
+        return result
+
+    bot.get_balance_equity_history = history
+    for _ in range(2):
+        await bot._equity_hard_stop_initialize_coin_from_history()
+        state = bot._hsl_coin_state("long", "A")
+        assert not state["halted"]
+        assert state["pnl_reset_timestamp_ms"] >= 180_501
+        metrics = state["last_metrics"]
+        assert metrics["realized_pnl"] == pytest.approx(-fee)
+        assert metrics["drawdown_raw"] == pytest.approx(
+            (fee + upnl) / metrics["slot_budget"]
+        )
+        current = bot._equity_hard_stop_apply_coin_sample(
+            "long", "A", 360_900, 700.0 - fee, -upnl
+        )
+        assert current["realized_pnl"] == pytest.approx(-fee)
+        assert current["drawdown_raw"] == pytest.approx(
+            (fee + upnl) / current["slot_budget"]
+        )

--- a/tests/test_hsl_cooldown_boundary_replay.py
+++ b/tests/test_hsl_cooldown_boundary_replay.py
@@ -1,0 +1,313 @@
+import pytest
+
+from test_hsl_coin_mode import _make_aggregate_episode_bot
+
+
+def _normal_override_history(signal_mode, *, closing_loss=100.0, same_minute=False):
+    bot = _make_aggregate_episode_bot(signal_mode, closing_loss=closing_loss)
+    bot._equity_hard_stop_cooldown_position_policy = lambda: "normal"
+    events = bot._pnls_manager.get_events()
+    panic_ts = 60_500 if same_minute else 30_500
+    events[0]["timestamp"] = 60_600 if same_minute else 60_000
+    events[:0] = [
+        dict(timestamp=10_000, symbol="A", pside="long", action="increase", qty=1.0, pnl=0.0),
+        dict(
+            timestamp=panic_ts,
+            symbol="A",
+            pside="long",
+            action="decrease",
+            qty=1.0,
+            pnl=-300.0,
+            pb_order_type="close_panic_long",
+        ),
+    ]
+    original_history = bot.get_balance_equity_history
+
+    async def history(**kwargs):
+        result = await original_history(**kwargs)
+        result["panic_flatten_events"] = [
+            dict(
+                timestamp=panic_ts,
+                minute_timestamp=panic_ts // 60_000 * 60_000,
+                pside="long",
+                symbol="A",
+            )
+        ]
+        return result
+
+    bot.get_balance_equity_history = history
+    return bot
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("signal_mode", ["pside", "unified"])
+@pytest.mark.parametrize("same_minute", [False, True])
+@pytest.mark.parametrize("ema_span", [1.0, 5.0])
+async def test_normal_cooldown_override_replays_later_ordinary_episode_reset(
+    signal_mode, same_minute, ema_span
+):
+    bot = _normal_override_history(signal_mode, same_minute=same_minute)
+    bot.hsl["long"]["ema_span_minutes"] = ema_span
+    for _ in range(2):  # Restart reconstruction must reproduce the same reset.
+        await bot._equity_hard_stop_initialize_from_history()
+        state = bot._hsl_state("long")
+        assert not state["halted"]
+        assert state["last_stop_event"] is None
+        assert state["pnl_reset_timestamp_ms"] == 180_501
+        metrics = state["last_metrics"]
+        assert metrics["peak_strategy_equity"] == pytest.approx(600.0)
+        assert metrics["drawdown_raw"] == pytest.approx(51.0 / 600.0)
+        assert metrics["tier"] != "red"
+        expected_ema = 51.0 / 600.0 * (1.0 - (1.0 - 2.0 / (ema_span + 1.0)) ** 2)
+        assert metrics["drawdown_ema"] == pytest.approx(expected_ema)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("signal_mode", ["pside", "unified"])
+@pytest.mark.parametrize("same_minute", [False, True])
+async def test_normal_cooldown_override_still_finalizes_new_red_at_exact_fill(
+    signal_mode, same_minute
+):
+    bot = _normal_override_history(signal_mode, closing_loss=300.0, same_minute=same_minute)
+    await bot._equity_hard_stop_initialize_from_history()
+    state = bot._hsl_state("long")
+    assert state["halted"]
+    assert state["last_stop_event"]["stop_event_timestamp_ms"] == 180_500
+    assert state["cooldown_until_ms"] == 480_500
+    assert state["last_stop_event"]["drawdown_raw"] == pytest.approx(300.0 / 700.0)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("signal_mode", ["pside", "unified"])
+async def test_normal_override_keeps_each_same_minute_reset_and_reentry_fee(signal_mode):
+    bot = _normal_override_history(signal_mode)
+    events = bot._pnls_manager.get_events()
+    events.extend(
+        [
+            dict(
+                timestamp=180_700, symbol="A", pside="long", action="decrease", qty=1.0, pnl=-20.0
+            ),
+            dict(
+                timestamp=180_800,
+                symbol="A",
+                pside="long",
+                action="increase",
+                qty=1.0,
+                pnl=0.0,
+                fee_paid=-2.0,
+            ),
+        ]
+    )
+    await bot._equity_hard_stop_initialize_from_history()
+    state = bot._hsl_state("long")
+    assert not state["halted"]
+    assert state["pnl_reset_timestamp_ms"] == 180_701
+    assert state["last_metrics"]["drawdown_raw"] == pytest.approx(52.0 / 579.0)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("signal_mode", ["pside", "unified"])
+async def test_normal_override_without_later_flatten_keeps_its_new_episode(signal_mode):
+    bot = _normal_override_history(signal_mode, same_minute=True)
+    events = bot._pnls_manager.get_events()
+    del events[3:]  # Retain the old panic and its in-minute intervention entry.
+    await bot._equity_hard_stop_initialize_from_history()
+    state = bot._hsl_state("long")
+    assert not state["halted"]
+    assert state["last_stop_event"] is None
+    assert state["pnl_reset_timestamp_ms"] is None
+    assert state["last_metrics"]["drawdown_raw"] == pytest.approx(50.0 / 700.0)
+
+
+from live.freshness import FreshnessLedger
+import passivbot_hsl as hsl
+from test_hsl_coin_mode import make_coin_bot, make_fake_pnls_manager
+
+
+def _manual_ownership_bot(signal_mode, events, *, refreshed_ms=1_000):
+    bot = make_coin_bot(policy="manual")
+    bot.config["live"]["hsl_signal_mode"] = signal_mode
+    bot.get_exchange_time = lambda: 300_000
+    bot._pnls_manager = make_fake_pnls_manager(events)
+    original_metadata = bot._pnls_manager.cache.load_metadata
+    bot._pnls_manager.cache.load_metadata = lambda: {
+        **original_metadata(),
+        "last_refresh_ms": refreshed_ms,
+    }
+    bot.freshness_ledger = FreshnessLedger()
+    bot.freshness_ledger.begin_epoch()
+    for surface in ("positions", "open_orders"):
+        bot.freshness_ledger.stamp(surface, (), now_ms=1_000)
+    symbol = "A" if signal_mode == "coin" else None
+    state = bot._hsl_coin_state("long", symbol) if symbol else bot._hsl_state("long")
+    state.update(
+        halted=True,
+        cooldown_until_ms=480_500,
+        last_stop_event={"stop_event_timestamp_ms": 180_500},
+        cooldown_intervention_active=False,
+    )
+    return bot, state, symbol
+
+
+def _manual_stop_events(*, intervention=True, pside="long", symbol="A"):
+    events = [dict(timestamp=180_500, symbol="A", pside="long", action="decrease", qty=1.0)]
+    if intervention:
+        events.extend(
+            [
+                dict(timestamp=180_600, symbol=symbol, pside=pside, action="increase", qty=1.0),
+                dict(timestamp=210_000, symbol=symbol, pside=pside, action="decrease", qty=1.0),
+            ]
+        )
+    return events
+
+
+@pytest.mark.parametrize("signal_mode", ["coin", "pside", "unified"])
+@pytest.mark.parametrize("refreshed_ms", [0, 999, 1_000])
+def test_manual_entry_then_flat_ownership_survives_missing_recent_tail(signal_mode, refreshed_ms):
+    bot, state, symbol = _manual_ownership_bot(
+        signal_mode,
+        _manual_stop_events(),
+        refreshed_ms=refreshed_ms,
+    )
+    assert not bot.positions
+    # This lifecycle field is deliberately false after flatten/restart.
+    assert not state["cooldown_intervention_active"]
+    assert hsl._equity_hard_stop_manual_cooldown_intervention(bot, "long", symbol) is True
+
+
+@pytest.mark.parametrize("signal_mode", ["coin", "pside", "unified"])
+@pytest.mark.parametrize(
+    "refreshed_ms, expected", [(0, None), (999, None), (1_000, False), (1_001, False)]
+)
+def test_manual_no_entry_requires_fill_tail_through_protective_observation(
+    signal_mode, refreshed_ms, expected
+):
+    bot, state, symbol = _manual_ownership_bot(
+        signal_mode,
+        _manual_stop_events(intervention=False),
+        refreshed_ms=refreshed_ms,
+    )
+    # A stale RAM flag cannot acquire manual ownership either.
+    state["cooldown_intervention_active"] = True
+    assert hsl._equity_hard_stop_manual_cooldown_intervention(bot, "long", symbol) is expected
+
+
+@pytest.mark.parametrize("signal_mode", ["coin", "pside", "unified"])
+@pytest.mark.parametrize(
+    "missing", ["stop", "stop_fill", "coverage", "snapshot", "quantity", "tied_entry"]
+)
+def test_manual_unknown_history_preserves_ownership(signal_mode, missing):
+    events = _manual_stop_events(intervention=False)
+    bot, state, symbol = _manual_ownership_bot(signal_mode, events)
+    if missing == "stop":
+        state["last_stop_event"] = None
+    elif missing == "stop_fill":
+        events.clear()
+    elif missing == "coverage":
+        bot._pnls_manager.cache.get_known_gaps = lambda: [{"start_ts": 180_500, "end_ts": 300_000}]
+        bot._pnls_manager.get_coverage_status = lambda **kwargs: {"ready": False}
+    elif missing == "snapshot":
+        bot.freshness_ledger.begin_epoch()
+    elif missing == "quantity":
+        events.append(dict(timestamp=180_700, symbol="A", pside="long", action="increase"))
+    else:
+        events.append(dict(timestamp=180_500, symbol="A", pside="long", action="increase", qty=1.0))
+    assert hsl._equity_hard_stop_manual_cooldown_intervention(bot, "long", symbol) is None
+
+
+@pytest.mark.parametrize("signal_mode", ["coin", "pside", "unified"])
+def test_prior_cooldown_entry_does_not_own_new_stop(signal_mode):
+    events = _manual_stop_events()
+    events.append(dict(timestamp=250_000, symbol="A", pside="long", action="decrease", qty=1.0))
+    bot, state, symbol = _manual_ownership_bot(signal_mode, events)
+    state["last_stop_event"] = {"stop_event_timestamp_ms": 250_000}
+    state["cooldown_until_ms"] = 550_000
+    assert hsl._equity_hard_stop_manual_cooldown_intervention(bot, "long", symbol) is False
+
+
+@pytest.mark.parametrize(
+    "signal_mode,entry_side,entry_symbol,expected",
+    [
+        ("coin", "long", "B", False),
+        ("coin", "short", "A", False),
+        ("pside", "long", "B", True),
+        ("pside", "short", "A", False),
+        ("unified", "short", "B", True),
+    ],
+)
+def test_manual_ownership_matches_configured_scope(signal_mode, entry_side, entry_symbol, expected):
+    bot, state, symbol = _manual_ownership_bot(
+        signal_mode,
+        _manual_stop_events(pside=entry_side, symbol=entry_symbol),
+    )
+    assert hsl._equity_hard_stop_manual_cooldown_intervention(bot, "long", symbol) is expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("signal_mode", ["pside", "unified"])
+async def test_restart_reconstructs_manual_entry_then_flat_ownership_from_ordinary_stop(
+    signal_mode,
+):
+    bot = _make_aggregate_episode_bot(signal_mode, closing_loss=300.0)
+    bot._equity_hard_stop_cooldown_position_policy = lambda: "manual"
+    events = bot._pnls_manager.get_events()
+    events.append(
+        dict(timestamp=210_000, symbol="A", pside="long", action="decrease", qty=1.0, pnl=0.0)
+    )
+    bot.positions["A"]["long"]["size"] = 0.0
+    for _ in range(2):
+        await bot._equity_hard_stop_initialize_from_history()
+        state = bot._hsl_state("long")
+        assert state["halted"]
+        assert state["last_stop_event"]["stop_event_timestamp_ms"] == 180_500
+        assert not state["cooldown_intervention_active"]
+        assert hsl._equity_hard_stop_manual_cooldown_intervention(bot, "long") is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("signal_mode", ["coin", "pside", "unified"])
+async def test_live_manual_flatten_clears_transient_flag_but_preserves_fill_ownership(signal_mode):
+    bot, state, symbol = _manual_ownership_bot(signal_mode, _manual_stop_events())
+    bot.positions = {"A": {"long": {"size": 1.0}, "short": {"size": 0.0}}}
+    if symbol:
+        await hsl._equity_hard_stop_handle_coin_position_during_cooldown(
+            bot, "long", symbol, 200_000
+        )
+    else:
+        await hsl._equity_hard_stop_handle_position_during_cooldown(bot, "long", 200_000)
+    assert state["cooldown_intervention_active"]
+    bot.positions["A"]["long"]["size"] = 0.0
+    if symbol:
+        await hsl._equity_hard_stop_handle_coin_position_during_cooldown(
+            bot, "long", symbol, 300_000
+        )
+    else:
+        await hsl._equity_hard_stop_handle_position_during_cooldown(bot, "long", 300_000)
+    assert not state["cooldown_intervention_active"]
+    assert hsl._equity_hard_stop_manual_cooldown_intervention(bot, "long", symbol) is True
+
+
+def test_manual_ownership_reads_canonical_fill_objects():
+    from fill_events_manager import FillEvent
+
+    events = [
+        FillEvent(
+            id=str(index),
+            timestamp=row["timestamp"],
+            datetime="",
+            symbol=row["symbol"],
+            side="buy" if row["action"] == "increase" else "sell",
+            qty=row["qty"],
+            price=100.0,
+            pnl=0.0,
+            fee_paid=0.0,
+            pnl_status="confirmed",
+            fees=[],
+            pb_order_type="",
+            position_side="long",
+            client_order_id="",
+        )
+        for index, row in enumerate(_manual_stop_events())
+    ]
+    bot, state, symbol = _manual_ownership_bot("coin", events)
+    assert hsl._equity_hard_stop_manual_cooldown_intervention(bot, "long", symbol) is True

--- a/tests/test_hsl_cooldown_boundary_replay.py
+++ b/tests/test_hsl_cooldown_boundary_replay.py
@@ -7,8 +7,8 @@ def _normal_override_history(signal_mode, *, closing_loss=100.0, same_minute=Fal
     bot = _make_aggregate_episode_bot(signal_mode, closing_loss=closing_loss)
     bot._equity_hard_stop_cooldown_position_policy = lambda: "normal"
     events = bot._pnls_manager.get_events()
-    panic_ts = 60_500 if same_minute else 30_500
-    events[0]["timestamp"] = 60_600 if same_minute else 60_000
+    panic_ts = 60_500 if same_minute else 90_500
+    events[0]["timestamp"] = 60_600 if same_minute else 120_000
     events[:0] = [
         dict(timestamp=10_000, symbol="A", pside="long", action="increase", qty=1.0, pnl=0.0),
         dict(
@@ -25,6 +25,13 @@ def _normal_override_history(signal_mode, *, closing_loss=100.0, same_minute=Fal
 
     async def history(**kwargs):
         result = await original_history(**kwargs)
+        # The first held episode has an observed zero-loss sample before its stop.
+        result["timeline"].insert(0, dict(
+            timestamp=0, balance=1000.0, realized_pnl=0.0,
+            realized_pnl_long=0.0, realized_pnl_short=0.0,
+            unrealized_pnl_long=0.0, unrealized_pnl_short=0.0,
+            is_flat=False, is_flat_long=False, is_flat_short=True,
+        ))
         result["panic_flatten_events"] = [
             dict(
                 timestamp=panic_ts,
@@ -52,7 +59,10 @@ async def test_normal_cooldown_override_replays_later_ordinary_episode_reset(
         await bot._equity_hard_stop_initialize_from_history()
         state = bot._hsl_state("long")
         assert not state["halted"]
-        assert state["last_stop_event"] is None
+        if ema_span == 1.0:
+            assert state["last_stop_event"]["stop_event_timestamp_ms"] == (60_500 if same_minute else 90_500)
+        else:
+            assert state["last_stop_event"] is None
         assert state["pnl_reset_timestamp_ms"] == 180_501
         metrics = state["last_metrics"]
         assert metrics["peak_strategy_equity"] == pytest.approx(600.0)
@@ -69,6 +79,9 @@ async def test_normal_cooldown_override_still_finalizes_new_red_at_exact_fill(
     signal_mode, same_minute
 ):
     bot = _normal_override_history(signal_mode, closing_loss=300.0, same_minute=same_minute)
+    # End at this RED close; a later normal-policy entry starts another episode.
+    bot._pnls_manager.get_events().pop()
+    bot.positions["A"]["long"]["size"] = 0.0
     await bot._equity_hard_stop_initialize_from_history()
     state = bot._hsl_state("long")
     assert state["halted"]
@@ -114,8 +127,8 @@ async def test_normal_override_without_later_flatten_keeps_its_new_episode(signa
     await bot._equity_hard_stop_initialize_from_history()
     state = bot._hsl_state("long")
     assert not state["halted"]
-    assert state["last_stop_event"] is None
-    assert state["pnl_reset_timestamp_ms"] is None
+    assert state["last_stop_event"]["stop_event_timestamp_ms"] == 60_500
+    assert state["pnl_reset_timestamp_ms"] == 60_501
     assert state["last_metrics"]["drawdown_raw"] == pytest.approx(50.0 / 700.0)
 
 
@@ -311,3 +324,105 @@ def test_manual_ownership_reads_canonical_fill_objects():
     ]
     bot, state, symbol = _manual_ownership_bot("coin", events)
     assert hsl._equity_hard_stop_manual_cooldown_intervention(bot, "long", symbol) is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("signal_mode", ["pside", "unified"])
+@pytest.mark.parametrize("ema_span", [1.0, 5.0])
+@pytest.mark.parametrize("multiple_episodes", [False, True])
+async def test_normal_override_seeds_before_same_minute_closing_loss(
+    signal_mode, ema_span, multiple_episodes
+):
+    bot = _normal_override_history(signal_mode, closing_loss=350.0, same_minute=True)
+    bot.hsl["long"]["ema_span_minutes"] = ema_span
+    events = bot._pnls_manager.get_events()
+    events[3]["timestamp"] = 60_700
+    events[4]["timestamp"] = 60_800
+    if multiple_episodes:
+        events[3]["pnl"] = -10.0
+        events.extend(
+            [
+                dict(
+                    timestamp=60_900,
+                    symbol="A",
+                    pside="long",
+                    action="decrease",
+                    qty=1.0,
+                    pnl=-350.0,
+                ),
+                dict(
+                    timestamp=61_000, symbol="A", pside="long", action="increase", qty=1.0, pnl=0.0
+                ),
+            ]
+        )
+    # Keep earlier ordinary reentry, but end at the closing RED under test.
+    events.pop()
+    bot.positions["A"]["long"]["size"] = 0.0
+    stop_ts = 60_900 if multiple_episodes else 60_700
+    expected_raw = 351.0 / 690.0 if multiple_episodes else 350.0 / 700.0
+    for _ in range(2):
+        await bot._equity_hard_stop_initialize_from_history()
+        state = bot._hsl_state("long")
+        assert state["halted"]
+        stop = state["last_stop_event"]
+        assert stop["stop_event_timestamp_ms"] == stop_ts
+        assert stop["drawdown_raw"] == pytest.approx(expected_raw)
+        assert stop["drawdown_ema"] == pytest.approx(expected_raw * 2.0 / (ema_span + 1.0))
+        assert state["cooldown_until_ms"] == stop_ts + 300_000
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("signal_mode", ["pside", "unified"])
+@pytest.mark.parametrize("entry_fee", [0.0, -1.0])
+@pytest.mark.parametrize("ema_span", [1.0, 5.0])
+@pytest.mark.parametrize("multiple_episodes", [False, True])
+async def test_expired_cooldown_seeds_before_same_minute_closing_loss(
+    signal_mode, entry_fee, ema_span, multiple_episodes
+):
+    bot = _make_aggregate_episode_bot(signal_mode, closing_loss=300.0)
+    bot.hsl["long"]["cooldown_minutes_after_red"] = 1.0
+    bot.hsl["long"]["restart_after_red_policy"] = "always"
+    bot.hsl["long"]["ema_span_minutes"] = ema_span
+    bot.hsl["long"]["red_threshold"] = 0.08
+    events = bot._pnls_manager.get_events()
+    events[2].update(timestamp=240_600, fee_paid=entry_fee)
+    events.extend(
+        [
+            dict(
+                timestamp=240_700, symbol="A", pside="long", action="decrease", qty=1.0, pnl=-200.0
+            ),
+            dict(timestamp=240_800, symbol="A", pside="long", action="increase", qty=1.0, pnl=0.0),
+        ]
+    )
+    expected_peak = 700.0
+    stop_ts = 240_700
+    if multiple_episodes:
+        events[3]["pnl"] = -10.0
+        events[4]["fee_paid"] = entry_fee
+        events.extend(
+            [
+                dict(
+                    timestamp=240_900,
+                    symbol="A",
+                    pside="long",
+                    action="decrease",
+                    qty=1.0,
+                    pnl=-200.0,
+                ),
+                dict(
+                    timestamp=241_000, symbol="A", pside="long", action="increase", qty=1.0, pnl=0.0
+                ),
+            ]
+        )
+        expected_peak = 690.0 + entry_fee
+        stop_ts = 240_900
+    expected_raw = (200.0 - entry_fee) / expected_peak
+    for _ in range(2):
+        await bot._equity_hard_stop_initialize_from_history()
+        state = bot._hsl_state("long")
+        assert state["halted"]
+        stop = state["last_stop_event"]
+        assert stop["stop_event_timestamp_ms"] == stop_ts
+        assert stop["drawdown_raw"] == pytest.approx(expected_raw)
+        assert stop["drawdown_ema"] == pytest.approx(expected_raw * 2.0 / (ema_span + 1.0))
+        assert state["cooldown_until_ms"] == stop_ts + 60_000

--- a/tests/test_hsl_live_restart_replay.py
+++ b/tests/test_hsl_live_restart_replay.py
@@ -1,0 +1,257 @@
+import asyncio
+from types import MethodType
+
+import pytest
+
+import passivbot_hsl as hsl
+from live.freshness import FreshnessLedger
+from live.state_refresh import AuthoritativeSurfaceUnavailable
+from test_hsl_coin_mode import _make_aggregate_episode_bot, make_coin_bot
+from test_hsl_cooldown_boundary_replay import _normal_override_history
+
+
+def _live_restart_bot(mode, kind, *, fee=0.0, upnl=300.0):
+    if kind == "normal":
+        bot = _normal_override_history("pside" if mode == "coin" else mode, same_minute=True)
+        events = bot._pnls_manager.get_events()
+        del events[3:]
+        now, stop, deadline = 180_900, 60_500, 360_500
+    else:
+        bot = _make_aggregate_episode_bot("pside" if mode == "coin" else mode, closing_loss=300.0)
+        bot.hsl["long"].update(cooldown_minutes_after_red=1.0, restart_after_red_policy="always")
+        events = bot._pnls_manager.get_events()
+        events[-1]["timestamp"] = 240_600
+        now, stop, deadline = 300_900, 180_500, 240_500
+    events[-1]["fee_paid"] = -fee
+    bot.config["live"]["hsl_signal_mode"] = mode
+    for name in (
+        "_equity_hard_stop_handle_position_during_cooldown",
+        "_equity_hard_stop_position_symbols",
+        "_equity_hard_stop_log_cooldown_status",
+    ):
+        setattr(bot, name, MethodType(getattr(hsl, name), bot))
+    bot.get_exchange_time = lambda: now
+
+    async def current_upnl(pside=None, symbol=None):
+        return -upnl if pside in (None, "long") else 0.0
+
+    bot._calc_upnl_sum_strict = current_upnl
+    original_history = bot.get_balance_equity_history
+
+    async def history(**kwargs):
+        result = await original_history(**kwargs)
+        for row in result["timeline"]:
+            row["unrealized_pnl_long"] = (
+                -upnl if not row["is_flat_long"] and row["timestamp"] > stop else 0.0
+            )
+            row["realized_pnl_by_coin_pside"] = {
+                "A": {"long": row["realized_pnl_long"], "short": 0.0}
+            }
+            row["unrealized_pnl_by_coin_pside"] = {
+                "A": {"long": row["unrealized_pnl_long"], "short": 0.0}
+            }
+        return result
+
+    bot.get_balance_equity_history = history
+    if mode == "coin":
+        bot.bot_value = lambda pside, key: 1.0
+        bot._equity_hard_stop_coin_initialized = True
+        bot._equity_hard_stop_apply_coin_metrics_sample(
+            "long", "A", stop - 1, 1000.0, 0.0, 0.0, 0.0
+        )
+        state = bot._hsl_coin_state("long", "A")
+    else:
+        bot._equity_hard_stop_apply_sample(
+            "long", stop - 1, 1000.0, 0.0, 0.0, 0.0, unrealized_pnl_total=0.0
+        )
+        state = bot._hsl_state("long")
+    state.update(halted=True, cooldown_until_ms=deadline, pnl_reset_timestamp_ms=stop + 1)
+    return bot, state
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["coin", "pside", "unified"])
+@pytest.mark.parametrize("kind", ["normal", "expiry"])
+@pytest.mark.parametrize("fee", [0.0, 2.0])
+async def test_live_restart_preserves_loss_and_matches_canonical_replay(mode, kind, fee):
+    bot, old = _live_restart_bot(mode, kind, fee=fee)
+    await hsl._equity_hard_stop_check(bot)
+    state = bot._hsl_coin_state("long", "A") if mode == "coin" else bot._hsl_state("long")
+    assert state is old
+    live = dict(state["last_metrics"])
+    assert live["drawdown_raw"] > 0.4
+    assert live["tier"] == "red"
+    if mode == "coin":
+        await bot._equity_hard_stop_initialize_coin_from_history()
+        state = bot._hsl_coin_state("long", "A")
+    else:
+        await bot._equity_hard_stop_initialize_from_history()
+        state = bot._hsl_state("long")
+    for key in ("drawdown_raw", "drawdown_ema", "peak_strategy_equity"):
+        assert live[key] == pytest.approx(state["last_metrics"][key])
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["coin", "pside", "unified"])
+@pytest.mark.parametrize(
+    "outcome",
+    [
+        "ready",
+        "unavailable",
+        "malformed",
+        "epoch",
+        "generation",
+        "not_ready",
+        "false_return",
+        "pending_confirmation",
+    ],
+)
+async def test_staged_restart_keeps_live_protection_until_ready_publish(mode, outcome):
+    bot = make_coin_bot()
+    bot.config["live"]["hsl_signal_mode"] = mode
+    bot.freshness_ledger = FreshnessLedger()
+    bot.freshness_ledger.begin_epoch()
+    bot._account_invalidation_generation = 1
+    bot._runtime_forced_modes = {"long": {"A": "panic", "B": "manual"}, "short": {"B": "panic"}}
+    symbol = "A" if mode == "coin" else None
+    state = bot._hsl_coin_state("long", symbol) if symbol else bot._hsl_state("long")
+    state.update(
+        halted=True, cooldown_until_ms=400_000,
+        last_stop_event={"stop_event_timestamp_ms": 100_000},
+    )
+    old_stop = state["last_stop_event"]
+    old_runtime = state["runtime"]
+    old_maps = bot._runtime_forced_modes
+    old_coin = bot._equity_hard_stop_coin
+    other = bot._hsl_coin_state("long", "B") if symbol else bot._hsl_state("short")
+    if mode != "unified":
+        other["no_restart_latched"] = True
+    writes = []
+    events = []
+    bot._emit_live_event = lambda *args, **kwargs: events.append(args)
+    bot._equity_hard_stop_write_latch = lambda *args, **kwargs: writes.append(args)
+
+    async def initializer(staged):
+        assert staged is not bot
+        staged._runtime_forced_modes["long"]["A"] = "graceful_stop"
+        target = staged._hsl_coin_state("long", symbol) if symbol else staged._hsl_state("long")
+        target.update(halted=True, cooldown_until_ms=500_000)
+        staged._equity_hard_stop_write_latch(
+            "long", {"stop_event_timestamp_ms": 200_000}, symbol=symbol
+        )
+        staged._emit_live_event("staged", {})
+        await asyncio.sleep(0)
+        assert state["halted"] and state["cooldown_until_ms"] == 400_000
+        assert state["runtime"] is old_runtime
+        assert bot._equity_hard_stop_coin is old_coin
+        assert bot._runtime_forced_modes is old_maps
+        assert bot._runtime_forced_modes["long"]["A"] == "panic"
+        assert not writes and not events
+        if outcome == "unavailable":
+            raise AuthoritativeSurfaceUnavailable("hsl_episode_boundaries", "missing candles")
+        if outcome == "malformed":
+            raise ValueError("malformed canonical replay")
+        if outcome == "epoch":
+            bot.freshness_ledger.begin_epoch()
+        if outcome == "generation":
+            bot._account_invalidation_generation += 1
+        if outcome == "pending_confirmation":
+            bot._authoritative_pending_confirmations = {"positions": bot.freshness_ledger.epoch + 1}
+        if outcome == "not_ready":
+            target["halted"] = False
+        staged._equity_hard_stop_coin_initialized = True
+        staged._equity_hard_stop_coin_replay_ready_pairs = (
+            {("long", "A")} if outcome != "not_ready" else set()
+        )
+        if outcome == "false_return":
+            return False
+
+    name = (
+        "_equity_hard_stop_initialize_coin_from_history"
+        if symbol
+        else "_equity_hard_stop_initialize_from_history"
+    )
+    setattr(bot, name, MethodType(initializer, bot))
+    if outcome == "malformed":
+        with pytest.raises(ValueError, match="malformed canonical replay"):
+            await hsl._equity_hard_stop_replay_live_restart(bot, "long", symbol)
+    else:
+        assert await hsl._equity_hard_stop_replay_live_restart(bot, "long", symbol) is (
+            outcome == "ready"
+        )
+    assert not bot._hsl_live_restart_replay_active
+    if outcome == "ready":
+        assert state["cooldown_until_ms"] == 500_000
+        assert state["last_stop_event"] is old_stop
+        assert len(writes) == 1
+        if mode == "coin":
+            assert bot._runtime_forced_modes["long"]["B"] == "manual"
+            assert ("long", "A") in bot._equity_hard_stop_coin_replay_ready_pairs
+    else:
+        assert state["runtime"] is old_runtime
+        assert state["cooldown_until_ms"] == 400_000
+        assert not writes
+    if mode != "unified":
+        assert other["no_restart_latched"]
+    assert not events
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["coin", "pside", "unified"])
+@pytest.mark.parametrize("kind", ["normal", "expiry"])
+async def test_unavailable_real_restart_retains_existing_runtime_and_modes(mode, kind):
+    bot, state = _live_restart_bot(mode, kind)
+    before = state["runtime"]
+    expected_mode = "graceful_stop" if kind == "normal" else "panic"
+    bot._runtime_forced_modes["long"]["A"] = expected_mode
+
+    async def unavailable(**kwargs):
+        assert state["halted"]
+        assert state["runtime"] is before
+        await asyncio.sleep(0)
+        raise AuthoritativeSurfaceUnavailable("hsl_episode_boundaries", "missing candle history")
+
+    bot.get_balance_equity_history = unavailable
+    await hsl._equity_hard_stop_check(bot)
+    assert state["runtime"] is before
+    assert state["halted"]
+    assert bot._runtime_forced_modes["long"]["A"] == expected_mode
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["coin", "pside", "unified"])
+async def test_restart_defers_while_background_replay_owns_state(mode):
+    bot, state = _live_restart_bot(mode, "normal")
+    task = asyncio.create_task(asyncio.Event().wait())
+    bot._equity_hard_stop_coin_replay_task = task
+    before = state["runtime"]
+    try:
+        assert not await hsl._equity_hard_stop_replay_live_restart(
+            bot, "long", "A" if mode == "coin" else None
+        )
+        assert state["runtime"] is before and state["halted"]
+    finally:
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["coin", "pside", "unified"])
+async def test_live_restart_does_not_resample_pre_await_observation(mode):
+    bot, state = _live_restart_bot(mode, "normal")
+    original_history = bot.get_balance_equity_history
+    now = [180_900]
+    bot.get_exchange_time = lambda: now[0]
+
+    async def history(**kwargs):
+        result = await original_history(**kwargs)
+        now[0] = 240_900
+        return result
+
+    bot.get_balance_equity_history = history
+    await hsl._equity_hard_stop_check(bot)
+    assert state["last_metrics"]["timestamp_ms"] >= 180_900
+    # Canonical replay owns its final sample; the outer check cannot write an
+    # earlier observation after that sample or compound its EMA.
+    assert state["last_metrics"]["drawdown_raw"] == pytest.approx(3.0 / 7.0)

--- a/tests/test_hsl_normal_ordinary_stop.py
+++ b/tests/test_hsl_normal_ordinary_stop.py
@@ -101,3 +101,137 @@ async def test_normal_entry_cannot_release_terminal_ordinary_red_stop(
     state = await _replay(bot, mode)
     assert state["halted"] and state["no_restart_latched"]
     assert state["last_stop_event"]["stop_event_timestamp_ms"] == 180_500
+
+
+def _tie_normal_stop_entry(bot, reverse=False, evidence=True):
+    events = bot._pnls_manager.get_events()
+    for event, before in zip(events[1:3], [1.0, 0.0]):
+        event["timestamp"] = 180_500
+        if evidence:
+            event["raw"] = [
+                {
+                    "data": {
+                        "side": "sell" if event["action"] == "decrease" else "buy",
+                        "amount": event["qty"],
+                        "price": 1.0,
+                        "info": {"startPosition": str(before)},
+                    }
+                }
+            ]
+    if reverse:
+        events[1:3] = reversed(events[1:3])
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["coin", "pside", "unified"])
+@pytest.mark.parametrize("reverse", [False, True])
+@pytest.mark.parametrize("panic_marker", [False, True])
+async def test_normal_tied_stop_entry_preserves_fee_after_restart_and_current_poll(
+    mode, reverse, panic_marker
+):
+    bot = _normal_after_red_bot(mode, panic_marker=panic_marker)
+    _tie_normal_stop_entry(bot, reverse)
+    for _ in range(2):
+        state = await _replay(bot, mode)
+        assert not state["halted"]
+        assert state["last_metrics"]["tier"] == "green"
+        raw = state["last_metrics"]["drawdown_raw"]
+        assert 0 < raw < 0.002
+        if mode == "coin":
+            current = bot._equity_hard_stop_apply_coin_sample(
+                "long", "A", 360_900, 699.0, 0.0
+            )
+            assert current["realized_pnl"] == pytest.approx(-1.0)
+        else:
+            current = bot._equity_hard_stop_apply_sample(
+                "long", 360_900, 699.0, -301.0, -301.0, 0.0, unrealized_pnl_total=0.0
+            )
+        assert current["drawdown_raw"] == pytest.approx(raw)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["coin", "pside", "unified"])
+@pytest.mark.parametrize("reverse", [False, True])
+async def test_normal_tied_stop_entry_cannot_release_terminal_scope(mode, reverse):
+    bot = _normal_after_red_bot(mode, terminal=True)
+    _tie_normal_stop_entry(bot, reverse)
+    state = await _replay(bot, mode)
+    assert state["halted"] and state["no_restart_latched"]
+    assert state["last_stop_event"]["stop_event_timestamp_ms"] == 180_500
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["coin", "pside", "unified"])
+async def test_normal_tied_stop_entry_requires_exchange_ordering_evidence(mode):
+    from live.state_refresh import AuthoritativeSurfaceUnavailable
+
+    bot = _normal_after_red_bot(mode)
+    _tie_normal_stop_entry(bot, evidence=False)
+    if mode == "coin":
+        state = await _replay(bot, mode)
+        assert state["runtime"].red_latched()
+        assert state["pnl_reset_timestamp_ms"] is None
+        assert bot._runtime_forced_modes["long"]["A"] == "panic"
+    else:
+        with pytest.raises(AuthoritativeSurfaceUnavailable):
+            await _replay(bot, mode)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["coin", "pside", "unified"])
+@pytest.mark.parametrize("reverse", [False, True])
+async def test_normal_branching_tied_stops_do_not_guess_intervention_prefix(
+    mode, reverse
+):
+    bot = _normal_after_red_bot(mode)
+    events = bot._pnls_manager.get_events()
+    events[2]["qty"] = 2.0
+    events.extend(
+        [
+            dict(
+                timestamp=180_500,
+                symbol="A",
+                pside="long",
+                action="decrease",
+                qty=2.0,
+                pnl=-150.0,
+            ),
+            dict(
+                timestamp=180_500,
+                symbol="A",
+                pside="long",
+                action="increase",
+                qty=3.0,
+                pnl=0.0,
+                fee_paid=-2.0,
+            ),
+        ]
+    )
+    for event, before in zip(events[1:], [1.0, 0.0, 2.0, 0.0]):
+        event["timestamp"] = 180_500
+        event["raw"] = [
+            {
+                "data": {
+                    "side": "sell" if event["action"] == "decrease" else "buy",
+                    "amount": event["qty"],
+                    "price": 1.0,
+                    "info": {"startPosition": str(before)},
+                }
+            }
+        ]
+    if reverse:
+        events[1:] = reversed(events[1:])
+    bot.positions["A"]["long"]["size"] = 3.0
+    from live.state_refresh import AuthoritativeSurfaceUnavailable
+
+    # Repeated exits from zero do not have a unique successor in the existing
+    # exchange-chain proof. Never pick an entry or PnL prefix from list order.
+    for _ in range(2):
+        if mode == "coin":
+            state = await _replay(bot, mode)
+            assert state["runtime"].red_latched()
+            assert state["pnl_reset_timestamp_ms"] is None
+            assert bot._runtime_forced_modes["long"]["A"] == "panic"
+        else:
+            with pytest.raises(AuthoritativeSurfaceUnavailable):
+                await _replay(bot, mode)

--- a/tests/test_hsl_normal_ordinary_stop.py
+++ b/tests/test_hsl_normal_ordinary_stop.py
@@ -1,0 +1,103 @@
+import pytest
+
+from test_hsl_coin_mode import _make_aggregate_episode_bot
+
+
+def _normal_after_red_bot(
+    mode, *, panic_marker=False, close_again=False, terminal=False
+):
+    bot = _make_aggregate_episode_bot(mode, closing_loss=300.0)
+    bot._equity_hard_stop_cooldown_position_policy = lambda: "normal"
+    bot.config["live"]["hsl_position_during_cooldown_policy"] = "normal"
+    bot.get_exchange_time = lambda: 300_900
+    if terminal:
+        bot.hsl["long"]["no_restart_drawdown_threshold"] = 0.2
+    events = bot._pnls_manager.get_events()
+    if panic_marker:
+        events[1]["pb_order_type"] = "close_panic_long"
+    if close_again:
+        events.append(
+            dict(
+                timestamp=180_700,
+                symbol="A",
+                pside="long",
+                action="decrease",
+                qty=1.0,
+                pnl=-300.0,
+            )
+        )
+        bot.positions["A"]["long"]["size"] = 0.0
+
+    async def upnl(pside=None, symbol=None):
+        return 0.0
+
+    bot._calc_upnl_sum_strict = upnl
+    original = bot.get_balance_equity_history
+
+    async def history(**kwargs):
+        result = await original(**kwargs)
+        for row in result["timeline"]:
+            row["unrealized_pnl_long"] = 0.0
+            row["realized_pnl_by_coin_pside"] = {
+                "A": {"long": row["realized_pnl_long"], "short": 0.0}
+            }
+            row["unrealized_pnl_by_coin_pside"] = {"A": {"long": 0.0, "short": 0.0}}
+        if panic_marker:
+            result["panic_flatten_events"] = [
+                dict(
+                    timestamp=180_500,
+                    minute_timestamp=180_000,
+                    pside="long",
+                    symbol="A",
+                )
+            ]
+        return result
+
+    bot.get_balance_equity_history = history
+    bot.bot_value = lambda pside, key: 1.0
+    return bot
+
+
+async def _replay(bot, mode):
+    if mode == "coin":
+        await bot._equity_hard_stop_initialize_coin_from_history()
+        return bot._hsl_coin_state("long", "A")
+    await bot._equity_hard_stop_initialize_from_history()
+    return bot._hsl_state("long")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["coin", "pside", "unified"])
+@pytest.mark.parametrize("close_again", [False, True])
+async def test_normal_override_after_red_is_independent_of_close_order_type(
+    mode, close_again
+):
+    results = []
+    for panic_marker in (False, True):
+        bot = _normal_after_red_bot(
+            mode, panic_marker=panic_marker, close_again=close_again
+        )
+        for _ in range(2):
+            state = await _replay(bot, mode)
+            if close_again:
+                assert state["halted"]
+                assert state["last_stop_event"]["stop_event_timestamp_ms"] == 180_700
+                assert state["cooldown_until_ms"] == 480_700
+            else:
+                assert not state["halted"]
+                assert state["last_metrics"]["tier"] == "green"
+                assert 0 < state["last_metrics"]["drawdown_raw"] < 0.002
+        results.append(state["last_metrics"]["drawdown_raw"])
+    assert results[0] == pytest.approx(results[1])
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["coin", "pside", "unified"])
+@pytest.mark.parametrize("panic_marker", [False, True])
+async def test_normal_entry_cannot_release_terminal_ordinary_red_stop(
+    mode, panic_marker
+):
+    bot = _normal_after_red_bot(mode, terminal=True, panic_marker=panic_marker)
+    state = await _replay(bot, mode)
+    assert state["halted"] and state["no_restart_latched"]
+    assert state["last_stop_event"]["stop_event_timestamp_ms"] == 180_500

--- a/tests/test_hsl_normal_ordinary_stop.py
+++ b/tests/test_hsl_normal_ordinary_stop.py
@@ -235,3 +235,93 @@ async def test_normal_branching_tied_stops_do_not_guess_intervention_prefix(
         else:
             with pytest.raises(AuthoritativeSurfaceUnavailable):
                 await _replay(bot, mode)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("reverse", [False, True])
+@pytest.mark.parametrize("residue", [0.001, 0.01])
+@pytest.mark.parametrize("pside", ["long", "short"])
+async def test_coin_tied_intervention_uses_symbol_flat_tolerance(
+    reverse, residue, pside
+):
+    from test_hsl_tied_intervention_evidence import _fill
+
+    bot = _normal_after_red_bot("coin")
+    bot.qty_steps = {"A": 0.01}
+    events = bot._pnls_manager.get_events()
+    events[:] = [
+        _fill("open", 60_000, 0.0, 1.0, pside=pside),
+        _fill("stop", 180_500, 1.0, residue, pnl=-300.0, pside=pside),
+        _fill("entry", 180_500, residue, residue + 1.0, fee=-1.0, pside=pside),
+    ]
+    if reverse:
+        events[1:] = reversed(events[1:])
+    if pside == "short":
+        bot.hsl["short"] = dict(bot.hsl["long"])
+        bot.hsl["long"]["enabled"] = False
+    bot.positions = {
+        "A": {
+            side: {
+                "size": (
+                    (1.0 + residue) * (1 if side == "long" else -1)
+                    if side == pside
+                    else 0.0
+                )
+            }
+            for side in ("long", "short")
+        }
+    }
+
+    async def history(**kwargs):
+        rows = []
+        for ts in (60_000, 120_000, 180_000, 240_000):
+            realized = sum(
+                e["pnl"] + e["fee_paid"] for e in events if e["timestamp"] < ts + 60_000
+            )
+            rows.append(
+                dict(
+                    timestamp=ts,
+                    balance=1000.0 + realized,
+                    realized_pnl=realized,
+                    realized_pnl_long=realized if pside == "long" else 0.0,
+                    realized_pnl_short=realized if pside == "short" else 0.0,
+                    unrealized_pnl_long=0.0,
+                    unrealized_pnl_short=0.0,
+                    realized_pnl_by_coin_pside={
+                        "A": {
+                            side: realized if side == pside else 0.0
+                            for side in ("long", "short")
+                        }
+                    },
+                    unrealized_pnl_by_coin_pside={"A": {"long": 0.0, "short": 0.0}},
+                    is_flat=False,
+                    is_flat_long=pside != "long",
+                    is_flat_short=pside != "short",
+                )
+            )
+        return dict(timeline=rows, fill_events=events, panic_flatten_events=[])
+
+    bot.get_balance_equity_history = history
+    stop = next(event for event in events if event["id"] == "stop")
+    stop["pb_order_type"] = f"close_panic_{pside}"
+    inferred = bot._equity_hard_stop_infer_coin_replay_contract(
+        pside, "A", events, 300_900
+    )
+    assert inferred["intervention_entry_ts"] == (180_500 if residue < 0.005 else None)
+    stop.pop("pb_order_type")
+    for _ in range(2):
+        await bot._equity_hard_stop_initialize_coin_from_history()
+        state = bot._hsl_coin_state(pside, "A")
+        if residue < 0.005:
+            assert not state["halted"]
+            assert state["last_metrics"]["tier"] == "green"
+            assert state["last_metrics"]["realized_pnl"] == pytest.approx(-1.0)
+            current = bot._equity_hard_stop_apply_coin_sample(
+                pside, "A", 360_900, 699.0, 0.0
+            )
+            assert current["realized_pnl"] == pytest.approx(-1.0)
+            assert current["drawdown_raw"] == pytest.approx(1.0 / 699.0)
+        else:
+            assert state["runtime"].red_latched()
+            assert state["pnl_reset_timestamp_ms"] is None
+            assert bot._runtime_forced_modes[pside]["A"] == "panic"

--- a/tests/test_hsl_protective_cancellation.py
+++ b/tests/test_hsl_protective_cancellation.py
@@ -1,0 +1,219 @@
+from types import MethodType
+from unittest.mock import AsyncMock
+
+import pytest
+
+import passivbot_hsl as hsl
+from passivbot import Passivbot
+from test_hsl_cooldown_boundary_replay import _manual_ownership_bot, _manual_stop_events
+
+
+def _protective_bot(signal_mode, events):
+    bot, state, symbol = _manual_ownership_bot(signal_mode, events, refreshed_ms=999)
+    bot._equity_hard_stop_coin_initialized = True
+    bot.config["live"]["execution_delay_seconds"] = 0.25
+    bot._canonical_open_order_reduce_only = MethodType(
+        Passivbot._canonical_open_order_reduce_only, bot
+    )
+    bot._equity_hard_stop_handle_position_during_cooldown = AsyncMock()
+    bot._equity_hard_stop_handle_coin_position_during_cooldown = AsyncMock()
+    bot.open_orders = {
+        "A": [
+            {
+                "id": "initial",
+                "symbol": "A",
+                "position_side": "long",
+                "reduce_only": False,
+            },
+            {
+                "id": "close",
+                "symbol": "A",
+                "position_side": "long",
+                "reduce_only": True,
+            },
+        ]
+    }
+    bot.calc_protective_panic_orders_to_cancel_and_create = AsyncMock(
+        return_value=([], [])
+    )
+    bot.execute_order_plan_to_exchange = AsyncMock()
+    bot.update_pnls = AsyncMock(return_value=False)
+    bot._sleep_unless_shutdown = AsyncMock()
+    bot.refresh_protective_authoritative_state = AsyncMock(return_value=True)
+    return bot, state, symbol
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("signal_mode", ["coin", "pside", "unified"])
+@pytest.mark.parametrize(
+    "policy", ["panic", "manual", "tp_only", "graceful_stop", "normal"]
+)
+@pytest.mark.parametrize("deadline", [None, 200_000])
+@pytest.mark.parametrize("held", [False, True])
+async def test_terminal_scope_cancels_entries_without_cooldown_or_creations(
+    signal_mode, policy, deadline, held
+):
+    bot, state, _ = _protective_bot(signal_mode, _manual_stop_events())
+    bot.config["live"]["hsl_position_during_cooldown_policy"] = policy
+    state.update(
+        no_restart_latched=True,
+        cooldown_until_ms=deadline,
+        cooldown_intervention_active=True,
+    )
+    bot.positions = {"A": {"long": {"size": float(held)}}}
+    assert await Passivbot._run_halted_hsl_protection_if_active(bot)
+    cancels, creates = bot.execute_order_plan_to_exchange.await_args.args
+    assert [order["id"] for order in cancels] == ["initial"]
+    assert creates == []
+    assert state["halted"] and state["no_restart_latched"]
+    assert state["cooldown_until_ms"] == deadline
+    assert bot.positions["A"]["long"]["size"] == float(held)
+    bot.calc_protective_panic_orders_to_cancel_and_create.assert_not_awaited()
+    bot._equity_hard_stop_handle_position_during_cooldown.assert_not_awaited()
+    bot._equity_hard_stop_handle_coin_position_during_cooldown.assert_not_awaited()
+    bot.update_pnls.assert_not_awaited()
+    bot._sleep_unless_shutdown.assert_awaited_once_with(
+        0.25, stage="hsl_cooldown_protection"
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("signal_mode", ["coin", "pside", "unified"])
+@pytest.mark.parametrize(
+    "outcome", ["no_entry", "entry", "failure", "invalidation", "confirmation"]
+)
+async def test_manual_proof_refreshes_fill_tail_after_account_observation(
+    signal_mode, outcome
+):
+    events = _manual_stop_events(intervention=False)
+    bot, state, symbol = _protective_bot(signal_mode, events)
+    clock = {"account": 1_000, "fills": 999}
+    calls = []
+    metadata = bot._pnls_manager.cache.load_metadata()
+    bot._pnls_manager.cache.load_metadata = lambda: {
+        **metadata,
+        "last_refresh_ms": clock["fills"],
+    }
+
+    async def account():
+        calls.append("account")
+        clock["account"] += 10
+        bot.freshness_ledger.begin_epoch()
+        for surface in ("positions", "open_orders"):
+            bot.freshness_ledger.stamp(surface, (), now_ms=clock["account"])
+        bot._authoritative_pending_confirmations = {}
+        return True
+
+    async def fills(*, source):
+        calls.append("fills")
+        assert source == "hsl_cooldown_protection"
+        assert (
+            hsl._equity_hard_stop_manual_cooldown_intervention(bot, "long", symbol)
+            is None
+        )
+        if outcome == "failure":
+            return False
+        clock["fills"] = clock["account"] + 1
+        if outcome == "entry":
+            events.extend(_manual_stop_events()[1:])
+        elif outcome == "invalidation":
+            bot._account_invalidation_generation = 1
+        elif outcome == "confirmation":
+            bot._authoritative_pending_confirmations = {
+                "positions": bot.freshness_ledger.epoch + 1
+            }
+        return True
+
+    bot.refresh_protective_authoritative_state = AsyncMock(side_effect=account)
+    bot.update_pnls = AsyncMock(side_effect=fills)
+    did_work = await Passivbot._run_halted_hsl_protection_if_active(bot)
+    assert did_work is (outcome == "no_entry")
+    assert calls == (
+        ["account", "fills", "account"]
+        if outcome in {"invalidation", "confirmation"}
+        else ["account", "fills"]
+    )
+    if outcome == "no_entry":
+        cancels, creates = bot.execute_order_plan_to_exchange.await_args.args
+        assert [order["id"] for order in cancels] == ["initial"]
+        assert creates == []
+        # An unchanged resting initial on the next deferred cycle must again
+        # acquire a newer fill tail; it cannot remain perpetually behind.
+        assert await Passivbot._run_halted_hsl_protection_if_active(bot)
+        assert calls == ["account", "fills", "account", "fills"]
+    else:
+        bot.execute_order_plan_to_exchange.assert_not_awaited()
+    bot.calc_protective_panic_orders_to_cancel_and_create.assert_not_awaited()
+    assert state["halted"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("known_entry", [False, True])
+async def test_manual_unknown_fill_failure_does_not_suppress_terminal_scope(
+    known_entry,
+):
+    bot, _, _ = _protective_bot("coin", _manual_stop_events(intervention=known_entry))
+    terminal = bot._hsl_coin_state("long", "B")
+    terminal.update(halted=True, no_restart_latched=True)
+    bot.open_orders["B"] = [
+        {"id": "terminal", "symbol": "B", "position_side": "long", "reduce_only": False}
+    ]
+    assert await Passivbot._run_halted_hsl_protection_if_active(bot)
+    cancels, creates = bot.execute_order_plan_to_exchange.await_args.args
+    assert [order["id"] for order in cancels] == ["terminal"]
+    assert not creates
+    assert bot.update_pnls.await_count == (0 if known_entry else 1)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("signal_mode", ["coin", "pside", "unified"])
+async def test_manual_without_resting_entry_does_not_refresh_fills(signal_mode):
+    bot, _, _ = _protective_bot(signal_mode, _manual_stop_events(intervention=False))
+    bot.open_orders["A"] = [bot.open_orders["A"][1]]
+    assert not await Passivbot._run_halted_hsl_protection_if_active(bot)
+    bot.update_pnls.assert_not_awaited()
+    bot.execute_order_plan_to_exchange.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("active_red", [False, True])
+async def test_terminal_cancel_wave_includes_newly_replayed_current_red(active_red):
+    bot, state, _ = _protective_bot("coin", _manual_stop_events())
+    bot.config["live"]["hsl_position_during_cooldown_policy"] = "normal"
+    bot.positions = {"A": {"long": {"size": 1.0}}}
+    terminal = bot._hsl_coin_state("long", "B")
+    terminal.update(halted=True, no_restart_latched=True)
+    bot.open_orders["B"] = [
+        {"id": "terminal", "symbol": "B", "position_side": "long", "reduce_only": False}
+    ]
+    protective_close = {"symbol": "A", "position_side": "long", "reduce_only": True}
+    bot.calc_protective_panic_orders_to_cancel_and_create.return_value = (
+        [],
+        [protective_close],
+    )
+
+    async def replay(*args):
+        state["halted"] = False
+        for ts, equity in [(60_000, 100.0), (120_000, 70.0)]:
+            state["runtime"].apply_sample(
+                timestamp_ms=ts,
+                equity=equity,
+                peak_strategy_equity=100.0,
+                red_threshold=0.2,
+                ema_span_minutes=1.0,
+                tier_ratio_yellow=0.5,
+                tier_ratio_orange=0.75,
+                latch_red=True,
+            )
+        state["last_metrics"] = {"red_active_now": active_red}
+        return True
+
+    bot._equity_hard_stop_handle_coin_position_during_cooldown.side_effect = replay
+    assert await Passivbot._run_halted_hsl_protection_if_active(bot)
+    cancels, creates = bot.execute_order_plan_to_exchange.await_args.args
+    assert [order["id"] for order in cancels] == ["terminal"]
+    assert creates == ([protective_close] if active_red else [])
+    assert bot.calc_protective_panic_orders_to_cancel_and_create.await_count == int(
+        active_red
+    )
+    bot.execute_order_plan_to_exchange.assert_awaited_once()

--- a/tests/test_hsl_tied_intervention_evidence.py
+++ b/tests/test_hsl_tied_intervention_evidence.py
@@ -1,0 +1,206 @@
+import itertools
+
+import pytest
+
+import passivbot_hsl as hsl
+
+
+def _fill(event_id, timestamp, before, after, *, pnl=0.0, fee=0.0, symbol="A", pside="long"):
+    increase = after > before
+    return dict(
+        id=event_id,
+        timestamp=timestamp,
+        symbol=symbol,
+        pside=pside,
+        action="increase" if increase else "decrease",
+        qty=abs(after - before),
+        side=(
+            ("buy" if increase else "sell") if pside == "long" else ("sell" if increase else "buy")
+        ),
+        pnl=pnl,
+        fee_paid=fee,
+        raw=[
+            {
+                "data": {
+                    "amount": abs(after - before),
+                    "price": 1.0,
+                    "side": (
+                        ("buy" if increase else "sell")
+                        if pside == "long"
+                        else ("sell" if increase else "buy")
+                    ),
+                    "info": {"startPosition": str(before if pside == "long" else -before)},
+                }
+            }
+        ],
+    )
+
+
+def _evidence(events, **kwargs):
+    return hsl._equity_hard_stop_intervention_entry_evidence(
+        events,
+        psides={"long"},
+        stop_ms=60_000,
+        cooldown_until_ms=120_000,
+        symbol="A",
+        **kwargs,
+    )
+
+
+@pytest.mark.parametrize("reverse", [False, True])
+@pytest.mark.parametrize("pside", ["long", "short"])
+def test_tied_intervention_uses_exchange_chain_and_prefix_before_entry(reverse, pside):
+    opening = _fill("open", 1_000, 0, 3, fee=-1.0, pside=pside)
+    stop = _fill("stop", 60_000, 3, 0, pnl=-300.0, fee=-2.0, pside=pside)
+    entry = _fill("entry", 60_000, 0, 2, fee=-5.0, pside=pside)
+    events = [opening, *([entry, stop] if reverse else [stop, entry])]
+    result = hsl._equity_hard_stop_intervention_entry_evidence(
+        events,
+        psides={pside},
+        stop_ms=60_000,
+        cooldown_until_ms=120_000,
+        symbol="A",
+    )
+    assert result["entry_timestamp_ms"] == 60_000
+    assert result["entry_event"] is entry
+    assert result["stop_event"] is stop
+    assert result["entry_index"] == 2
+    assert result["stop_index"] == 1
+    assert result["realized_before_entry"] == -303.0
+    assert (
+        hsl._equity_hard_stop_intervention_entry_timestamp(
+            events,
+            psides={pside},
+            stop_ms=60_000,
+            cooldown_until_ms=120_000,
+            symbol="A",
+        )
+        == 60_000
+    )
+
+
+@pytest.mark.parametrize("order", list(itertools.permutations(range(4))))
+def test_multiple_tied_episodes_not_proven_by_existing_chain_validator_stay_closed(order):
+    opening = _fill("open", 1_000, 0, 3, fee=-1.0)
+    cohort = [
+        _fill("stop1", 60_000, 3, 0, pnl=-300.0),
+        _fill("entry1", 60_000, 0, 2, fee=-2.0),
+        _fill("stop2", 60_000, 2, 0, pnl=-9.0),
+        _fill("entry2", 60_000, 0, 1, fee=-4.0),
+    ]
+    events = [opening, *(cohort[index] for index in order)]
+    # Existing unique-successor evidence cannot choose at the repeated zero
+    # node. An explicit index must not bypass that ordering contract.
+    assert _evidence(events) is None
+    assert _evidence(events, stop_index=1) is None
+    assert _evidence(events, stop_index=3) is None
+
+
+@pytest.mark.parametrize(
+    "case", ["missing_chain", "entry_before_stop", "partial_close", "cooldown_end"]
+)
+def test_tied_entry_requires_after_flatten_proof_and_strict_cooldown(case):
+    events = [_fill("open", 1_000, 0, 3), _fill("stop", 60_000, 3, 0), _fill("entry", 60_000, 0, 2)]
+    if case == "missing_chain":
+        events[1].pop("raw")
+    elif case == "entry_before_stop":
+        events = [_fill("entry", 60_000, 0, 3), _fill("stop", 60_000, 3, 0)]
+    elif case == "partial_close":
+        events[1:] = [_fill("partial", 60_000, 3, 1), _fill("entry", 60_000, 1, 2)]
+    else:
+        events[-1]["timestamp"] = 120_000
+    assert _evidence(events) is None
+    assert (
+        hsl._equity_hard_stop_intervention_entry_timestamp(
+            events,
+            psides={"long"},
+            stop_ms=60_000,
+            cooldown_until_ms=120_000,
+            symbol="A",
+        )
+        is None
+    )
+
+
+def test_scope_must_be_flat_not_only_the_entry_coin():
+    events = [
+        _fill("openA", 1_000, 0, 3),
+        _fill("openB", 2_000, 0, 1, symbol="B"),
+        _fill("stop", 60_000, 3, 0),
+        _fill("entry", 60_000, 0, 2),
+    ]
+    assert _evidence(events) is not None
+    assert (
+        hsl._equity_hard_stop_intervention_entry_evidence(
+            events,
+            psides={"long"},
+            stop_ms=60_000,
+            cooldown_until_ms=120_000,
+        )
+        is None
+    )
+
+
+def test_separate_timestamp_inference_does_not_require_missing_stop_tape():
+    events = [dict(timestamp=60_001, symbol="A", pside="long", action="increase")]
+    assert (
+        hsl._equity_hard_stop_intervention_entry_timestamp(
+            events,
+            psides={"long"},
+            stop_ms=60_000,
+            cooldown_until_ms=120_000,
+        )
+        == 60_001
+    )
+
+
+@pytest.mark.parametrize("stop_ms, stop_index, prefix", [(60_000, 1, -301.0), (61_000, 3, -312.0)])
+def test_explicit_stop_index_selects_its_own_cumulative_prefix(stop_ms, stop_index, prefix):
+    events = [
+        _fill("open", 1_000, 0, 3, fee=-1.0),
+        _fill("stop1", 60_000, 3, 0, pnl=-300.0),
+        _fill("entry1", 60_000, 0, 2, fee=-2.0),
+        _fill("stop2", 61_000, 2, 0, pnl=-9.0),
+        _fill("entry2", 61_000, 0, 1, fee=-4.0),
+    ]
+    result = hsl._equity_hard_stop_intervention_entry_evidence(
+        reversed(events),
+        psides={"long"},
+        stop_ms=stop_ms,
+        cooldown_until_ms=120_000,
+        symbol="A",
+        stop_index=stop_index,
+    )
+    assert result["entry_event"] is events[stop_index + 1]
+    assert result["realized_before_entry"] == prefix
+    assert result["realized_at_stop"] == prefix
+    assert (
+        hsl._equity_hard_stop_intervention_entry_evidence(
+            events,
+            psides={"long"},
+            stop_ms=stop_ms,
+            cooldown_until_ms=120_000,
+            symbol="A",
+            stop_index=stop_index + 1,
+        )
+        is None
+    )
+
+
+def test_tied_flatten_proof_tolerates_only_existing_hsl_quantity_epsilon():
+    partial = _fill("partial", 2_000, 0.3, 0.2)
+    partial["qty"] = 0.1
+    partial["raw"][0]["data"]["amount"] = 0.1
+    events = [
+        _fill("open", 1_000, 0.0, 0.3), partial,
+        _fill("stop", 60_000, 0.2, 0.0), _fill("entry", 60_000, 0.0, 0.4),
+    ]
+    ordered, ambiguous = hsl._equity_hard_stop_order_fill_cohorts(events)
+    assert not ambiguous
+    assert [event["id"] for event in ordered] == ["open", "partial", "stop", "entry"]
+    result = _evidence(events)
+    assert result["entry_event"] is events[-1]
+    assert result["realized_before_entry"] == 0.0
+    # A material canonical quantity mismatch still cannot prove a flatten.
+    partial["qty"] = 0.1001
+    assert _evidence(events) is None

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -13481,3 +13481,40 @@ async def test_hyperliquid_normal_partial_fill_self_echo_invalidates_account(
     assert set(bot._authoritative_pending_confirmations) == (
         {"balance", "positions", "open_orders", "fills"} if has_fill else set()
     )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("latched", [False, True])
+async def test_execution_loop_defers_unavailable_hsl_boundaries_and_keeps_protection(latched):
+    from live.state_refresh import AuthoritativeSurfaceUnavailable
+
+    bot = Passivbot.__new__(Passivbot)
+    bot.stop_signal_received = False
+    bot.execution_scheduled = False
+    bot.state_change_detected_by_symbol = set()
+    bot.debug_mode = True
+    bot._equity_hard_stop_coin_initialized = True
+    bot._equity_hard_stop_enabled = lambda *args, **kwargs: True
+    bot._equity_hard_stop_signal_mode = lambda: "coin"
+    bot._equity_hard_stop_coin_red_active = lambda: latched
+    bot._equity_hard_stop_check = AsyncMock(
+        side_effect=AuthoritativeSurfaceUnavailable(
+            "hsl_episode_boundaries", "ambiguous fill cohort"
+        )
+    )
+    bot._set_log_silence_watchdog_context = lambda *args, **kwargs: None
+    bot._emit_live_cycle_degraded = MagicMock()
+    bot.refresh_authoritative_state = AsyncMock(return_value=True)
+    bot.prepare_planning_universe = AsyncMock()
+    bot.execute_to_exchange = AsyncMock()
+
+    async def stop(*args, **kwargs):
+        bot.stop_signal_received = True
+
+    bot._sleep_unless_shutdown = AsyncMock(side_effect=stop)
+    bot._equity_hard_stop_run_coin_red_supervisor = AsyncMock(side_effect=stop)
+    assert await bot.run_execution_loop() is None
+    bot.prepare_planning_universe.assert_not_awaited()
+    bot.execute_to_exchange.assert_not_awaited()
+    assert bot._equity_hard_stop_run_coin_red_supervisor.await_count == int(latched)
+    assert bot._sleep_unless_shutdown.await_count == int(not latched)

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -13494,6 +13494,7 @@ async def test_execution_loop_defers_unavailable_hsl_boundaries_and_keeps_protec
     bot.state_change_detected_by_symbol = set()
     bot.debug_mode = True
     bot._equity_hard_stop_coin_initialized = True
+    bot._run_halted_hsl_protection_if_active = AsyncMock(return_value=False)
     bot._equity_hard_stop_enabled = lambda *args, **kwargs: True
     bot._equity_hard_stop_signal_mode = lambda: "coin"
     bot._equity_hard_stop_coin_red_active = lambda: latched

--- a/tests/test_run_fake_live.py
+++ b/tests/test_run_fake_live.py
@@ -1786,6 +1786,8 @@ async def test_fake_cycle_defers_unknown_episode_and_preserves_red_supervision(
 ):
     from live.state_refresh import AuthoritativeSurfaceUnavailable
 
+    from unittest.mock import AsyncMock
+
     calls = []
 
     async def unavailable(bot):
@@ -1796,6 +1798,7 @@ async def test_fake_cycle_defers_unknown_episode_and_preserves_red_supervision(
 
     monkeypatch.setattr(run_fake_live_module, "_run_fake_cycle_ready", unavailable)
     bot = SimpleNamespace(
+        _run_halted_hsl_protection_if_active=AsyncMock(return_value=False),
         _equity_hard_stop_signal_mode=lambda: "coin",
         _equity_hard_stop_coin_red_active=lambda: latched,
         _equity_hard_stop_run_coin_red_supervisor=supervise,

--- a/tests/test_run_fake_live.py
+++ b/tests/test_run_fake_live.py
@@ -1758,3 +1758,52 @@ async def test_fake_live_writes_remote_call_artifacts(tmp_path, monkeypatch):
     assert remote_summary["by_method"]["fetch_ohlcv"] >= 1
 
     assert any(entry["kind"] == "ccxt_fetch_ohlcv" for entry in candle_fetches)
+
+
+@pytest.mark.fake_live
+@pytest.mark.parametrize('declared', [False, True])
+def test_fake_boot_fill_preserves_only_explicit_position_chain_evidence(declared):
+    scenario = _scenario()
+    fill = {
+        'id': '1', 'timestamp': '2026-01-01T00:00:00Z',
+        'symbol': 'BTC/USDT:USDT', 'position_side': 'long', 'side': 'sell',
+        'amount': 1.0, 'price': 100.0,
+    }
+    if declared:
+        fill['info'] = {'startPosition': '1.0'}
+    scenario['account']['fills'] = [fill]
+    client = FakeCCXTClient(scenario, quote='USDT')
+    info = client.fills[0]['info']
+    assert ('startPosition' in info) is declared
+    if declared:
+        assert info['startPosition'] == '1.0'
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("latched", [False, True])
+async def test_fake_cycle_defers_unknown_episode_and_preserves_red_supervision(
+    monkeypatch, latched
+):
+    from live.state_refresh import AuthoritativeSurfaceUnavailable
+
+    calls = []
+
+    async def unavailable(bot):
+        raise AuthoritativeSurfaceUnavailable("hsl_episode_boundaries", "fill tape pending")
+
+    async def supervise():
+        calls.append("supervisor")
+
+    monkeypatch.setattr(run_fake_live_module, "_run_fake_cycle_ready", unavailable)
+    bot = SimpleNamespace(
+        _equity_hard_stop_signal_mode=lambda: "coin",
+        _equity_hard_stop_coin_red_active=lambda: latched,
+        _equity_hard_stop_run_coin_red_supervisor=supervise,
+    )
+    result = await run_fake_live_module._run_fake_cycle(bot)
+    assert calls == (["supervisor"] if latched else [])
+    assert result == (
+        {"red_supervisor": True, "mode": "coin"}
+        if latched
+        else {"updated": False, "hsl_ready": False}
+    )

--- a/tests/test_run_fake_live.py
+++ b/tests/test_run_fake_live.py
@@ -1044,13 +1044,29 @@ async def test_hsl_replay_scenarios_run_end_to_end(
 
 @pytest.mark.asyncio
 @pytest.mark.fake_live
-async def test_documented_hsl_restart_scenario_runs_unmodified(tmp_path):
+async def test_documented_hsl_restart_scenario_runs_unmodified(tmp_path, monkeypatch):
     """Keep the checked-in offline smoke command and its assertions executable as written."""
     import passivbot_rust as pbr
 
     if getattr(pbr, "__is_stub__", False):
         pytest.skip("requires real passivbot_rust extension")
 
+    import passivbot_hsl as hsl
+
+    original_restart = hsl._equity_hard_stop_replay_live_restart
+    restart_fill_evidence = []
+
+    async def checked_restart(bot, pside, symbol=None):
+        # Simulation dates can precede wall-clock cache refresh watermarks.
+        # The real backend closing fill must still reach the canonical manager
+        # before the completed cooldown is reconstructed.
+        cached = bot._pnls_manager.get_events()
+        restart_fill_evidence.append((len(cached), len(bot.cca.fills)))
+        assert len(cached) == len(bot.cca.fills) == 4
+        assert any("panic" in event.pb_order_type and event.pnl == -15.0 for event in cached)
+        return await original_restart(bot, pside, symbol)
+
+    monkeypatch.setattr(hsl, "_equity_hard_stop_replay_live_restart", checked_restart)
     user = f"fake_hsl_documented_{tmp_path.name}"
     _cleanup_fake_user_state(user)
     try:
@@ -1066,6 +1082,7 @@ async def test_documented_hsl_restart_scenario_runs_unmodified(tmp_path):
             snapshot_each_step=False,
         )
         assert await _async_main(args) == 0
+        assert restart_fill_evidence
     finally:
         _cleanup_fake_user_state(user)
 

--- a/tests/test_unstucking_safeguards.py
+++ b/tests/test_unstucking_safeguards.py
@@ -302,6 +302,7 @@ def _make_mock_pbr():
             tier_ratio_yellow,
             tier_ratio_orange,
             latch_red=True,
+            at_fill_boundary=False,
         ):
             current_minute = int(timestamp_ms) // 60_000
             alpha = 2.0 / (ema_span_minutes + 1.0)

--- a/tests/test_unstucking_safeguards.py
+++ b/tests/test_unstucking_safeguards.py
@@ -5796,6 +5796,15 @@ async def test_pside_replay_red_episode_ordinary_flatten_latches_cooldown(monkey
     rows = _pside_parity_timeline()
     fills = [
         {
+            "timestamp": 1_000,
+            "symbol": "XMR/USDT:USDT",
+            "position_side": "long",
+            "side": "buy",
+            "qty": 1.0,
+            "price": 105.0,
+            "pnl": 0.0,
+        },
+        {
             "timestamp": 195_000,
             "symbol": "XMR/USDT:USDT",
             "position_side": "long",
@@ -6239,13 +6248,23 @@ async def test_hard_stop_initialize_from_history_ignores_panic_marker_without_re
                 }
             ],
             "fill_events": [
-                _make_hsl_fill_event(
-                    121_500,
-                    symbol=symbol,
-                    pside="long",
-                    action="decrease",
-                    pb_order_type="close_panic_long",
-                )
+                {
+                    "timestamp": 60_000,
+                    "symbol": symbol,
+                    "pside": "long",
+                    "action": "increase",
+                    "qty": 1.0,
+                    "pnl": 0.0,
+                },
+                {
+                    "timestamp": 121_500,
+                    "symbol": symbol,
+                    "pside": "long",
+                    "action": "decrease",
+                    "qty": 1.0,
+                    "pnl": 0.0,
+                    "pb_order_type": "close_panic_long",
+                },
             ],
         }
 
@@ -7236,10 +7255,20 @@ async def test_hard_stop_initialize_from_history_normal_policy_replays_from_entr
             ],
             "fill_events": [
                 {
+                    "timestamp": 1_000,
+                    "symbol": symbol,
+                    "pside": "long",
+                    "action": "increase",
+                    "qty": 1.0,
+                    "pnl": 0.0,
+                },
+                {
                     "timestamp": 121_500,
                     "symbol": symbol,
                     "pside": "long",
                     "action": "decrease",
+                    "qty": 1.0,
+                    "pnl": -20.0,
                     "pb_order_type": "close_panic_long",
                 },
                 {
@@ -7247,6 +7276,8 @@ async def test_hard_stop_initialize_from_history_normal_policy_replays_from_entr
                     "symbol": symbol,
                     "pside": "long",
                     "action": "increase",
+                    "qty": 1.0,
+                    "pnl": 0.0,
                     "pb_order_type": "entry_initial_normal_long",
                 },
             ],
@@ -7334,10 +7365,20 @@ async def test_hard_stop_initialize_from_history_unresolved_panic_residue_stays_
             ],
             "fill_events": [
                 {
+                    "timestamp": 1_000,
+                    "symbol": symbol,
+                    "pside": "long",
+                    "action": "increase",
+                    "qty": 1.0,
+                    "pnl": 0.0,
+                },
+                {
                     "timestamp": 121_500,
                     "symbol": symbol,
                     "pside": "long",
                     "action": "decrease",
+                    "qty": 0.5,
+                    "pnl": -20.0,
                     "pb_order_type": "close_panic_long",
                 }
             ],

--- a/tests/test_unstucking_safeguards.py
+++ b/tests/test_unstucking_safeguards.py
@@ -4417,10 +4417,20 @@ async def test_hsl_cooldown_normal_resets_runtime_and_clears_halt(monkeypatch):
         lambda pside: removed.__setitem__("count", removed["count"] + 1),
     )
 
+    import passivbot_hsl
+
+    async def replay_restart(target, pside, symbol=None):
+        target._equity_hard_stop_reset_after_restart(pside)
+        target._equity_hard_stop_remove_latch_file(pside)
+        return True
+
+    replay = AsyncMock(side_effect=replay_restart)
+    monkeypatch.setattr(passivbot_hsl, "_equity_hard_stop_replay_live_restart", replay)
     changed = await bot._equity_hard_stop_handle_position_during_cooldown(
         "long", 150_000
     )
     assert changed is True
+    replay.assert_awaited_once_with(bot, "long")
     assert removed["count"] == 1
     assert state["halted"] is False
     assert state["cooldown_until_ms"] is None
@@ -7297,6 +7307,11 @@ async def test_hard_stop_initialize_from_history_normal_policy_replays_from_entr
     monkeypatch.setattr(bot, "get_balance_equity_history", fake_history)
     monkeypatch.setattr(bot, "get_exchange_time", lambda: 200_000)
     monkeypatch.setattr(bot, "_calc_upnl_sum_strict", fake_upnl)
+    # Current cumulative PnL must match the fill tape used to seed the intervention.
+    monkeypatch.setattr(
+        bot, "_equity_hard_stop_realized_pnl_now",
+        lambda pside=None: -20.0 if pside in (None, "long") else 0.0,
+    )
 
     await bot._equity_hard_stop_initialize_from_history()
 


### PR DESCRIPTION
Equity Hard Stop Loss now starts a fresh episode at a proven ordinary flatten fill in live trading, exact backtests, and Apple MPS screening for coin, position-side, and unified scopes. Closing PnL and fees are evaluated before resetting episode drawdown; a closing fill that first triggers RED finalizes its stop before same-step re-entry. Persistent no-restart limits and RED cooldowns remain intact.

Distinct fill boundaries in one minute replace that minute's risk sample without adding another EMA time step. Live reconstruction preserves exchange position-chain evidence for tied fills, including re-entry fees after a same-millisecond flatten. Unprovable required held-episode history defers startup replay before replacing existing protection and defers ordinary shared-account planning while independently latched RED supervision and required panic protection for active cooldown positions continue; startup replay ownership and panic-marker validation are preserved. Cancellation-only cooldown waves remove prohibited resting entries without constructing fresh order intent. Manual ownership is determined from intervention evidence, while graceful-stop adds to held positions retain their policy semantics. Terminal no-restart scopes cancel resting entries independently of cooldown deadlines or intervention policies. Unknown manual ownership requests a canonical fill refresh after the protective account observation, preserving orders if proof remains unavailable. Normal-policy overrides and cooldown expiry reconstruct the new episode from its proven entry before releasing a halt, retaining entry fees and losses before the next observation. The same canonical path handles ordinary and panic RED closes, preserves terminal precedence, and admits newly proven current RED protection immediately. A normal re-entry sharing its stop timestamp is recognized only when the validated exchange position chain proves it follows that stop; the same cumulative PnL boundary preserves entry fees in replay and subsequent live samples.

Coin replay reconstructs each boundary balance from the account-wide fill prefix, so later PnL or fees on another coin cannot change the earlier RED decision. It retains the existing same-timestamp account-cohort convention and the proven same-pair fill tail.

The offline fake-live harness explicitly refreshes its finite canonical fill tape, so simulated historical dates cannot be clipped by wall-clock cache refresh watermarks. The documented restart scenario runs with its original assertions.

Validation on the integrated master base:

- 285 Rust tests; rebuilt and verified source-matched Python extension.
- 1,505 Python tests covering HSL replay/runtime, fills, orchestration, configuration bindings, and the full offline fake-live harness.
- 1,195 optimizer integration tests covering checkpoint compatibility, prepared-data identity, suite context, CLI, and GPU backend plumbing on the combined branch at `bc7ffca6f`; the subsequent changes are confined to HSL replay and its regressions.
- 807 tests on actual Apple MPS covering all four kernels and HSL episode boundaries.
- AI documentation check: zero errors; generated live-event registry current; diff whitespace check clean.
