### PR TITLE
Reject backtest gaps with unavailable position valuation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ All notable user-facing changes will be documented in this file.
   Stop older backtest/optimizer workers before sharing their cache with the new lock protocol;
   ambiguous legacy locks require explicit cleanup after those workers have stopped.
 
+- Backtests reject non-finite H/L/C inside declared valid candle windows, including all-NaN
+  gaps in direct or prepared datasets. Held positions require an available valuation candle;
+  missing data no longer removes their unrealized PnL from equity or risk samples. Unheld
+  symbols may retain unavailable rows outside their listing windows.
+
 - Gate.io and KuCoin fill-history refreshes now reject unfinished pagination instead of marking
   partial or failed fetches as complete coverage for realized-PnL risk checks. A traversal that
   completes on its final allowed request remains valid.

--- a/docs/backtesting.md
+++ b/docs/backtesting.md
@@ -72,6 +72,13 @@ The workspace includes `config`, `analysis`, `fills`, `balance_and_equity`, `hlc
 
 ## HLCV Data Contract
 
+Direct or prepared backtest inputs must contain finite high, low, and close prices throughout
+each symbol's declared valid window. Internal all-NaN gaps are rejected before simulation;
+missing prices never turn a held position's unrealized PnL into zero. Missing rows before a
+symbol's listing or after its declared end remain permitted while it is flat. A position still
+held when its valuation candle becomes unavailable rejects the run. These checks also apply to
+GPU preparation and do not replace the normal data materializer's gap repair policy.
+
 Without `backtest.ohlcv_source_dir`, backtest and optimize data preparation follows one
 deterministic order:
 

--- a/passivbot-rust/src/backtest.rs
+++ b/passivbot-rust/src/backtest.rs
@@ -2271,7 +2271,51 @@ impl<'a> Backtest<'a> {
         self.liquidated
     }
 
+    fn validate_candle_coverage(&self) -> Result<(), String> {
+        let n_timesteps = self.hlcvs.shape()[0];
+        for idx in 0..self.n_coins {
+            // Empty declared ranges represent symbols absent for this dataset.
+            if let (Some(&first), Some(&last)) = (
+                self.backtest_params.first_valid_indices.get(idx),
+                self.backtest_params.last_valid_indices.get(idx),
+            ) {
+                if first >= n_timesteps || last < first {
+                    continue;
+                }
+            }
+            if let Some((first, last)) = self.coin_valid_range(idx) {
+                for k in first..=last {
+                    for field in [HIGH, LOW, CLOSE] {
+                        if !self.hlcvs_value(k, idx, field).is_finite() {
+                            return Err(format!(
+                                    "backtest requires contiguous finite H/L/C within each valid range: coin {} index {} candle {} field {}",
+                                    self.backtest_params.coins[idx], idx, k, field,
+                                ));
+                        }
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn validate_held_position_valuation(&self, k: usize) -> Result<(), String> {
+        for idx in 0..self.n_coins {
+            if self.positions.long[idx].size == 0.0 && self.positions.short[idx].size == 0.0 {
+                continue;
+            }
+            if !self.coin_is_valid_at(idx, k) || !self.hlcvs_value(k, idx, CLOSE).is_finite() {
+                return Err(format!(
+                    "missing held-position valuation candle: coin {} index {} candle {}",
+                    self.backtest_params.coins[idx], idx, k,
+                ));
+            }
+        }
+        Ok(())
+    }
+
     pub fn run(&mut self) -> Result<(Vec<Fill>, Equities), String> {
+        self.validate_candle_coverage()?;
         let n_timesteps = self.hlcvs.shape()[0];
 
         // --- register first & last valid candle for every coin ---
@@ -2291,6 +2335,7 @@ impl<'a> Backtest<'a> {
             .max(self.first_timestamp_ms);
         for k in 1..(n_timesteps - 1) {
             self.current_step = k;
+            self.validate_held_position_valuation(k)?;
             for idx in 0..self.n_coins {
                 if !self.trade_activation_logged[idx] && self.coin_is_tradeable_at(idx, k) {
                     self.trade_activation_logged[idx] = true;
@@ -6412,7 +6457,7 @@ mod tests {
     }
 
     #[test]
-    fn all_nan_hlc_gap_is_not_valid_or_tradeable() {
+    fn missing_candles_reject_held_valuation_and_preserve_unheld_boundaries() {
         let mut values = vec![1.0; 3 * 4];
         values[4] = f64::NAN;
         values[5] = f64::NAN;
@@ -6470,9 +6515,17 @@ mod tests {
         assert!(bt.coin_is_valid_at(0, 2));
 
         bt.positions.long[0] = Position {
-            size: 1.0,
-            price: 1.0,
+            size: 100.0,
+            price: 2.0,
         };
+        assert_eq!(bt.current_usd_equity_at(0), 900.0);
+        assert_eq!(bt.current_usd_equity_at(2), 900.0);
+        let error = bt.run().err().expect("missing candle must reject backtest");
+        assert!(error.contains("contiguous finite H/L/C"), "{error}");
+        assert!(error.contains("candle 1"), "{error}");
+        assert!(bt.equities.timestamps_ms.is_empty());
+        assert!(bt.validate_held_position_valuation(1).is_err());
+
         let input = bt.build_orchestrator_input_iter(1, None, None, 0..1);
         assert!(!input.symbols[0].tradable);
         assert_ne!(
@@ -6480,6 +6533,21 @@ mod tests {
             Some(orchestrator::TradingMode::Panic),
             "an internal data gap must not be mistaken for a delist"
         );
+        // Missing rows outside the declared listing window are permitted while flat.
+        bt.positions.long[0] = Position::default();
+        bt.coin_first_valid_idx[0] = 2;
+        bt.coin_last_valid_idx[0] = 2;
+        assert!(bt.validate_candle_coverage().is_ok());
+        assert!(bt.validate_held_position_valuation(1).is_ok());
+        bt.coin_first_valid_idx[0] = 0;
+        bt.coin_last_valid_idx[0] = 0;
+        assert!(bt.validate_candle_coverage().is_ok());
+        assert!(bt.validate_held_position_valuation(1).is_ok());
+        bt.positions.short[0] = Position {
+            size: -100.0,
+            price: 2.0,
+        };
+        assert!(bt.validate_held_position_valuation(1).is_err());
     }
 
     #[test]

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -848,7 +848,8 @@ mod tests {
         assert!(source.contains("candle_eligibility_mask"));
         assert_eq!(source.matches("if (!managed_candidate) continue;").count(), 3);
         assert!(!source.contains("any_valid"));
-        assert!(source.contains("declared all-invalid gaps and"));
+        assert!(source.contains("held_positions_have_missing_prices("));
+        assert!(source.contains("scalars[int(b) * FUSED_SCALAR_COLS + 9] = -2.0f;"));
         assert!(source.contains("update_ema_multicoin_dual_side_hsl("));
         assert!(source.contains("if (long_side.hsl.signal_mode != short_side.hsl.signal_mode)"));
         assert!(source.contains("update_joint_pside_hsl("));
@@ -1386,7 +1387,8 @@ mod tests {
         assert!(source.contains("candle_eligibility_mask"));
         assert_eq!(source.matches("if (!managed_candidate) continue;").count(), 3);
         assert!(!source.contains("any_valid"));
-        assert!(source.contains("declared all-invalid gaps and"));
+        assert!(source.contains("held_positions_have_missing_prices("));
+        assert!(source.contains("scalars[int(b) * FUSED_SCALAR_COLS + 9] = -2.0f;"));
         assert!(source.contains("update_tm_multicoin_dual_side_hsl("));
         assert!(source.contains("update_tm_multicoin_side_selection("));
         assert!(source.contains("generate_tm_multicoin_side_orders("));

--- a/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_directional.metal
@@ -1298,6 +1298,15 @@ inline void passivbot_single_coin_impl(
         const float high = bars[bo + 0];
         const float low = bars[bo + 1];
         const float close = bars[bo + 2];
+        // -2 is an invalid-valuation sentinel, never a liquidation result.
+        // Python rejects this candidate before decoding any metrics.
+        if (alive && (long_side.psize > 0.0f || short_side.psize > 0.0f)
+            && !(flags[fo + 0] != 0 && isfinite(high) && high > 0.0f
+                && isfinite(low) && low > 0.0f && isfinite(close) && close > 0.0f)) {
+            scalars[int(b) * SCALAR_COLS + 9] = -2.0f;
+            return;
+        }
+
         const float log_range = bars[bo + 3];
         const float hour_lr = bars[bo + 4];
         const bool valid = flags[fo + 0] != 0;
@@ -1963,9 +1972,8 @@ inline void passivbot_single_coin_impl(
             }
         }
 
-        // Exact Rust keeps sampling account equity through a short invalid
-        // tail, but excludes positions whose coin is no longer valid.  Such a
-        // tail is non-tradable and therefore contributes balance-only equity.
+        // Held positions must remain inside their declared valid candle range.
+        // Missing held-position prices were rejected before this bar's fills.
         const bool after_valid_tail = k > last_valid;
         float long_unreal = valid && long_side.psize > 0.0f
             ? long_side.psize * c_mult * (close - long_side.pprice) : 0.0f;
@@ -2083,8 +2091,8 @@ inline void passivbot_single_coin_impl(
             }
         }
         // Exact Rust records an equity sample at every tracked timestamp.
-        // Invalid candles are non-tradable and contribute balance-only equity,
-        // just like the already-supported tail after last_valid.
+        // Unheld invalid tails remain non-tradable; held positions still require
+        // the finite prices checked at the start of the bar.
         bool active = eq_started && alive;
         if (active) {
             if (first_eq_k < 0.0f) first_eq_k = kf;

--- a/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
+++ b/passivbot-rust/src/gpu/mps_ema_anchor_multicoin_long.metal
@@ -3000,6 +3000,12 @@ inline void passivbot_ema_anchor_multicoin_impl(
     thread float& day_fill_count = fills.day_fill_count;
 
     for (int k = 1; k < stop_k; ++k) {
+        if (alive && (held_positions_have_missing_prices(side.psize, bars, coin_settings, k, C))) {
+            // The decoder rejects -2 as unavailable held-position valuation.
+            scalars[int(b) * SCALAR_COLS + 9] = -2.0f;
+            return;
+        }
+
         const int day_index = multicoin_utc_day_index(
             start_day_minute, k, interval_ms
         );
@@ -3180,10 +3186,8 @@ inline void passivbot_ema_anchor_multicoin_impl(
             }
         }
         float equity = balance + unrealized;
-        // Exact Rust keeps advancing balance-only equity and HSL time once
-        // portfolio tracking starts, including declared all-invalid gaps and
-        // tails. Per-coin validity still blocks fills, orders, and unrealized
-        // PnL above.
+        // Held positions have valid valuation candles; unavailable tails are unheld.
+        // Missing held-position prices were rejected before this bar's fills.
         if (can_generate && alive
             && balance > 0.0f && equity > liquidation_floor) {
             int sampled_hsl_tier = 0;
@@ -3854,6 +3858,13 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
     float day_start_balance = account.balance;
 
     for (int k = 1; k < stop_k; ++k) {
+        if (alive && (held_positions_have_missing_prices(long_side.psize, bars, coin_settings, k, C)
+            || held_positions_have_missing_prices(short_side.psize, bars, coin_settings, k, C))) {
+            // The decoder rejects -2 as unavailable held-position valuation.
+            scalars[int(b) * FUSED_SCALAR_COLS + 9] = -2.0f;
+            return;
+        }
+
         const int day_index = multicoin_utc_day_index(
             start_day_minute, k, interval_ms
         );
@@ -4189,10 +4200,8 @@ inline void passivbot_ema_anchor_multicoin_fused_impl(
         float equity = joint_portfolio_equity(
             account, long_unrealized, short_unrealized
         );
-        // Exact Rust keeps advancing balance-only equity and HSL time once
-        // portfolio tracking starts, including declared all-invalid gaps and
-        // tails. Per-coin validity still blocks fills, orders, and unrealized
-        // PnL above.
+        // Held positions have valid valuation candles; unavailable tails are unheld.
+        // Missing held-position prices were rejected before this bar's fills.
         bool can_sample_hsl = (long_can_generate || short_can_generate)
             && alive
             && joint_portfolio_can_generate(

--- a/passivbot-rust/src/gpu/mps_multicoin_common.metal
+++ b/passivbot-rust/src/gpu/mps_multicoin_common.metal
@@ -428,3 +428,25 @@ inline int joint_pside_hsl_global_tier(
 ) {
     return max(long_hsl.tier, short_hsl.tier);
 }
+
+// Unheld unavailable coins need no valuation. Held positions must remain
+// inside their declared range with finite positive H/L/C.
+inline bool held_positions_have_missing_prices(
+    thread const float* psize,
+    constant float* bars,
+    constant float* coin_settings,
+    int k,
+    int coin_count
+) {
+    for (int coin = 0; coin < coin_count; ++coin) {
+        if (!(psize[coin] > 0.0f)) continue;
+        int settings = coin * COIN_COLS;
+        if (k < int(coin_settings[settings + 6]) || k > int(coin_settings[settings + 7])) return true;
+        int offset = (k * coin_count + coin) * 4;
+        for (int field = 0; field < 3; ++field) {
+            float value = bars[offset + field];
+            if (!(isfinite(value) && value > 0.0f)) return true;
+        }
+    }
+    return false;
+}

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_directional.metal
@@ -2028,6 +2028,15 @@ inline void passivbot_single_coin_impl(
         const float high = bars[bo + 0];
         const float low = bars[bo + 1];
         const float close = bars[bo + 2];
+        // -2 is an invalid-valuation sentinel, never a liquidation result.
+        // Python rejects this candidate before decoding any metrics.
+        if (alive && (long_side.psize > 0.0f || short_side.psize > 0.0f)
+            && !(flags[fo + 0] != 0 && isfinite(high) && high > 0.0f
+                && isfinite(low) && low > 0.0f && isfinite(close) && close > 0.0f)) {
+            scalars[int(b) * SCALAR_COLS + 9] = -2.0f;
+            return;
+        }
+
 #if !PASSIVBOT_TM_VOLATILITY_DISABLED
         const float log_range = bars[bo + 3];
         float hour_lr = bars[bo + 4];
@@ -4080,9 +4089,8 @@ inline void passivbot_single_coin_impl(
             }
         }
 
-        // Exact Rust keeps sampling account equity through a short invalid
-        // tail, but excludes positions whose coin is no longer valid.  Such a
-        // tail is non-tradable and therefore contributes balance-only equity.
+        // Held positions must remain inside their declared valid candle range.
+        // Missing held-position prices were rejected before this bar's fills.
         const bool after_valid_tail = k > last_valid;
         float long_unreal = valid && long_side.psize > 0.0f
             ? long_side.psize * c_mult * (close - long_side.pprice) : 0.0f;
@@ -4302,8 +4310,8 @@ inline void passivbot_single_coin_impl(
 #endif
         }
         // Exact Rust records an equity sample at every tracked timestamp.
-        // Invalid candles are non-tradable and contribute balance-only equity,
-        // just like the already-supported tail after last_valid.
+        // Unheld invalid tails remain non-tradable; held positions still require
+        // the finite prices checked at the start of the bar.
         bool active = eq_started && alive;
         if (active) {
             if (first_eq_k < 0.0f) first_eq_k = kf;

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
@@ -4982,6 +4982,13 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
     float day_start_balance = account.balance;
 
     for (int k = 1; k < stop_k; ++k) {
+        if (alive && (held_positions_have_missing_prices(long_side.psize, bars, coin_settings, k, C)
+            || held_positions_have_missing_prices(short_side.psize, bars, coin_settings, k, C))) {
+            // The decoder rejects -2 as unavailable held-position valuation.
+            scalars[int(b) * FUSED_SCALAR_COLS + 9] = -2.0f;
+            return;
+        }
+
         const int day_index = multicoin_utc_day_index(
             start_day_minute, k, interval_ms
         );
@@ -5334,10 +5341,8 @@ inline void passivbot_trailing_martingale_multicoin_fused_impl(
         float equity = joint_portfolio_equity(
             account, long_unrealized, short_unrealized
         );
-        // Exact Rust keeps advancing balance-only equity and HSL time once
-        // portfolio tracking starts, including declared all-invalid gaps and
-        // tails. Per-coin validity still blocks fills, orders, and unrealized
-        // PnL above.
+        // Held positions have valid valuation candles; unavailable tails are unheld.
+        // Missing held-position prices were rejected before this bar's fills.
         bool can_sample_hsl = (long_can_generate || short_can_generate)
             && alive
             && joint_portfolio_can_generate(
@@ -5893,6 +5898,12 @@ inline void passivbot_trailing_martingale_multicoin_impl(
     thread float& day_fill_count = fills.day_fill_count;
 
     for (int k = 1; k < stop_k; ++k) {
+        if (alive && (held_positions_have_missing_prices(side.psize, bars, coin_settings, k, C))) {
+            // The decoder rejects -2 as unavailable held-position valuation.
+            scalars[int(b) * SCALAR_COLS + 9] = -2.0f;
+            return;
+        }
+
         const int day_index = multicoin_utc_day_index(
             start_day_minute, k, interval_ms
         );
@@ -6079,10 +6090,8 @@ inline void passivbot_trailing_martingale_multicoin_impl(
             }
         }
         float equity = balance + unrealized;
-        // Exact Rust keeps advancing balance-only equity and HSL time once
-        // portfolio tracking starts, including declared all-invalid gaps and
-        // tails. Per-coin validity still blocks fills, orders, and unrealized
-        // PnL above.
+        // Held positions have valid valuation candles; unavailable tails are unheld.
+        // Missing held-position prices were rejected before this bar's fills.
         if (can_generate && alive
             && balance > 0.0f && equity > liquidation_floor) {
             int sampled_hsl_tier = 0;

--- a/src/optimization/gpu/model.py
+++ b/src/optimization/gpu/model.py
@@ -853,6 +853,23 @@ def _maximum_effective_min_cost(prices, market: ProxyMarket) -> float:
     return float(encoded)
 
 
+def _require_contiguous_mps_hlc(high, low, close, run: ProxyRun, *, coin: int = 0):
+    """Reject missing valuation inputs before any packing or GPU allocation."""
+    first = max(0, int(run.first_valid_idx))
+    last = min(int(run.last_valid_idx), len(close) - 1)
+    if first > last:
+        return
+    with np.errstate(over="ignore", under="ignore", invalid="ignore"):
+        packed = np.asarray([high[first:last + 1], low[first:last + 1], close[first:last + 1]], dtype=np.float32)
+    invalid = np.flatnonzero(~np.all(np.isfinite(packed) & (packed > 0.0), axis=0))
+    if invalid.size:
+        raise ValueError(
+            "MPS proxy requires contiguous finite positive float32 H/L/C between "
+            "first and last valid indices; "
+            f"coin index {coin}, invalid candle at {first + int(invalid[0])}"
+        )
+
+
 def build_mps_data(high, low, close, timestamps_ms, run: ProxyRun, market: ProxyMarket):
     """Prepare immutable minute data and keep it resident on Apple MPS.
 
@@ -879,6 +896,7 @@ def build_mps_data(high, low, close, timestamps_ms, run: ProxyRun, market: Proxy
         raise ValueError("MPS price and timestamp arrays must have matching lengths")
     if len(close) < 3:
         raise ValueError("MPS proxy requires at least three candles")
+    _require_contiguous_mps_hlc(high, low, close, run)
 
     n = len(close)
     with np.errstate(divide="ignore", invalid="ignore"):
@@ -1004,10 +1022,13 @@ def build_mps_multicoin_data(
     if np.any(intervals != interval_ms):
         raise ValueError("MPS multicoin proxy requires a continuous candle timeline")
 
+    for coin, run in enumerate(runs):
+        _require_contiguous_mps_hlc(
+            values[:, coin, 0], values[:, coin, 1], values[:, coin, 2], run, coin=coin
+        )
     bars = np.ascontiguousarray(values[:, :, :4], dtype=np.float32)
-    # Preserve a non-finite close so portfolio-equity accumulation can mirror
-    # exact Rust by omitting that coin's unrealized PnL. Other non-finite
-    # fields use zero sentinels and remain blocked by candle validity.
+    # Unavailable listing/delisting tails remain outside the declared valid
+    # range. Internal missing H/L/C is rejected before reaching this packing.
     for field in (0, 1, 3):
         field_values = bars[:, :, field]
         field_values[~np.isfinite(field_values)] = 0.0

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -1042,7 +1042,21 @@ def strategy_eq_recovery_distribution_from_samples(
     return output * sample_interval_days
 
 
+def _require_available_held_valuation(scalars):
+    # Scalar 9 normally holds -1 (not liquidated) or a liquidation day >= 0.
+    # Metal writes -2 and returns immediately if a held coin has no price.
+    invalid = scalars[:, 9] == -2.0
+    if bool(invalid.any()):
+        rows = invalid.nonzero().flatten().cpu().tolist()
+        raise ValueError(
+            "MPS proxy unavailable held-position valuation: candle outside its declared "
+            "valid range or missing finite positive H/L/C; "
+            f"candidate rows {rows}"
+        )
+
+
 def _decode_outputs(daily, scalars, gaps) -> dict:
+    _require_available_held_valuation(scalars)
     active_days = torch.isfinite(daily[:, :, 1]) & (daily[:, :, 1] < float("inf"))
 
     def timestamp_column(index: int):
@@ -1182,6 +1196,7 @@ def _decode_multicoin_fused_outputs(daily, scalars, gaps) -> dict:
 
 
 def _decode_directional_outputs(daily, scalars, gaps) -> dict:
+    _require_available_held_valuation(scalars)
     active_days = torch.isfinite(daily[:, :, 1]) & (daily[:, :, 1] < float("inf"))
 
     def timestamp_column(index: int):

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -1232,20 +1232,14 @@ def _require_supported_multicoin_valid_tails(
         (candle_indices >= np.asarray(starts, dtype=np.int64)[None, :])
         & (candle_indices <= np.asarray(tails, dtype=np.int64)[None, :])
     )
-    actual_coverage = np.any(within_declared_window & actual_valid, axis=1)
-    missing = np.flatnonzero(
-        np.any(within_declared_window, axis=1) & ~actual_coverage
-    )
-    for candle_index in missing:
-        declared = within_declared_window[candle_index]
-        raw_hlc = np.asarray(values[candle_index, declared, :3], dtype=np.float64)
-        if bool(np.all(np.isnan(raw_hlc))):
-            continue
+    missing = np.argwhere(within_declared_window & ~actual_valid)
+    if missing.size:
+        candle_index, coin = (int(value) for value in missing[0])
         raise ValueError(
-            "GPU multicoin proxy only supports an all-invalid internal candle "
-            "when every declared coin's raw H/L/C is NaN; infinities, finite but "
-            "non-positive or float32-unrepresentable values remain fail-closed; "
-            f"candle_index={int(candle_index)}, valid_windows={windows}"
+            "GPU multicoin proxy requires contiguous finite positive float32 H/L/C "
+            "inside every declared coin window; non-finite, finite but non-positive "
+            "or float32-unrepresentable values remain fail-closed; "
+            f"coin index {coin}, candle_index={candle_index}, valid_windows={windows}"
         )
 
 
@@ -1306,7 +1300,7 @@ def _require_exact_safe_proxy_candles(
     last_valid_indices,
     require_positive_high_low: bool,
 ) -> None:
-    """Allow exact balance-only gaps, but reject finite unmodeled prices."""
+    """Reject missing valuation inputs in each exposure-eligible coin window."""
 
     values = np.asarray(hlcvs)
     if values.ndim != 3 or values.shape[2] < 3:
@@ -1322,7 +1316,6 @@ def _require_exact_safe_proxy_candles(
         last = min(int(last_valid_indices[coin]), values.shape[0] - 1)
         if first > last:
             continue
-        raw_hlc = np.asarray(values[first : last + 1, coin, :3], dtype=np.float64)
         packed_hlc = packed[first : last + 1, coin]
         packed_valid = (
             np.all(np.isfinite(packed_hlc), axis=1)
@@ -1332,13 +1325,11 @@ def _require_exact_safe_proxy_candles(
             packed_valid &= (packed_hlc[:, 0] > 0.0) & (
                 packed_hlc[:, 1] > 0.0
             )
-        exact_balance_only = np.all(np.isnan(raw_hlc), axis=1)
-        unsafe = np.flatnonzero(~(packed_valid | exact_balance_only))
+        unsafe = np.flatnonzero(~packed_valid)
         if unsafe.size:
             candle_index = first + int(unsafe[0])
             raise ValueError(
-                "MPS proxy only supports internal "
-                "invalid candles whose raw H/L/C values are all NaN; "
+                "MPS proxy requires contiguous valid internal candles; all-NaN, "
                 "infinite, finite but non-positive, partially invalid, or float32-"
                 "unrepresentable prices remain fail-closed; "
                 f"coin index {coin}, invalid candle at {candle_index}"

--- a/tests/optimization/test_gpu_candle_input_validation.py
+++ b/tests/optimization/test_gpu_candle_input_validation.py
@@ -1,0 +1,68 @@
+from types import SimpleNamespace
+import sys
+
+import numpy as np
+import pytest
+
+from optimization.gpu.model import ProxyMarket, ProxyRun, build_mps_data, build_mps_multicoin_data
+
+
+@pytest.fixture
+def cpu_packer(monkeypatch):
+    class Array(np.ndarray):
+        def contiguous(self):
+            return self
+
+    calls = []
+
+    def as_tensor(value, dtype=None, device=None):
+        calls.append(device)
+        return np.asarray(value, dtype=dtype).view(Array)
+
+    monkeypatch.setitem(sys.modules, "torch", SimpleNamespace(
+        as_tensor=as_tensor, float32=np.float32, int32=np.int32, mps=SimpleNamespace()
+    ))
+    return calls
+
+
+def _run(first=0, last=5):
+    return ProxyRun(1000.0, 0, 0, 0, 0, 0, 60000, 0.05, first, last)
+
+
+def _market():
+    return ProxyMarket(0.001, 0.01, 0.001, 1.0, 1.0, 0.0002)
+
+
+@pytest.mark.parametrize("multicoin", [False, True])
+@pytest.mark.parametrize("bad_hlc", [
+    [np.nan, np.nan, np.nan], [101.0, 99.0, np.nan], [np.inf, 99.0, 100.0],
+    [0.0, 99.0, 100.0], [101.0, 99.0, np.nextafter(0.0, 1.0)],
+    [np.finfo(np.float64).max, 99.0, 100.0],
+])
+def test_direct_builders_reject_internal_invalid_hlc_before_gpu_allocation(cpu_packer, multicoin, bad_hlc):
+    values = np.tile([101.0, 99.0, 100.0, 1.0], (6, 2, 1))
+    values[3, 0, :3] = bad_hlc
+    original = values.copy()
+    timestamps = np.arange(6) * 60000
+    with pytest.raises(ValueError, match="coin index 0, invalid candle at 3"):
+        if multicoin:
+            build_mps_multicoin_data(values, timestamps, [_run()] * 2, [_market()] * 2)
+        else:
+            build_mps_data(*[values[:, 0, column] for column in range(3)], timestamps, _run(), _market())
+    assert cpu_packer == []
+    np.testing.assert_array_equal(values, original)
+
+
+@pytest.mark.parametrize("multicoin", [False, True])
+def test_direct_builders_allow_unavailable_listing_prefix_and_delisting_tail(cpu_packer, multicoin):
+    values = np.tile([101.0, 99.0, 100.0, 1.0], (6, 2, 1))
+    values[:2, 0] = np.nan
+    values[5:, 0] = np.nan
+    timestamps = np.arange(6) * 60000
+    if multicoin:
+        packed = build_mps_multicoin_data(values, timestamps, [_run(2, 4), _run()], [_market()] * 2)
+        np.testing.assert_array_equal(packed["coin_settings"][:, 6:8], [[2, 4], [0, 5]])
+    else:
+        packed = build_mps_data(*[values[:, 0, column] for column in range(3)], timestamps, _run(2, 4), _market())
+        np.testing.assert_array_equal(packed["valid"], [False, False, True, True, True, False])
+    assert cpu_packer

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -4460,14 +4460,19 @@ def test_mps_single_coin_invalid_tail_matches_forced_delist_boundary(
     if strategy_kind == "trailing_martingale":
         runner_kwargs["hsl_enabled"] = hsl_enabled
 
-    output = runner_cls(
+    runner = runner_cls(
         market,
         run,
         data,
         long_enabled=side == "long",
         short_enabled=side == "short",
         **runner_kwargs,
-    ).run(np.asarray([row + row], dtype=np.float64))
+    )
+    if not forced_delist:
+        with pytest.raises(ValueError, match="held-position valuation"):
+            runner.run(np.asarray([row + row], dtype=np.float64))
+        return
+    output = runner.run(np.asarray([row + row], dtype=np.float64))
     torch.mps.synchronize()
 
     size_key = "psize" if side == "long" else "short_psize"
@@ -4588,232 +4593,6 @@ def test_mps_single_coin_forced_delist_closes_both_hedged_sides(strategy_kind):
     assert output["loss_sum_long"].item() > 0.0
     assert output["profit_sum_short"].item() > 0.0
     assert output["hsl_panic_close_loss_sum"].item() > 0.0
-
-
-@pytest.mark.skipif(
-    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
-)
-@pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
-@pytest.mark.parametrize("topology", ["long", "short", "fused"])
-def test_mps_single_coin_recovery_samples_internal_nan_candle(
-    strategy_kind, topology
-):
-    from optimization.gpu.mps_kernel import (
-        MpsEmaAnchorRunner,
-        MpsTrailingMartingaleRunner,
-    )
-
-    count = 123
-    invalid_index = 61
-    close = np.full(count, 100.0)
-    high = close.copy()
-    low = close.copy()
-    high[invalid_index] = np.nan
-    low[invalid_index] = np.nan
-    close[invalid_index] = np.nan
-    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
-    market = ProxyMarket(0.001, 0.01, 0.001, 0.0, 1.0, 0.0)
-    run = ProxyRun(
-        1_000.0,
-        1,
-        1,
-        int(timestamps[0]),
-        int(timestamps[0]),
-        int(timestamps[0]),
-        60_000,
-        0.05,
-        0,
-        count - 1,
-    )
-    data = build_mps_data(high, low, close, timestamps, run, market)
-    if strategy_kind == "ema_anchor":
-        row = _single_coin_param_row(
-            {
-                "base_qty_pct": 0.1,
-                "ema_span_0": 2.0,
-                "ema_span_1": 3.0,
-                "entry_double_down_factor": 0.0,
-                "offset": 0.5,
-                "offset_psize_weight": 0.0,
-                "offset_volatility_1h_weight": 0.0,
-                "offset_volatility_1m_weight": 0.0,
-                "offset_volatility_ema_span_1h": 2.0,
-                "offset_volatility_ema_span_1m": 2.0,
-                "entry_cooldown_minutes": 0.0,
-                "total_wallet_exposure_limit": 1.0,
-                "we_excess_allowance_pct": 0.0,
-                "we_excess_allowance_legacy_raw": 0.0,
-                "twel_entry_gate_enabled": 1.0,
-                "twel_enforcer_threshold": 1.0,
-                "twel_enforcer_enabled": 0.0,
-            },
-            EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS,
-        )
-        runner_cls = MpsEmaAnchorRunner
-        runner_kwargs = {}
-    else:
-        row = _tm_single_row(initial_ema_dist=0.5)
-        runner_cls = MpsTrailingMartingaleRunner
-        runner_kwargs = {"hsl_enabled": False}
-
-    sides = ("long", "short") if topology == "fused" else (topology,)
-    output = runner_cls(
-        market,
-        run,
-        data,
-        long_enabled="long" in sides,
-        short_enabled="short" in sides,
-        hedge_mode=topology == "fused",
-        recovery_distribution_enabled=True,
-        **runner_kwargs,
-    ).run(np.asarray([row + row], dtype=np.float64))
-    torch.mps.synchronize()
-
-    samples = output["strategy_eq_recovery_samples"][0].cpu().numpy()
-    assert samples[:3].tolist() == pytest.approx([1_000.0, 1_000.0, 1_000.0])
-    assert np.isnan(samples[3:]).all()
-    assert output["last_eq_ts"].item() == pytest.approx(121 * run.interval_ms)
-
-
-@pytest.mark.skipif(
-    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
-)
-@pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
-def test_mps_single_coin_internal_nan_candle_clears_pending_entry(strategy_kind):
-    from optimization.gpu.mps_kernel import (
-        MpsEmaAnchorRunner,
-        MpsTrailingMartingaleRunner,
-    )
-
-    count = 5
-    close = np.full(count, 100.0)
-    high = close.copy()
-    low = close.copy()
-    high[2] = np.nan
-    low[2] = np.nan
-    close[2] = np.nan
-    low[3] = 50.0
-    timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
-    market = ProxyMarket(0.001, 0.01, 0.001, 0.0, 1.0, 0.0)
-    run = ProxyRun(
-        1_000.0,
-        1,
-        1,
-        int(timestamps[0]),
-        int(timestamps[0]),
-        int(timestamps[0]),
-        60_000,
-        0.05,
-        0,
-        count - 1,
-    )
-    data = build_mps_data(high, low, close, timestamps, run, market)
-    if strategy_kind == "ema_anchor":
-        side = _single_coin_param_row(
-            {
-                "base_qty_pct": 0.1,
-                "ema_span_0": 2.0,
-                "ema_span_1": 3.0,
-                "entry_double_down_factor": 0.0,
-                "offset": 0.1,
-                "offset_psize_weight": 0.0,
-                "offset_volatility_1h_weight": 0.0,
-                "offset_volatility_1m_weight": 0.0,
-                "offset_volatility_ema_span_1h": 2.0,
-                "offset_volatility_ema_span_1m": 2.0,
-                "entry_cooldown_minutes": 0.0,
-                "total_wallet_exposure_limit": 1.0,
-                "we_excess_allowance_pct": 0.0,
-                "we_excess_allowance_legacy_raw": 0.0,
-                "twel_entry_gate_enabled": 1.0,
-                "twel_enforcer_threshold": 1.0,
-                "twel_enforcer_enabled": 0.0,
-            },
-            EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS,
-        )
-        runner_cls = MpsEmaAnchorRunner
-        runner_kwargs = {}
-    else:
-        side = _tm_single_row(initial_ema_dist=0.1)
-        runner_cls = MpsTrailingMartingaleRunner
-        runner_kwargs = {"hsl_enabled": False}
-
-    output = runner_cls(
-        market,
-        run,
-        data,
-        long_enabled=True,
-        short_enabled=False,
-        hedge_mode=False,
-        **runner_kwargs,
-    ).run(np.asarray([side + side], dtype=np.float64))
-    torch.mps.synchronize()
-
-    assert output["fill_count"].item() == 0.0
-
-
-@pytest.mark.skipif(
-    not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
-)
-@pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
-@pytest.mark.parametrize("topology", ["long", "short", "fused"])
-def test_mps_multicoin_recovery_samples_all_internal_nan_candle(
-    strategy_kind, topology
-):
-    count = 123
-    invalid_index = 61
-    closes = np.full((count, 2), 100.0)
-    highs = closes.copy()
-    lows = closes.copy()
-    if topology != "fused":
-        highs[3, :] = 101.0
-        lows[3, :] = 99.0
-    highs[invalid_index, :] = np.nan
-    lows[invalid_index, :] = np.nan
-    closes[invalid_index, :] = np.nan
-    fixture_side = topology if topology != "fused" else "long"
-    runner, row, run, data = _multicoin_exposure_fixture(
-        strategy_kind,
-        fixture_side,
-        count=count,
-        closes=closes,
-        highs=highs,
-        lows=lows,
-        recovery_distribution_enabled=True,
-        return_context=True,
-    )
-    if topology == "fused":
-        runner_cls = (
-            MpsEmaAnchorMulticoinFusedRunner
-            if strategy_kind == "ema_anchor"
-            else MpsTrailingMartingaleMulticoinFusedRunner
-        )
-        runner = runner_cls(
-            run,
-            data,
-            recovery_distribution_enabled=True,
-        )
-        params = row + row
-    else:
-        params = row
-
-    assert torch.isnan(data["bars"][invalid_index, :, 2]).all().item()
-    output = runner.run(np.asarray([params], dtype=np.float64))
-    torch.mps.synchronize()
-
-    samples = output["strategy_eq_recovery_samples"][0].cpu().numpy()
-    if topology == "fused":
-        assert output["fill_count"].item() == 0.0
-    else:
-        assert output["fill_count"].item() > 0.0
-        assert (
-            output["psize"].item() > 0.0
-            or output.get("short_psize", torch.zeros(1)).item() > 0.0
-        )
-    assert np.isfinite(samples[:3]).all()
-    assert samples[1] == pytest.approx(output["balance"].item())
-    assert np.isnan(samples[3:]).all()
-    assert output["last_eq_ts"].item() == pytest.approx(121 * run.interval_ms)
 
 
 @pytest.mark.skipif(
@@ -5515,6 +5294,12 @@ def test_mps_multicoin_service_matches_exact_declared_all_invalid_time(
             "position_held_days_max",
         },
     )
+    if count < 1400:
+        with pytest.raises(ValueError, match="held-position valuation"):
+            proxy.evaluate([{}])
+        with pytest.raises(ValueError, match="held-position valuation"):
+            run_backtest(hlcvs, market_settings, config, "bybit", np.full(count, 50_000.0), timestamps)
+        return
     result = proxy.evaluate([{}])[0]
     exact_fills, _, exact_analysis = run_backtest(
         hlcvs,
@@ -6425,6 +6210,10 @@ def test_mps_multicoin_staggered_tail_keeps_balance_only_equity_and_hsl(
         params = np.asarray([row + short_row], dtype=np.float64)
     else:
         params = np.asarray([row], dtype=np.float64)
+    if not forced_delist:
+        with pytest.raises(ValueError, match="held-position valuation"):
+            runner.run(params)
+        return
     output = runner.run(params)
     torch.mps.synchronize()
 
@@ -6492,8 +6281,8 @@ def test_mps_multicoin_all_invalid_time_keeps_equity_and_hsl_clock(
     closes = np.full((count, 2), 100.0)
     highs = closes.copy()
     lows = closes.copy()
-    highs[3, :] = 101.0
-    lows[3, :] = 99.0
+    # Keep positions flat: this test owns the equity/HSL clock across unavailable
+    # listing windows. Held invalid tails are rejected in the boundary tests.
     fixture_side = topology if topology != "fused" else "long"
     runner, row, run, data = _multicoin_exposure_fixture(
         strategy_kind,
@@ -6537,6 +6326,7 @@ def test_mps_multicoin_all_invalid_time_keeps_equity_and_hsl_clock(
     torch.mps.synchronize()
 
     assert output["balance"].item() > 0.0
+    assert output["fill_count"].item() == 0.0
     assert output["first_eq_ts"].item() == pytest.approx(
         expected_first_eq_index * run.interval_ms
     )
@@ -6607,12 +6397,17 @@ def test_mps_multicoin_fused_hsl_restarts_during_all_coins_ended_tail(
     }.items():
         row[keys.index(key)] = value
 
+    # Exercise restart with the entire tail flat: the opposite side must not
+    # retain an unrelated profitable trailing position past its valid range.
+    long_row, short_row = list(row), list(row)
+    inactive_row = short_row if adverse_side == "long" else long_row
+    inactive_row[keys.index("total_wallet_exposure_limit")] = 0.0
     output = fused_runner_cls(
         run,
         data,
         long_coin_overrides=overrides,
         short_coin_overrides=overrides,
-    ).run(np.asarray([row + row], dtype=np.float64))
+    ).run(np.asarray([long_row + short_row], dtype=np.float64))
     torch.mps.synchronize()
 
     assert output[f"hsl_triggers_{adverse_side}"].item() == 1.0
@@ -6631,11 +6426,8 @@ def test_mps_multicoin_reselects_recovered_flat_candidate(
     import passivbot_rust
 
     closes = np.full((4, 2), 100.0)
-    closes[2, 0] = 0.0
     highs = np.full((4, 2), 101.0)
     lows = np.full((4, 2), 99.0)
-    highs[2, 0] = 0.0
-    lows[2, 0] = 0.0
     runner, row, _run, data = _multicoin_exposure_fixture(
         strategy_kind,
         side,
@@ -6645,6 +6437,8 @@ def test_mps_multicoin_reselects_recovered_flat_candidate(
         lows=lows,
         return_context=True,
     )
+    # Inject only into the isolated selection probe; public builders reject internal gaps.
+    data["bars"][2, 0, :3] = 0.0
     if strategy_kind == "ema_anchor":
         state_type = "EmaMulticoinSideState"
         config_type = "EmaMulticoinSideConfig"
@@ -6735,7 +6529,6 @@ def test_mps_tm_recursive_entry_twel_gate_does_not_expand_invalid_coin(
     last_valid_indices = (0, 2)
     if invalid_mode == "internal":
         last_valid_indices = (2, 2)
-        lows[1, 0] = 0.0
     runner, row, _run, data = _multicoin_exposure_fixture(
         "trailing_martingale",
         side,
@@ -6747,6 +6540,9 @@ def test_mps_tm_recursive_entry_twel_gate_does_not_expand_invalid_coin(
         market_orders_allowed=True,
         return_context=True,
     )
+    if invalid_mode == "internal":
+        # The isolated guard probe owns this malformed state, not the public builder.
+        data["bars"][1, 0, 1] = 0.0
     values = dict(zip(TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS, row))
     values.update(
         {
@@ -6975,7 +6771,6 @@ kernel void passivbot_tm_multicoin_tail_twel_probe(
     closes = np.full((3, 2), 100.0)
     last_valid_indices = (0, 2)
     if mark_case == "in_range_zero":
-        closes[1, 0] = 0.0
         last_valid_indices = (2, 2)
     runner, row, _run, data = _multicoin_exposure_fixture(
         strategy_kind,
@@ -6985,6 +6780,9 @@ kernel void passivbot_tm_multicoin_tail_twel_probe(
         last_valid_indices=last_valid_indices,
         return_context=True,
     )
+    if mark_case == "in_range_zero":
+        # Keep the narrow reducer test independent of input preflight.
+        data["bars"][1, 0, :3] = 0.0
     values = dict(zip(keys, row))
     values.update(
         {
@@ -19617,7 +19415,7 @@ def test_mps_ema_multicoin_loss_gate_blocks_fee_only_ordinary_close(side):
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
 @pytest.mark.parametrize("side", ["long", "short"])
-def test_mps_tm_multicoin_twel_repair_excludes_tailed_positions(side):
+def test_mps_tm_multicoin_rejects_held_tails_before_twel_repair(side):
     count = 7
     timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
     hlcvs = np.zeros((count, 2, 4), dtype=np.float64)
@@ -19625,9 +19423,8 @@ def test_mps_tm_multicoin_twel_repair_excludes_tailed_positions(side):
     hlcvs[:, :, 1] = 99.0
     hlcvs[:, :, 2] = 100.0
     hlcvs[:, :, 3] = 100.0
-    # Coin zero tails after this close. It remains part of total exposure but
-    # is no longer a managed TWEL reducer candidate.
-    hlcvs[3, 0, :3] = [111.0, 109.0, 110.0]
+    # A still-held coin tail cannot be valued or hidden by a TWEL repair.
+    hlcvs[3, 0, :3] = [111.0, 89.0, 110.0]
     hlcvs[4:, 0, :] = 0.0
     # The still-tradable coin is adverse for long and favorable for short.
     hlcvs[4:, 1, :3] = [91.0, 89.0, 90.0]
@@ -19672,27 +19469,17 @@ def test_mps_tm_multicoin_twel_repair_excludes_tailed_positions(side):
             "twel_enforcer_enabled"
         )
     ] = 0.0
-    output = MpsTrailingMartingaleMulticoinRunner(
-        runs[1], data, side=side
-    ).run(np.asarray([baseline, repaired], dtype=np.float64))
-    torch.mps.synchronize()
-
-    size_key = "psize" if side == "long" else "short_psize"
-    sizes = output[size_key].cpu().numpy()
-    if side == "long":
-        # Only the tailed coin holds a long position, so no reachable repair
-        # exists and the total size stays unchanged.
-        assert sizes[1] == pytest.approx(sizes[0])
-    else:
-        # The surviving short position receives the reachable reducer.
-        assert sizes[1] < sizes[0]
+    with pytest.raises(ValueError, match="held-position valuation"):
+        MpsTrailingMartingaleMulticoinRunner(
+            runs[1], data, side=side
+        ).run(np.asarray([baseline, repaired], dtype=np.float64))
 
 
 @pytest.mark.skipif(
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )
 @pytest.mark.parametrize("side", ["long", "short"])
-def test_mps_ema_multicoin_twel_repair_excludes_tailed_positions(side):
+def test_mps_ema_multicoin_rejects_held_tails_before_twel_repair(side):
     count = 70
     timestamps = 1_700_000_000_000 + np.arange(count, dtype=np.int64) * 60_000
     hlcvs = np.zeros((count, 2, 4), dtype=np.float64)
@@ -19700,9 +19487,8 @@ def test_mps_ema_multicoin_twel_repair_excludes_tailed_positions(side):
     hlcvs[:, :, 1] = 99.0
     hlcvs[:, :, 2] = 100.0
     hlcvs[:, :, 3] = 100.0
-    # Fill the wide-offset entries, then tail coin zero while coin one remains
-    # tradable. The tailed position stays in total exposure but cannot receive
-    # a reducer.
+    # Fill wide-offset entries, then lose coin zero coverage while coin one
+    # remains tradable. Both baseline and repair must reject unavailable valuation.
     hlcvs[62, 0, :3] = [140.0, 70.0, 130.0]
     hlcvs[62, 1, :3] = [130.0, 70.0, 90.0]
     hlcvs[63:, 0, :] = 0.0
@@ -19743,14 +19529,10 @@ def test_mps_ema_multicoin_twel_repair_excludes_tailed_positions(side):
     baseline[
         EMA_ANCHOR_MULTICOIN_PARAM_KEYS.index("twel_enforcer_enabled")
     ] = 0.0
-    output = MpsEmaAnchorMulticoinRunner(
-        runs[1], data, side=side
-    ).run(np.asarray([baseline, repaired], dtype=np.float64))
-    torch.mps.synchronize()
-
-    size_key = "psize" if side == "long" else "short_psize"
-    sizes = output[size_key].cpu().numpy()
-    assert sizes[1] < sizes[0]
+    with pytest.raises(ValueError, match="held-position valuation"):
+        MpsEmaAnchorMulticoinRunner(
+            runs[1], data, side=side
+        ).run(np.asarray([baseline, repaired], dtype=np.float64))
 
 
 @pytest.mark.skipif(

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -1761,11 +1761,12 @@ def test_gpu_multicoin_proxy_accepts_staggered_valid_gaps_and_ended_tails():
         _require_supported_multicoin_valid_tails(hlcvs, [99, 0], [98, 99])
 
 
-def test_gpu_multicoin_proxy_accepts_all_nan_candle_in_windows():
+def test_gpu_multicoin_proxy_rejects_all_nan_candle_in_windows():
     hlcvs = np.ones((100, 2, 4), dtype=np.float64)
     hlcvs[40, :, :3] = np.nan
 
-    _require_supported_multicoin_valid_tails(hlcvs, [0, 0], [59, 99])
+    with pytest.raises(ValueError, match="contiguous.*candle_index=40"):
+        _require_supported_multicoin_valid_tails(hlcvs, [0, 0], [59, 99])
 
 
 def test_gpu_multicoin_proxy_rejects_all_nan_first_valid_candle():
@@ -1856,17 +1857,18 @@ def test_gpu_multicoin_hsl_requires_each_coin_to_have_contiguous_valid_candles()
     )
 
 
-def test_gpu_proxy_accepts_only_exact_balance_only_internal_gaps():
+def test_gpu_proxy_rejects_all_internal_gaps():
     hlcvs = np.ones((4, 2, 4), dtype=np.float64)
     hlcvs[2, 1, :3] = np.nan
 
-    _require_exact_safe_proxy_candles(
-        hlcvs,
-        exposure_eligible_coins=[True, True],
-        first_valid_indices=[0, 0],
-        last_valid_indices=[3, 3],
-        require_positive_high_low=True,
-    )
+    with pytest.raises(ValueError, match="all-NaN.*invalid candle at 2"):
+        _require_exact_safe_proxy_candles(
+            hlcvs,
+            exposure_eligible_coins=[True, True],
+            first_valid_indices=[0, 0],
+            last_valid_indices=[3, 3],
+            require_positive_high_low=True,
+        )
 
     hlcvs[2, 1, :3] = 0.0
     with pytest.raises(ValueError, match="coin index 1, invalid candle at 2"):
@@ -1899,7 +1901,7 @@ def test_gpu_proxy_accepts_only_exact_balance_only_internal_gaps():
         )
 
 
-def test_gpu_single_coin_accepts_nan_gap_but_rejects_zero_for_all_metrics():
+def test_gpu_single_coin_rejects_nan_gap_and_zero_for_all_metrics():
     hlcvs = np.ones((4, 1, 4), dtype=np.float64)
     hlcvs[2, 0, :3] = np.nan
     kwargs = {
@@ -1907,7 +1909,8 @@ def test_gpu_single_coin_accepts_nan_gap_but_rejects_zero_for_all_metrics():
         "last_valid_idx": 3,
     }
 
-    _require_no_unsafe_single_coin_candles(hlcvs, **kwargs)
+    with pytest.raises(ValueError, match="invalid candle at 2"):
+        _require_no_unsafe_single_coin_candles(hlcvs, **kwargs)
 
     hlcvs[2, 0, :3] = 0.0
     with pytest.raises(ValueError, match="invalid candle at 2"):

--- a/tests/test_backtest_directional_eligibility.py
+++ b/tests/test_backtest_directional_eligibility.py
@@ -169,3 +169,34 @@ def test_zero_wel_coin_override_disables_approved_side_entries():
     assert entry_pairs == {("LONGCOIN", "entry_ema_anchor_long")}
     params_by_coin = dict(zip(payload.backtest_params["coins"], payload.bot_params_list))
     assert params_by_coin["SHORTCOIN"]["short"]["entry_eligible"] is False
+
+
+@pytest.mark.parametrize("fields", [[0, 1, 2], [0], [1], [2]])
+def test_backtest_rejects_nonfinite_internal_candles(fields):
+    config = _ema_anchor_config(hedge_mode=True)
+    hlcvs, market_settings, btc_prices, timestamps = _synthetic_inputs()
+    hlcvs[20, 0, fields] = np.nan
+    with pytest.raises(ValueError, match="contiguous finite H/L/C.*candle 20"):
+        run_backtest(hlcvs, market_settings, config, "binance", btc_prices, timestamps)
+
+
+def test_backtest_accepts_unheld_listing_boundaries_but_rejects_held_missing_tail():
+    config = _ema_anchor_config(hedge_mode=True)
+    hlcvs, market_settings, btc_prices, timestamps = _synthetic_inputs()
+    market_settings["LONGCOIN"].update(first_valid_index=9, last_valid_index=20)
+    hlcvs[:9, 0, :] = np.nan
+    hlcvs[21:, 0, :] = np.nan
+    # Keep the other symbol active, proving the whole simulation can continue
+    # past this absent symbol's listing window while it has no position.
+    config["bot"]["long"]["risk"]["total_wallet_exposure_limit"] = 0.0
+    fills, _, _ = run_backtest(
+        hlcvs, market_settings, config, "binance", btc_prices, timestamps
+    )
+    assert len(fills) > 0
+    assert all(str(fill[2]) == "SHORTCOIN" for fill in fills)
+
+    config["bot"]["long"]["risk"]["total_wallet_exposure_limit"] = 1.5
+    # Fill a long entry, but keep highs below its close order until data ends.
+    hlcvs[9:21, 0, 0] = 100.0
+    with pytest.raises(ValueError, match="missing held-position valuation candle.*candle 21"):
+        run_backtest(hlcvs, market_settings, config, "binance", btc_prices, timestamps)


### PR DESCRIPTION
Backtests previously omitted unrealized PnL when a held symbol had an unavailable candle, which could temporarily inflate equity and suppress loss checks. Direct and prepared datasets now reject non-finite H/L/C inside each declared valid window, and exact Rust plus GPU execution reject positions that remain held beyond available valuation coverage.

Unheld listing prefixes and delisting tails remain supported, as do forced closes completed before coverage ends. GPU builders validate float32 prices before allocation, and Metal reports missing held-position valuation as an error before metrics can be consumed. The ordinary materializer gap-repair policy is unchanged.

Validation:
- Rust unit tests and default-feature test compilation.
- Real-extension backtest regressions for internal gaps, flat listing boundaries, and held missing tails.
- GPU service and direct-builder validation plus actual Apple Metal tests covering both strategies, long/short/fused execution, and forced delisting.
- Rebuilt isolated Python extension verified against the current Rust source fingerprint.
