### PR TITLE
Fix stale GPU rejection in coin override composer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- `compose-coin-overrides --include-backtest-optimize` now retains the master's GPU optimizer
+  settings instead of rejecting multi-coin configs with static coin overrides. GPU-specific
+  compatibility checks still run when starting the optimizer.
+
 - Backtest and optimizer results now expose `n_days` and effective UTC analysis dates in
   existing metrics payloads, preserving per-exchange and per-scenario windows. Saved backtest
   configs include current `metrics` or `suite_metrics`; `fills_analysis_duration_days` remains

--- a/docs/coin_overrides.md
+++ b/docs/coin_overrides.md
@@ -227,8 +227,10 @@ gate and enforcer, so it is normalized only when both are disabled.
 By default the output omits `backtest` and `optimize`, producing a lean live config. Add
 `--include-backtest-optimize` to copy both sections from the master input, which makes the result
 directly usable for backtesting or fine-tuning inherited master parameters while the coin overrides
-remain fixed. A master using the single-coin-only `gpu` optimizer backend is rejected in this mode;
-select a CPU optimizer backend before composing. Existing output files are protected unless
+remain fixed. This also preserves `optimize.backend: gpu`: the GPU optimizer supports multi-coin
+EMA Anchor and Trailing Martingale configs with static coin overrides. GPU-specific scope checks
+remain the optimizer's responsibility; see [GPU support and limitations](optimizing.md).
+Existing output files are protected unless
 `--overwrite` is supplied.
 
 ## Common pitfalls

--- a/src/tools/compose_coin_overrides.py
+++ b/src/tools/compose_coin_overrides.py
@@ -526,16 +526,6 @@ def compose_configs(
 ) -> tuple[dict, CompositionReport]:
     if len(configs) < 2:
         raise ValueError("at least two single-coin configs are required")
-    if (
-        include_backtest_optimize
-        and str(configs[0].config.get("optimize", {}).get("backend", "")).casefold()
-        == "gpu"
-    ):
-        raise ValueError(
-            "--include-backtest-optimize cannot retain optimize.backend='gpu': the GPU "
-            "optimizer supports neither multi-coin datasets nor coin_overrides; select a "
-            "CPU optimizer backend in the master input"
-        )
     canonicalized_features = canonicalize_inactive_features(configs)
     master_source = configs[0]
     master = deepcopy(master_source.config)

--- a/tests/test_compose_coin_overrides_tool.py
+++ b/tests/test_compose_coin_overrides_tool.py
@@ -328,16 +328,45 @@ def test_qualified_identifier_venue_removes_ignored_alias(tmp_path: Path, monkey
     assert composed["live"]["ignored_coins"]["long"] == []
 
 
-def test_rejects_retaining_gpu_optimizer_for_composed_config(tmp_path: Path):
+@pytest.mark.parametrize("strategy_kind", ["ema_anchor", "trailing_martingale"])
+def test_retains_gpu_optimizer_with_coin_overrides(tmp_path: Path, strategy_kind: str):
     master = _single_coin_config("BTC")
+    other = _single_coin_config("ETH")
+    for config in (master, other):
+        config["live"]["strategy_kind"] = strategy_kind
     master["optimize"]["backend"] = "gpu"
+    master["optimize"]["iters"] = 123
+    master["backtest"]["start_date"] = "2021-01-01"
+    if strategy_kind == "ema_anchor":
+        master["bot"]["long"]["strategy"][strategy_kind]["offset"] = 0.01
+        other["bot"]["long"]["strategy"][strategy_kind]["offset"] = 0.02
+        expected_strategy = {"offset": 0.02}
+    else:
+        master["bot"]["long"]["strategy"][strategy_kind]["entry"]["initial_qty_pct"] = 0.01
+        other["bot"]["long"]["strategy"][strategy_kind]["entry"]["initial_qty_pct"] = 0.02
+        expected_strategy = {"entry": {"initial_qty_pct": 0.02}}
     _write(tmp_path / "a.json", master)
-    _write(tmp_path / "b.json", _single_coin_config("ETH"))
+    _write(tmp_path / "b.json", other)
 
     lean, _report = compose_directory(tmp_path)
     assert "optimize" not in lean
-    with pytest.raises(ValueError, match="optimize.backend='gpu'"):
-        compose_directory(tmp_path, include_backtest_optimize=True)
+    assert "backtest" not in lean
+
+    output = tmp_path / "composed.json"
+    assert main([str(tmp_path), str(output), "--include-backtest-optimize"]) == 0
+    composed = json.loads(output.read_text(encoding="utf-8"))
+    assert composed["optimize"]["backend"] == "gpu"
+    assert composed["optimize"]["gpu"] == master["optimize"]["gpu"]
+    assert composed["optimize"]["iters"] == 123
+    assert composed["backtest"]["start_date"] == "2021-01-01"
+    assert composed["live"]["approved_coins"]["long"] == ["BTC", "ETH"]
+    assert composed["bot"]["long"]["risk"]["n_positions"] == 2.0
+    assert composed["coin_overrides"] == {
+        "ETH": {"bot": {"long": {"strategy": {strategy_kind: expected_strategy}}}}
+    }
+    prepared = prepare_config(composed, verbose=False, log_config_transforms=False)
+    parse_overrides(prepared, verbose=False)
+    assert prepared["optimize"]["backend"] == "gpu"
 
 
 def test_cli_writes_sorted_config_and_protects_existing_output(tmp_path: Path, capsys):


### PR DESCRIPTION
`compose-coin-overrides --include-backtest-optimize` rejects any master using `optimize.backend: gpu`, even though the GPU optimizer supports multi-coin EMA Anchor and Trailing Martingale configs with static coin overrides. Remove that stale blanket rejection so composition preserves the master's GPU settings; GPU-specific compatibility checks remain in the optimizer.

Update the coin-override documentation and changelog, and replace the rejection test with CLI composition and config-reload regressions for both strategies. The regressions verify retained GPU settings, combined coin selection, and the generated strategy overrides.

Validation:
- Compose tool tests: 18 passed; both new regressions reproduced the stale rejection before the fix.
- Focused GPU override validation and packing tests: 39 passed.
- AI documentation and event-registry checks passed, with existing documentation-size warnings; documentation tests: 6 passed.
- `git diff --check` passed.
