### PR TITLE
Improve long-history MPS optimizer throughput with bounded replay chunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Apple MPS multi-coin Trailing Martingale optimization uses bounded history chunks when long
+  datasets would otherwise restrict candidate parallelism. Replays preserve their full strategy
+  and metric state between dispatches, retain the configured work limit, and check interruption
+  between chunks. Profiling reports temporal dispatch counts and maximum dispatch duration.
+
 - `compose-coin-overrides --override-params` pins selected groups or leaves using fine-tune-style
   dotted selectors, retaining equal values while unselected fields inherit the master. Custom
   selection takes precedence over lean/verbose mode and rejects selectors matching no allowed

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -825,6 +825,20 @@ MPS Metal integration and hybrid validation gates are specific to this implement
 
 #### Profiling Apple MPS optimization
 
+For long multi-coin Trailing Martingale datasets with one active side, MPS can retain each
+candidate's replay state between history chunks. This activates automatically when the full-history
+dispatch cap would admit fewer than 512 candidates (or the requested batch size, if smaller).
+Each dispatch processes at most 8,192 bars, shortening to 4,096 for a full 512-candidate batch,
+and stays within `max_dispatch_candidate_bars`; the
+runner synchronizes and checks interruption between dispatches. Up to 512 candidates can then
+advance together. Every candidate still processes its complete history, and exact Rust validation
+remains authoritative. Shorter workloads and dual-side portfolios retain their existing dispatch
+path.
+
+Temporal replay profiling includes `temporal_dispatches`, with chunk lengths, replay-state memory,
+and `max_dispatch_seconds`. These are portions of one replay; candidate-bar totals count each
+processed step once.
+
 Set `PASSIVBOT_GPU_PROFILE=1` to emit structured `[gpu-profile]` JSON records. Profiling is disabled
 by default because its synchronization points deliberately trade throughput for trustworthy phase
 boundaries.
@@ -880,6 +894,7 @@ passivbot tool gpu-proxy-benchmark --case tm-single-long-close-ladder
 passivbot tool gpu-proxy-benchmark --case tm-single-long-hsl
 passivbot tool gpu-proxy-benchmark --case ema-multicoin-overhead
 passivbot tool gpu-proxy-benchmark --case ema-multicoin-overrides
+passivbot tool gpu-proxy-benchmark --case tm-multicoin-overhead
 # Hold one candidate matrix constant while measuring dispatch chunking:
 passivbot tool gpu-proxy-benchmark --case ema-single-long \
   --candidates 4096 --dispatch-batch-size 1024

--- a/passivbot-rust/src/gpu.rs
+++ b/passivbot-rust/src/gpu.rs
@@ -1316,7 +1316,7 @@ mod tests {
         assert!(source.contains("long_has_position || short_has_position"));
         assert!(source.contains("multicoin_min_cost_rejection_possible"));
         assert_eq!(
-            source.matches("bool min_cost_exact_open_uncertain").count(),
+            source.matches("bool min_cost_exact_open_uncertain =").count(),
             2
         );
         assert!(source.contains("never reuse the equity-derived liquidation floor"));

--- a/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
+++ b/passivbot-rust/src/gpu/mps_trailing_martingale_multicoin.metal
@@ -5768,6 +5768,61 @@ kernel void passivbot_trailing_martingale_multicoin_fused(
     );
 }
 
+// A temporal dispatch boundary preserves the entire candidate replay. Output
+// finalization runs only at its actual end step; partial chunks never become scores.
+#if PASSIVBOT_TM_MULTICOIN_CHUNKED
+struct TrailingMartingaleMulticoinReplayState {
+    TrailingMartingaleMulticoinSideState side;
+    JointPortfolioAccount account;
+    TrailingMartingaleMulticoinFillState fills;
+    float fills_active_days_count;
+    int last_active_fill_day;
+    bool alive;
+    bool equity_started;
+    bool min_cost_exact_open_uncertain;
+    float run_peak;
+    float max_dd;
+    float total_wallet_exposure_max;
+    float total_wallet_exposure_mean;
+    float total_wallet_exposure_samples;
+    float first_fill_k;
+    float last_fill_k;
+    float gap_max_min;
+    float last_high_k;
+    float recovery_max_min;
+    float account_peak;
+    float account_peak_k;
+    float account_recovery_max_min;
+    float first_eq_k;
+    float last_eq_k;
+    int liquidation_day;
+    float hsl_tier_samples_total;
+    float hsl_tier_samples_yellow;
+    float hsl_tier_samples_orange;
+    float hsl_tier_samples_red;
+    int current_day;
+    bool day_touched;
+    float day_end;
+    float day_min;
+    float day_dd;
+    float day_has_fill;
+    float day_min_balance;
+    float day_start_balance;
+#if PASSIVBOT_BTC_RISK_ENABLED
+    BtcRiskState btc_risk;
+#endif
+#if PASSIVBOT_EQUITY_BALANCE_DIFF_ENABLED
+    EquityBalanceDiffState equity_balance_diff_state;
+#endif
+#if defined(PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED)
+    int recovery_start_k;
+#endif
+};
+kernel void passivbot_tm_multicoin_replay_state_bytes(device uint* result) {
+    result[0] = sizeof(TrailingMartingaleMulticoinReplayState);
+}
+#endif
+
 inline void passivbot_trailing_martingale_multicoin_impl(
     constant float* bars,
     constant int* fill_ticks,
@@ -5799,6 +5854,10 @@ inline void passivbot_trailing_martingale_multicoin_impl(
 #ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
     device float* recovery_samples,
 #endif
+#if PASSIVBOT_TM_MULTICOIN_CHUNKED
+    device TrailingMartingaleMulticoinReplayState* replay_states,
+    constant int* replay_range,
+#endif
     uint b,
     bool short_side
 ) {
@@ -5815,13 +5874,25 @@ inline void passivbot_trailing_martingale_multicoin_impl(
 #endif
     if (b >= uint(B)) return;
 #if PASSIVBOT_ENTRY_INTERVAL_ENABLED
+#if PASSIVBOT_TM_MULTICOIN_CHUNKED
+    if (replay_range[0] == 1)
+#endif
     init_entry_interval_output(
         entry_interval_stats, entry_interval_counts, b
     );
 #endif
     const int stop_k = clamp(end_steps[b], 1, T - 1);
+#if PASSIVBOT_TM_MULTICOIN_CHUNKED
+    const int begin_k = replay_range[0];
+    const int chunk_stop_k = min(replay_range[1], stop_k);
+    if (begin_k >= stop_k && begin_k > 1) return;
+    if (begin_k > 1 && scalars[int(b) * SCALAR_COLS + 9] == -2.0f) return;
+#else
+    const int begin_k = 1;
+    const int chunk_stop_k = stop_k;
+#endif
     const bool collect_coin_fill_counts = run_settings[6] > 0.5f;
-    if (collect_coin_fill_counts) {
+    if (collect_coin_fill_counts && begin_k == 1) {
         for (int c = 0; c < C; ++c) {
             coin_fill_counts[int(b) * C + c] = 0.0f;
         }
@@ -5864,7 +5935,7 @@ inline void passivbot_trailing_martingale_multicoin_impl(
     thread float* position_open_k = side.position_open_k;
     thread float* position_last_fill_k = side.position_last_fill_k;
     thread float* coin_realized_pnl = side.coin_realized_pnl;
-    for (int j = 0; j < GAP_BINS; ++j) {
+    for (int j = 0; begin_k == 1 && j < GAP_BINS; ++j) {
         gap_hist[int(b) * GAP_BINS + j] = 0;
     }
 
@@ -5935,7 +6006,57 @@ inline void passivbot_trailing_martingale_multicoin_impl(
     float day_start_balance = balance;
     thread float& day_fill_count = fills.day_fill_count;
 
-    for (int k = 1; k < stop_k; ++k) {
+#if PASSIVBOT_TM_MULTICOIN_CHUNKED
+    if (begin_k > 1) {
+        side = replay_states[b].side;
+        account = replay_states[b].account;
+        fills = replay_states[b].fills;
+        fills_active_days_count = replay_states[b].fills_active_days_count;
+        last_active_fill_day = replay_states[b].last_active_fill_day;
+        alive = replay_states[b].alive;
+        equity_started = replay_states[b].equity_started;
+        min_cost_exact_open_uncertain = replay_states[b].min_cost_exact_open_uncertain;
+        run_peak = replay_states[b].run_peak;
+        max_dd = replay_states[b].max_dd;
+        total_wallet_exposure_max = replay_states[b].total_wallet_exposure_max;
+        total_wallet_exposure_mean = replay_states[b].total_wallet_exposure_mean;
+        total_wallet_exposure_samples = replay_states[b].total_wallet_exposure_samples;
+        first_fill_k = replay_states[b].first_fill_k;
+        last_fill_k = replay_states[b].last_fill_k;
+        gap_max_min = replay_states[b].gap_max_min;
+        last_high_k = replay_states[b].last_high_k;
+        recovery_max_min = replay_states[b].recovery_max_min;
+        account_peak = replay_states[b].account_peak;
+        account_peak_k = replay_states[b].account_peak_k;
+        account_recovery_max_min = replay_states[b].account_recovery_max_min;
+        first_eq_k = replay_states[b].first_eq_k;
+        last_eq_k = replay_states[b].last_eq_k;
+        liquidation_day = replay_states[b].liquidation_day;
+        hsl_tier_samples_total = replay_states[b].hsl_tier_samples_total;
+        hsl_tier_samples_yellow = replay_states[b].hsl_tier_samples_yellow;
+        hsl_tier_samples_orange = replay_states[b].hsl_tier_samples_orange;
+        hsl_tier_samples_red = replay_states[b].hsl_tier_samples_red;
+        current_day = replay_states[b].current_day;
+        day_touched = replay_states[b].day_touched;
+        day_end = replay_states[b].day_end;
+        day_min = replay_states[b].day_min;
+        day_dd = replay_states[b].day_dd;
+        day_has_fill = replay_states[b].day_has_fill;
+        day_min_balance = replay_states[b].day_min_balance;
+        day_start_balance = replay_states[b].day_start_balance;
+#if PASSIVBOT_BTC_RISK_ENABLED
+        btc_risk = replay_states[b].btc_risk;
+#endif
+#if PASSIVBOT_EQUITY_BALANCE_DIFF_ENABLED
+        equity_balance_diff_state = replay_states[b].equity_balance_diff_state;
+#endif
+#if defined(PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED)
+        recovery_start_k = replay_states[b].recovery_start_k;
+#endif
+    }
+#endif
+
+    for (int k = begin_k; k < chunk_stop_k; ++k) {
         if (alive && (held_positions_have_missing_prices(side.psize, bars, coin_settings, k, C))) {
             // The decoder rejects -2 as unavailable held-position valuation.
             scalars[int(b) * SCALAR_COLS + 9] = -2.0f;
@@ -6315,6 +6436,57 @@ inline void passivbot_trailing_martingale_multicoin_impl(
         }
     }
 
+#if PASSIVBOT_TM_MULTICOIN_CHUNKED
+    if (chunk_stop_k < stop_k) {
+        replay_states[b].side = side;
+        replay_states[b].account = account;
+        replay_states[b].fills = fills;
+        replay_states[b].fills_active_days_count = fills_active_days_count;
+        replay_states[b].last_active_fill_day = last_active_fill_day;
+        replay_states[b].alive = alive;
+        replay_states[b].equity_started = equity_started;
+        replay_states[b].min_cost_exact_open_uncertain = min_cost_exact_open_uncertain;
+        replay_states[b].run_peak = run_peak;
+        replay_states[b].max_dd = max_dd;
+        replay_states[b].total_wallet_exposure_max = total_wallet_exposure_max;
+        replay_states[b].total_wallet_exposure_mean = total_wallet_exposure_mean;
+        replay_states[b].total_wallet_exposure_samples = total_wallet_exposure_samples;
+        replay_states[b].first_fill_k = first_fill_k;
+        replay_states[b].last_fill_k = last_fill_k;
+        replay_states[b].gap_max_min = gap_max_min;
+        replay_states[b].last_high_k = last_high_k;
+        replay_states[b].recovery_max_min = recovery_max_min;
+        replay_states[b].account_peak = account_peak;
+        replay_states[b].account_peak_k = account_peak_k;
+        replay_states[b].account_recovery_max_min = account_recovery_max_min;
+        replay_states[b].first_eq_k = first_eq_k;
+        replay_states[b].last_eq_k = last_eq_k;
+        replay_states[b].liquidation_day = liquidation_day;
+        replay_states[b].hsl_tier_samples_total = hsl_tier_samples_total;
+        replay_states[b].hsl_tier_samples_yellow = hsl_tier_samples_yellow;
+        replay_states[b].hsl_tier_samples_orange = hsl_tier_samples_orange;
+        replay_states[b].hsl_tier_samples_red = hsl_tier_samples_red;
+        replay_states[b].current_day = current_day;
+        replay_states[b].day_touched = day_touched;
+        replay_states[b].day_end = day_end;
+        replay_states[b].day_min = day_min;
+        replay_states[b].day_dd = day_dd;
+        replay_states[b].day_has_fill = day_has_fill;
+        replay_states[b].day_min_balance = day_min_balance;
+        replay_states[b].day_start_balance = day_start_balance;
+#if PASSIVBOT_BTC_RISK_ENABLED
+        replay_states[b].btc_risk = btc_risk;
+#endif
+#if PASSIVBOT_EQUITY_BALANCE_DIFF_ENABLED
+        replay_states[b].equity_balance_diff_state = equity_balance_diff_state;
+#endif
+#if defined(PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED)
+        replay_states[b].recovery_start_k = recovery_start_k;
+#endif
+        return;
+    }
+#endif
+
     if (day_touched && current_day >= 0 && current_day < D) {
         int output = (int(b) * D + current_day) * DAILY_COLS;
         daily[output + 0] = day_end;
@@ -6498,6 +6670,10 @@ kernel void passivbot_trailing_martingale_multicoin(
 #ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
     device float* recovery_samples,
 #endif
+#if PASSIVBOT_TM_MULTICOIN_CHUNKED
+    device TrailingMartingaleMulticoinReplayState* replay_states,
+    constant int* replay_range,
+#endif
     uint b [[thread_position_in_grid]]
 ) {
     const bool short_side = run_settings[3] > 0.5f;
@@ -6519,6 +6695,9 @@ kernel void passivbot_trailing_martingale_multicoin(
         daily, scalars, gap_hist, coin_fill_counts,
 #ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
         recovery_samples,
+#endif
+#if PASSIVBOT_TM_MULTICOIN_CHUNKED
+        replay_states, replay_range,
 #endif
         b, short_side
     );
@@ -6555,6 +6734,10 @@ kernel void passivbot_trailing_martingale_multicoin_long(
 #ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
     device float* recovery_samples,
 #endif
+#if PASSIVBOT_TM_MULTICOIN_CHUNKED
+    device TrailingMartingaleMulticoinReplayState* replay_states,
+    constant int* replay_range,
+#endif
     uint b [[thread_position_in_grid]]
 ) {
     passivbot_trailing_martingale_multicoin_impl(
@@ -6575,6 +6758,9 @@ kernel void passivbot_trailing_martingale_multicoin_long(
         daily, scalars, gap_hist, coin_fill_counts,
 #ifdef PASSIVBOT_STRATEGY_EQ_RECOVERY_DISTRIBUTION_ENABLED
         recovery_samples,
+#endif
+#if PASSIVBOT_TM_MULTICOIN_CHUNKED
+        replay_states, replay_range,
 #endif
         b, false
     );

--- a/src/optimization/gpu/model.py
+++ b/src/optimization/gpu/model.py
@@ -9,6 +9,10 @@ import numpy as np
 GAP_BINS = 128
 GAP_MAX_MINUTES = 4_000_000.0
 MPS_MULTICOIN_MAX_COINS = 64
+# Bound both temporal launch duration and per-candidate replay-state allocation.
+MPS_TM_MULTICOIN_CHUNK_BARS = 8192
+MPS_TM_MULTICOIN_CHUNK_CANDIDATES = 512
+MPS_TM_MULTICOIN_CHUNK_CANDIDATE_STEPS = 2_097_152
 HSL_SIGNAL_MODES = {"unified", "pside", "coin"}
 
 

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from functools import lru_cache
+import logging
 import time
 
 import numpy as np
@@ -14,6 +15,8 @@ from optimization.gpu.model import (
     EMA_ANCHOR_MULTICOIN_PARAM_KEYS,
     EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS,
     GAP_BINS,
+    MPS_TM_MULTICOIN_CHUNK_BARS,
+    MPS_TM_MULTICOIN_CHUNK_CANDIDATE_STEPS,
     ProxyMarket,
     ProxyRun,
     TRAILING_MARTINGALE_COIN_OVERRIDE_COOLDOWN_COLUMN,
@@ -947,6 +950,7 @@ def _trailing_martingale_multicoin_shader_library(
     btc_risk_enabled: bool = False,
     equity_balance_diff_enabled: bool = False,
     entry_interval_enabled: bool = False,
+    temporal_chunking: bool = False,
 ):
     if not torch.backends.mps.is_available():
         raise RuntimeError("Apple MPS is not available in this process")
@@ -965,6 +969,10 @@ def _trailing_martingale_multicoin_shader_library(
     source = _with_btc_risk(source, btc_risk_enabled)
     source = _with_equity_balance_diff(source, equity_balance_diff_enabled)
     source = _with_entry_interval(source, entry_interval_enabled)
+    if temporal_chunking:
+        if "#if PASSIVBOT_TM_MULTICOIN_CHUNKED" not in source:
+            raise RuntimeError("MPS source is missing the multicoin replay-state contract")
+        source = "#define PASSIVBOT_TM_MULTICOIN_CHUNKED 1\n" + source
     return torch.mps.compile_shader(source)
 
 
@@ -2527,7 +2535,16 @@ class MpsTrailingMartingaleMulticoinRunner(MpsEmaAnchorMulticoinRunner):
         btc_risk_enabled: bool | None = None,
         equity_balance_diff_enabled: bool = False,
         entry_interval_enabled: bool = False,
+        max_dispatch_candidate_bars: int | None = None,
+        interrupt_check=None,
     ):
+        if max_dispatch_candidate_bars is not None and max_dispatch_candidate_bars <= 0:
+            raise ValueError("max_dispatch_candidate_bars must be positive")
+        self.max_dispatch_candidate_bars = max_dispatch_candidate_bars
+        self.interrupt_check = interrupt_check or (lambda: None)
+        self._replay_state_bytes = None
+        self._replay_states = {}
+        self._last_temporal_dispatch = None
         super().__init__(
             run,
             data,
@@ -2584,6 +2601,7 @@ class MpsTrailingMartingaleMulticoinRunner(MpsEmaAnchorMulticoinRunner):
             self.btc_risk_enabled,
             self.equity_balance_diff_enabled,
             self.entry_interval_enabled,
+            self.max_dispatch_candidate_bars is not None,
         )
 
     def _dispatch(
@@ -2632,10 +2650,76 @@ class MpsTrailingMartingaleMulticoinRunner(MpsEmaAnchorMulticoinRunner):
         )
         if self.recovery_distribution_enabled:
             kernel_args += (recovery_samples,)
-        library.passivbot_trailing_martingale_multicoin(
-            *kernel_args,
-            threads=(batch_size, 1, 1),
+        if self.max_dispatch_candidate_bars is None:
+            library.passivbot_trailing_martingale_multicoin(
+                *kernel_args, threads=(batch_size, 1, 1)
+            )
+            return
+        chunk_bars = min(
+            MPS_TM_MULTICOIN_CHUNK_BARS,
+            MPS_TM_MULTICOIN_CHUNK_CANDIDATE_STEPS // batch_size,
+            self.max_dispatch_candidate_bars // (batch_size * self.n_coins),
         )
+        if chunk_bars < 1:
+            raise ValueError("MPS replay batch exceeds the per-dispatch work envelope")
+        if self._replay_state_bytes is None:
+            size = torch.empty(1, dtype=torch.int32, device="mps")
+            library.passivbot_tm_multicoin_replay_state_bytes(size, threads=1)
+            self._replay_state_bytes = int(size.item())
+        if batch_size not in self._replay_states:
+            self._replay_states = {
+                batch_size: torch.empty(
+                    (batch_size, self._replay_state_bytes),
+                    dtype=torch.uint8, device="mps",
+                )
+            }
+        replay_states = self._replay_states[batch_size]
+        stop_k = int(end_steps.max().item())
+        dispatch_count = 0
+        max_dispatch_seconds = 0.0
+        replay_started = time.perf_counter()
+        next_progress = replay_started + 30.0
+        for begin_k in range(1, max(2, stop_k), chunk_bars):
+            self.interrupt_check()
+            replay_range = torch.tensor(
+                [begin_k, min(begin_k + chunk_bars, stop_k)],
+                dtype=torch.int32, device="mps",
+            )
+            started = time.perf_counter()
+            library.passivbot_trailing_martingale_multicoin(
+                *kernel_args, replay_states, replay_range,
+                threads=(batch_size, 1, 1),
+            )
+            # Bound queued work as well as each command, and make Ctrl+C visible
+            # between temporal chunks even when profiling is disabled.
+            torch.mps.synchronize()
+            dispatch_count += 1
+            max_dispatch_seconds = max(
+                max_dispatch_seconds, time.perf_counter() - started
+            )
+            now = time.perf_counter()
+            completed_k = min(begin_k + chunk_bars, stop_k)
+            if now >= next_progress and completed_k < stop_k:
+                logging.info(
+                    "GPU temporal replay progress | candidates=%d bars=%d/%d elapsed=%.1fs",
+                    batch_size, completed_k - 1, stop_k - 1, now - replay_started,
+                )
+                next_progress = now + 30.0
+        self.interrupt_check()
+        self._last_temporal_dispatch = {
+            "dispatch_count": dispatch_count,
+            "temporal_chunk_bars": chunk_bars,
+            "max_dispatch_seconds": max_dispatch_seconds,
+            "kernel_candidate_steps": int((end_steps - 1).clamp(min=0).sum().item()),
+            "replay_state_bytes_per_candidate": self._replay_state_bytes,
+        }
+
+    def run(self, params, *, profile=False, end_steps=None):
+        self._last_temporal_dispatch = None
+        output = super().run(params, profile=profile, end_steps=end_steps)
+        if profile and self._last_temporal_dispatch is not None:
+            self.last_profile.update(self._last_temporal_dispatch)
+        return output
 
     def _decode(self, daily, scalars, gaps) -> dict:
         return _decode_outputs(daily, scalars, gaps)

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -29,6 +29,9 @@ from optimization.gpu.model import (
     GPU_STRATEGY_PARAM_KEYS,
     HSL_COIN_OVERRIDE_PATHS,
     MPS_MULTICOIN_MAX_COINS,
+    MPS_TM_MULTICOIN_CHUNK_BARS,
+    MPS_TM_MULTICOIN_CHUNK_CANDIDATE_STEPS,
+    MPS_TM_MULTICOIN_CHUNK_CANDIDATES,
     ProxyMarket,
     ProxyRun,
     TRAILING_MARTINGALE_COIN_OVERRIDE_ALLOWANCE_PCT_COLUMN,
@@ -340,8 +343,12 @@ def _add_gpu_runner_profile(
     if dispatch_specialization is not None:
         profile["dispatch_specializations"].append(dict(dispatch_specialization))
     profile["dispatch_count"] += dispatch_count
-    profile["cold_dispatch_count"] += dispatch_count if cold else 0
-    profile["warm_dispatch_count"] += 0 if cold else dispatch_count
+    cold_dispatches = (
+        int(cold) if "temporal_chunk_bars" in runner_profile
+        else dispatch_count if cold else 0
+    )
+    profile["cold_dispatch_count"] += cold_dispatches
+    profile["warm_dispatch_count"] += dispatch_count - cold_dispatches
     runner_steps = int(getattr(runner, "n", 0))
     if effective_candidate_steps is None:
         candidate_steps = batch_size * runner_steps
@@ -356,12 +363,20 @@ def _add_gpu_runner_profile(
         candidate_steps = int(
             np.clip(candidate_steps_array, 0, runner_steps).sum()
         )
+    # Temporal dispatches partition one replay; they do not repeat its history.
+    candidate_steps = int(runner_profile.get(
+        "kernel_candidate_steps", candidate_steps * dispatch_count
+    ))
     profile["kernel_candidate_bars"] += (
-        candidate_steps
-        * int(getattr(runner, "n_coins", 1))
-        * int(side_count)
-        * dispatch_count
+        candidate_steps * int(getattr(runner, "n_coins", 1)) * int(side_count)
     )
+    if "temporal_chunk_bars" in runner_profile:
+        profile.setdefault("temporal_dispatches", []).append({
+            key: runner_profile[key] for key in (
+                "dispatch_count", "temporal_chunk_bars", "max_dispatch_seconds",
+                "replay_state_bytes_per_candidate",
+            )
+        })
     timings = profile["timings_seconds"]
     timings["candidate_packing"] += float(
         runner_profile.get("cpu_pack_seconds", 0.0)
@@ -697,6 +712,39 @@ def _single_coin_candle_interval_minutes(backtest_params: dict) -> int:
             "integer >= 1"
         )
     return int(interval)
+
+
+def _mps_multicoin_dispatch_plan(
+    strategy_kind: str, requested_batch_size: int, *, n_bars: int, n_coins: int,
+    n_sides: int, max_candidate_bars: int,
+) -> tuple[bool, int, int]:
+    temporal_chunking = (
+        strategy_kind == "trailing_martingale"
+        and n_sides == 1
+        and n_bars > MPS_TM_MULTICOIN_CHUNK_BARS
+        and n_bars * n_coins * min(
+            requested_batch_size, MPS_TM_MULTICOIN_CHUNK_CANDIDATES
+        ) > max_candidate_bars
+    )
+    dispatch_candidates = (
+        min(requested_batch_size, MPS_TM_MULTICOIN_CHUNK_CANDIDATES)
+        if temporal_chunking else requested_batch_size
+    )
+    dispatch_history = (
+        min(
+            n_bars, MPS_TM_MULTICOIN_CHUNK_BARS,
+            MPS_TM_MULTICOIN_CHUNK_CANDIDATE_STEPS // dispatch_candidates,
+            max(1, max_candidate_bars // n_coins),
+        ) if temporal_chunking else n_bars
+    )
+    dispatch_batch_size = _mps_dispatch_batch_size(
+        dispatch_candidates,
+        n_bars=dispatch_history,
+        n_coins=n_coins,
+        n_sides=n_sides,
+        max_candidate_bars=max_candidate_bars,
+    )
+    return temporal_chunking, dispatch_batch_size, dispatch_history
 
 
 def _log_mps_dispatch_cap(
@@ -2896,21 +2944,29 @@ class MpsMulticoinProxy:
                 "MPS multicoin proxy requires one or two enabled sides"
             )
         self.sides = enabled_sides
-        self.dispatch_batch_size = _mps_dispatch_batch_size(
-            self.batch_size,
-            n_bars=len(values),
-            n_coins=coin_count,
-            n_sides=len(enabled_sides),
-            max_candidate_bars=self.max_dispatch_candidate_bars,
+        self.temporal_chunking, self.dispatch_batch_size, dispatch_history = (
+            _mps_multicoin_dispatch_plan(
+                self.strategy_kind, self.batch_size, n_bars=len(values),
+                n_coins=coin_count, n_sides=len(enabled_sides),
+                max_candidate_bars=self.max_dispatch_candidate_bars,
+            )
         )
-        _log_mps_dispatch_cap(
-            requested_batch_size=self.batch_size,
-            dispatch_batch_size=self.dispatch_batch_size,
-            n_bars=len(values),
-            n_coins=coin_count,
-            n_sides=len(enabled_sides),
-            max_candidate_bars=self.max_dispatch_candidate_bars,
-        )
+        if self.temporal_chunking:
+            logging.info(
+                "GPU MPS temporal replay | candidate_batch=%d chunk_bars<=%d "
+                "history_bars=%d coins=%d max_candidate_bars=%d",
+                self.dispatch_batch_size, dispatch_history, len(values), coin_count,
+                self.max_dispatch_candidate_bars,
+            )
+        else:
+            _log_mps_dispatch_cap(
+                requested_batch_size=self.batch_size,
+                dispatch_batch_size=self.dispatch_batch_size,
+                n_bars=len(values),
+                n_coins=coin_count,
+                n_sides=len(enabled_sides),
+                max_candidate_bars=self.max_dispatch_candidate_bars,
+            )
         self.shared_account_fused = len(self.sides) == 2
         self.shared_account_proxy_mode = (
             "shared-account-fused-tm-v1"
@@ -3349,6 +3405,9 @@ class MpsMulticoinProxy:
                     **common_runner_kwargs,
                 }
                 runner_kwargs["coin_overrides"] = per_side_coin_overrides[side]
+                if self.temporal_chunking:
+                    runner_kwargs["max_dispatch_candidate_bars"] = self.max_dispatch_candidate_bars
+                    runner_kwargs["interrupt_check"] = self.interrupt_check
                 self.runners[side] = runner_cls(
                     self.run,
                     self.data,

--- a/src/tools/gpu_proxy_benchmark.py
+++ b/src/tools/gpu_proxy_benchmark.py
@@ -16,6 +16,7 @@ from optimization.gpu.model import (
     EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS,
     ProxyMarket,
     ProxyRun,
+    TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS,
     TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS,
     build_mps_data,
     build_mps_multicoin_data,
@@ -30,6 +31,7 @@ CASES = (
     "tm-single-long-hsl",
     "ema-multicoin-overhead",
     "ema-multicoin-overrides",
+    "tm-multicoin-overhead",
 )
 SINGLE_COIN_CASES = frozenset(
     {
@@ -263,6 +265,7 @@ def _build_case(
         MpsEmaAnchorMulticoinRunner,
         MpsEmaAnchorRunner,
         MpsTrailingMartingaleRunner,
+        MpsTrailingMartingaleMulticoinRunner,
     )
     from optimization.gpu.metrics import compute_objectives
     from optimization.gpu.service import (
@@ -401,13 +404,24 @@ def _build_case(
         overrides[0, EMA_ANCHOR_COIN_OVERRIDE_WALLET_EXPOSURE_COLUMN] = 0.5
         if coins > 1:
             overrides[1, 0] = 0.04
-    runner = MpsEmaAnchorMulticoinRunner(
+    tm_multicoin = name == "tm-multicoin-overhead"
+    runner_cls = (
+        MpsTrailingMartingaleMulticoinRunner
+        if tm_multicoin else MpsEmaAnchorMulticoinRunner
+    )
+    param_keys = (
+        TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS
+        if tm_multicoin else EMA_ANCHOR_MULTICOIN_PARAM_KEYS
+    )
+    runner = runner_cls(
         runs[0],
         data,
         side="long",
         coin_overrides=overrides,
+        **({"max_dispatch_candidate_bars": MAX_DISPATCH_CANDIDATE_BARS}
+           if tm_multicoin else {}),
     )
-    matrix = _parameter_matrix(EMA_ANCHOR_MULTICOIN_PARAM_KEYS, candidates, seed)
+    matrix = _parameter_matrix(param_keys, candidates, seed)
     proxy = MpsMulticoinProxy.__new__(MpsMulticoinProxy)
     proxy.batch_size = candidates
     proxy.dispatch_batch_size = dispatch_batch_size
@@ -419,12 +433,12 @@ def _build_case(
     proxy.run = runs[0]
     proxy.sides = ["long"]
     proxy.needed_metrics = needed_metrics
-    proxy.strategy_kind = "ema_anchor"
+    proxy.strategy_kind = "trailing_martingale" if tm_multicoin else "ema_anchor"
     proxy.entry_interval_enabled = False
     proxy.btc_analysis_enabled = False
     proxy.btc_risk_enabled = False
     proxy.equity_balance_diff_enabled = False
-    proxy.param_keys = EMA_ANCHOR_MULTICOIN_PARAM_KEYS
+    proxy.param_keys = param_keys
     proxy.base_params = {"long": {key: base_values[key] for key in proxy.param_keys}}
     proxy.base_total_wallet_exposure_limits = {"long": 1.0, "short": 0.0}
     proxy.base_n_positions = {"long": 4.0, "short": 0.0}

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -5673,6 +5673,107 @@ def _multicoin_exposure_fixture(
     return runner, row
 
 
+@pytest.mark.skipif(not torch.backends.mps.is_available(), reason="Apple MPS unavailable")
+@pytest.mark.parametrize("side", ["long", "short"])
+@pytest.mark.parametrize("features", [False, True])
+def test_tm_multicoin_temporal_replay_preserves_every_output(side, features):
+    from optimization.gpu.mps_kernel import MpsTrailingMartingaleMulticoinRunner
+
+    count = 1513
+    steps = np.arange(count)
+    closes = np.column_stack([
+        base * (1 + 0.12 * np.sin(steps / 37.0 + coin))
+        for coin, base in enumerate((100.0, 120.0))
+    ])
+    _, row, run, data = _multicoin_exposure_fixture(
+        "trailing_martingale", side, count=count, closes=closes,
+        requested_start_index=31,
+        return_context=True,
+    )
+    if features:
+        for key, value in (
+            ("hsl_enabled", 1.0), ("hsl_signal_mode", 2.0),
+            ("hsl_red_threshold", 0.02), ("hsl_ema_span_minutes", 1.0),
+            ("hsl_cooldown_minutes_after_red", 3.0),
+        ):
+            row[TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS.index(key)] = value
+    kwargs = dict(
+        side=side, collect_coin_fill_counts=True,
+        recovery_distribution_enabled=features, entry_interval_enabled=features,
+        hsl_ema_tail_enabled=features, hsl_raw_drawdown_enabled=features,
+        hsl_raw_tail_enabled=features, btc_risk_enabled=features,
+        equity_balance_diff_enabled=features,
+        btc_prices=30_000.0 + steps if features else None,
+    )
+    generic = MpsTrailingMartingaleMulticoinRunner(run, data, **kwargs)
+    # Include empty and early-finished candidates alongside a full replay. The
+    # boundary crosses activation, hours, UTC days, and HSL episodes.
+    params = np.asarray([row] * 3, dtype=np.float64)
+    ends = np.asarray([1, 123, count - 1], dtype=np.int32)
+    expected = generic.run(params, end_steps=ends)
+    expected = {key: value.cpu().clone() if isinstance(value, torch.Tensor) else value
+                for key, value in expected.items()}
+    chunked = MpsTrailingMartingaleMulticoinRunner(
+        run, data, max_dispatch_candidate_bars=3 * 2 * 47, **kwargs
+    )
+    for _ in range(2):
+        actual = chunked.run(params, profile=True, end_steps=ends)
+        assert actual.keys() == expected.keys()
+        for key, value in actual.items():
+            if isinstance(value, torch.Tensor):
+                torch.testing.assert_close(value.cpu(), expected[key], rtol=0, atol=0, equal_nan=True)
+            else:
+                assert value == expected[key]
+        assert chunked.last_profile["dispatch_count"] == 33
+        assert chunked.last_profile["kernel_candidate_steps"] == int((ends - 1).sum())
+        assert chunked.last_profile["temporal_chunk_bars"] == 47
+
+
+@pytest.mark.skipif(not torch.backends.mps.is_available(), reason="Apple MPS unavailable")
+def test_tm_multicoin_temporal_replay_interrupt_does_not_leak_partial_state():
+    from optimization.gpu.mps_kernel import MpsTrailingMartingaleMulticoinRunner
+
+    generic, row, run, data = _multicoin_exposure_fixture(
+        "trailing_martingale", "long", return_context=True
+    )
+    matrix = np.asarray([row], dtype=np.float64)
+    expected = {key: value.cpu().clone() for key, value in generic.run(matrix).items()}
+    calls = 0
+
+    def interrupt():
+        nonlocal calls
+        calls += 1
+        if calls == 3:
+            raise InterruptedError("test interruption")
+
+    chunked = MpsTrailingMartingaleMulticoinRunner(
+        run, data, side="long", max_dispatch_candidate_bars=2 * 7,
+        interrupt_check=interrupt,
+    )
+    with pytest.raises(InterruptedError, match="test interruption"):
+        chunked.run(matrix)
+    chunked.interrupt_check = lambda: None
+    actual = chunked.run(matrix)
+    for key, value in actual.items():
+        torch.testing.assert_close(value.cpu(), expected[key], rtol=0, atol=0, equal_nan=True)
+
+
+@pytest.mark.skipif(not torch.backends.mps.is_available(), reason="Apple MPS unavailable")
+def test_tm_multicoin_temporal_replay_preserves_unavailable_valuation():
+    from optimization.gpu.mps_kernel import MpsTrailingMartingaleMulticoinRunner
+
+    generic, row, run, data = _multicoin_exposure_fixture(
+        "trailing_martingale", "long", count=64, last_valid_indices=(24, 63),
+        return_context=True,
+    )
+    chunked = MpsTrailingMartingaleMulticoinRunner(
+        run, data, side="long", max_dispatch_candidate_bars=2 * 7,
+    )
+    for runner in (generic, chunked):
+        with pytest.raises(ValueError, match="unavailable held-position valuation"):
+            runner.run(np.asarray([row], dtype=np.float64))
+
+
 @pytest.mark.skipif(
     not torch.backends.mps.is_available(), reason="Apple MPS unavailable"
 )

--- a/tests/optimization/test_gpu_proxy_benchmark.py
+++ b/tests/optimization/test_gpu_proxy_benchmark.py
@@ -7,6 +7,7 @@ from optimization.gpu.model import (
     EMA_ANCHOR_MULTICOIN_PARAM_KEYS,
     EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS,
     TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS,
+    TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS,
 )
 from tools.gpu_proxy_benchmark import (
     HSL_PNL_LOOKBACK_BARS,
@@ -30,6 +31,7 @@ from tools.gpu_proxy_benchmark import (
         EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS,
         TRAILING_MARTINGALE_SINGLE_COIN_PARAM_KEYS,
         EMA_ANCHOR_MULTICOIN_PARAM_KEYS,
+        TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS,
     ),
 )
 def test_gpu_proxy_benchmark_candidate_matrix_is_fixed_and_finite(keys):

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -48,6 +48,7 @@ from optimization.gpu.service import (
     _hsl_params,
     _hsl_diagnostics_needed,
     _mps_dispatch_batch_size,
+    _mps_multicoin_dispatch_plan,
     _mps_strategy_eq_recovery_distribution,
     _new_gpu_dispatch_progress,
     _new_gpu_proxy_profile,
@@ -406,6 +407,27 @@ def test_single_coin_shader_topology_is_fail_closed(
     )
 
 
+@pytest.mark.parametrize("strategy,batch,bars,sides,cap,expected", [
+    ("trailing_martingale", 4096, 900000, 1, 1_000_000_000, (True, 512, 4096)),
+    ("trailing_martingale", 4096, 60000, 1, 1_000_000_000, (False, 574, 60000)),
+    ("trailing_martingale", 4096, 4320, 1, 1_000_000_000, (False, 4096, 4320)),
+    ("trailing_martingale", 16, 900000, 1, 1_000_000_000, (False, 16, 900000)),
+    ("trailing_martingale", 4096, 900000, 2, 1_000_000_000, (False, 19, 900000)),
+    ("ema_anchor", 4096, 900000, 1, 1_000_000_000, (False, 38, 900000)),
+    ("trailing_martingale", 4096, 900000, 1, 100, (True, 1, 3)),
+])
+def test_mps_multicoin_temporal_plan_preserves_work_limit(
+    strategy, batch, bars, sides, cap, expected
+):
+    result = _mps_multicoin_dispatch_plan(
+        strategy, batch, n_bars=bars, n_coins=29, n_sides=sides,
+        max_candidate_bars=cap,
+    )
+    assert result == expected
+    _, candidate_batch, history_chunk = result
+    assert candidate_batch * history_chunk * 29 * sides <= cap
+
+
 def test_mps_dispatch_batch_size_bounds_single_and_multicoin_work():
     n_bars = 1_923_175
 
@@ -737,6 +759,24 @@ def test_gpu_profile_candidate_bars_include_coin_and_side_topology():
 
     assert profile["candidate_bars"] == 1_600
     assert profile["kernel_candidate_bars"] == 1_600
+
+
+def test_gpu_profile_temporal_dispatches_count_replayed_steps_once():
+    proxy = SimpleNamespace(batch_size=256, dispatch_batch_size=256,
+                            strategy_kind="trailing_martingale")
+    runner = SimpleNamespace(n=60_000, n_coins=29, last_profile={
+        "batch_size": 256, "dispatch_count": 8, "cold": True,
+        "kernel_candidate_steps": 256 * 59_999, "temporal_chunk_bars": 8192,
+        "max_dispatch_seconds": 4.0, "replay_state_bytes_per_candidate": 29_296,
+    })
+    profile = _new_gpu_proxy_profile(proxy, [{}] * 256, (runner,), coin_count=29,
+                                     side_count=1)
+    _add_gpu_runner_profile(profile, runner)
+    assert profile["kernel_candidate_bars"] == 256 * 59_999 * 29
+    assert profile["dispatch_count"] == 8
+    assert profile["cold_dispatch_count"] == 1
+    assert profile["warm_dispatch_count"] == 7
+    assert profile["temporal_dispatches"][0]["max_dispatch_seconds"] == 4.0
 
 
 def test_gpu_profile_candidate_bars_use_truncated_effective_steps():


### PR DESCRIPTION
Long histories can make the MPS work cap admit too few candidates to use the GPU efficiently. For example, a one-billion candidate-bar cap admits only 31 candidates over one million bars and 32 coins.

The single-side multicoin Trailing Martingale runner now preserves complete replay state between synchronized history chunks. When full-history dispatches would constrain parallelism, it advances up to 512 candidates together, shortening history chunks as batches grow while respecting the existing work cap. Finalization and scoring still happen only after each candidate reaches its actual end step. Shorter workloads and dual-side portfolios retain their existing dispatch path.

The change also checks interruption between chunks, reports temporal dispatch timing without double-counting replayed history, and adds a reproducible synthetic multicoin Trailing Martingale benchmark case.

Validation:
- 969 focused Python tests passed; 679 device-dependent tests were skipped in that pass.
- 11 focused Metal tests passed on Apple Silicon, including exact equality against uninterrupted replay across HSL and optional metrics, variable end steps, reset after interruption, and unavailable valuation.
- All 289 Rust tests passed; `cargo check --tests` passed; rebuilt extension fingerprint verified.
- Synthetic CLI smoke: `passivbot tool gpu-proxy-benchmark --case tm-multicoin-overhead --candidates 16 --coins 3 --multicoin-bars 10000 --warm-runs 1 --compact`.
- Documentation checks and six documentation tests passed; existing documentation-size advisories remain.
