### PR TITLE
Reduce GPU suite memory use and improve MPS replay scheduling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- GPU suite optimization shares identical prepared MPS market tensors across scenarios, reducing
+  memory use and repeated preparation. Long-history single-side Trailing Martingale replays use
+  smaller threadgroups for higher throughput while retaining bounded, interruptible dispatches.
+
 - Apple MPS multi-coin Trailing Martingale optimization uses bounded history chunks when long
   datasets would otherwise restrict candidate parallelism. Replays preserve their full strategy
   and metric state between dispatches, retain the configured work limit, and check interruption

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -831,13 +831,19 @@ dispatch cap would admit fewer than 512 candidates (or the requested batch size,
 Each dispatch processes at most 8,192 bars, shortening to 4,096 for a full 512-candidate batch,
 and stays within `max_dispatch_candidate_bars`; the
 runner synchronizes and checks interruption between dispatches. Up to 512 candidates can then
-advance together. Every candidate still processes its complete history, and exact Rust validation
+advance together, scheduled in groups of at most 32 threads to distribute independent replays
+across GPU cores. Every candidate still processes its complete history, and exact Rust validation
 remains authoritative. Shorter workloads and dual-side portfolios retain their existing dispatch
 path.
 
+Suite scenarios with identical candle contents, timelines, market settings, and prepared replay
+boundaries share their immutable MPS market tensors. Strategy parameters, output buffers, and replay
+state remain separate for every scenario. Reuse is logged during preparation and lasts only for
+that optimizer run; differing fees, validity windows, or candle contents require separate tensors.
+
 Temporal replay profiling includes `temporal_dispatches`, with chunk lengths, replay-state memory,
-and `max_dispatch_seconds`. These are portions of one replay; candidate-bar totals count each
-processed step once.
+`threads_per_threadgroup`, and `max_dispatch_seconds`. These are portions of one replay;
+candidate-bar totals count each processed step once.
 
 Set `PASSIVBOT_GPU_PROFILE=1` to emit structured `[gpu-profile]` JSON records. Profiling is disabled
 by default because its synchronization points deliberately trade throughput for trustworthy phase

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -4510,6 +4510,7 @@ def run_backend(
 
     if suite_enabled:
         scenario_proxy_groups = {}
+        prepared_mps_data = {}
         for item in suite_inputs:
             scenario_proxy = (
                 MpsMulticoinProxy
@@ -4528,6 +4529,10 @@ def run_backend(
                 ),
                 needed_metrics=needed_metrics,
                 interrupt_check=interrupt_check,
+                **(
+                    {"prepared_data_cache": prepared_mps_data}
+                    if item["coin_count"] > 1 else {}
+                ),
             )
             item["coin_override_contract"] = getattr(
                 scenario_proxy, "coin_override_contract", {}

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -2679,6 +2679,9 @@ class MpsTrailingMartingaleMulticoinRunner(MpsEmaAnchorMulticoinRunner):
         max_dispatch_seconds = 0.0
         replay_started = time.perf_counter()
         next_progress = replay_started + 30.0
+        # One SIMD-width group distributes independent, state-heavy replays
+        # across GPU cores instead of packing the batch into a large group.
+        threads_per_threadgroup = min(batch_size, 32)
         for begin_k in range(1, max(2, stop_k), chunk_bars):
             self.interrupt_check()
             replay_range = torch.tensor(
@@ -2689,6 +2692,7 @@ class MpsTrailingMartingaleMulticoinRunner(MpsEmaAnchorMulticoinRunner):
             library.passivbot_trailing_martingale_multicoin(
                 *kernel_args, replay_states, replay_range,
                 threads=(batch_size, 1, 1),
+                group_size=(threads_per_threadgroup, 1, 1),
             )
             # Bound queued work as well as each command, and make Ctrl+C visible
             # between temporal chunks even when profiling is disabled.
@@ -2709,6 +2713,7 @@ class MpsTrailingMartingaleMulticoinRunner(MpsEmaAnchorMulticoinRunner):
         self._last_temporal_dispatch = {
             "dispatch_count": dispatch_count,
             "temporal_chunk_bars": chunk_bars,
+            "threads_per_threadgroup": threads_per_threadgroup,
             "max_dispatch_seconds": max_dispatch_seconds,
             "kernel_candidate_steps": int((end_steps - 1).clamp(min=0).sum().item()),
             "replay_state_bytes_per_candidate": self._replay_state_bytes,

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -374,7 +374,7 @@ def _add_gpu_runner_profile(
         profile.setdefault("temporal_dispatches", []).append({
             key: runner_profile[key] for key in (
                 "dispatch_count", "temporal_chunk_bars", "max_dispatch_seconds",
-                "replay_state_bytes_per_candidate",
+                "replay_state_bytes_per_candidate", "threads_per_threadgroup",
             )
         })
     timings = profile["timings_seconds"]
@@ -2839,6 +2839,33 @@ def _build_single_coin_override_params(
     )
 
 
+def _prepared_multicoin_data(
+    values, timestamps, *, runs, markets, checkpoint_contract, cache=None,
+):
+    """Share immutable suite tensors only for identical validated packing inputs."""
+    candles = checkpoint_contract["hlcvs"]
+    timeline = checkpoint_contract["timestamps"]
+    key = (
+        tuple(checkpoint_contract["coins"]),
+        tuple(candles["shape"]), candles["dtype"], candles["sha256"],
+        timeline["count"], timeline["first"], timeline["last"], timeline["sha256"],
+        tuple(runs), tuple(markets),
+    )
+    if cache is not None and key in cache:
+        data = cache[key]
+        logging.info(
+            "GPU suite reusing prepared MPS market tensors | coins=%d bars=%d saved=%.2f GiB",
+            data["n_coins"], data["n"], data["invariant_bytes"] / 2**30,
+        )
+        return data
+    data = build_mps_multicoin_data(
+        values, timestamps, runs=runs, markets=markets, include_hourly_ranges=True,
+    )
+    if cache is not None:
+        cache[key] = data
+    return data
+
+
 class MpsMulticoinProxy:
     """Batched multi-coin MPS proxy for the supported strategy topology."""
 
@@ -2855,6 +2882,7 @@ class MpsMulticoinProxy:
         needed_metrics,
         interrupt_check=None,
         max_dispatch_candidate_bars: int = MPS_MAX_DISPATCH_CANDIDATE_BARS,
+        prepared_data_cache: dict | None = None,
     ):
         try:
             import torch
@@ -3292,12 +3320,9 @@ class MpsMulticoinProxy:
             last_valid_indices=backtest_params["last_valid_indices"],
             require_positive_high_low=True,
         )
-        self.data = build_mps_multicoin_data(
-            values,
-            timestamps,
-            runs=runs,
-            markets=markets,
-            include_hourly_ranges=True,
+        self.data = _prepared_multicoin_data(
+            values, timestamps, runs=runs, markets=markets,
+            checkpoint_contract=self.checkpoint_contract, cache=prepared_data_cache,
         )
         self.metrics_data = {
             "ts0": self.data["ts0"],

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -5676,7 +5676,8 @@ def _multicoin_exposure_fixture(
 @pytest.mark.skipif(not torch.backends.mps.is_available(), reason="Apple MPS unavailable")
 @pytest.mark.parametrize("side", ["long", "short"])
 @pytest.mark.parametrize("features", [False, True])
-def test_tm_multicoin_temporal_replay_preserves_every_output(side, features):
+@pytest.mark.parametrize("batch_size", [3, 35])
+def test_tm_multicoin_temporal_replay_preserves_every_output(side, features, batch_size):
     from optimization.gpu.mps_kernel import MpsTrailingMartingaleMulticoinRunner
 
     count = 1513
@@ -5708,13 +5709,13 @@ def test_tm_multicoin_temporal_replay_preserves_every_output(side, features):
     generic = MpsTrailingMartingaleMulticoinRunner(run, data, **kwargs)
     # Include empty and early-finished candidates alongside a full replay. The
     # boundary crosses activation, hours, UTC days, and HSL episodes.
-    params = np.asarray([row] * 3, dtype=np.float64)
-    ends = np.asarray([1, 123, count - 1], dtype=np.int32)
+    params = np.asarray([row] * batch_size, dtype=np.float64)
+    ends = np.resize(np.asarray([1, 123, count - 1], dtype=np.int32), batch_size)
     expected = generic.run(params, end_steps=ends)
     expected = {key: value.cpu().clone() if isinstance(value, torch.Tensor) else value
                 for key, value in expected.items()}
     chunked = MpsTrailingMartingaleMulticoinRunner(
-        run, data, max_dispatch_candidate_bars=3 * 2 * 47, **kwargs
+        run, data, max_dispatch_candidate_bars=batch_size * 2 * 47, **kwargs
     )
     for _ in range(2):
         actual = chunked.run(params, profile=True, end_steps=ends)
@@ -5727,6 +5728,7 @@ def test_tm_multicoin_temporal_replay_preserves_every_output(side, features):
         assert chunked.last_profile["dispatch_count"] == 33
         assert chunked.last_profile["kernel_candidate_steps"] == int((ends - 1).sum())
         assert chunked.last_profile["temporal_chunk_bars"] == 47
+        assert chunked.last_profile["threads_per_threadgroup"] == min(batch_size, 32)
 
 
 @pytest.mark.skipif(not torch.backends.mps.is_available(), reason="Apple MPS unavailable")

--- a/tests/optimization/test_gpu_prepared_data.py
+++ b/tests/optimization/test_gpu_prepared_data.py
@@ -1,0 +1,99 @@
+"""Suite market tensors are reusable; candidate/replay state is not cached."""
+from copy import deepcopy
+from dataclasses import replace
+
+import pytest
+
+from optimization.gpu import service
+from optimization.gpu.model import ProxyMarket, ProxyRun
+
+
+def _inputs():
+    return dict(
+        values=object(), timestamps=object(),
+        runs=[ProxyRun(1000, 1, 1, 0, 0, 0, 60000, 0.05, 0, 9)] * 2,
+        markets=[ProxyMarket(0.01, 0.1, 0.01, 1, 1, 0.0002)] * 2,
+        checkpoint_contract={
+            "coins": ["A", "B"],
+            "hlcvs": {"shape": [10, 2, 4], "dtype": "<f8", "sha256": "candles"},
+            "timestamps": {"count": 10, "first": 0, "last": 540000, "sha256": "timeline"},
+            "base_params": {"n_positions": 1},
+        },
+    )
+
+
+@pytest.fixture
+def builds(monkeypatch):
+    calls = []
+    def build(*args, **kwargs):
+        result = dict(n_coins=2, n=10, invariant_bytes=1024, token=object())
+        calls.append((args, kwargs, result))
+        return result
+    monkeypatch.setattr(service, "build_mps_multicoin_data", build)
+    return calls
+
+
+def test_suite_prepared_data_reuses_equal_content_across_scenario_params(builds):
+    cache = {}
+    inputs = _inputs()
+    first = service._prepared_multicoin_data(**inputs, cache=cache)
+    other = _inputs()  # Different input objects with the same validated content identity.
+    other["checkpoint_contract"]["base_params"]["n_positions"] = 2
+    assert service._prepared_multicoin_data(**other, cache=cache) is first
+    assert len(builds) == 1
+    assert builds[0][1]["include_hourly_ranges"] is True
+
+
+@pytest.mark.parametrize("field", ["coins", "shape", "dtype", "candles", "timeline", "count", "first", "last"])
+def test_suite_prepared_data_rejects_changed_dataset_identity(builds, field):
+    inputs = _inputs()
+    cache = {}
+    first = service._prepared_multicoin_data(**inputs, cache=cache)
+    changed = deepcopy(inputs)
+    contract = changed["checkpoint_contract"]
+    if field == "coins":
+        contract["coins"].reverse()
+    elif field == "shape":
+        contract["hlcvs"]["shape"] = [10, 2, 5]
+    elif field == "dtype":
+        contract["hlcvs"]["dtype"] = "<f4"
+    elif field == "candles":
+        contract["hlcvs"]["sha256"] = "changed"
+    elif field == "timeline":
+        contract["timestamps"]["sha256"] = "changed"
+    else:
+        contract["timestamps"][field] += 1
+    assert service._prepared_multicoin_data(**changed, cache=cache) is not first
+    assert len(builds) == 2
+
+
+@pytest.mark.parametrize("kind,field", [
+    ("runs", field) for field in ProxyRun.__dataclass_fields__
+] + [("markets", field) for field in ProxyMarket.__dataclass_fields__])
+def test_suite_prepared_data_rejects_changed_run_or_market_settings(builds, kind, field):
+    inputs = _inputs()
+    cache = {}
+    first = service._prepared_multicoin_data(**inputs, cache=cache)
+    changed = deepcopy(inputs)
+    row = changed[kind][1]
+    changed[kind][1] = replace(row, **{field: getattr(row, field) + 1})
+    assert service._prepared_multicoin_data(**changed, cache=cache) is not first
+    assert len(builds) == 2
+
+
+def test_prepared_data_cache_is_optional_and_scoped_to_its_suite(builds):
+    first = service._prepared_multicoin_data(**_inputs(), cache={})
+    second = service._prepared_multicoin_data(**_inputs(), cache={})
+    third = service._prepared_multicoin_data(**_inputs())
+    assert first is not second and second is not third
+    assert len(builds) == 3
+
+
+def test_failed_preparation_never_publishes_cache_entry(monkeypatch):
+    def fail(*args, **kwargs):
+        raise ValueError("invalid candles")
+    monkeypatch.setattr(service, "build_mps_multicoin_data", fail)
+    cache = {}
+    with pytest.raises(ValueError, match="invalid candles"):
+        service._prepared_multicoin_data(**_inputs(), cache=cache)
+    assert cache == {}

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -768,6 +768,7 @@ def test_gpu_profile_temporal_dispatches_count_replayed_steps_once():
         "batch_size": 256, "dispatch_count": 8, "cold": True,
         "kernel_candidate_steps": 256 * 59_999, "temporal_chunk_bars": 8192,
         "max_dispatch_seconds": 4.0, "replay_state_bytes_per_candidate": 29_296,
+        "threads_per_threadgroup": 32,
     })
     profile = _new_gpu_proxy_profile(proxy, [{}] * 256, (runner,), coin_count=29,
                                      side_count=1)
@@ -777,6 +778,7 @@ def test_gpu_profile_temporal_dispatches_count_replayed_steps_once():
     assert profile["cold_dispatch_count"] == 1
     assert profile["warm_dispatch_count"] == 7
     assert profile["temporal_dispatches"][0]["max_dispatch_seconds"] == 4.0
+    assert profile["temporal_dispatches"][0]["threads_per_threadgroup"] == 32
 
 
 def test_gpu_profile_candidate_bars_use_truncated_effective_steps():


### PR DESCRIPTION
GPU suite scenarios currently rebuild and retain separate MPS candle/tick tensors even when their market inputs are identical. A suite-local cache now reuses those immutable tensors, keyed by their existing content fingerprints, ordered coins, timestamps, and complete run/market settings. Scenario parameters, output buffers, and replay state remain independent; changed fees, validity windows, or candle contents require a separate dataset.

Long-history single-side Trailing Martingale replays also dispatch in groups of at most 32 threads to improve throughput. Candidate counts, history lengths, per-dispatch work limits, synchronization, and interruption checks are preserved. Temporal profiling includes the threadgroup size. Rust strategy logic and scoring are unchanged.

Validation: 899 Python tests passed; 12 focused Metal tests passed, including exact replay equality for long/short and partial threadgroups. Added cache invalidation and failure-publication coverage. Documentation checks passed.
