### PR TITLE
Skip unavailable live coin overrides and improve crash diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Live startup skips unavailable coin overrides with a bounded notice and retries resolution on
+  market refresh. Inactive-market overrides and protection of existing positions remain intact;
+  an empty eligible market set no longer admits unsupported approved coins.
+- Unexpected failures that abort a bot run show bounded traceback frames, the failing phase,
+  and stop/restart action at normal console logging levels. Known missing market keys are shown
+  without exposing raw exception payloads or locals. Repeated startup failures share traceback
+  suppression across restarts, with periodic counts and a recovery notice after successful startup.
+
 - Apple MPS multi-coin Trailing Martingale optimization uses bounded history chunks when long
   datasets would otherwise restrict candidate parallelism. Replays preserve their full strategy
   and metric state between dispatches, retain the configured work limit, and check interruption

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ All notable user-facing changes will be documented in this file.
   market refresh. Inactive-market overrides and protection of existing positions remain intact;
   an empty eligible market set no longer admits unsupported approved coins.
 - Unexpected failures that abort a bot run show bounded traceback frames, the failing phase,
-  and stop/restart action at normal console logging levels. Known missing market keys are shown
+  and stop/restart action at normal console logging levels, including failures before bot
+  construction. Known missing market keys are shown
   without exposing raw exception payloads or locals. Repeated startup failures share traceback
   suppression across restarts, with periodic counts and a recovery notice after successful startup.
 

--- a/docs/ai/features/exchange_integrations.md
+++ b/docs/ai/features/exchange_integrations.md
@@ -720,6 +720,20 @@ Handling:
 
 Primary reference: [WEEX V3 trade-detail API](https://www.weex.com/api-doc/contract/Transaction_API/GetTradeDetails).
 
+## Unavailable Configured Live Markets
+
+Live coin overrides are resolved against the current exchange market snapshot before downstream
+mode or sizing lookups. Skip an unavailable market (including an exact identifier classified as
+`UnknownMarketIdentifier`) with a bounded notice on change, retaining the original config so the
+next market refresh can reconsider it. Do not synthesize an active market or change the shared
+resolver's historical/backtest behavior. Ambiguous identifiers, conflicting overrides, and other
+resolution failures still propagate; a failed refresh must not publish a partial override map.
+
+An inactive market is not an absent market: retain its overrides and existing protective-mode
+handling. Never drop exchange positions or open orders because their coin is unavailable in config;
+missing market metadata for such state remains an explicit failure. Approved-list filtering also
+applies when the eligible market set is empty.
+
 ## General Guidance
 
 1. Check raw exchange payloads when CCXT abstraction is insufficient.

--- a/docs/ai/features/exchange_integrations.md
+++ b/docs/ai/features/exchange_integrations.md
@@ -733,6 +733,8 @@ An inactive market is not an absent market: retain its overrides and existing pr
 handling. Never drop exchange positions or open orders because their coin is unavailable in config;
 missing market metadata for such state remains an explicit failure. Approved-list filtering also
 applies when the eligible market set is empty.
+Connector-specific live-state hooks must run the shared base validation before any connector
+early return, including Hyperliquid unified-account support.
 
 ## General Guidance
 

--- a/docs/ai/logging_policy.md
+++ b/docs/ai/logging_policy.md
@@ -35,8 +35,12 @@ authentication material must not be copied from its configured credential store 
 
 - Connector-local and structured execution events retain stable classifications, bounded context,
   and exception type—not raw responses, exception text, or tracebacks.
-- Outer process/startup failure logs may include a traceback in the protected developer text log
-  when needed for diagnosis, but should sanitize known request and credential material first.
+- Unexpected failures that abort startup or a running bot emit a bounded traceback at ERROR in
+  the console and text log. Reuse the diagnostic frame formatter: retain exception classes,
+  cause/context chains, file names, functions, and line numbers, without locals, source lines,
+  or raw exception text. A missing market key may be shown only when its syntax is bounded and
+  it independently exists in the bot's market, override, position, or open-order map; arbitrary
+  exception arguments are not safe merely because the exception is a built-in Python type.
 - Unexpected runtime incidents must retain a correlated, bounded frame chain in a private durable
   diagnostic event at normal logging levels. Frame diagnostics exclude exception text, locals, and
   source lines unless a producer has an explicitly reviewed sanitizer for those values; a rare
@@ -104,16 +108,22 @@ test values on both sides; the console sink must not invent a generic threshold 
 
 ### Incident Projection
 
-The normal console projects an incident as a bounded signature, not a traceback:
+Recoverable incidents use a bounded signature. Unexpected failures that abort a run additionally
+show diagnostic frames:
 
 1. Emit the first occurrence immediately with component, operation, exception class, status/code
    when safe, affected scope, action, and correlation id. Failed exchange writes may also include
    a bounded sanitized reason extracted from the exchange's structured error payload.
 2. Aggregate equivalent repeats and emit a compact count at most every five minutes. Emit recovery
    once when the condition clears.
-3. Keep sanitized tracebacks in the protected developer text/structured diagnostic path at normal
-   logging levels. A terminal outer-process failure may tell the operator where that detail was
-   retained, but must not dump it into the normal console.
+3. Keep bounded frame chains in the durable diagnostic path at normal logging levels. For an
+   unexpected run-aborting failure, also print the frame chain on the console, with the original
+   failing phase, stop/restart action, and the startup incident ID when available. Preserve phase
+   context before teardown changes observer state. Identical restart failures share suppression
+   across bot instances: print the first trace, then a repeat count at most every five minutes.
+   A changed failure prints immediately; successful startup clears suppression and reports recovery.
+   Expected restart control flow does not need a traceback. Do not change retry or stop policy
+   merely to improve diagnostics.
 
 Distinct safety transitions and distinct failed exchange writes are never coalesced merely to meet
 a volume target.

--- a/docs/ai/logging_policy.md
+++ b/docs/ai/logging_policy.md
@@ -41,6 +41,10 @@ authentication material must not be copied from its configured credential store 
   or raw exception text. A missing market key may be shown only when its syntax is bounded and
   it independently exists in the bot's market, override, position, or open-order map; arbitrary
   exception arguments are not safe merely because the exception is a built-in Python type.
+  This boundary includes configuration preparation, initial public metadata loading, and bot
+  construction before the restart loop. Failures there retain a nonzero terminal exit, with a
+  process incident ID and phase, rather than leaking a second interpreter traceback. CLI help,
+  argument-parser exits, and requested interruption retain their normal behavior.
 - Unexpected runtime incidents must retain a correlated, bounded frame chain in a private durable
   diagnostic event at normal logging levels. Frame diagnostics exclude exception text, locals, and
   source lines unless a producer has an explicitly reviewed sanitizer for those values; a rare

--- a/src/exchanges/hyperliquid.py
+++ b/src/exchanges/hyperliquid.py
@@ -496,6 +496,7 @@ class HyperliquidBot(CCXTBot):
         return bool(getattr(self, "_hl_unified_enabled", False))
 
     def _assert_supported_live_state(self) -> None:
+        super()._assert_supported_live_state()
         if self.HIP3_ISOLATED_SUPPORTED or self._hl_supports_hip3_live_trading():
             return
         unsupported = []

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -141,6 +141,7 @@ from logging_setup import (
 )
 from utils import (
     MarketIdentifierResolutionError,
+    UnknownMarketIdentifier,
     load_markets,
     coin_to_symbol,
     symbol_to_coin,
@@ -651,17 +652,99 @@ def _bounded_runtime_stage(bot: Any) -> str:
     return stage if re.fullmatch(r"[A-Za-z0-9_.-]{1,64}", stage) else "unknown"
 
 
-def _log_process_failure(label: str, exc: BaseException) -> None:
+def _process_failure_key_context(exc: BaseException, current_bot: Any) -> str:
+    """Expose missing market keys only when independently known to this bot.
+
+    Arbitrary exception arguments can contain credentials, even for KeyError.
+    Membership in the market/override map plus symbol syntax provides context
+    without formatting an arbitrary exception value.
+    """
+    try:
+        if type(exc) is not KeyError or len(exc.args) != 1:
+            return ""
+        key = exc.args[0]
+        if type(key) is not str or not re.fullmatch(
+            r"[A-Za-z0-9_.:-]{1,64}/[A-Z0-9]{1,12}:[A-Z0-9]{1,12}", key
+        ):
+            return ""
+        if any(
+            key in getattr(current_bot, attr, {})
+            for attr in ("markets_dict", "coin_overrides", "positions", "open_orders")
+        ):
+            return f"missing_market_key={key}"
+    except Exception:
+        pass  # Optional diagnostic context must not replace the original failure.
+    return ""
+
+
+def _log_process_failure(
+    label: str,
+    exc: BaseException,
+    *,
+    action: str = "restart",
+    failure_state: dict | None = None,
+) -> None:
     current_bot = globals().get("bot")
+    context = (
+        getattr(current_bot, "_startup_failure_context", {})
+        if action != "cleanup"
+        else {}
+    )
+    stage = context.get("stage", _bounded_runtime_stage(current_bot))
+    incident_id = context.get("incident_id", "process")
+    detail = _bounded_traceback_detail(exc)
+    key_context = _process_failure_key_context(exc, current_bot)
+    signature = (
+        label,
+        action,
+        stage,
+        detail,
+        key_context,
+        bounded_exception_status(exc),
+        bounded_exception_code(exc),
+    )
+    now = time.monotonic()
+    if isinstance(exc, RestartBotException):
+        failure_state = None  # An intentional restart is not a failed-run incident.
+    if failure_state is not None:
+        if failure_state.get("signature") == signature:
+            failure_state["repeats"] += 1
+            if now - failure_state["last_summary"] < 300:
+                return
+            logging.error(
+                "%s | stage=%s action=%s repeated=%s incident_id=%s (traceback unchanged)",
+                label,
+                stage,
+                action,
+                failure_state["repeats"],
+                incident_id,
+            )
+            failure_state["last_summary"] = now
+            return
+        failure_state.update(signature=signature, repeats=0, last_summary=now)
     logging.error(
-        "%s | error_type=%s status=%s code=%s stage=%s origin=%s",
+        "%s | error_type=%s status=%s code=%s stage=%s origin=%s action=%s incident_id=%s %s",
         label,
         bounded_exception_type(exc),
         bounded_exception_status(exc) or "-",
         bounded_exception_code(exc) or "-",
-        _bounded_runtime_stage(current_bot),
+        stage,
         _bounded_traceback_origin(exc),
+        action,
+        incident_id,
+        key_context,
     )
+    if detail["frame_count"] and not isinstance(exc, RestartBotException):
+        lines = ["Traceback (bounded frames; no locals or raw exception text):"]
+        for item in detail["exceptions"]:
+            lines.append(f"  {item['relation']}: {item['error_type']}")
+            for frame in item["frames"]:
+                lines.append(
+                    f"    {frame['file']}:{frame['line']} in {frame['function']}"
+                )
+        if detail["truncated"]:
+            lines.append("  ... traceback truncated")
+        logging.error("%s", "\n".join(lines))
 
 
 def _log_startup_observer_failure(
@@ -2343,6 +2426,15 @@ class Passivbot:
 
     def _assert_supported_live_state(self) -> None:
         """Hook: exchange-specific startup/runtime validation for unsupported live state."""
+        # Config-only unavailable symbols may be skipped; exchange state cannot.
+        for symbol, sides in getattr(self, "positions", {}).items():
+            if symbol not in self.markets_dict and any(
+                side["size"] != 0 for side in sides.values()
+            ):
+                raise KeyError(symbol)
+        for symbol, orders in getattr(self, "open_orders", {}).items():
+            if orders and symbol not in self.markets_dict:
+                raise KeyError(symbol)
         dated_symbols = sorted(self._unsupported_dated_futures_symbols_in_live_state())
         if dated_symbols:
             raise FatalBotException(
@@ -3480,6 +3572,12 @@ class Passivbot:
 
             Passivbot._startup_timing_mark(self, "startup")
             self._bot_ready = True
+            failure_state = getattr(self, "_process_failure_state", None)
+            if failure_state:
+                logging.info(
+                    "[bot] recovered from previous run failure; trading startup ready"
+                )
+                failure_state.clear()
             ready_ts = utc_ms()
             ready_data = {"debug_mode": bool(self.debug_mode)}
             if live_event_debug_profiles:
@@ -3540,6 +3638,12 @@ class Passivbot:
                 "origin": _bounded_traceback_origin(exc),
                 "action": incident_action,
                 "cycle": incident_cycle,
+            }
+            self._startup_failure_context = {
+                "stage": (
+                    boot_stage if not self._bot_ready else _bounded_runtime_stage(self)
+                ),
+                "incident_id": incident_id,
             }
             self._monitor_record_event(
                 "error.bot",
@@ -4463,11 +4567,20 @@ class Passivbot:
         """Populate coin override map keyed by symbols for quick lookup."""
         resolved_coin_overrides = {}
         override_keys_by_symbol = {}
+        unavailable = []
         for key, value in self.config.get("coin_overrides", {}).items():
-            symbol = self.coin_to_symbol(key)
-            if not symbol:
+            try:
+                symbol = self.coin_to_symbol(key, verbose=False)
+            except UnknownMarketIdentifier:
+                unavailable.append(key)
                 continue
-            if symbol in resolved_coin_overrides and resolved_coin_overrides[symbol] != value:
+            if not symbol or symbol not in self.markets_dict:
+                unavailable.append(key)
+                continue
+            if (
+                symbol in resolved_coin_overrides
+                and resolved_coin_overrides[symbol] != value
+            ):
                 raise ValueError(
                     f"conflicting coin_overrides keys resolve to {symbol}: "
                     f"{override_keys_by_symbol[symbol]!r} and {key!r}"
@@ -4475,6 +4588,30 @@ class Passivbot:
             resolved_coin_overrides[symbol] = value
             override_keys_by_symbol.setdefault(symbol, key)
         self.coin_overrides = resolved_coin_overrides
+        skipped = tuple(sorted(unavailable))
+        if skipped != getattr(self, "_unavailable_coin_overrides", ()):
+            if skipped:
+                logging.info(
+                    "[config] skipping unavailable coin_overrides: exchange=%s count=%d coins=%s",
+                    self.exchange,
+                    len(skipped),
+                    self._log_symbols(
+                        [
+                            (
+                                (key if len(key) <= 32 else key[:29] + "...")
+                                if re.fullmatch(r"[A-Za-z0-9_./:-]{1,80}", key)
+                                else "[invalid identifier]"
+                            )
+                            for key in skipped
+                        ],
+                        limit=3,
+                    ),
+                )
+            else:
+                logging.info(
+                    "[config] all coin_overrides available: exchange=%s", self.exchange
+                )
+            self._unavailable_coin_overrides = skipped
         if self.coin_overrides:
             logging.debug(
                 "Initialized coin overrides for %s",
@@ -21546,7 +21683,7 @@ class Passivbot:
                             resolved_identifier_symbols[identifier] = symbol
                     symbols = {s for s in symbols if s}
                     eligible = getattr(self, "eligible_symbols", None)
-                    if eligible:
+                    if eligible is not None:
                         skipped = [sym for sym in symbols if sym not in eligible]
                         if skipped:
                             coin_list = ", ".join(
@@ -22115,23 +22252,29 @@ async def main():
     config = compile_runtime_config(config, runtime="live")
     cooldown_secs = 60
     restarts = []
+    failure_state = {}
     while True:
 
         bot = setup_bot(config)
         globals()["bot"] = bot
+        bot._process_failure_state = failure_state
         fatal_error = None
         try:
             await bot.start_bot()
         except FatalBotException as e:
             fatal_error = e
-            _log_process_failure("passivbot fatal error", e)
+            _log_process_failure(
+                "passivbot fatal error", e, action="stop", failure_state=failure_state
+            )
         except asyncio.CancelledError as e:
             if bot.stop_signal_received or getattr(bot, "_shutdown_in_progress", False):
                 logging.info("passivbot cancellation received during shutdown")
             else:
-                _log_process_failure("passivbot cancelled unexpectedly", e)
+                _log_process_failure(
+                    "passivbot cancelled unexpectedly", e, failure_state=failure_state
+                )
         except Exception as e:
-            _log_process_failure("passivbot error", e)
+            _log_process_failure("passivbot error", e, failure_state=failure_state)
         finally:
             try:
                 if bot.stop_signal_received or getattr(
@@ -22145,7 +22288,7 @@ async def main():
                 else:
                     await bot.cleanup_for_restart()
             except Exception as exc:
-                _log_process_failure("passivbot cleanup error", exc)
+                _log_process_failure("passivbot cleanup error", exc, action="cleanup")
             if bot is not None and getattr(bot, "_shutdown_in_progress", False):
                 logging.info(
                     "[%s] [shutdown] cleanup complete", getattr(bot, "exchange", "?")

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -683,13 +683,15 @@ def _log_process_failure(
     *,
     action: str = "restart",
     failure_state: dict | None = None,
+    context: dict | None = None,
 ) -> None:
     current_bot = globals().get("bot")
-    context = (
-        getattr(current_bot, "_startup_failure_context", {})
-        if action != "cleanup"
-        else {}
-    )
+    if context is None:
+        context = (
+            getattr(current_bot, "_startup_failure_context", {})
+            if action != "cleanup"
+            else {}
+        )
     stage = context.get("stage", _bounded_runtime_stage(current_bot))
     incident_id = context.get("incident_id", "process")
     detail = _bounded_traceback_detail(exc)
@@ -22068,6 +22070,20 @@ async def shutdown_bot(bot):
 
 
 async def main():
+    """Keep failures before bot construction inside the bounded diagnostic boundary."""
+    global bot
+    bot = None
+    context = {"stage": "cli", "incident_id": f"process-{int(utc_ms())}"}
+    try:
+        await _run_live(context)
+    except Exception as exc:
+        # Pre-loop failures remain terminal. SystemExit prevents a second, raw
+        # interpreter traceback without changing the unsuccessful exit status.
+        _log_process_failure("passivbot startup error", exc, action="stop", context=context)
+        raise SystemExit(1) from None
+
+
+async def _run_live(startup_context: dict):
     """Entry point: parse CLI args, load config, and launch the bot lifecycle."""
     global bot
     raw_argv = sys.argv[1:]
@@ -22149,6 +22165,7 @@ async def main():
     cli_log_level = "debug" if args.verbose else args.log_level
     initial_log_level = resolve_log_level(cli_log_level, None, fallback=1)
     configure_logging(debug=initial_log_level)
+    startup_context["stage"] = "load_config"
     source_config, base_config_path, raw_snapshot = load_input_config(args.config_path)
     update_config_with_args(
         source_config, args, verbose=True, allowed_keys=allowed_config_keys
@@ -22179,6 +22196,7 @@ async def main():
     if effective_log_level != initial_log_level or log_file_settings["log_file"]:
         configure_logging(debug=effective_log_level, **log_file_settings)
 
+    startup_context["stage"] = "custom_endpoints"
     custom_endpoints_cli = args.custom_endpoints
     live_section = config.get("live") if isinstance(config.get("live"), dict) else {}
     custom_endpoints_cfg = (
@@ -22240,14 +22258,17 @@ async def main():
         preloaded=preloaded_override,
     )
 
+    startup_context["stage"] = "load_user_info"
     user_info = load_user_info(live_user)
     # Reconfigure logging with exchange prefix now that we know the exchange
     exchange_prefix = user_info["exchange"]
     configure_logging(
         debug=effective_log_level, prefix=exchange_prefix, **log_file_settings
     )
+    startup_context["stage"] = "load_markets"
     await load_markets(user_info["exchange"], verbose=True)
 
+    startup_context["stage"] = "compile_config"
     config = parse_overrides(config, verbose=True)
     config = compile_runtime_config(config, runtime="live")
     cooldown_secs = 60
@@ -22255,9 +22276,12 @@ async def main():
     failure_state = {}
     while True:
 
+        startup_context["stage"] = "setup_bot"
+        bot = None
         bot = setup_bot(config)
         globals()["bot"] = bot
         bot._process_failure_state = failure_state
+        startup_context["stage"] = "bot_lifecycle"
         fatal_error = None
         try:
             await bot.start_bot()
@@ -22300,6 +22324,7 @@ async def main():
             break
 
         logging.info(f"restarting bot...")
+        startup_context["stage"] = "restart_cooldown"
         print()
         for z in range(cooldown_secs, -1, -1):
             if bot is not None and getattr(bot, "stop_signal_received", False):
@@ -22313,6 +22338,7 @@ async def main():
             )
             break
 
+        startup_context["stage"] = "restart_budget"
         restarts.append(utc_ms())
         restarts = [x for x in restarts if x > utc_ms() - 1000 * 60 * 60 * 24]
         max_restarts = int(require_live_value(bot.config, "max_n_restarts_per_day"))

--- a/tests/test_coin_overrides.py
+++ b/tests/test_coin_overrides.py
@@ -52,7 +52,8 @@ def test_live_coin_overrides_reject_conflicting_aliases_for_one_market():
             "BTCUSDT": {"live": {"forced_mode_long": "panic"}},
         }
     }
-    bot.coin_to_symbol = lambda _coin: "BTC/USDT:USDT"
+    bot.markets_dict = {"BTC/USDT:USDT": {"active": True}}
+    bot.coin_to_symbol = lambda _coin, verbose=True: "BTC/USDT:USDT"
 
     with pytest.raises(ValueError, match="conflicting coin_overrides keys"):
         bot.init_coin_overrides()
@@ -69,7 +70,9 @@ def test_live_coin_overrides_refresh_is_atomic_on_resolution_failure():
         }
     }
 
-    def resolve(coin):
+    bot.markets_dict = {"BTC/USDT:USDT": {"active": True}}
+
+    def resolve(coin, verbose=True):
         if coin == "BTC":
             return "BTC/USDT:USDT"
         raise ValueError("unavailable override market")

--- a/tests/test_init_markets_retry.py
+++ b/tests/test_init_markets_retry.py
@@ -565,3 +565,41 @@ async def test_init_markets_waits_for_initial_balance_consistency(monkeypatch):
         (5.0, "initial_balance_consistency_check"),
     ]
     assert bot.min_cost_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_init_markets_with_unavailable_overrides_completes_mode_lookup(monkeypatch):
+    import passivbot as pb_mod
+
+    class Bot(_FakeBot, pb_mod.Passivbot):
+        init_coin_overrides = pb_mod.Passivbot.init_coin_overrides
+
+        async def update_effective_min_cost(self):
+            # Exercise the real symbol/mode lookup that sizing consumes at startup.
+            self.sizing_symbols = self.get_symbols_approved_or_has_pos()
+            self.min_cost_calls += 1
+
+    async def load_markets(*args, **kwargs):
+        return {"AAA/USDT:USDT": {"id": "AAAUSDT", "active": True}}
+
+    async def update_exchange_config(attempt):
+        return None
+
+    monkeypatch.setattr(pb_mod, "load_markets", load_markets)
+    monkeypatch.setattr(pb_mod, "filter_markets", lambda *a, **kw: ({"AAA/USDT:USDT"}, {}, {}))
+    bot = Bot(update_exchange_config)
+    bot.config = {
+        "live": {"forced_mode_long": "", "forced_mode_short": ""},
+        "coin_overrides": {"AAA": {}, "UNLISTED": {}},
+    }
+    bot.positions = {}
+    bot.approved_coins_minus_ignored_coins = {"long": {"AAA/USDT:USDT"}, "short": set()}
+    bot.coin_to_symbol = lambda coin, verbose=True: f"{coin}/USDT:USDT"
+    bot._equity_hard_stop_enabled = lambda pside: False
+
+    await pb_mod.Passivbot.init_markets(bot, verbose=False)
+
+    assert bot.refresh_authoritative_state_calls == 1
+    assert bot.min_cost_calls == 1
+    assert bot.sizing_symbols == {"AAA/USDT:USDT"}
+    assert bot.coin_overrides == {"AAA/USDT:USDT": {}}

--- a/tests/test_live_coin_lists.py
+++ b/tests/test_live_coin_lists.py
@@ -187,13 +187,18 @@ def test_retained_order_and_position_do_not_expand_forager_eligibility():
         assert overrides[pside][held_symbol] == "graceful_stop"
 
 
-def test_add_to_coins_lists_skips_symbols_not_in_eligible_markets(caplog):
+@pytest.mark.parametrize("eligible_available", [True, False])
+def test_add_to_coins_lists_skips_symbols_not_in_eligible_markets(
+    caplog, eligible_available
+):
     bot = Passivbot.__new__(Passivbot)
     bot.exchange = "bitget"
     eligible_symbol = "AAA/USDT:USDT"
     skipped_symbols = {f"ZZ{index:02d}/USDT:USDT" for index in range(14)}
     bot.markets_dict = {eligible_symbol: {"swap": True}}
-    bot.eligible_symbols = {eligible_symbol}
+    bot.eligible_symbols = {eligible_symbol} if eligible_available else set()
+    if not eligible_available:
+        skipped_symbols.add(eligible_symbol)
     bot.approved_coins = {"long": set(), "short": set()}
     bot.ignored_coins = {"long": set(), "short": set()}
     structured = ListEventSink()
@@ -222,7 +227,9 @@ def test_add_to_coins_lists_skips_symbols_not_in_eligible_markets(caplog):
             log_psides={"long"},
         )
 
-    assert bot.approved_coins["long"] == {eligible_symbol}
+    assert bot.approved_coins["long"] == (
+        {eligible_symbol} if eligible_available else set()
+    )
     assert bot.approved_coins["short"] == set()
     warnings = [
         rec.message for rec in caplog.records if "skipping unsupported markets" in rec.message.lower()
@@ -241,14 +248,14 @@ def test_add_to_coins_lists_skips_symbols_not_in_eligible_markets(caplog):
     assert event.pside == "long"
     assert event.data == {
         "list_kind": "approved_coins",
-        "skipped_count": 14,
+        "skipped_count": len(skipped_symbols),
         "skipped_symbols": sorted(skipped_symbols)[:12],
         "skipped_symbols_truncated": True,
-        "reason_counts": {ReasonCodes.CONFIG_MARKET_UNSUPPORTED: 14},
+        "reason_counts": {ReasonCodes.CONFIG_MARKET_UNSUPPORTED: len(skipped_symbols)},
         "reason_samples": [
             {
                 "reason_code": ReasonCodes.CONFIG_MARKET_UNSUPPORTED,
-                "count": 14,
+                "count": len(skipped_symbols),
                 "symbols": sorted(skipped_symbols)[:12],
                 "symbols_truncated": True,
             }

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -2971,6 +2971,19 @@ async def test_start_bot_treats_hsl_value_error_as_terminal_startup_failure(
     assert secret not in str(exc_info.value)
     assert secret not in caplog.text
     assert "Traceback" not in caplog.text
+    # The outer lifecycle handler retains the failing phase even after cleanup
+    # observers have returned to idle, and correlates the visible traceback.
+    monkeypatch.setattr(passivbot_module, "bot", bot, raising=False)
+    bot._log_silence_watchdog_stage = "idle"
+    with caplog.at_level(logging.ERROR):
+        passivbot_module._log_process_failure(
+            "passivbot fatal error", exc_info.value, action="stop"
+        )
+    assert "stage=equity_hard_stop_initialize_coin_from_history" in caplog.text
+    assert f"incident_id={summary['incident_id']}" in caplog.text
+    assert "Traceback" in caplog.text
+    assert "cause: ValueError" in caplog.text
+    assert secret not in caplog.text
 
 
 def test_coin_hsl_status_logs_distance_only_for_open_position(caplog, monkeypatch):

--- a/tests/test_process_failure_diagnostics.py
+++ b/tests/test_process_failure_diagnostics.py
@@ -1,0 +1,119 @@
+import logging
+from types import SimpleNamespace
+
+import pytest
+import passivbot as pb
+from passivbot_exceptions import FatalBotException, RestartBotException
+
+
+def crash():
+    try:
+        raise ValueError(
+            "api_key=CHAIN_SECRET https://private.invalid?signature=SECRET"
+        )
+    except ValueError as cause:
+        raise RuntimeError("password=OUTER_SECRET") from cause
+
+
+def test_run_failure_console_preserves_chain_without_payloads(caplog, monkeypatch):
+    monkeypatch.setattr(pb, "bot", SimpleNamespace(), raising=False)
+    with caplog.at_level(logging.ERROR):
+        try:
+            crash()
+        except RuntimeError as exc:
+            pb._log_process_failure("passivbot error", exc)
+    assert "Traceback" in caplog.text
+    assert "test_process_failure_diagnostics.py:" in caplog.text
+    assert "in crash" in caplog.text
+    assert "raised: RuntimeError" in caplog.text
+    assert "cause: ValueError" in caplog.text
+    assert "action=restart" in caplog.text
+    for forbidden in ("CHAIN_SECRET", "OUTER_SECRET", "private.invalid", "signature="):
+        assert forbidden not in caplog.text
+
+
+def test_known_missing_market_key_is_visible_but_arbitrary_key_is_not(
+    caplog, monkeypatch
+):
+    symbol = "UNLISTED/USDT:USDT"
+    bot = SimpleNamespace(coin_overrides={symbol: {}})
+    monkeypatch.setattr(pb, "bot", bot, raising=False)
+    with caplog.at_level(logging.ERROR):
+        for key in (symbol, "api_key=SECRET", "OPAQUE_SECRET/USDT:USDT"):
+            try:
+                raise KeyError(key)
+            except KeyError as exc:
+                pb._log_process_failure("passivbot error", exc)
+    assert f"missing_market_key={symbol}" in caplog.text
+    assert "SECRET" not in caplog.text
+
+
+def test_restarted_bots_share_repeat_suppression_but_changed_failure_prints(
+    caplog, monkeypatch
+):
+    state = {}
+    clock = [0.0]
+    monkeypatch.setattr(pb.time, "monotonic", lambda: clock[0])
+
+    def emit(key, incident):
+        bot = SimpleNamespace(
+            coin_overrides={key: {}},
+            _startup_failure_context={"stage": "init_markets", "incident_id": incident},
+        )
+        monkeypatch.setattr(pb, "bot", bot, raising=False)
+        try:
+            raise KeyError(key)
+        except KeyError as exc:
+            pb._log_process_failure("passivbot error", exc, failure_state=state)
+
+    with caplog.at_level(logging.ERROR):
+        emit("AAA/USDT:USDT", "startup-1")
+        clock[0] = 69
+        emit("AAA/USDT:USDT", "startup-2")
+        clock[0] = 301
+        emit("AAA/USDT:USDT", "startup-3")
+        emit("BBB/USDT:USDT", "startup-4")
+    assert caplog.text.count("Traceback (") == 2
+    assert "repeated=2" in caplog.text
+    assert "incident_id=startup-2" not in caplog.text
+    assert "incident_id=startup-3" in caplog.text
+    assert "missing_market_key=BBB/USDT:USDT" in caplog.text
+
+
+def test_diagnostic_projection_failure_keeps_failure_summary(caplog, monkeypatch):
+    monkeypatch.setattr(pb, "bot", SimpleNamespace(), raising=False)
+
+    def broken(_exc):
+        raise RuntimeError("diagnostic failure")
+
+    monkeypatch.setattr(pb, "_bounded_traceback_detail_inner", broken)
+    with caplog.at_level(logging.ERROR):
+        pb._log_process_failure(
+            "passivbot fatal error", FatalBotException("SECRET"), action="stop"
+        )
+    assert "action=stop" in caplog.text
+    assert "SECRET" not in caplog.text
+
+
+def test_missing_key_context_is_optional_even_with_broken_observer(monkeypatch):
+    class BrokenObserver:
+        @property
+        def markets_dict(self):
+            raise RuntimeError("observer failure")
+
+    assert (
+        pb._process_failure_key_context(KeyError("AAA/USDT:USDT"), BrokenObserver())
+        == ""
+    )
+
+
+def test_intentional_restart_does_not_create_failure_recovery_state(caplog, monkeypatch):
+    monkeypatch.setattr(pb, "bot", SimpleNamespace(), raising=False)
+    state = {}
+    with caplog.at_level(logging.ERROR):
+        try:
+            raise RestartBotException("expected restart")
+        except RestartBotException as exc:
+            pb._log_process_failure("passivbot error", exc, failure_state=state)
+    assert state == {}
+    assert "Traceback" not in caplog.text

--- a/tests/test_process_failure_diagnostics.py
+++ b/tests/test_process_failure_diagnostics.py
@@ -107,7 +107,9 @@ def test_missing_key_context_is_optional_even_with_broken_observer(monkeypatch):
     )
 
 
-def test_intentional_restart_does_not_create_failure_recovery_state(caplog, monkeypatch):
+def test_intentional_restart_does_not_create_failure_recovery_state(
+    caplog, monkeypatch
+):
     monkeypatch.setattr(pb, "bot", SimpleNamespace(), raising=False)
     state = {}
     with caplog.at_level(logging.ERROR):
@@ -117,3 +119,71 @@ def test_intentional_restart_does_not_create_failure_recovery_state(caplog, monk
             pb._log_process_failure("passivbot error", exc, failure_state=state)
     assert state == {}
     assert "Traceback" not in caplog.text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failing_stage", ["load_config", "load_markets", "setup_bot"])
+async def test_early_startup_failure_is_bounded_and_exits_unsuccessfully(
+    failing_stage, caplog, monkeypatch
+):
+    from unittest.mock import AsyncMock, Mock
+
+    config = pb.get_template_config()
+    config["live"]["user"] = "offline_test"
+    failure = RuntimeError("api_key=EARLY_SECRET https://private.invalid?signature=SIG")
+    monkeypatch.setattr(pb.sys, "argv", ["passivbot"])
+    monkeypatch.setattr(pb, "configure_logging", lambda **kwargs: None)
+    monkeypatch.setattr(
+        pb, "load_input_config", Mock(return_value=(config, None, None))
+    )
+    monkeypatch.setattr(pb, "prepare_config", lambda *args, **kwargs: config)
+    monkeypatch.setattr(
+        pb, "resolve_live_log_file_settings", lambda *a, **kw: {"log_file": None}
+    )
+    monkeypatch.setattr(pb, "configure_custom_endpoint_loader", lambda *a, **kw: None)
+    monkeypatch.setattr(pb, "load_user_info", Mock(return_value={"exchange": "fake"}))
+    monkeypatch.setattr(pb, "load_markets", AsyncMock())
+    monkeypatch.setattr(pb, "parse_overrides", lambda config, **kwargs: config)
+    monkeypatch.setattr(pb, "compile_runtime_config", lambda config, **kwargs: config)
+    monkeypatch.setattr(pb, "setup_bot", Mock())
+    target = "load_input_config" if failing_stage == "load_config" else failing_stage
+    getattr(pb, target).side_effect = failure
+    # A previous invocation must not supply a stale phase, identity, or key map.
+    monkeypatch.setattr(
+        pb,
+        "bot",
+        SimpleNamespace(_startup_failure_context={"stage": "stale"}),
+        raising=False,
+    )
+
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(SystemExit) as result:
+            await pb.main()
+
+    assert result.value.code == 1
+    assert result.value.__suppress_context__ is True
+    assert pb.bot is None
+    assert "action=stop" in caplog.text
+    assert f"stage={failing_stage}" in caplog.text
+    assert "incident_id=process-" in caplog.text
+    assert "Traceback" in caplog.text
+    assert "in _run_live" in caplog.text
+    assert "EARLY_SECRET" not in caplog.text
+    assert "private.invalid" not in caplog.text
+    if failing_stage != "setup_bot":
+        pb.setup_bot.assert_not_called()
+    if failing_stage == "load_config":
+        pb.load_user_info.assert_not_called()
+        pb.load_markets.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_cli_help_keeps_successful_exit_without_failure_diagnostic(
+    caplog, monkeypatch
+):
+    monkeypatch.setattr(pb.sys, "argv", ["passivbot", "--help"])
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(SystemExit) as result:
+            await pb.main()
+    assert result.value.code == 0
+    assert "passivbot startup error" not in caplog.text

--- a/tests/test_unavailable_coin_overrides.py
+++ b/tests/test_unavailable_coin_overrides.py
@@ -120,3 +120,25 @@ def test_skip_notice_is_bounded_and_omits_invalid_identifier_text(caplog):
     assert len(notice) < 240
     assert "SECRET" not in notice
     assert "INJECTED" not in notice
+
+
+@pytest.mark.parametrize("unified", [False, True])
+@pytest.mark.parametrize("surface", ["positions", "open_orders"])
+def test_hyperliquid_runs_shared_market_guard_before_connector_early_return(
+    unified, surface
+):
+    from exchanges.hyperliquid import HyperliquidBot
+
+    bot = HyperliquidBot.__new__(HyperliquidBot)
+    bot._hl_unified_enabled = unified
+    bot.markets_dict = {"AAA/USDC:USDC": {"active": True, "swap": True}}
+    bot.positions = {}
+    bot.open_orders = {}
+    symbol = "UNLISTED/USDC:USDC"
+    getattr(bot, surface)[symbol] = (
+        {"long": {"size": 1}, "short": {"size": 0}}
+        if surface == "positions"
+        else [{"id": "test"}]
+    )
+    with pytest.raises(KeyError, match="UNLISTED"):
+        bot._assert_supported_live_state()

--- a/tests/test_unavailable_coin_overrides.py
+++ b/tests/test_unavailable_coin_overrides.py
@@ -1,0 +1,122 @@
+"""Offline live-universe regressions; no exchange sessions or account requests."""
+
+from copy import deepcopy
+import logging
+
+import pytest
+
+from passivbot import Passivbot
+from utils import AmbiguousMarketIdentifier, UnknownMarketIdentifier
+
+
+def make_bot(overrides):
+    bot = Passivbot.__new__(Passivbot)
+    bot.exchange = "bitget"
+    bot.config = {
+        "coin_overrides": overrides,
+        "live": {"forced_mode_long": "", "forced_mode_short": ""},
+    }
+    bot.markets_dict = {"AAA/USDT:USDT": {"active": True}}
+    bot.positions = {}
+    bot.open_orders = {}
+    bot.approved_coins_minus_ignored_coins = {"long": {"AAA/USDT:USDT"}, "short": set()}
+    bot._equity_hard_stop_enabled = lambda _pside: False
+    bot.coin_to_symbol = lambda coin, verbose=True: f"{coin}/USDT:USDT"
+    return bot
+
+
+def test_unavailable_overrides_do_not_reach_startup_mode_lookup(caplog):
+    bot = make_bot({"AAA": {}, "UNLISTED": {"live": {"forced_mode_long": "normal"}}})
+    original = deepcopy(bot.config)
+    with caplog.at_level(logging.INFO):
+        bot.init_coin_overrides()
+        bot.init_coin_overrides()
+    assert bot.coin_overrides == {"AAA/USDT:USDT": {}}
+    assert bot.get_symbols_approved_or_has_pos() == {"AAA/USDT:USDT"}
+    assert bot.config == original
+    assert caplog.text.count("skipping unavailable coin_overrides") == 1
+    assert "UNLISTED" in caplog.text
+    assert "exchange=bitget" in caplog.text
+
+
+def test_unknown_exact_identifier_is_skipped_but_ambiguity_propagates():
+    bot = make_bot({"AAA": {}, "UNLISTED/USDT:USDT": {}})
+
+    def resolve(coin, verbose=True):
+        if coin == "AAA":
+            return "AAA/USDT:USDT"
+        raise UnknownMarketIdentifier("unavailable")
+
+    bot.coin_to_symbol = resolve
+    bot.init_coin_overrides()
+    assert bot.coin_overrides == {"AAA/USDT:USDT": {}}
+    prior = deepcopy(bot.coin_overrides)
+
+    def ambiguous(coin, verbose=True):
+        raise AmbiguousMarketIdentifier("ambiguous")
+
+    bot.coin_to_symbol = ambiguous
+    with pytest.raises(AmbiguousMarketIdentifier):
+        bot.init_coin_overrides()
+    assert bot.coin_overrides == prior
+
+
+def test_market_refresh_reconsiders_original_overrides(caplog):
+    bot = make_bot({"AAA": {}, "UNLISTED": {"live": {"forced_mode_long": "manual"}}})
+    with caplog.at_level(logging.INFO):
+        bot.init_coin_overrides()
+        bot.markets_dict["UNLISTED/USDT:USDT"] = {"active": True}
+        bot.init_coin_overrides()
+    assert bot.get_forced_PB_mode("long", "UNLISTED/USDT:USDT") == "manual"
+    assert "all coin_overrides available" in caplog.text
+
+
+def test_inactive_held_market_retains_override_and_protection():
+    override = {"bot": {"long": {"strategy": {"custom": 0.123}}}}
+    bot = make_bot({"INACTIVE": override})
+    symbol = "INACTIVE/USDT:USDT"
+    bot.markets_dict[symbol] = {"active": False}
+    bot.positions[symbol] = {"long": {"size": 1}, "short": {"size": 0}}
+    bot.init_coin_overrides()
+    assert bot.coin_overrides[symbol] == override
+    assert bot.get_forced_PB_mode("long", symbol) == "tp_only"
+    assert symbol in bot.get_symbols_approved_or_has_pos()
+    bot._assert_supported_live_state()
+
+
+@pytest.mark.parametrize("surface", ["positions", "open_orders"])
+def test_unavailable_override_never_hides_existing_exchange_state(surface):
+    bot = make_bot({"UNLISTED": {}})
+    symbol = "UNLISTED/USDT:USDT"
+    getattr(bot, surface)[symbol] = (
+        {"long": {"size": 1}, "short": {"size": 0}}
+        if surface == "positions"
+        else [{"id": "test"}]
+    )
+    original = deepcopy(getattr(bot, surface))
+    bot.init_coin_overrides()
+    with pytest.raises(KeyError, match="UNLISTED"):
+        bot._assert_supported_live_state()
+    assert getattr(bot, surface) == original
+
+
+def test_all_overrides_unavailable_is_valid_empty_runtime_map():
+    bot = make_bot({"UNLISTED": {}})
+    bot.approved_coins_minus_ignored_coins = {"long": set(), "short": set()}
+    bot.init_coin_overrides()
+    assert bot.coin_overrides == {}
+    assert bot.get_symbols_approved_or_has_pos() == set()
+
+
+def test_skip_notice_is_bounded_and_omits_invalid_identifier_text(caplog):
+    bot = make_bot(
+        {"0api_key=SECRET\nINJECTED": {}, **{f"ZZ{i:03d}": {} for i in range(50)}}
+    )
+    with caplog.at_level(logging.INFO):
+        bot.init_coin_overrides()
+    notice = next(
+        r.message for r in caplog.records if "skipping unavailable" in r.message
+    )
+    assert len(notice) < 240
+    assert "SECRET" not in notice
+    assert "INJECTED" not in notice


### PR DESCRIPTION
A live config containing an override for an unavailable exchange market could pass approved-list filtering and then crash during startup's market-mode lookup. Resolve overrides against the loaded market snapshot, skip unavailable identifiers with a bounded notice, and reconsider the original config on market refresh. Retain inactive-market overrides, run the shared live-state guards on Hyperliquid before connector early returns, reject ambiguous/conflicting resolution, and preserve strict handling of positions or open orders whose market metadata is missing. Empty eligible sets now filter approved coins correctly.

Unexpected failures, including configuration preparation, initial market loading, and bot construction before the restart loop, now print bounded traceback frames and exception chains at ERROR, with the failing phase, stop/restart action, and startup incident ID. Known missing market keys receive validated context; raw exception payloads and locals stay excluded. Identical failures share trace suppression across restarts, with periodic repeat counts and reset on successful startup. Logging policy and changelog document the new behavior.

Validation:
- 679 focused tests passed across override resolution, startup, live coin lists, failure diagnostics, monitor/logging behavior, and documentation.
- Rebuilt and fingerprint-verified the Rust extension for the reviewed source before Python validation; no Rust behavior changed.
- Offline fake-exchange HSL restart scenario completed with an added unavailable override, including scenario assertions and graceful shutdown.
- AI documentation and generated-event registry checks passed; only existing documentation-size advisories remain. `git diff --check` passed.

No authenticated exchange validation was performed.
