### PR TITLE
Fix KuCoin market-age discovery blocking forager entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- KuCoin market-age discovery uses a valid millisecond history range, fixing
+  `Parameter 'from' must be milliseconds` errors and restoring eligibility for
+  new forager entries when the configured minimum market age is met.
+
 - Live startup skips unavailable coin overrides with a bounded notice and retries resolution on
   market refresh. Inactive-market overrides and protection of existing positions remain intact;
   an empty eligible market set no longer admits unsupported approved coins.

--- a/docs/ai/features/exchange_integrations.md
+++ b/docs/ai/features/exchange_integrations.md
@@ -175,6 +175,17 @@ Primary reference: `src/fill_events_manager.py` (`BybitFetcher._fetch_positions_
 
 ## KuCoin Futures
 
+### First-candle market-age discovery
+
+KuCoin rejects `from=1`. Request daily candles from a valid millisecond timestamp
+before futures launch (`2018-01-01`), with `to` explicitly set to the current time.
+Pinned CCXT otherwise derives `to=since + limit * duration`; with `limit=1`, that
+queries only one pre-listing day and returns no data. Retain the first returned
+candle as the age basis. Empty or failed responses remain unknown and do not
+bypass the configured minimum market age; zero cache entries are retried.
+
+Primary reference: [KuCoin futures klines](https://www.kucoin.com/docs-new/rest/futures-trading/market-data/get-klines).
+
 ### IPv4 API-key whitelist transport
 
 Problem: A dual-stack host may select IPv6 for KuCoin REST and private

--- a/src/procedures.py
+++ b/src/procedures.py
@@ -362,6 +362,18 @@ async def get_first_timestamps_unified(
             # Weekly timeframe; data since 2021
             return await cc.fetch_ohlcv(symbol, since=int(date_to_ts("2021-01-01")), timeframe="1w")
 
+        elif exchange_name == "kucoin":
+            # KuCoin rejects epoch-sized `from` values. Start before its futures
+            # launch and override CCXT's since + limit * duration end bound so
+            # later-listed markets are included. Keep the first returned candle.
+            return await cc.fetch_ohlcv(
+                symbol,
+                since=int(date_to_ts("2018-01-01")),
+                timeframe="1d",
+                limit=1,
+                params={"to": cc.milliseconds()},
+            )
+
         else:
             # Dynamic CCXT venues must not inherit another exchange's listing
             # horizon. Ask for the first daily candle from the epoch instead.

--- a/tests/test_procedures_first_timestamps.py
+++ b/tests/test_procedures_first_timestamps.py
@@ -27,6 +27,9 @@ class _DummyCC:
             return [[self.first_ts, 1.0, 1.0, 1.0, 1.0, 1.0]]
         return []
 
+    def milliseconds(self):
+        return 1788825600000
+
     async def close(self):
         return None
 
@@ -358,9 +361,10 @@ async def test_exchange_specific_first_timestamps_supports_non_default_exchange(
     assert loaded_clients[0].fetch_calls == [
         {
             "symbol": "ABC/USDT:USDT",
-            "since": 1,
+            "since": 1514764800000,
             "timeframe": "1d",
             "limit": 1,
+            "params": {"to": 1788825600000},
         }
     ]
     exchange_cache = cache_dir / "first_ohlcv_timestamps_unified_exchange_specific.json"
@@ -406,9 +410,10 @@ async def test_qualified_dynamic_exchange_is_discovered_without_exchange_argumen
     assert loaded_clients["kucoinfutures"].fetch_calls == [
         {
             "symbol": "ABC/USDT:USDT",
-            "since": 1,
+            "since": 1514764800000,
             "timeframe": "1d",
             "limit": 1,
+            "params": {"to": 1788825600000},
         }
     ]
     exchange_cache = cache_dir / "first_ohlcv_timestamps_unified_exchange_specific.json"
@@ -456,9 +461,10 @@ async def test_configured_dynamic_exchange_scopes_unqualified_discovery(monkeypa
     assert loaded_clients["kucoinfutures"].fetch_calls == [
         {
             "symbol": "EDGE/USDT:USDT",
-            "since": 1,
+            "since": 1514764800000,
             "timeframe": "1d",
             "limit": 1,
+            "params": {"to": 1788825600000},
         }
     ]
 
@@ -517,3 +523,94 @@ async def test_exchange_specific_first_timestamps_uses_native_bitunix_client(
     assert observed_configs == [
         {"enableRateLimit": True, "timeout": 60_000, "wsEnabled": False}
     ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("exchange", ["kucoin", "kucoinfutures"])
+@pytest.mark.parametrize("outcome", ["candles", "empty", "failure"])
+async def test_kucoin_first_timestamp_wire_range_and_age_gate(
+    monkeypatch, tmp_path, exchange, outcome
+):
+    import ccxt.async_support as ccxt
+    from passivbot import Passivbot
+
+    cache_dir = tmp_path / "caches"
+    cache_dir.mkdir()
+    _mark_first_ohlcv_cache_current(cache_dir)
+    monkeypatch.chdir(tmp_path)
+    symbol = "ABC/USDT:USDT"
+    first_ts = 1710115200000
+    now_ms = 1788825600000
+    monkeypatch.setattr("passivbot.utc_ms", lambda: now_ms)
+    cache = cache_dir / "first_ohlcv_timestamps_unified_exchange_specific.json"
+    cache.write_text(json.dumps({symbol: {"kucoin": 0.0}}))
+    _write_first_ohlcv_provenance(cache_dir, {symbol: {"kucoin": symbol}})
+    requests = []
+    clients = []
+    current_outcome = outcome
+
+    def load_client(exchange_id):
+        assert exchange_id == "kucoinfutures"
+        client = ccxt.kucoinfutures()
+        client.set_markets(
+            [{
+                "id": "ABCUSDTM", "symbol": symbol, "base": "ABC", "quote": "USDT",
+                "settle": "USDT", "type": "swap", "spot": False, "swap": True,
+                "contract": True, "linear": True, "inverse": False,
+            }]
+        )
+        monkeypatch.setattr(client, "milliseconds", lambda: now_ms)
+
+        async def request(path, api="public", method="GET", params=None, **kwargs):
+            assert path == "kline/query"
+            assert api == "futuresPublic"
+            assert method == "GET"
+            requests.append(dict(params))
+            if current_outcome == "failure":
+                raise ccxt.RequestTimeout("fixture timeout")
+            if current_outcome == "empty":
+                return {"code": "200000", "data": []}
+            # Mimic an exchange whose listing is later than the requested start.
+            # A one-day pre-listing window cannot find this market.
+            if not params["from"] <= first_ts <= params["to"]:
+                return {"code": "200000", "data": []}
+            return {
+                "code": "200000",
+                "data": [
+                    [first_ts, 10, 12, 9, 11, 100],
+                    [first_ts + 86400000, 11, 13, 10, 12, 110],
+                ],
+            }
+
+        monkeypatch.setattr(client, "request", request)
+        clients.append(client)
+        return client
+
+    async def load_markets(_exchange):
+        return {}
+
+    monkeypatch.setattr(procedures, "load_ccxt_instance", load_client)
+    monkeypatch.setattr(procedures, "load_markets", load_markets)
+    monkeypatch.setattr(procedures, "coin_to_symbol", lambda *_args: symbol)
+
+    result = await procedures.get_first_timestamps_unified([symbol], exchange=exchange)
+    expected = first_ts if outcome == "candles" else 0.0
+    assert result == {symbol: expected}
+    assert requests == [
+        {"symbol": "ABCUSDTM", "granularity": 1440, "from": 1514764800000, "to": now_ms}
+    ]
+    assert json.loads(cache.read_text())[symbol] == {"kucoin": expected}
+
+    bot = types.SimpleNamespace(
+        is_forager_mode=lambda _side: True,
+        minimum_market_age_millis=30 * 86400000,
+        get_first_timestamp=lambda s: result[s],
+    )
+    assert Passivbot.is_old_enough(bot, "long", symbol) is (outcome == "candles")
+
+    # A valid result survives a reload; unknown results retry and recover.
+    current_outcome = "candles"
+    recovered = await procedures.get_first_timestamps_unified([symbol], exchange=exchange)
+    assert recovered == {symbol: first_ts}
+    assert len(requests) == (1 if outcome == "candles" else 2)
+    assert all(client.session is None for client in clients)


### PR DESCRIPTION
KuCoin first-candle discovery sends `since=1`, which its futures API rejects with `Parameter 'from' must be milliseconds`. The resulting unknown market ages exclude otherwise eligible markets from new forager entries whenever a positive minimum market age is configured.

Use a valid millisecond start before KuCoin futures launch and explicitly set the end to the current time. Both bounds matter: pinned CCXT otherwise derives a one-day pre-listing window from `limit=1`. Keep the first exchange-returned daily candle, existing market identity provenance, and the fail-closed behavior for empty or failed lookups.

Validation:
- 23 focused first-timestamp and AI documentation tests passed.
- Six new cases fail against the base code and pass with the fix, covering both exchange aliases, actual CCXT request construction, age eligibility, empty/failed responses, zero-cache retry, recovery, and successful cache reuse.
- Public unauthenticated KuCoin probes reproduced the rejection and confirmed historical candles with the corrected bounds for ETH, HBAR, and HYPE.
- Python compilation, diff checks, AI docs validation, and event-registry freshness passed; documentation size warnings are pre-existing.
