### PR TITLE
Fix KuCoin partial-close PnL and automatically repair cached history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- KuCoin partial closes now contribute realized losses to auto-unstuck and other PnL
+  risk inputs before the whole position closes. Existing trade-derived closes mislabeled
+  as authoritative are automatically backed up and reconstructed on cache load; the
+  fill-events doctor can also inspect or repair them. Reconciled position-history PnL
+  is preserved, and incomplete reconstruction remains unavailable to PnL risk checks.
+
 - KuCoin market-age discovery uses a valid millisecond history range, fixing
   `Parameter 'from' must be milliseconds` errors and restoring eligibility for
   new forager entries when the configured minimum market age is met.

--- a/docs/ai/features/fill_events_manager.md
+++ b/docs/ai/features/fill_events_manager.md
@@ -161,7 +161,16 @@ logs, runtime windows, and immutable manifests.
 6. KuCoin position-history PnL is authoritative for a completed position cycle. Overlapping trade
    refreshes may return the same close as pending again; they must preserve an already reconciled
    cycle value. Reapplying an unchanged cycle observation is a no-op, while a changed authoritative
-   total is redistributed across that lifecycle and persisted.
+   total is redistributed across that lifecycle and persisted. Classify trade reductions from
+   `side` and `position_side` before optional order-label enrichment; trade-window estimates
+   are pending until reconstruction against the cached basis or cycle reconciliation.
+   On ordinary current-contract cache load, use the KuCoin doctor to back up and repair
+   trade-derived reductions mislabeled as `authoritative`, including nonzero estimates.
+   Preserve explicit synthetic and cycle-reconciled sources, raw data, provenance, coverage,
+   and the incremental refresh checkpoint. This accounting normalization is automatic;
+   standalone doctor check mode remains read-only. An incomplete basis remains degraded
+   and blocks enabled PnL risk consumers. Repeated loads do not create another backup once
+   the mislabeled rows have been repaired.
 7. Fills sharing one millisecond carry no execution order in exchange responses or caches, yet
    position reconstruction replays them in list order. When the exchange reports the position size
    preceding each fill (Hyperliquid `startPosition`), retain each execution boundary and reorder an

--- a/src/fill_events_manager.py
+++ b/src/fill_events_manager.py
@@ -1791,6 +1791,32 @@ def _is_close_payload(payload: Dict[str, object]) -> bool:
     return closed_size > 0.0
 
 
+def _is_kucoin_close(payload: Dict[str, object]) -> bool:
+    # Order labels arrive after trade normalization and may be absent on manual fills.
+    return (payload.get("side"), payload.get("position_side")) in {
+        ("sell", "long"),
+        ("buy", "short"),
+    }
+
+
+def _kucoin_trade_pnl_needs_repair(payload: Dict[str, object]) -> bool:
+    # KuCoin trades contain no authoritative realized PnL. Older fetchers stamped
+    # batch-local estimates (including nonzero ones) authoritative before order
+    # enrichment identified the close. Cycle-reconciled and synthetic rows already
+    # carry explicit sources and must retain their accounting.
+    return (
+        payload.get("pnl_contract") == PNL_CONTRACT_CURRENT
+        and _is_kucoin_close(payload)
+        and _payload_pnl_status(payload) == "complete"
+        and _payload_pnl_source(payload) == PNL_SOURCE_AUTHORITATIVE
+        and any(
+            row.get("source") == "fetch_my_trades"
+            for row in _normalize_raw_field(payload.get("raw"))
+            if isinstance(row, dict)
+        )
+    )
+
+
 # ---------------------------------------------------------------------------
 # Cache
 # ---------------------------------------------------------------------------
@@ -3833,6 +3859,8 @@ class FillEventsManager:
             # Doctor mode loads legacy caches read-only first so backup/repair can
             # operate on the original files.
             if self._events and not allow_legacy_contract:
+                if self.exchange.lower() == "kucoin":
+                    self._run_kucoin_doctor({}, auto_repair=True)
                 payload = [ev.to_dict() for ev in self._events]
                 if self.exchange.lower() == "hyperliquid":
                     payload = _expand_hyperliquid_coalesced_events(payload)
@@ -4809,8 +4837,16 @@ class FillEventsManager:
             self.cache._data_files()
         )
         missing_fee_paid = [ev for ev in self._events if "fee_paid" not in ev.to_dict()]
-        anomaly_count = len(self._events) if legacy_contract else len(legacy_events) + len(missing_fee_paid)
-        report["legacy_contract"] = bool(legacy_contract)
+        trade_pnl_events = [
+            ev for ev in self._events if _kucoin_trade_pnl_needs_repair(ev.to_dict())
+        ]
+        contract_repair = bool(legacy_contract or legacy_events or missing_fee_paid)
+        anomaly_count = (
+            len(self._events)
+            if legacy_contract
+            else len({ev.id for ev in legacy_events + missing_fee_paid + trade_pnl_events})
+        )
+        report["legacy_contract"] = bool(legacy_contract or legacy_events)
         report["anomaly_events"] = anomaly_count
         if not anomaly_count:
             return report
@@ -4819,9 +4855,13 @@ class FillEventsManager:
                 "id": ev.id,
                 "symbol": ev.symbol,
                 "timestamp": ev.timestamp,
-                "reason": "legacy_or_missing_pnl_contract",
+                "reason": (
+                    "legacy_or_missing_pnl_contract"
+                    if contract_repair
+                    else "trade_pnl_mislabeled_authoritative"
+                ),
             }
-            for ev in self._events[:5]
+            for ev in (self._events if contract_repair else trade_pnl_events)[:5]
         ]
         if not auto_repair:
             return report
@@ -4830,7 +4870,20 @@ class FillEventsManager:
         payload = [ev.to_dict() for ev in self._events]
         ensure_qty_signage(payload)
         order_same_timestamp_fills(payload)
-        repaired_payload, degraded_count = self._repair_kucoin_payload_contract(payload)
+        if contract_repair:
+            repaired_payload, degraded_count = self._repair_kucoin_payload_contract(payload)
+        else:
+            for ev in payload:
+                self._apply_fee_policy(ev)
+                if _kucoin_trade_pnl_needs_repair(ev):
+                    ev["pnl_status"] = "pending"
+                    ev["pnl_source"] = PNL_SOURCE_PENDING
+            self._synthesize_missing_pnls(payload)
+            repaired_payload = payload
+            degraded_count = sum(
+                ev.get("pnl_source") == PNL_SOURCE_SYNTHETIC_DEGRADED
+                for ev in repaired_payload
+            )
         compute_psize_pprice(repaired_payload)
         self._events = [FillEvent.from_dict(ev) for ev in repaired_payload]
         self.cache.save(self._events)
@@ -7195,18 +7248,13 @@ class KucoinFetcher(BaseFetcher):
         # are stored separately as signed balance cashflow in fee_paid.
         local_pnls, _ = compute_realized_pnls_from_trades(trades)
 
-        closes = [
-            t
-            for t in trades
-            if (t["side"] == "sell" and t["position_side"] == "long")
-            or (t["side"] == "buy" and t["position_side"] == "short")
-        ]
+        closes = [t for t in trades if _is_kucoin_close(t)]
         events: Dict[str, Dict[str, object]] = {}
         for t in trades:
             ev = dict(t)
             ev["fee_paid"] = signed_fee_paid_from_payload(ev)
             ev["pnl"] = local_pnls.get(ev["id"], 0.0)
-            ev["pnl_status"] = "pending" if _is_close_payload(ev) else "complete"
+            ev["pnl_status"] = "pending" if _is_kucoin_close(ev) else "complete"
             if ev["pnl_status"] == "pending":
                 ev["pnl_source"] = PNL_SOURCE_PENDING
             events[ev["id"]] = ev

--- a/tests/test_fill_events_manager.py
+++ b/tests/test_fill_events_manager.py
@@ -9041,3 +9041,192 @@ def test_hyperliquid_empty_fee_wrapper_uses_native_amount_without_replacing_zero
     paid, metadata = fem._normalize_fee_paid_from_payload(event, quote_currency="USDC")
     assert paid == pytest.approx(expected)
     assert metadata["fee_source"] == fem.FEE_SOURCE_REPORTED_QUOTE
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("position_side,entry_side,close_side", [("long", "buy", "sell"), ("short", "sell", "buy")])
+@pytest.mark.parametrize("owned", [False, True])
+async def test_kucoin_raw_partial_close_is_pending_before_order_enrichment(
+    position_side, entry_side, close_side, owned
+):
+    ts = 1_700_000_000_000
+    raw = {
+        "id": "partial", "order": "order-partial", "timestamp": ts,
+        "symbol": "TON/USDT:USDT", "side": close_side, "amount": 2, "price": 12,
+        "fee": {"currency": "USDT", "cost": 0.0024},
+        "info": {"positionSide": position_side.upper(), "closeFeePay": "0.0024", "value": "2.4"},
+    }
+
+    class API:
+        async def fetch_my_trades(self, params):
+            return [deepcopy(raw)] if params["startAt"] <= ts <= params["endAt"] else []
+
+        async def fetch_positions_history(self, params):
+            return []
+
+        async def fetch_order(self, order_id, symbol):
+            return {"clientOrderId": "external"}
+
+    fetcher = KucoinFetcher(API(), now_func=lambda: ts + 60_000)
+    detail_cache = {"partial": ("owned", f"close_unstuck_{position_side}")} if owned else {}
+    batches = []
+    rows = await fetcher.fetch(ts, ts + 60_000, detail_cache, on_batch=batches.extend)
+    assert len(rows) == 1
+    assert rows == batches
+    assert rows[0]["position_side"] == position_side
+    assert rows[0]["pnl_status"] == "pending"
+    assert rows[0]["pnl_source"] == fem.PNL_SOURCE_PENDING
+    # Entry normalization is independent of the order label as well.
+    raw["side"] = entry_side
+    raw["info"]["closeFeePay"] = "0"
+    rows = await fetcher.fetch(ts, ts + 60_000, detail_cache)
+    assert rows[0]["pnl_status"] == "complete"
+
+
+def _write_kucoin_mislabeled_cache(cache_dir, *, position_side="long", with_entry=True):
+    ts = 1_700_000_000_000
+    side = "buy" if position_side == "long" else "sell"
+    close_side = "sell" if position_side == "long" else "buy"
+    rows = [
+        _kucoin_manager_fill("basis", ts, side=side, qty=10, price=10, position_side=position_side),
+        _kucoin_manager_fill("partial-zero", ts + 60_000, side=close_side, qty=2, price=12, position_side=position_side),
+        _kucoin_manager_fill("partial-nonzero", ts + 86_400_000, side=close_side, qty=3, price=14, position_side=position_side),
+        _kucoin_manager_fill("reconciled", ts + 86_460_000, side=close_side, qty=1, price=13, position_side=position_side),
+    ]
+    for row in rows:
+        row.update(
+            pnl_contract=fem.PNL_CONTRACT_CURRENT, pnl_status="complete",
+            pnl_source=fem.PNL_SOURCE_AUTHORITATIVE, c_mult=0.1,
+            fees={"currency": "USDT", "cost": 0.001}, fee_paid=-0.001,
+            raw=[{"source": "fetch_my_trades", "data": {"id": row["id"]}}],
+        )
+        # Reproduce old caches even when no Passivbot order label was recovered.
+        row["pb_order_type"] = ""
+    rows[2]["pnl"] = 999.0  # a nonzero batch-local estimate is not authority either
+    rows[2]["provenance"] = {"runtime_run_id": "first-ingestion-fixture"}
+    rows[3].update(pnl=0.25, pnl_source=fem.PNL_SOURCE_AUTHORITATIVE_CYCLE_RECONCILED)
+    if not with_entry:
+        rows = rows[1:]
+    cache = FillEventCache(cache_dir)
+    cache.save([FillEvent.from_dict(row) for row in rows])
+    cache.update_metadata_from_events([FillEvent.from_dict(row) for row in rows], mark_refreshed=False)
+    metadata = json.loads(cache.metadata_path.read_text())
+    metadata.update(last_refresh_ms=ts + 100_000_000, covered_start_ms=ts - 1000, history_scope="all")
+    cache.metadata_path.write_text(json.dumps(metadata))
+    return rows, metadata
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("position_side", ["long", "short"])
+@pytest.mark.parametrize("via_doctor", [False, True])
+async def test_kucoin_current_cache_auto_repair_preserves_archive_checkpoint_and_authority(
+    tmp_path, caplog, position_side, via_doctor
+):
+    cache_dir = tmp_path / "fills"
+    original, metadata = _write_kucoin_mislabeled_cache(cache_dir, position_side=position_side)
+    original_files = {p.name: p.read_bytes() for p in cache_dir.iterdir()}
+    manager = FillEventsManager(exchange="kucoin", user="fixture", fetcher=_StaticFetcher([]), cache_path=cache_dir)
+    caplog.set_level(logging.INFO, logger=fem.logger.name)
+    if via_doctor:
+        report = await manager.run_doctor(auto_repair=False)
+        assert report["anomaly_events"] == 2
+        assert report["anomaly_examples"][0]["reason"] == "trade_pnl_mislabeled_authoritative"
+        assert {p.name: p.read_bytes() for p in cache_dir.iterdir()} == original_files
+        report = await manager.run_doctor(auto_repair=True)
+        assert report["repaired"]
+        assert report["legacy_contract"] is False
+    else:
+        await manager.ensure_loaded()
+    by_id = {ev.id: ev for ev in manager._events}
+    sign = 1 if position_side == "long" else -1
+    assert by_id["partial-zero"].pnl == pytest.approx(sign * 0.4)
+    assert by_id["partial-nonzero"].pnl == pytest.approx(sign * 1.2)
+    for key in ("partial-zero", "partial-nonzero"):
+        assert by_id[key].pnl_source == fem.PNL_SOURCE_SYNTHETIC_EXACT
+        assert by_id[key].fee_paid == pytest.approx(-0.001)
+    assert by_id["reconciled"].pnl == 0.25
+    assert by_id["reconciled"].pnl_source == fem.PNL_SOURCE_AUTHORITATIVE_CYCLE_RECONCILED
+    assert by_id["partial-nonzero"].provenance == original[2]["provenance"]
+    assert not by_id["partial-zero"].provenance
+    for ev, raw in zip(manager._events, original):
+        assert ev.raw == raw["raw"]
+    backup, = tmp_path.glob("fills.backup.*")
+    assert {p.name: p.read_bytes() for p in backup.iterdir()} == original_files
+    after_metadata = json.loads((cache_dir / "metadata.json").read_text())
+    for field in ("last_refresh_ms", "covered_start_ms", "history_scope"):
+        assert after_metadata[field] == metadata[field]
+    assert "cache backed up at" in caplog.text
+    repaired_rows = [ev.to_dict() for ev in manager._events]
+    reloaded = FillEventsManager(exchange="kucoin", user="fixture", fetcher=_StaticFetcher([]), cache_path=cache_dir)
+    await reloaded.ensure_loaded()
+    assert [ev.to_dict() for ev in reloaded._events] == repaired_rows
+    assert len(list(tmp_path.glob("fills.backup.*"))) == 1
+    assert (await reloaded.run_doctor())["anomaly_events"] == 0
+
+
+@pytest.mark.asyncio
+async def test_kucoin_auto_repair_incomplete_basis_remains_degraded(tmp_path):
+    cache_dir = tmp_path / "fills"
+    _write_kucoin_mislabeled_cache(cache_dir, with_entry=False)
+    manager = FillEventsManager(exchange="kucoin", user="fixture", fetcher=_StaticFetcher([]), cache_path=cache_dir)
+    await manager.ensure_loaded()
+    repaired = [ev for ev in manager._events if ev.id != "reconciled"]
+    assert all(ev.pnl_source == fem.PNL_SOURCE_SYNTHETIC_DEGRADED for ev in repaired)
+    assert all(ev.pnl_synthetic_reason == "incomplete_position_basis" for ev in repaired)
+    reloaded = FillEventsManager(exchange="kucoin", user="fixture", fetcher=_StaticFetcher([]), cache_path=cache_dir)
+    await reloaded.ensure_loaded()
+    assert [ev.to_dict() for ev in reloaded._events] == [ev.to_dict() for ev in manager._events]
+    assert len(list(tmp_path.glob("fills.backup.*"))) == 1
+
+
+@pytest.mark.asyncio
+async def test_kucoin_auto_repair_backup_failure_does_not_rewrite_or_load(tmp_path, monkeypatch):
+    cache_dir = tmp_path / "fills"
+    _write_kucoin_mislabeled_cache(cache_dir)
+    original_files = {p.name: p.read_bytes() for p in cache_dir.iterdir()}
+    manager = FillEventsManager(exchange="kucoin", user="fixture", fetcher=_StaticFetcher([]), cache_path=cache_dir)
+
+    def fail_backup():
+        raise OSError("backup unavailable")
+
+    monkeypatch.setattr(manager, "_backup_cache_for_repair", fail_backup)
+    with pytest.raises(OSError, match="backup unavailable"):
+        await manager.ensure_loaded()
+    assert not manager._loaded
+    assert {p.name: p.read_bytes() for p in cache_dir.iterdir()} == original_files
+
+
+@pytest.mark.asyncio
+async def test_kucoin_repaired_history_survives_overlap_and_delayed_cycle_reconciliation(tmp_path):
+    cache_dir = tmp_path / "fills"
+    original, _ = _write_kucoin_mislabeled_cache(cache_dir)
+    # Keep a single open lifecycle with two defective partial closes.
+    rows = original[:3]
+    cache = FillEventCache(cache_dir)
+    cache.save([FillEvent.from_dict(row) for row in rows])
+    cache.update_metadata_from_events([FillEvent.from_dict(row) for row in rows], mark_refreshed=False)
+    overlap = deepcopy(rows[-1])
+    overlap.update(pnl=0, pnl_status="pending", pnl_source=fem.PNL_SOURCE_PENDING)
+    manager = FillEventsManager(exchange="kucoin", user="fixture", fetcher=_StaticFetcher([overlap]), cache_path=cache_dir)
+    await manager.refresh()
+    assert sum(ev.pnl for ev in manager._events) == pytest.approx(1.6)
+    final = deepcopy(overlap)
+    final.update(id="final", timestamp=overlap["timestamp"] + 60_000, qty=-5, price=11, raw=[{"source": "fetch_my_trades", "data": {"id": "final"}}])
+    manager.fetcher = _StaticFetcher([overlap, final])
+    await manager.refresh()
+    assert sum(ev.pnl for ev in manager._events) == pytest.approx(2.1)
+    observation = _kucoin_cycle_observation(
+        "cycle", realized_pnl=2.496, open_time=rows[0]["timestamp"], close_time=final["timestamp"]
+    )
+    manager.fetcher = _StaticFetcher([final], [observation])
+    await manager.refresh()
+    assert sum(ev.pnl + ev.fee_paid for ev in manager._events) == pytest.approx(2.496)
+    assert all(ev.pnl_source == fem.PNL_SOURCE_AUTHORITATIVE_CYCLE_RECONCILED for ev in manager._events[1:])
+    expected = [ev.to_dict() for ev in manager._events]
+    manager.fetcher = _StaticFetcher([overlap, final])
+    await manager.refresh()
+    assert [ev.to_dict() for ev in manager._events] == expected
+    reloaded = FillEventsManager(exchange="kucoin", user="fixture", fetcher=_StaticFetcher([]), cache_path=cache_dir)
+    await reloaded.ensure_loaded()
+    assert [ev.to_dict() for ev in reloaded._events] == expected
+    assert len(list(tmp_path.glob("fills.backup.*"))) == 1


### PR DESCRIPTION
KuCoin trade fills do not carry authoritative realized PnL. Close detection previously ran before order-label enrichment, so partial reductions could be cached as complete/authoritative with zero or a batch-local estimate. Realized-loss consumers could consequently undercount losses until the entire position closed.

Classify reductions from side and position side before enrichment. On cache load, automatically reuse the KuCoin doctor to archive and reconstruct affected trade-derived rows against the full cached position basis. Preserve reconciled cycle PnL, provenance, raw records, coverage, and the incremental checkpoint. Incomplete reconstruction stays degraded and unavailable to PnL risk consumers. Standalone doctor check mode remains read-only; repeated loads do not create further backups after repair.

Validation: 243 fill-manager tests and 369 risk/readiness and documentation tests passed. New regressions cover raw long/short partial closes, external fills, zero/nonzero corrupt estimates, automatic and explicit doctor repair, backup failure, missing basis, restart idempotence, overlap, and delayed cycle reconciliation. AI documentation and generated event-registry checks passed.
