### PR TITLE
Add opt-in coupled strategy and unstuck EMA search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Add `couple_unstuck_ema_spans` to `optimize.enable_overrides` to search strategy and unstuck
+  EMA spans together on CPU or Apple MPS, including effective coin/scenario strategy overrides.
+  Coupled search omits redundant unstuck span genes and saves explicit horizons for ordinary
+  replay. Independent search remains the default; changing the option requires a fresh run.
+
 - Auto-unstuck now owns independent `bot.<side>.unstuck.ema_span_0` / `ema_span_1`, including
   coin overrides and CPU optimizer bounds. Schema v8.3.0 migrates missing spans from each coin's
   effective strategy to preserve saved trading behavior, with warnings where exact migration is

--- a/docs/ai/features/strategy_runtime.md
+++ b/docs/ai/features/strategy_runtime.md
@@ -175,6 +175,12 @@ Apple MPS models a separate price EMA band for unstuck in all directional and mu
 It uses the same seeded recurrence, floating horizons and candle-interval scaling as exact Rust.
 Coin overrides win over candidate globals, and temporal replay persists the independent band.
 
+The opt-in optimizer override `couple_unstuck_ema_spans` derives each side/coin's unstuck pair
+from its effective strategy, after mirroring and fixed/scenario overrides. It removes redundant
+unstuck span genes and materializes explicit runtime spans in saved candidates and scenarios.
+GPU packing preserves the dependency on candidate strategy genes while retaining strategy coin
+pins. This is optimizer configuration finalization, not a live/backtest coupling mode.
+
 ## Live/Backtest Market Slippage Boundary
 
 `backtest.market_order_slippage_pct` is a backtest simulation knob only. Live orchestrator input

--- a/docs/config.bot.md
+++ b/docs/config.bot.md
@@ -160,7 +160,8 @@ strategy defaults with a warning to review them before enabling the side.
 
 A former optimizer search with varying strategy spans cannot be migrated one-to-one: those genes
 previously moved both bands. Migration copies fixed legacy bounds exactly; for varying ranges it
-warns and fixes missing new unstuck bounds at the starting values. Set new bounds explicitly to tune them. Migrated per-coin unstuck span overrides remain
+warns and fixes missing new unstuck bounds at the starting values. Set new bounds explicitly to tune them independently, or add
+`couple_unstuck_ema_spans` to `optimize.enable_overrides` to restore coupled search. Migrated per-coin unstuck span overrides remain
 pinned; remove those leaves deliberately to tune a shared global pair. Restart optimizer searches
 rather than resuming old checkpoints after this schema change.
 

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -543,8 +543,27 @@ Exact-selected seeds are placed first in the initial GPU population, followed by
 seeds and then random candidates. Their exact objective values are never inserted into the proxy
 NSGA-II fitness matrix.
 
-The V8 `optimize.enable_overrides` values `mirror_short_from_long` and
-`lossless_close_trailing` are applied to Metal candidates in the same order as exact candidate
+To search the strategy and unstuck EMA horizons together, set:
+
+```json
+"enable_overrides": ["couple_unstuck_ema_spans"]
+```
+
+This opt-in setting belongs under `optimize`. It restores the former coupled EMA search on CPU
+and Apple MPS: each candidate's effective strategy spans determine its unstuck spans, including
+per-coin strategy overrides. Independent unstuck span bounds and existing unstuck span pins are
+ignored while coupling is enabled, and the redundant genes are omitted. Strategy spans must be
+positive and finite. The default remains independent search.
+
+Coupling runs after fixed runtime overrides and long-to-short mirroring, and follows effective
+scenario strategy overrides. Saved candidates materialize the derived spans, including scenario
+and coin overrides, so normal backtests and live bots reproduce them without an optimizer hook.
+Disable the option and set unstuck bounds explicitly to resume independent search; remove any
+saved per-coin unstuck pins when you want to tune a shared global pair. Start a fresh optimizer
+run when changing this option because its search dimensions and evaluation policy differ.
+
+The V8 `optimize.enable_overrides` values `mirror_short_from_long`, `couple_unstuck_ema_spans`,
+and `lossless_close_trailing` are applied to Metal candidates in the same order as exact candidate
 materialization. Mirroring may be used with the supported single-coin directional scopes; short
 genes that exact materialization overwrites are omitted from the proxy search dimensions.
 `lossless_close_trailing` is available only with `strategy_kind: trailing_martingale`. The legacy

--- a/src/config/migrations/unstuck_ema.py
+++ b/src/config/migrations/unstuck_ema.py
@@ -175,7 +175,8 @@ def migrate_unstuck_ema_spans(
             "optimizer-search migration is impossible: strategy spans previously also controlled "
             "unstucking (%s). New unstuck span bounds are fixed at migrated values unless explicitly "
             "provided. Set optimize.bounds.<side>.unstuck.ema_span_0/1 to tune them independently; "
-            "previous optimizer checkpoints must start a new search.",
+            "or add couple_unstuck_ema_spans to optimize.enable_overrides to restore coupled search. "
+            "Previous optimizer checkpoints must start a new search.",
             ", ".join(coupled_search),
         )
     if pinned:

--- a/src/config_utils.py
+++ b/src/config_utils.py
@@ -1615,6 +1615,11 @@ def _argument_metavar(type_, full_name: str, value):
 
 
 CLI_HELP_OVERRIDES = {
+    "optimize.enable_overrides": (
+        "Optimizer convenience overrides. couple_unstuck_ema_spans derives each coin and side's "
+        "unstuck horizons from its effective strategy, removing redundant unstuck span genes. "
+        "Saved candidates retain explicit spans. Default: no overrides."
+    ),
     "backtest.scenarios": (
         "Suite scenario definitions. Use --scenarios to select labels; use "
         "--suite-config for complex scenario files. Scenario entries support "

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -362,6 +362,7 @@ GPU_CAPABILITIES_DOC = "docs/optimizing.md#deliberate-current-limitations"
 GPU_SUPPORTED_STRATEGY_KINDS = frozenset(GPU_STRATEGY_BOUND_MAPS)
 
 GPU_SUPPORTED_OPTIMIZER_OVERRIDES = {
+    "couple_unstuck_ema_spans",
     "lossless_close_trailing",
     "mirror_short_from_long",
 }
@@ -4272,6 +4273,15 @@ def run_backend(
             bound_map.update(mapper(multicoin_side, gpu_optimizer_overrides))
     else:
         bound_map = GPU_STRATEGY_BOUND_MAPS[strategy_kind]
+
+    if "couple_unstuck_ema_spans" in gpu_optimizer_overrides:
+        from optimizer_overrides import COUPLED_UNSTUCK_EMA_BOUND_KEYS
+
+        bound_map = {
+            key: value
+            for key, value in bound_map.items()
+            if key not in COUPLED_UNSTUCK_EMA_BOUND_KEYS
+        }
 
     fixed_bound_values, fixed_parameter_overrides = _gpu_fixed_bound_context(
         config,

--- a/src/optimization/config_adapter.py
+++ b/src/optimization/config_adapter.py
@@ -23,6 +23,10 @@ from config.strategy_spec import (
     strategy_optimize_key_path_map,
 )
 from optimization.bounds import Bound
+from optimizer_overrides import (
+    COUPLED_UNSTUCK_EMA_BOUND_KEYS,
+    unstuck_ema_spans_coupled,
+)
 
 
 def _flatten_bounds_for_config(config: dict, optimize_bounds: dict) -> dict:
@@ -146,6 +150,11 @@ def get_optimization_key_paths(config) -> List[Tuple[str, Tuple[str, ...]]]:
             continue
         canonical_key = canonical_optimizer_key(bound_key)
         if canonical_key != bound_key and canonical_key in optimize_bounds:
+            continue
+        if (
+            unstuck_ema_spans_coupled(config)
+            and canonical_key in COUPLED_UNSTUCK_EMA_BOUND_KEYS
+        ):
             continue
         resolved = resolve_optimization_bound_path(config, bound_key)
         if resolved is None:

--- a/src/optimization/evaluation_contract.py
+++ b/src/optimization/evaluation_contract.py
@@ -9,7 +9,7 @@ from optimization.config_adapter import _flatten_bounds_for_config
 from optimization.fine_tune_anchors import get_anchor_plan
 from optimization.evaluation_implementation import evaluation_implementation_identity
 from optimization.warmup import _apply_config_overrides
-from optimizer_overrides import optimizer_overrides
+from optimizer_overrides import optimizer_overrides, unstuck_ema_spans_coupled
 
 CONTRACT_KEY = "optimizer_evaluation_contract"
 CONTRACT_CACHE_KEY = "_optimizer_evaluation_contract"
@@ -82,6 +82,17 @@ def build_evaluation_contract(config: dict) -> dict:
 
     # Resolve before removing the base values required to validate coin patches.
     coin_overrides = deepcopy(effective.get("coin_overrides", {}))
+    coupled = unstuck_ema_spans_coupled(config)
+    if coupled:
+        # These leaves derive from the strategy policy already recorded below;
+        # candidate-dependent materialized coin values are not fixed policy.
+        for bot in [
+            effective.get("bot", {}),
+            *(patch.get("bot", {}) for patch in coin_overrides.values()),
+        ]:
+            for side in ("long", "short"):
+                for key in ("ema_span_0", "ema_span_1"):
+                    bot.get(side, {}).get("unstuck", {}).pop(key, None)
     bounds = _flatten_bounds_for_config(effective, effective["optimize"]["bounds"])
     for key in bounds:
         path = resolve_optimizer_key_path(effective, key)
@@ -110,6 +121,7 @@ def build_evaluation_contract(config: dict) -> dict:
         }
     return {
         "version": 1,
+        "coupled_unstuck_ema_spans": coupled,
         "implementation": deepcopy(evaluation_implementation_identity()),
         "prepared_data": deepcopy(config.get("_optimizer_prepared_dataset_identity")),
         "bot": effective.get("bot", {}),

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -10,6 +10,7 @@ import time
 import numpy as np
 
 from config.shared_bot import flatten_shared_bot_side
+from optimizer_overrides import unstuck_ema_spans_coupled
 from optimization.gpu.metric_registry import (
     BTC_INTRADAY_RISK_METRICS,
     ENTRY_INTERVAL_METRICS,
@@ -1940,6 +1941,7 @@ class MpsSingleCoinProxy:
                 signal_mode, enabled_side_count=sum(self.enabled.values())
             )
         hsl_panic_market = {}
+        self.couple_unstuck_emas = unstuck_ema_spans_coupled(config)
         self.base_params = {}
         configured_total_wallet_exposure_limits = {
             side: float(bot["total_wallet_exposure_limit"])
@@ -2216,6 +2218,9 @@ class MpsSingleCoinProxy:
                 merged.update(
                     getattr(self, "static_coin_override_params", {}).get(side, {})
                 )
+                if getattr(self, "couple_unstuck_emas", False):
+                    for i in (0, 1):
+                        merged[f"unstuck_ema_span_{i}"] = merged[f"ema_span_{i}"]
                 row.extend(float(merged[key]) for key in self.param_keys)
             rows.append(row)
         return np.asarray(rows, dtype=np.float64)
@@ -2583,11 +2588,17 @@ def _build_multicoin_ema_coin_overrides(
             if patch_key in unstuck_patch:
                 matrix[coin_index, offset] = float(effective_bot[bot_key])
         for offset, key in enumerate(UNSTUCK_EMA_PARAM_KEYS):
-            if key.removeprefix("unstuck_") in unstuck_patch:
-                matrix[
+            column = EMA_ANCHOR_COIN_OVERRIDE_UNSTUCK_EMA_START_COLUMN + offset
+            strategy_key = key.removeprefix("unstuck_")
+            if unstuck_ema_spans_coupled(config):
+                # Inherited spans stay NaN so each candidate supplies its own
+                # strategy value; only actual strategy coin pins remain static.
+                matrix[coin_index, column] = matrix[
                     coin_index,
-                    EMA_ANCHOR_COIN_OVERRIDE_UNSTUCK_EMA_START_COLUMN + offset,
-                ] = float(effective_bot[key])
+                    EMA_ANCHOR_COIN_OVERRIDE_STRATEGY_KEYS.index(strategy_key),
+                ]
+            elif strategy_key in unstuck_patch:
+                matrix[coin_index, column] = float(effective_bot[key])
         _pack_multicoin_hsl_overrides(
             matrix,
             row=coin_index,
@@ -2732,11 +2743,19 @@ def _build_multicoin_tm_coin_overrides(
             if patch_key in unstuck_patch:
                 matrix[coin_index, offset] = float(effective_bot[bot_key])
         for offset, key in enumerate(UNSTUCK_EMA_PARAM_KEYS):
-            if key.removeprefix("unstuck_") in unstuck_patch:
-                matrix[
+            column = TRAILING_MARTINGALE_COIN_OVERRIDE_UNSTUCK_EMA_START_COLUMN + offset
+            strategy_key = key.removeprefix("unstuck_")
+            if unstuck_ema_spans_coupled(config):
+                # Inherited spans stay NaN so each candidate supplies its own
+                # strategy value; only actual strategy coin pins remain static.
+                matrix[coin_index, column] = matrix[
                     coin_index,
-                    TRAILING_MARTINGALE_COIN_OVERRIDE_UNSTUCK_EMA_START_COLUMN + offset,
-                ] = float(effective_bot[key])
+                    TRAILING_MARTINGALE_COIN_OVERRIDE_PATHS.index(
+                        (strategy_key, (strategy_key,))
+                    ),
+                ]
+            elif strategy_key in unstuck_patch:
+                matrix[coin_index, column] = float(effective_bot[key])
         _pack_multicoin_hsl_overrides(
             matrix,
             row=coin_index,
@@ -3139,6 +3158,7 @@ class MpsMulticoinProxy:
             side: float(payload.bot_params_list[0][side]["n_positions"])
             for side in ("long", "short")
         }
+        self.couple_unstuck_emas = unstuck_ema_spans_coupled(config)
         self.base_params = {}
         for side in self.sides:
             first_bot = payload.bot_params_list[0][side]
@@ -3492,6 +3512,9 @@ class MpsMulticoinProxy:
                     if key.startswith(f"{side}_")
                 }
             )
+            if getattr(self, "couple_unstuck_emas", False):
+                for i in (0, 1):
+                    merged[f"unstuck_ema_span_{i}"] = merged[f"ema_span_{i}"]
             rows.append([float(merged[key]) for key in param_keys])
         return np.asarray(rows, dtype=np.float64)
 

--- a/src/optimization/warmup.py
+++ b/src/optimization/warmup.py
@@ -9,7 +9,7 @@ from config.bot import normalize_forager_score_weights
 from config.optimize_bounds import flatten_optimize_bounds
 from config.param_paths import require_existing_config_path, resolve_dotted_config_path
 from config.shared_bot import flatten_shared_bot_side
-from optimizer_overrides import optimizer_overrides
+from optimizer_overrides import optimizer_overrides, materialize_coupled_scenario_spans
 from optimization.bounds import Bound, enforce_bounds
 from optimization.config_adapter import (
     extract_bounds_tuple_list_from_config,
@@ -155,6 +155,8 @@ def _finalize_optimizer_vector_config(config: dict, overrides_list=None) -> dict
         config,
         config.get("optimize", {}).get("fixed_runtime_overrides", {}),
     )
+    if overrides_list is None:
+        overrides_list = config.get("optimize", {}).get("enable_overrides", [])
     config = optimizer_overrides(overrides_list or [], config, None)
     _refresh_shared_bot_runtime_aliases(config)
     for pside in ("long", "short"):
@@ -185,6 +187,7 @@ def _finalize_optimizer_vector_config(config: dict, overrides_list=None) -> dict
         if isinstance(forager_cfg, dict):
             forager_cfg["score_weights"] = deepcopy(normalized)
     canonicalize_dead_optimizer_params(config)
+    materialize_coupled_scenario_spans(config)
     return config
 
 

--- a/src/optimize.py
+++ b/src/optimize.py
@@ -2106,6 +2106,13 @@ class SuiteEvaluator:
         if ctx.overrides:
             scenario_config = deepcopy(scenario_config)
             _apply_config_overrides(scenario_config, ctx.overrides)
+        from optimizer_overrides import (
+            apply_coupled_unstuck_ema_spans,
+            unstuck_ema_spans_coupled,
+        )
+
+        if unstuck_ema_spans_coupled(scenario_config):
+            scenario_config = apply_coupled_unstuck_ema_spans(deepcopy(scenario_config))
         return scenario_config
 
     def _build_scenario_candidate_config(
@@ -3475,8 +3482,16 @@ async def main():
     )
     config = parse_overrides(config, verbose=False)
     validate_optimizer_overrides(config.get("optimize", {}).get("enable_overrides", []))
+    if "couple_unstuck_ema_spans" in (
+        config.get("optimize", {}).get("enable_overrides") or []
+    ):
+        logging.info(
+            "Coupled unstuck EMA search: effective strategy spans own unstuck horizons; independent unstuck span bounds and pins are ignored. Saved candidates retain explicit spans."
+        )
     config_logging_value = get_optional_config_value(config, "logging.level", None)
-    effective_log_level = resolve_log_level(args.log_level, config_logging_value, fallback=1)
+    effective_log_level = resolve_log_level(
+        args.log_level, config_logging_value, fallback=1
+    )
     if effective_log_level != initial_log_level:
         configure_logging(debug=effective_log_level)
     logging.info(

--- a/src/optimizer_overrides.py
+++ b/src/optimizer_overrides.py
@@ -90,6 +90,11 @@ def couple_unstuck_ema_spans(config, pside):
 def apply_coupled_unstuck_ema_spans(config):
     """Apply coupling after scenario overrides without replaying other overrides."""
     if unstuck_ema_spans_coupled(config):
+        from config.overrides import parse_overrides
+
+        config["coin_overrides"] = parse_overrides(config, verbose=False)[
+            "coin_overrides"
+        ]
         for side in ("long", "short"):
             couple_unstuck_ema_spans(config, side)
     return config
@@ -100,10 +105,17 @@ def materialize_coupled_scenario_spans(config):
     if not unstuck_ema_spans_coupled(config):
         return
     from optimization.warmup import _apply_config_overrides
+    from config.param_paths import resolve_dotted_config_path
+    from suite_runner import _normalize_scenario_overrides
 
     for scenario in config.get("backtest", {}).get("scenarios", []) or []:
         effective = deepcopy(config)
-        overrides = scenario.get("overrides") or {}
+        overrides = {
+            ".".join(resolve_dotted_config_path(effective, key)): value
+            for key, value in _normalize_scenario_overrides(
+                scenario.get("overrides")
+            ).items()
+        }
         _apply_config_overrides(effective, overrides)
         apply_coupled_unstuck_ema_spans(effective)
         # Resolve dotted coin patches into one canonical map to preserve their

--- a/src/optimizer_overrides.py
+++ b/src/optimizer_overrides.py
@@ -1,4 +1,5 @@
 from copy import deepcopy
+import math
 
 from config.access import require_config_value
 from config.shared_bot import BOT_SHARED_GROUPS
@@ -6,12 +7,17 @@ from config.strategy import DEFAULT_STRATEGY_KIND, normalize_strategy_kind
 
 TRAILING_GRID_V7_STRATEGY_KIND = "trailing_grid_v7"
 
+COUPLED_UNSTUCK_EMA_BOUND_KEYS = frozenset(
+    f"{side}_unstuck_ema_span_{i}" for side in ("long", "short") for i in (0, 1)
+)
+
 KNOWN_OPTIMIZER_OVERRIDES = frozenset(
     {
         "backward_tp_grid",
         "forward_tp_grid",
         "lossless_close_trailing",
         "mirror_short_from_long",
+        "couple_unstuck_ema_spans",
     }
 )
 
@@ -35,6 +41,86 @@ def _mirror_short_from_long(config):
         short_strategy[strategy_kind] = deepcopy(long_strategy[strategy_kind])
 
     return config
+
+
+def unstuck_ema_spans_coupled(config):
+    return "couple_unstuck_ema_spans" in (
+        config.get("optimize", {}).get("enable_overrides") or []
+    )
+
+
+def couple_unstuck_ema_spans(config, pside):
+    """Materialize the effective strategy horizons, including each coin's patches.
+
+    This is optimizer finalization only. Saved candidates contain ordinary explicit
+    unstuck parameters and require no live/backtest coupling mode.
+    """
+    kind = normalize_strategy_kind(config.get("live", {}).get("strategy_kind"))
+    if any(
+        patch.get("override_config_path")
+        for patch in (config.get("coin_overrides") or {}).values()
+    ):
+        from config.overrides import parse_overrides
+
+        config["coin_overrides"] = parse_overrides(config, verbose=False)[
+            "coin_overrides"
+        ]
+    base = config["bot"][pside]
+    strategy = base["strategy"][kind]
+    targets = [("global", base, strategy)]
+    for coin, patch in (config.get("coin_overrides") or {}).items():
+        side_patch = patch.setdefault("bot", {}).setdefault(pside, {})
+        effective = {**strategy, **side_patch.get("strategy", {}).get(kind, {})}
+        targets.append((coin, side_patch, effective))
+    for coin, target, source in targets:
+        for key in ("ema_span_0", "ema_span_1"):
+            value = source[key]
+            if not math.isfinite(float(value)) or float(value) <= 0:
+                raise ValueError(
+                    f"couple_unstuck_ema_spans requires positive finite strategy spans: {coin} {pside}.{key}={value!r}"
+                )
+            target.setdefault("unstuck", {})[key] = value
+            # Refresh transport aliases only when this config already carries them.
+            alias = f"unstuck_{key}"
+            if alias in target:
+                target[alias] = value
+    return config
+
+
+def apply_coupled_unstuck_ema_spans(config):
+    """Apply coupling after scenario overrides without replaying other overrides."""
+    if unstuck_ema_spans_coupled(config):
+        for side in ("long", "short"):
+            couple_unstuck_ema_spans(config, side)
+    return config
+
+
+def materialize_coupled_scenario_spans(config):
+    """Save scenario-local dependencies explicitly for ordinary suite replay."""
+    if not unstuck_ema_spans_coupled(config):
+        return
+    from optimization.warmup import _apply_config_overrides
+
+    for scenario in config.get("backtest", {}).get("scenarios", []) or []:
+        effective = deepcopy(config)
+        overrides = scenario.get("overrides") or {}
+        _apply_config_overrides(effective, overrides)
+        apply_coupled_unstuck_ema_spans(effective)
+        # Resolve dotted coin patches into one canonical map to preserve their
+        # effective precedence even when a saved JSON sorts object keys.
+        saved = {
+            key: deepcopy(value)
+            for key, value in overrides.items()
+            if key != "coin_overrides" and not key.startswith("coin_overrides.")
+        }
+        if "coin_overrides" in effective:
+            saved["coin_overrides"] = effective["coin_overrides"]
+        for side in ("long", "short"):
+            for key in ("ema_span_0", "ema_span_1"):
+                saved[f"bot.{side}.unstuck.{key}"] = effective["bot"][side]["unstuck"][
+                    key
+                ]
+        scenario["overrides"] = saved
 
 
 def validate_optimizer_overrides(overrides_list):
@@ -116,7 +202,10 @@ def optimizer_overrides(overrides_list, config, pside=None):
         if pside is None:
             continue
 
-        if override == "lossless_close_trailing":
+        if override == "couple_unstuck_ema_spans":
+            config = couple_unstuck_ema_spans(config, pside)
+
+        elif override == "lossless_close_trailing":
             strategy_cfg = _require_trailing_martingale_side(config, pside)
             threshold = require_config_value(
                 config,

--- a/tests/optimization/test_coupled_unstuck_ema.py
+++ b/tests/optimization/test_coupled_unstuck_ema.py
@@ -1,0 +1,356 @@
+from copy import deepcopy
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from config_utils import clean_config, get_template_config
+from config.load import prepare_config
+from config.overrides import parse_overrides
+from optimization.config_adapter import get_optimization_key_paths
+from optimization.warmup import (
+    _apply_config_overrides,
+    _finalize_optimizer_vector_config,
+    build_optimizer_vector_config,
+    compute_optimizer_per_coin_warmup_minutes,
+)
+from optimizer_overrides import apply_coupled_unstuck_ema_spans
+
+
+def config_for(kind="trailing_martingale"):
+    config = get_template_config()
+    config["live"]["strategy_kind"] = kind
+    config["optimize"]["enable_overrides"] = ["couple_unstuck_ema_spans"]
+    config = parse_overrides(prepare_config(config, verbose=False), verbose=False)
+    for side in ("long", "short"):
+        config["bot"][side]["strategy"][kind].update(
+            ema_span_0=17.25, ema_span_1=211.75
+        )
+        config["bot"][side]["unstuck"].update(ema_span_0=9999.5, ema_span_1=8888.5)
+    return config
+
+
+@pytest.mark.parametrize(
+    "kind", ["trailing_martingale", "ema_anchor", "trailing_grid_v7"]
+)
+def test_coupled_candidates_drop_redundant_genes_and_materialize_effective_coin_spans(
+    kind,
+):
+    config = config_for(kind)
+    config["coin_overrides"] = {
+        "BTC": {
+            "bot": {
+                "long": {
+                    "strategy": {kind: {"ema_span_0": 71.5}},
+                    "unstuck": {"ema_span_0": 1.0, "ema_span_1": 2.0},
+                }
+            }
+        },
+        "ETH": {"bot": {"short": {"unstuck": {"ema_span_0": 3.0}}}},
+    }
+    original = deepcopy(config)
+    paths = get_optimization_key_paths(config)
+    assert not any("unstuck_ema_span" in key for key, _ in paths)
+    vector = []
+    for key, path in paths:
+        value = config
+        for part in path:
+            value = value[part]
+        vector.append(101.25 if key == "long_ema_span_1" else value)
+    candidate = build_optimizer_vector_config(vector, config, key_paths=paths)
+    assert config == original
+    assert candidate["bot"]["long"]["unstuck"]["ema_span_1"] == 101.25
+    btc = candidate["coin_overrides"]["BTC"]["bot"]
+    assert btc["long"]["unstuck"]["ema_span_0"] == 71.5
+    assert btc["long"]["unstuck"]["ema_span_1"] == 101.25
+    assert btc["short"]["unstuck"]["ema_span_0"] == 17.25
+    # Reopening a saved candidate with optimizer overrides disabled preserves behavior.
+    saved = clean_config(candidate)
+    saved["optimize"]["enable_overrides"] = []
+    loaded = parse_overrides(prepare_config(saved, verbose=False), verbose=False)
+    assert (
+        loaded["coin_overrides"]["BTC"]["bot"]["long"]["unstuck"]
+        == btc["long"]["unstuck"]
+    )
+
+
+def test_independent_default_and_mirror_fixed_override_order():
+    config = config_for()
+    config["optimize"]["enable_overrides"] = []
+    assert any(
+        "unstuck_ema_span" in key for key, _ in get_optimization_key_paths(config)
+    )
+    independent = _finalize_optimizer_vector_config(deepcopy(config))
+    assert independent["bot"]["long"]["unstuck"]["ema_span_0"] == 9999.5
+    config["optimize"]["enable_overrides"] = [
+        "couple_unstuck_ema_spans",
+        "mirror_short_from_long",
+    ]
+    config["optimize"]["fixed_runtime_overrides"] = {
+        "bot.long.strategy.trailing_martingale.ema_span_0": 61.25,
+        "bot.short.unstuck.ema_span_0": 1.5,
+    }
+    candidate = _finalize_optimizer_vector_config(deepcopy(config))
+    for side in ("long", "short"):
+        assert candidate["bot"][side]["unstuck"]["ema_span_0"] == 61.25
+        assert candidate["bot"][side]["unstuck_ema_span_0"] == 61.25
+
+
+def test_coupling_materializes_scenario_dependencies_for_plain_saved_suite_replay():
+    config = config_for()
+    config["coin_overrides"] = {
+        "BTC": {"bot": {"long": {"unstuck": {"ema_span_0": 4.5}}}}
+    }
+    config["backtest"]["scenarios"] = [
+        {
+            "label": "alternate",
+            "overrides": {
+                "bot.long.strategy.trailing_martingale.ema_span_0": 301.25,
+                "bot.long.unstuck.ema_span_0": 3.0,
+                "coin_overrides.BTC.bot.long.unstuck.ema_span_0": 5.0,
+            },
+        }
+    ]
+    finalized = _finalize_optimizer_vector_config(deepcopy(config))
+    replay = clean_config(finalized)
+    replay["optimize"]["enable_overrides"] = []
+    _apply_config_overrides(replay, replay["backtest"]["scenarios"][0]["overrides"])
+    assert replay["bot"]["long"]["unstuck"]["ema_span_0"] == 301.25
+    assert (
+        replay["coin_overrides"]["BTC"]["bot"]["long"]["unstuck"]["ema_span_0"]
+        == 301.25
+    )
+    assert config["bot"]["long"]["unstuck"]["ema_span_0"] == 9999.5
+
+
+def test_coupling_contract_ignores_derived_coin_values_but_tracks_mode_and_sources():
+    from optimization.evaluation_contract import build_evaluation_contract
+
+    config = config_for()
+    config["coin_overrides"] = {
+        "BTC": {"bot": {"long": {"unstuck": {"ema_span_0": 4.5}}}}
+    }
+    first = build_evaluation_contract(config)
+    config["bot"]["long"]["strategy"]["trailing_martingale"]["ema_span_0"] = 501.25
+    assert build_evaluation_contract(config) == first
+    config["coin_overrides"]["BTC"]["bot"]["long"]["strategy"] = {
+        "trailing_martingale": {"ema_span_0": 71.5}
+    }
+    assert build_evaluation_contract(config) != first
+    config["optimize"]["enable_overrides"] = []
+    assert build_evaluation_contract(config)["coupled_unstuck_ema_spans"] is False
+
+
+@pytest.mark.parametrize("kind", ["ema_anchor", "trailing_martingale"])
+@pytest.mark.parametrize("single", [True, False])
+def test_gpu_candidate_packing_couples_after_candidate_and_exact_coin_values(
+    kind, single
+):
+    from optimization.gpu import model, service
+
+    cls = service.MpsSingleCoinProxy if single else service.MpsMulticoinProxy
+    proxy = cls.__new__(cls)
+    prefix = "EMA_ANCHOR" if kind == "ema_anchor" else "TRAILING_MARTINGALE"
+    keys = getattr(
+        model,
+        prefix + ("_SINGLE_COIN_PARAM_KEYS" if single else "_MULTICOIN_PARAM_KEYS"),
+    )
+    proxy.param_keys = keys
+    proxy.sides = ["long", "short"]
+    proxy.couple_unstuck_emas = True
+    proxy.base_params = {side: {key: 1.0 for key in keys} for side in proxy.sides}
+    proxy.static_coin_override_params = {
+        "long": {"ema_span_0": 71.5, "unstuck_ema_span_0": 4.0}
+    }
+    candidates = [
+        {
+            "long_ema_span_0": 17.25,
+            "long_ema_span_1": 211.75,
+            "long_unstuck_ema_span_1": 9.0,
+        }
+    ]
+    matrix = (
+        proxy._parameter_matrix(candidates)
+        if single
+        else proxy._parameter_matrix(candidates, side="long")
+    )
+    assert matrix[0, keys.index("unstuck_ema_span_0")] == (71.5 if single else 17.25)
+    assert matrix[0, keys.index("unstuck_ema_span_1")] == 211.75
+
+
+@pytest.mark.parametrize("kind", ["ema_anchor", "trailing_martingale"])
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_gpu_coin_packing_preserves_dependency_when_only_one_strategy_span_is_pinned(
+    kind, side
+):
+    from optimization.gpu import model, service
+
+    prefix = "EMA_ANCHOR" if kind == "ema_anchor" else "TRAILING_MARTINGALE"
+    strategy_keys = (
+        model.EMA_ANCHOR_COIN_OVERRIDE_STRATEGY_KEYS
+        if kind == "ema_anchor"
+        else tuple(key for key, _ in model.TRAILING_MARTINGALE_COIN_OVERRIDE_PATHS)
+    )
+    config = config_for(kind)
+    config["coin_overrides"] = {
+        "BTC": {
+            "bot": {
+                side: {
+                    "strategy": {kind: {"ema_span_0": 71.5}},
+                    "unstuck": {"ema_span_0": 4.0, "ema_span_1": 5.0},
+                }
+            }
+        }
+    }
+    strategy = deepcopy(config["bot"][side]["strategy"][kind])
+    strategy["ema_span_0"] = 71.5
+    payload = SimpleNamespace(
+        strategy_params_list=[{side: strategy}],
+        bot_params_list=[
+            {side: {"risk_entry_cooldown_minutes": 0, "total_wallet_exposure_limit": 1}}
+        ],
+    )
+    build = (
+        service._build_multicoin_ema_coin_overrides
+        if kind == "ema_anchor"
+        else service._build_multicoin_tm_coin_overrides
+    )
+    matrix, _ = build(
+        config=config,
+        mss={"BTC": {}},
+        exchange="bybit",
+        coins=["BTC"],
+        payload=payload,
+        side=side,
+        resolve_override=lambda config, mss, exchange, coin: config["coin_overrides"][
+            coin
+        ],
+    )
+    assert matrix[0, -2] == 71.5
+    assert np.isnan(matrix[0, -1])
+
+
+def test_coupled_warmup_tracks_strategy_bounds_and_ignores_migrated_unstuck_pins():
+    config = config_for()
+    config["live"].update(warmup_ratio=1.0, max_warmup_minutes=1_000_000)
+    config["coin_overrides"] = {
+        "BTC": {"bot": {"long": {"unstuck": {"ema_span_0": 900_000.5}}}}
+    }
+    config["optimize"]["bounds"]["long"]["strategy"]["trailing_martingale"][
+        "ema_span_0"
+    ] = [17.25, 80_000.5]
+    coupled = compute_optimizer_per_coin_warmup_minutes(config)
+    assert coupled["BTC"] >= 80_001
+    assert coupled["BTC"] < 900_000
+
+
+def test_anchored_search_derives_spans_from_selected_anchor_and_tunable_strategy():
+    from optimize import install_anchored_fine_tune_plan
+    from optimization.shape import build_optimization_shape
+
+    config = config_for()
+    config["optimize"]["bounds"]["long"]["strategy"]["trailing_martingale"][
+        "ema_span_0"
+    ] = [1.0, 1000.0]
+    config["optimize"]["round_to_n_significant_digits"] = 6
+    anchors = [deepcopy(config), deepcopy(config)]
+    anchors[0]["bot"]["long"]["strategy"]["trailing_martingale"]["ema_span_0"] = 101.25
+    anchors[1]["bot"]["long"]["strategy"]["trailing_martingale"]["ema_span_0"] = 401.75
+    install_anchored_fine_tune_plan(
+        config, ["long.ema_span_1"], "<memory>", starting_configs_override=anchors
+    )
+    shape = build_optimization_shape(config)
+    assert [key for key, _ in shape.key_paths] == ["__anchor_id__", "long_ema_span_1"]
+    candidate = build_optimizer_vector_config([1.0, 311.5], config)
+    assert candidate["bot"]["long"]["unstuck"]["ema_span_0"] == 401.75
+    assert candidate["bot"]["long"]["unstuck"]["ema_span_1"] == 311.5
+
+
+def test_exact_suite_finalization_couples_after_context_overrides_without_mutating_candidate():
+    from optimize import SuiteEvaluator
+
+    config = config_for()
+    config["backtest"].update(coins={"bybit": ["BTC"]}, cache_dir={})
+    config["coin_overrides"] = {
+        "BTC": {"bot": {"long": {"unstuck": {"ema_span_0": 3.0}}}}
+    }
+    before = deepcopy(config)
+    ctx = SimpleNamespace(
+        config=deepcopy(config),
+        overrides={
+            "bot.long.strategy.trailing_martingale.ema_span_0": 401.5,
+            "bot.long.unstuck.ema_span_0": 4.5,
+        },
+    )
+    evaluator = SuiteEvaluator.__new__(SuiteEvaluator)
+    actual = evaluator.build_scenario_candidate_config(config, ctx)
+    assert actual["bot"]["long"]["unstuck"]["ema_span_0"] == 401.5
+    assert (
+        actual["coin_overrides"]["BTC"]["bot"]["long"]["unstuck"]["ema_span_0"] == 401.5
+    )
+    assert config == before
+
+
+@pytest.mark.parametrize("bad", [0, -1, float("nan"), float("inf")])
+def test_coupling_fails_explicitly_for_invalid_strategy_spans(bad):
+    config = config_for()
+    config["bot"]["long"]["strategy"]["trailing_martingale"]["ema_span_0"] = bad
+    with pytest.raises(
+        ValueError, match="couple_unstuck_ema_spans requires positive finite"
+    ):
+        _finalize_optimizer_vector_config(config)
+
+
+def test_scenario_override_file_is_resolved_before_materializing_coupled_spans(
+    tmp_path,
+):
+    import json
+
+    config = config_for()
+    file_config = clean_config(config)
+    file_config["bot"]["long"]["strategy"]["trailing_martingale"].update(
+        ema_span_0=71.25, ema_span_1=99.5
+    )
+    path = tmp_path / "coin.json"
+    path.write_text(json.dumps(file_config))
+    config["backtest"]["scenarios"] = [
+        {
+            "label": "file",
+            "overrides": {
+                "coin_overrides": {
+                    "BTC": {
+                        "override_config_path": str(path),
+                        "bot": {
+                            "long": {
+                                "strategy": {
+                                    "trailing_martingale": {"ema_span_1": 211.5}
+                                }
+                            }
+                        },
+                    }
+                }
+            },
+        }
+    ]
+    candidate = _finalize_optimizer_vector_config(config)
+    saved = candidate["backtest"]["scenarios"][0]["overrides"]["coin_overrides"]["BTC"]
+    assert "override_config_path" not in saved
+    assert saved["bot"]["long"]["unstuck"]["ema_span_0"] == 71.25
+    assert saved["bot"]["long"]["unstuck"]["ema_span_1"] == 211.5
+
+
+def test_coupled_saved_scenario_preserves_explicit_coin_override_clear():
+    config = config_for()
+    config["coin_overrides"] = {
+        "BTC": {
+            "bot": {"long": {"strategy": {"trailing_martingale": {"ema_span_0": 71.5}}}}
+        }
+    }
+    config["backtest"]["scenarios"] = [
+        {"label": "clear", "overrides": {"coin_overrides": {}}}
+    ]
+    candidate = _finalize_optimizer_vector_config(config)
+    overrides = candidate["backtest"]["scenarios"][0]["overrides"]
+    assert overrides["coin_overrides"] == {}
+    _apply_config_overrides(candidate, overrides)
+    assert candidate["coin_overrides"] == {}

--- a/tests/optimization/test_coupled_unstuck_ema.py
+++ b/tests/optimization/test_coupled_unstuck_ema.py
@@ -354,3 +354,33 @@ def test_coupled_saved_scenario_preserves_explicit_coin_override_clear():
     assert overrides["coin_overrides"] == {}
     _apply_config_overrides(candidate, overrides)
     assert candidate["coin_overrides"] == {}
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {
+            "bot": {
+                "long": {
+                    "strategy": {"trailing_martingale": {"ema_span_0": 71.25}},
+                    "unstuck": {"ema_span_0": 3.0},
+                }
+            }
+        },
+        {"long.ema_span_0": 71.25, "long.unstuck_ema_span_0": 3.0},
+        {"bot.long.ema_span_0": 71.25, "bot.long.unstuck_ema_span_0": 3.0},
+    ],
+)
+def test_coupled_saved_scenarios_normalize_nested_and_legacy_aliases(overrides):
+    import json
+
+    config = config_for()
+    config["backtest"]["scenarios"] = [{"label": "legacy", "overrides": overrides}]
+    candidate = _finalize_optimizer_vector_config(config)
+    saved = json.loads(json.dumps(clean_config(candidate), sort_keys=True))
+    saved["optimize"]["enable_overrides"] = []
+    _apply_config_overrides(saved, saved["backtest"]["scenarios"][0]["overrides"])
+    assert (
+        saved["bot"]["long"]["strategy"]["trailing_martingale"]["ema_span_0"] == 71.25
+    )
+    assert saved["bot"]["long"]["unstuck"]["ema_span_0"] == 71.25


### PR DESCRIPTION
Add `couple_unstuck_ema_spans` to `optimize.enable_overrides` to restore the former coupled EMA search. Each candidate's effective strategy spans determine its unstuck spans on CPU and Apple MPS, including coin strategy pins, fixed runtime overrides, mirroring and scenario overrides. Independent search remains the default.

The redundant unstuck EMA genes are omitted. Saved candidates contain explicit spans, including resolved scenario/coin overrides, so ordinary live/backtest replay needs no optimizer hook. GPU packing keeps inherited horizons dependent on each candidate while preserving actual strategy coin pins. Evaluation contracts record the coupling mode without treating derived coin values as fixed policy. Invalid strategy spans fail explicitly. Migration warnings, CLI help and user/architecture docs explain the option and the need for a fresh search when changing modes.

Validation: 1,688 optimizer/configuration/documentation tests; dedicated coverage for all CPU strategies, GPU packing for both supported strategies and sides, anchors, fixed/mirror ordering, warmup, scenario files and override clears, candidate reload and evaluation identity. Real cached-data CLI runs completed with four CPU evaluations and 128 GPU proxy / 64 exact evaluations; saved candidate pairs were verified. The CLI case produced tied zero scores, so it validates execution and persistence rather than strategy performance. GPU EMA/gate behavior and Rust parity are covered by merged #1720.
