### PR TITLE
Wait and recover when live balance risk inputs are unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Live startup and trading now wait and retry with clear risk diagnostics when current balances
+  or required HSL replay balances cannot support risk evaluation, instead of crashing or exhausting
+  the restart budget. Ordinary planning resumes automatically after valid inputs recover; existing
+  HSL protection is retained and may act only when its own inputs are valid. Malformed payloads and
+  configuration remain errors; balances and required history are never substituted or discarded.
+
 - Coin HSL no longer clears live protection or repeatedly reconstructs history when a delayed
   ordinary flatten falls before the bounded replay window. Successful empty-window replays now
   establish the proven episode boundary before calculating current risk, preventing discarded

--- a/docs/ai/error_contract.md
+++ b/docs/ai/error_contract.md
@@ -96,6 +96,12 @@ candles; it does not retain per-span contexts or consecutive-use counters.
 Protective panic and reduce-only actions may proceed when their own account-critical and
 symbol-scoped requirements are fresh, even if unrelated strategy surfaces are unavailable.
 
+Numeric non-positive/non-finite current balances and unusable historical HSL balance denominators
+have an explicit live readiness policy in `features/equity_hard_stop_loss.md`: pause ordinary
+planning, retain valid protection, refresh and retry with capped backoff, and expose recovery.
+This is unavailability, not a substitute input or permission to ignore Rust validation. Shape/type
+errors, malformed configuration, and unrelated validation errors are outside this policy.
+
 ## Forager And Eligibility Inputs
 
 Flat-symbol forager candidates may remain rankable within

--- a/docs/ai/features/equity_hard_stop_loss.md
+++ b/docs/ai/features/equity_hard_stop_loss.md
@@ -103,3 +103,27 @@ adds to held positions retain their policy semantics.
 
 User-facing behavior and configuration are documented in `../../equity_hard_stop_loss.md` and
 `../../equity_hard_stop_loss_cooldown_contracts.md`.
+
+### Live balance input recovery
+
+A numeric current raw/sizing balance that is non-finite or non-positive, or an invalid balance
+in the required reconstructed HSL history, is explicitly unavailable for live risk evaluation.
+Python keeps the process alive and refreshes authoritative account/fill state instead of consuming
+the restart budget. Startup remains unready; runtime ordinary planning waits. No balance is
+clamped to a positive substitute, no required history is discarded, and HSL remains enabled.
+Malformed configuration, payload types/shapes, and unrelated validation errors retain their strict
+failure policy. Rust and individual HSL sample consumers keep their positive-balance guards.
+
+Retry delays grow from 5 seconds to 60 seconds for current balances and 300 seconds for history.
+Account refresh, shutdown observation, and independently ready protection continue between replay
+attempts. Scoped cooldown replays observe the same deadline so protective supervision cannot
+bypass the backoff. History balance validation occurs before clearing live protection; existing
+latched/cooldown state is retained on this failure. Protection may act only with its own required
+inputs; the panic planner also requires positive current balances. Deferral does not fabricate
+replacement strategy orders or new HSL state.
+
+`risk.input.status` reports the cause, bounded balance values (non-finite values are `null`), first
+invalid historical timestamp/value, invalid-row count, replay window, retry count and delay. It
+emits a warning on entry/reason change and at most every five minutes for an unchanged reason,
+then a recovery event after successful input validation and HSL initialization/check. Runtime
+readiness state is retry scheduling only and is not persisted across process restarts.

--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -639,3 +639,13 @@ converting it to zero. Totals may be summed across compatible windows; maxima re
 - `src/live/event_producers.py`
 - `tests/test_live_event_registry_docs.py`
 - event-family tests under `tests/`
+
+### Risk input readiness
+
+`risk.input.status` reports entry into or recovery from the live balance-input readiness gate.
+The producer in `live/risk_input_recovery.py` emits only code-owned reason/action strings and bounded
+numeric diagnostics: current raw/sizing balances, first invalid replay timestamp/balance, invalid
+row count, replay start/end, retry count and delay. Non-finite numbers become null. Raw payloads and
+exception text are excluded. Deferred status blocks ordinary planning; succeeded status reports
+recovery to the remaining readiness checks. Console warnings coalesce unchanged reasons for five
+minutes; recovery is immediate. See `equity_hard_stop_loss.md` for retry/protection policy.

--- a/docs/ai/generated/live_event_registry.md
+++ b/docs/ai/generated/live_event_registry.md
@@ -86,6 +86,7 @@ The code-owned registries live in `src/live/event_bus.py`. Payload and emission 
 - `remote_call.throttled`
 - `resource.memory_snapshot`
 - `risk.entry_cooldown_delta_anchored`
+- `risk.input.status`
 - `risk.mode_changed`
 - `risk.realized_loss_gate_blocked`
 - `runtime.started`
@@ -170,6 +171,7 @@ The code-owned registries live in `src/live/event_bus.py`. Payload and emission 
 - `config_stock_perp_unavailable_market`
 - `config_stock_perp_wrong_exchange`
 - `connector_call_started`
+- `current_balance_unavailable`
 - `ema_fallback_used`
 - `entry_cooldown_position_delta`
 - `exchange_acknowledged`
@@ -187,6 +189,7 @@ The code-owned registries live in `src/live/event_bus.py`. Payload and emission 
 - `fresh_entry_eligibility`
 - `hsl_balance_override_account_level_replay_unsafe`
 - `hsl_held_protective_ready`
+- `hsl_history_balance_unavailable`
 - `hsl_history_empty`
 - `hsl_history_inputs_loaded`
 - `hsl_price_history_fetch_completed`

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -172,6 +172,7 @@ class EventTypes:
     CYCLE_STARTED = "cycle.started"
     CYCLE_COMPLETED = "cycle.completed"
     CYCLE_DEGRADED = "cycle.degraded"
+    RISK_INPUT_STATUS = "risk.input.status"
     DATA_PACKET_UPDATED = "data_packet.updated"
     SNAPSHOT_BUILT = "snapshot.built"
     OPEN_ORDERS_SNAPSHOT_DELTA = "open_orders.snapshot_delta"
@@ -315,6 +316,8 @@ class EventTags:
 
 
 class ReasonCodes:
+    CURRENT_BALANCE_UNAVAILABLE = "current_balance_unavailable"
+    HSL_HISTORY_BALANCE_UNAVAILABLE = "hsl_history_balance_unavailable"
     AUTHORITATIVE_CONFIRMATION = "authoritative_confirmation"
     AUTHORITATIVE_CONFIRMATION_TIMEOUT = "authoritative_confirmation_timeout"
     BALANCE_CHANGED = "balance_changed"
@@ -1316,6 +1319,7 @@ DEFAULT_ROUTES: dict[str, EventRoute] = {
         console=True, text=True, throttle_interval_ms=60_000
     ),
     EventTypes.CYCLE_DEGRADED: EventRoute(console=True, text=True),
+    EventTypes.RISK_INPUT_STATUS: EventRoute(console=True, text=True),
     EventTypes.DATA_PACKET_UPDATED: EventRoute(console=False),
     EventTypes.SNAPSHOT_BUILT: EventRoute(console=False),
     EventTypes.OPEN_ORDERS_SNAPSHOT_DELTA: EventRoute(console=True, text=True),
@@ -1503,6 +1507,7 @@ _CONSOLE_EVENT_TAGS = {
     EventTypes.CYCLE_STARTED: "cycle",
     EventTypes.CYCLE_COMPLETED: "cycle",
     EventTypes.CYCLE_DEGRADED: "cycle",
+    EventTypes.RISK_INPUT_STATUS: "risk",
     EventTypes.PLANNING_UNAVAILABLE: "gate",
     EventTypes.OPEN_ORDERS_SNAPSHOT_DELTA: "order",
     EventTypes.FORAGER_SELECTION: "forager",

--- a/src/live/risk_input_recovery.py
+++ b/src/live/risk_input_recovery.py
@@ -1,0 +1,195 @@
+"""Live readiness for valid balance observations that cannot yet support risk math.
+
+This module schedules retries; it never supplies substitute balances or strategy intent.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+import math
+from time import monotonic
+
+import numpy as np
+
+from live.event_bus import EventTypes, ReasonCodes, LiveEvent, emit_event, format_console_event
+
+
+class RiskInputUnavailable(RuntimeError):
+    """A numeric balance observation cannot support live risk evaluation."""
+
+    def __init__(self, reason: str, **details):
+        self.reason = reason
+        self.details = details
+        super().__init__(reason)
+
+
+def _number(value):
+    value = float(value)
+    return value if math.isfinite(value) else None
+
+
+def validate_current_balances(bot):
+    validate_balances(bot.get_raw_balance(), bot.get_hysteresis_snapped_balance())
+
+
+def validate_balances(raw, sizing):
+    if not all(math.isfinite(value) and value > 0.0 for value in (raw, sizing)):
+        raise RiskInputUnavailable(
+            ReasonCodes.CURRENT_BALANCE_UNAVAILABLE,
+            balance_raw=_number(raw),
+            balance=_number(sizing),
+        )
+
+
+def validate_history_balances(timestamps, balances, *, current_balance):
+    """Validate numeric values after the producer's shape/type checks."""
+    values = np.asarray(balances, dtype=np.float64)
+    times = np.asarray(timestamps, dtype=np.int64)
+    if values.ndim != 1 or times.ndim != 1 or values.shape != times.shape:
+        raise ValueError("HSL replay balance and timestamp arrays must be matching vectors")
+    invalid = np.flatnonzero(~np.isfinite(values) | (values <= 0.0))
+    if invalid.size:
+        first = int(invalid[0])
+        raise RiskInputUnavailable(
+            ReasonCodes.HSL_HISTORY_BALANCE_UNAVAILABLE,
+            balance_raw=_number(current_balance),
+            first_invalid_timestamp_ms=int(times[first]),
+            first_invalid_balance=_number(values[first]),
+            invalid_rows=int(invalid.size),
+            replay_start_ms=int(times[0]),
+            replay_end_ms=int(times[-1]),
+        )
+
+
+def validate_history_rows(rows, *, current_balance):
+    validate_history_balances(
+        [row["timestamp"] for row in rows],
+        [row["balance"] for row in rows],
+        current_balance=current_balance,
+    )
+
+
+@dataclass
+class RecoveryState:
+    reason: str = ""
+    attempts: int = 0
+    retry_at: float = 0.0
+    warning_at: float = 0.0
+
+
+def _emit(bot, *, reason, status, details, level):
+    message = " ".join(f"{key}={value}" for key, value in details.items())
+    event = LiveEvent(
+        EventTypes.RISK_INPUT_STATUS,
+        level=level,
+        source="live",
+        component="risk_input_recovery",
+        tags=("risk", "readiness"),
+        exchange=getattr(bot, "exchange", None),
+        user=getattr(bot, "user", None),
+        bot_id=getattr(bot, "bot_id", None),
+        status=status,
+        reason_code=reason,
+        message=message,
+        data=details,
+    )
+    emit_event(bot, event)
+    pipeline = getattr(bot, "_live_event_pipeline", None)
+    if not (
+        getattr(bot, "live_event_console_enabled", False)
+        and callable(getattr(pipeline, "emit", None))
+        and getattr(pipeline, "console_sink", None) is not None
+    ):
+        logging.log(
+            logging.WARNING if level == "warning" else logging.INFO,
+            format_console_event(event),
+        )
+
+
+def defer(bot, exc):
+    now = monotonic()
+    state = getattr(bot, "_risk_input_recovery", None)
+    changed = state is None or state.reason != exc.reason
+    if changed:
+        state = RecoveryState(reason=exc.reason)
+        bot._risk_input_recovery = state
+    state.attempts += 1
+    cap = 300.0 if exc.reason == ReasonCodes.HSL_HISTORY_BALANCE_UNAVAILABLE else 60.0
+    delay = min(cap, 5.0 * 2 ** min(state.attempts - 1, 6))
+    state.retry_at = now + delay
+    if changed or now >= state.warning_at:
+        state.warning_at = now + 300.0
+        _emit(bot, reason=exc.reason, status="deferred", level="warning", details={
+            **exc.details,
+            "retry_count": state.attempts,
+            "retry_delay_seconds": delay,
+            "action": "block_ordinary_trading_and_retry",
+        })
+
+
+async def ensure_ready(bot, *, startup=False):
+    """Run only on a fresh authoritative account/history cohort."""
+    state = getattr(bot, "_risk_input_recovery", None)
+    try:
+        validate_current_balances(bot)
+    except RiskInputUnavailable as exc:
+        if state is None or state.reason != exc.reason or monotonic() >= state.retry_at:
+            defer(bot, exc)
+        return False
+    if state is not None and monotonic() < state.retry_at:
+        return False
+    try:
+        if bot._equity_hard_stop_enabled():
+            if startup:
+                if bot._equity_hard_stop_signal_mode() == "coin":
+                    await bot._equity_hard_stop_start_coin_history_replay()
+                else:
+                    await bot._equity_hard_stop_initialize_from_history()
+            else:
+                await bot._equity_hard_stop_check()
+    except RiskInputUnavailable as exc:
+        defer(bot, exc)
+        return False
+    if state is not None:
+        _emit(bot, reason=state.reason, status="succeeded", level="info", details={
+            "retry_count": state.attempts,
+            "action": "resume_readiness_checks",
+        })
+        bot._risk_input_recovery = None
+    return True
+
+
+async def protect_and_wait(bot, *, cycle_id=None, loop_timings_ms=None):
+    # The existing panic planner also needs positive current balances. Do not
+    # feed it stale/fabricated denominators when the account itself is invalid.
+    try:
+        validate_current_balances(bot)
+    except RiskInputUnavailable:
+        current_ready = False
+    else:
+        current_ready = True
+    if current_ready and bot._equity_hard_stop_enabled():
+        try:
+            await bot._run_halted_hsl_protection_if_active()
+            await bot._run_latched_hsl_supervisor_if_active(
+                cycle_id=cycle_id, loop_timings_ms=loop_timings_ms or {},
+            )
+        except RiskInputUnavailable as exc:
+            # A protective cooldown restart may itself require replay.
+            state = getattr(bot, "_risk_input_recovery", None)
+            if state is None or state.reason != exc.reason:
+                defer(bot, exc)
+    await bot._monitor_flush_snapshot()
+    await bot._sleep_unless_shutdown(5.0, stage="risk_inputs_waiting")
+
+
+async def wait_for_startup(bot):
+    # Maintainers do not exist yet; this owner refreshes account/fill inputs.
+    authoritative_ready = await bot.refresh_authoritative_state()
+    while not bot.stop_signal_received:
+        if authoritative_ready and await ensure_ready(bot, startup=True):
+            return
+        await protect_and_wait(bot)
+        if bot.stop_signal_received:
+            return
+        authoritative_ready = await bot.refresh_authoritative_state()

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -56,6 +56,7 @@ from fill_events_manager import (
     signed_fee_paid_from_payload,
 )
 from live import candle_ws, executor, market_data, planning_gates, reconciler, state_refresh
+from live import risk_input_recovery
 from live.order_churn_gate import (
     ORDER_CHURN_GATE_SUPPORTED_EXCHANGES,
     OrderChurnGateState,
@@ -3546,22 +3547,24 @@ class Passivbot:
                     payload={"stage": boot_stage, "stop_signal_received": True},
                 )
                 return
+            boot_stage = "risk_input_readiness"
             if self._equity_hard_stop_enabled():
-                boot_stage = "equity_hard_stop_initialize_from_history"
-                hsl_mode = self._equity_hard_stop_signal_mode()
-                if hsl_mode == "coin":
-                    boot_stage = "equity_hard_stop_initialize_coin_from_history"
-                    await self._equity_hard_stop_start_coin_history_replay()
-                else:
-                    await self._equity_hard_stop_initialize_from_history()
-                Passivbot._startup_timing_mark(self, "hsl", details=f"mode={hsl_mode}")
-                if self.stop_signal_received:
-                    self._monitor_emit_stop(
-                        "startup_aborted",
-                        ts=utc_ms(),
-                        payload={"stage": boot_stage, "stop_signal_received": True},
-                    )
-                    return
+                boot_stage = (
+                    "equity_hard_stop_initialize_coin_from_history"
+                    if self._equity_hard_stop_signal_mode() == "coin"
+                    else "equity_hard_stop_initialize_from_history"
+                )
+            await risk_input_recovery.wait_for_startup(self)
+            if self._equity_hard_stop_enabled():
+                Passivbot._startup_timing_mark(
+                    self, "hsl", details=f"mode={self._equity_hard_stop_signal_mode()}"
+                )
+            if self.stop_signal_received:
+                self._monitor_emit_stop(
+                    "startup_aborted", ts=utc_ms(),
+                    payload={"stage": boot_stage, "stop_signal_received": True},
+                )
+                return
             boot_stage = "post_init_sleep"
             await self._sleep_unless_shutdown(1, stage="post_init_sleep")
             if self.stop_signal_received:
@@ -6298,6 +6301,7 @@ class Passivbot:
             return False
         if not await self.refresh_protective_authoritative_state():
             return False
+        risk_input_recovery.validate_current_balances(self)
         now_ms = int(self.get_exchange_time())
         panic_needed = False
         cooldown_entry_cancels = []
@@ -6447,6 +6451,7 @@ class Passivbot:
                 return False
             reason_code = "hsl_red_supervisor"
             supervisor = self._equity_hard_stop_run_red_supervisor
+        risk_input_recovery.validate_current_balances(self)
         self._emit_live_cycle_degraded(
             cycle_id=cycle_id,
             reason_code=reason_code,
@@ -6468,19 +6473,6 @@ class Passivbot:
         balance_consistency_retry_count = 0
         balance_consistency_last_warning_ms = 0
         max_n_fails = 10
-        if self._equity_hard_stop_enabled():
-            if self._equity_hard_stop_signal_mode() == "coin":
-                if not (
-                    getattr(self, "_equity_hard_stop_coin_initialized", False)
-                    or getattr(self, "_equity_hard_stop_coin_protective_ready", False)
-                ):
-                    await self._equity_hard_stop_initialize_coin_from_history()
-            elif not all(
-                self._equity_hard_stop_runtime_initialized(pside)
-                or not self._equity_hard_stop_enabled(pside)
-                for pside in self._hsl_psides()
-            ):
-                await self._equity_hard_stop_initialize_from_history()
         while not self.stop_signal_received:
             loop_start_ms = utc_ms()
             loop_timings_ms: dict[str, int] = {}
@@ -6668,33 +6660,37 @@ class Passivbot:
                         data={"timings_ms": dict(loop_timings_ms)},
                     )
                     break
-                if self._equity_hard_stop_enabled():
-                    try:
-                        await self._equity_hard_stop_check()
-                    except state_refresh.AuthoritativeSurfaceUnavailable as exc:
-                        if exc.surface != "hsl_episode_boundaries":
-                            raise
-                        self._emit_live_cycle_degraded(
-                            cycle_id=cycle_id,
-                            reason_code="hsl_episode_boundaries_unavailable",
-                            data={"reason": exc.reason},
-                        )
-                        if not (
-                            await self._run_halted_hsl_protection_if_active()
-                            or await self._run_latched_hsl_supervisor_if_active(
-                                cycle_id=cycle_id,
-                                loop_timings_ms=loop_timings_ms,
-                            )
-                        ):
-                            await self._sleep_unless_shutdown(
-                                0.5, stage="hsl_episode_boundaries_retry"
-                            )
-                        continue
-                    if await self._run_latched_hsl_supervisor_if_active(
+                try:
+                    risk_ready = await risk_input_recovery.ensure_ready(self)
+                except state_refresh.AuthoritativeSurfaceUnavailable as exc:
+                    if exc.surface != "hsl_episode_boundaries":
+                        raise
+                    self._emit_live_cycle_degraded(
                         cycle_id=cycle_id,
-                        loop_timings_ms=loop_timings_ms,
+                        reason_code="hsl_episode_boundaries_unavailable",
+                        data={"reason": exc.reason},
+                    )
+                    if not (
+                        await self._run_halted_hsl_protection_if_active()
+                        or await self._run_latched_hsl_supervisor_if_active(
+                            cycle_id=cycle_id,
+                            loop_timings_ms=loop_timings_ms,
+                        )
                     ):
-                        continue
+                        await self._sleep_unless_shutdown(
+                            0.5, stage="hsl_episode_boundaries_retry"
+                        )
+                    continue
+                if not risk_ready:
+                    await risk_input_recovery.protect_and_wait(
+                        self, cycle_id=cycle_id, loop_timings_ms=loop_timings_ms,
+                    )
+                    continue
+                if await self._run_latched_hsl_supervisor_if_active(
+                    cycle_id=cycle_id,
+                    loop_timings_ms=loop_timings_ms,
+                ):
+                    continue
                 blocked, barrier_details = self._authoritative_execution_barrier_state()
                 if blocked:
                     self._log_authoritative_execution_barrier(barrier_details)
@@ -6947,6 +6943,11 @@ class Passivbot:
                             data={"timings_ms": dict(loop_timings_ms)},
                         )
                     break
+            except risk_input_recovery.RiskInputUnavailable as exc:
+                risk_input_recovery.defer(self, exc)
+                await risk_input_recovery.protect_and_wait(
+                    self, cycle_id=cycle_id, loop_timings_ms=loop_timings_ms,
+                )
             except FillHistoryCoverageUnavailable as e:
                 if self._shutdown_requested():
                     self._emit_live_cycle_degraded(
@@ -16611,6 +16612,7 @@ class Passivbot:
                 }
             )
 
+        risk_input_recovery.validate_balances(input_dict["balance_raw"], input_dict["balance"])
         out, orders = reconciler.parse_and_validate_rust_orchestrator_output(
             pbr.compute_ideal_orders_json(json.dumps(input_dict)),
             idx_to_symbol,
@@ -19857,6 +19859,7 @@ class Passivbot:
                 }
             )
 
+        risk_input_recovery.validate_balances(input_dict["balance_raw"], input_dict["balance"])
         input_json = json.dumps(input_dict)
         rust_call_id = self._next_live_event_remote_call_id("rust")
         orchestrator_started_ms = int(utc_ms())

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -34,6 +34,12 @@ from fill_events_manager import (
     _unique_position_chain_order,
 )
 from live.state_refresh import AuthoritativeSurfaceUnavailable
+from live.risk_input_recovery import (
+    RiskInputUnavailable,
+    validate_current_balances,
+    validate_history_balances,
+    validate_history_rows,
+)
 from live.freshness import ACCOUNT_SURFACES
 from live.diagnostic_safety import bounded_exception_type as _bounded_hsl_exception_type
 from live.event_bus import EventTypes, ReasonCodes, live_event_debug_profile_enabled
@@ -3215,6 +3221,9 @@ async def _equity_hard_stop_replay_live_restart(
     replay_flatten_timestamp_ms: Optional[int] = None,
 ) -> bool:
     """Publish a completed canonical replay without clearing live protection while awaiting it."""
+    recovery = getattr(self, "_risk_input_recovery", None)
+    if recovery is not None and time.monotonic() < recovery.retry_at:
+        return False
     background = getattr(self, "_equity_hard_stop_coin_replay_task", None)
     if getattr(self, "_hsl_live_restart_replay_active", False) or (
         background is not None and not background.done()
@@ -3919,6 +3928,9 @@ async def _equity_hard_stop_initialize_from_history(self) -> None:
                 )
             scope_boundaries_by_pside[pside] = boundaries
         # Validate every enabled scope before replacing existing protective state.
+        validate_history_rows(timeline, current_balance=current_balance)
+        for boundaries in scope_boundaries_by_pside.values():
+            validate_history_rows(boundaries, current_balance=current_balance)
         self._equity_hard_stop_reset_state()
         n_rows = {pside: 0 for pside in self._hsl_psides()}
         for pside in self._hsl_psides():
@@ -4267,14 +4279,12 @@ async def _equity_hard_stop_initialize_coin_from_history(
     initialization_started_s = time.monotonic()
     watchdog_context_restored = False
     protective_ready_elapsed_s: Optional[float] = None
+    if not hasattr(self, "_equity_hard_stop_coin_protective_ready"):
+        self._equity_hard_stop_coin_protective_ready = False
     ready_event = getattr(self, "_equity_hard_stop_coin_replay_ready_event", None)
     if ready_event is None:
         ready_event = asyncio.Event()
         self._equity_hard_stop_coin_replay_ready_event = ready_event
-    self._equity_hard_stop_coin_protective_ready = False
-    self._equity_hard_stop_coin_replay_ready_pairs = set()
-    self._equity_hard_stop_coin_replay_pending_pairs = set()
-    self._equity_hard_stop_coin_replay_failure = None
 
     def check_shutdown(stage: str) -> None:
         if callable(raise_if_shutdown):
@@ -4291,8 +4301,6 @@ async def _equity_hard_stop_initialize_coin_from_history(
         )
     try:
         check_shutdown("hsl_coin_history_replay_start")
-        self._equity_hard_stop_coin = {"long": {}, "short": {}}
-        self._runtime_forced_modes = {"long": {}, "short": {}}
         lookback = parse_pnls_max_lookback_days(
             self.live_value("pnls_max_lookback_days"),
             field_name="live.pnls_max_lookback_days",
@@ -4416,12 +4424,6 @@ async def _equity_hard_stop_initialize_coin_from_history(
                 raise ValueError(
                     "compact coin HSL replay timestamps must be contiguous 1m samples"
                 )
-            if not bool(np.all(np.isfinite(compact_balances))) or bool(
-                np.any(compact_balances <= 0.0)
-            ):
-                raise ValueError(
-                    "compact coin HSL replay balances must be finite and > 0"
-                )
             if not bool(np.all(np.isfinite(compact_realized_pnl))):
                 raise ValueError("compact coin HSL replay realized_pnl must be finite")
             normalized_pair_values: dict[tuple[str, str], dict[str, Any]] = {}
@@ -4457,6 +4459,20 @@ async def _equity_hard_stop_initialize_coin_from_history(
                     "unrealized_pnl": unrealized_values,
                 }
             compact_pair_values = normalized_pair_values
+
+        # Reject unavailable balances before replacing any live protective state.
+        if compact_replay is not None:
+            validate_history_balances(
+                compact_timestamps, compact_balances, current_balance=self.get_raw_balance(),
+            )
+        else:
+            validate_history_rows(timeline, current_balance=self.get_raw_balance())
+        self._equity_hard_stop_coin_protective_ready = False
+        self._equity_hard_stop_coin_replay_ready_pairs = set()
+        self._equity_hard_stop_coin_replay_pending_pairs = set()
+        self._equity_hard_stop_coin_replay_failure = None
+        self._equity_hard_stop_coin = {"long": {}, "short": {}}
+        self._runtime_forced_modes = {"long": {}, "short": {}}
 
         now_ms = int(self.get_exchange_time())
         lookback_ms = self._equity_hard_stop_lookback_ms()
@@ -7067,6 +7083,7 @@ async def _equity_hard_stop_run_red_supervisor(self) -> None:
             if not await self.refresh_protective_authoritative_state():
                 await asyncio.sleep(0.5)
                 continue
+            validate_current_balances(self)
             for pside in list(active_red_psides):
                 state = self._hsl_state(pside)
                 n_positions = self._equity_hard_stop_count_open_positions(pside)
@@ -7169,7 +7186,7 @@ async def _equity_hard_stop_run_red_supervisor(self) -> None:
                     to_create,
                     configure_creations=False,
                 )
-            except FatalBotException:
+            except (FatalBotException, RiskInputUnavailable):
                 raise
             except RestartBotException as e:
                 logging.error("[risk] RED supervisor ignored restart request: %s", e)
@@ -7198,6 +7215,7 @@ async def _equity_hard_stop_run_coin_red_supervisor(self) -> None:
             if not await self.refresh_protective_authoritative_state():
                 await asyncio.sleep(0.5)
                 continue
+            validate_current_balances(self)
             for pside, symbol in list(active):
                 state = self._hsl_coin_state(pside, symbol)
                 has_position = self._equity_hard_stop_has_open_position_symbol(pside, symbol)
@@ -7313,7 +7331,7 @@ async def _equity_hard_stop_run_coin_red_supervisor(self) -> None:
                     to_create,
                     configure_creations=False,
                 )
-            except FatalBotException:
+            except (FatalBotException, RiskInputUnavailable):
                 raise
             except RestartBotException as e:
                 logging.error("[risk] coin RED supervisor ignored restart request: %s", e)

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -1277,6 +1277,7 @@ def make_coin_bot(policy="panic"):
     bot._monitor_record_event = lambda *args, **kwargs: None
     bot._equity_hard_stop_write_latch = lambda pside, payload, symbol=None: "/tmp/hsl_coin.json"
     bot._equity_hard_stop_remove_latch_file = lambda pside, symbol=None: None
+    bot.get_hysteresis_snapped_balance = lambda: 100.0
     bot.get_raw_balance = lambda: 100.0
     bot.get_exchange_time = lambda: 180_000
     bot.live_value = lambda key: bot.config["live"][key]
@@ -5817,6 +5818,7 @@ async def test_boundary_deferral_supervises_new_cooldown_position_until_flat(sig
     monkeypatch.setattr(hsl, "_equity_hard_stop_replay_live_restart", AsyncMock(return_value=False))
     fixture = make_coin_bot(policy=policy)
     bot = Passivbot.__new__(Passivbot)
+    bot.balance = 100.0
     bot.__dict__.update(vars(fixture))
     for name, value in list(vars(bot).items()):
         if isinstance(value, MethodType) and value.__self__ is fixture:

--- a/tests/test_order_orchestration.py
+++ b/tests/test_order_orchestration.py
@@ -771,6 +771,9 @@ async def test_red_supervisor_uses_protective_refresh_and_order_plan():
     calls = []
 
     class FakeBot:
+        get_hysteresis_snapped_balance = staticmethod(lambda: 100.0)
+        get_raw_balance = staticmethod(lambda: 100.0)
+
         _equity_hard_stop_supervisor_running = False
         stop_signal_received = False
 
@@ -862,6 +865,9 @@ async def test_red_supervisor_uses_protective_refresh_and_order_plan():
 @pytest.mark.asyncio
 async def test_red_supervisor_propagates_fatal_protective_plan_failure():
     class FakeBot:
+        get_hysteresis_snapped_balance = staticmethod(lambda: 100.0)
+        get_raw_balance = staticmethod(lambda: 100.0)
+
         _equity_hard_stop_supervisor_running = False
         stop_signal_received = False
 
@@ -925,6 +931,8 @@ async def test_red_supervisor_refreshes_late_flatten_fill_and_exits():
     ]
 
     class FakeBot:
+        get_hysteresis_snapped_balance = staticmethod(lambda: 100.0)
+
         _equity_hard_stop_supervisor_running = False
         _equity_hard_stop_cooldown_log_interval_ms = 60_000
         stop_signal_received = False
@@ -1058,6 +1066,8 @@ async def test_coin_red_supervisor_refreshes_late_cooldown_repanic_fill():
     ]
 
     class FakeBot:
+        get_hysteresis_snapped_balance = staticmethod(lambda: 100.0)
+
         _equity_hard_stop_supervisor_running = False
         _equity_hard_stop_cooldown_log_interval_ms = 60_000
         stop_signal_received = False
@@ -1177,6 +1187,8 @@ async def test_coin_red_supervisor_propagates_fatal_protective_plan_failure():
     symbol = "BTC/USDT:USDT"
 
     class FakeBot:
+        get_hysteresis_snapped_balance = staticmethod(lambda: 100.0)
+
         _equity_hard_stop_supervisor_running = False
         stop_signal_received = False
 

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -2856,6 +2856,8 @@ async def test_start_bot_treats_shutdown_cancelled_warmup_as_clean_stop(monkeypa
 @pytest.mark.asyncio
 async def test_start_bot_bounds_trading_ready_warmup_failure(monkeypatch, caplog):
     bot = Passivbot.__new__(Passivbot)
+    bot.balance = 100.0
+    bot.refresh_authoritative_state = AsyncMock(return_value=True)
     bot.runtime_identity = TEST_RUNTIME_IDENTITY
     bot._runtime_manifest_written = True
     bot.exchange = "bybit"
@@ -2905,6 +2907,8 @@ async def test_start_bot_treats_hsl_value_error_as_terminal_startup_failure(
     monkeypatch, caplog
 ):
     bot = Passivbot.__new__(Passivbot)
+    bot.balance = 100.0
+    bot.refresh_authoritative_state = AsyncMock(return_value=True)
     bot.runtime_identity = TEST_RUNTIME_IDENTITY
     bot._runtime_manifest_written = True
     bot.exchange = "gateio"
@@ -11040,6 +11044,7 @@ def test_authoritative_barrier_does_not_block_on_balance_only_change():
 @pytest.mark.asyncio
 async def test_run_execution_loop_waits_for_clean_authoritative_cycle_before_execute():
     bot = Passivbot.__new__(Passivbot)
+    bot.balance = 100.0
     cycle = {"n": 0}
     executes = []
 
@@ -11093,6 +11098,7 @@ async def test_run_execution_loop_waits_for_clean_authoritative_cycle_before_exe
 @pytest.mark.asyncio
 async def test_run_execution_loop_does_not_reinitialize_coin_hsl_after_startup():
     bot = Passivbot.__new__(Passivbot)
+    bot.balance = 100.0
     calls = []
 
     bot.stop_signal_received = False
@@ -11150,6 +11156,7 @@ async def test_run_execution_loop_does_not_reinitialize_coin_hsl_after_startup()
 @pytest.mark.asyncio
 async def test_run_execution_loop_does_not_defer_for_completed_candles():
     bot = Passivbot.__new__(Passivbot)
+    bot.balance = 100.0
     cycle = {"n": 0}
     executes = []
 
@@ -11216,6 +11223,7 @@ async def test_run_execution_loop_does_not_defer_for_completed_candles():
 @pytest.mark.asyncio
 async def test_run_execution_loop_waits_on_pending_pnl_without_restart(monkeypatch):
     bot = Passivbot.__new__(Passivbot)
+    bot.balance = 100.0
     cycle = {"n": 0}
     executes = []
     sleeps = []
@@ -11284,6 +11292,7 @@ async def test_run_execution_loop_waits_on_pending_pnl_without_restart(monkeypat
 @pytest.mark.asyncio
 async def test_run_execution_loop_waits_on_bitunix_balance_confirmation_without_restart():
     bot = Passivbot.__new__(Passivbot)
+    bot.balance = 100.0
     cycle = {"n": 0}
     sleeps = []
 
@@ -11349,6 +11358,7 @@ async def test_run_execution_loop_waits_on_bitunix_balance_confirmation_without_
 @pytest.mark.asyncio
 async def test_run_execution_loop_waits_on_degraded_pnl_without_restart():
     bot = Passivbot.__new__(Passivbot)
+    bot.balance = 100.0
     cycle = {"n": 0}
     sleeps = []
 
@@ -11413,6 +11423,7 @@ async def test_run_execution_loop_waits_on_degraded_pnl_without_restart():
 @pytest.mark.asyncio
 async def test_run_execution_loop_waits_on_fill_coverage_without_restart():
     bot = Passivbot.__new__(Passivbot)
+    bot.balance = 100.0
     cycle = {"n": 0}
     sleeps = []
 
@@ -11486,6 +11497,7 @@ async def test_run_execution_loop_waits_on_fill_coverage_without_restart():
 @pytest.mark.asyncio
 async def test_run_execution_loop_resets_fill_retry_backoff_when_reason_changes():
     bot = Passivbot.__new__(Passivbot)
+    bot.balance = 100.0
     reasons = iter(
         [
             "fill_history_coverage",
@@ -11554,6 +11566,7 @@ async def test_run_execution_loop_keeps_latched_hsl_supervision_during_coverage_
     signal_mode,
 ):
     bot = Passivbot.__new__(Passivbot)
+    bot.balance = 100.0
 
     async def stop_after_supervision():
         bot.stop_signal_received = True
@@ -11610,6 +11623,7 @@ async def test_run_execution_loop_retries_fill_history_coverage_without_restart(
     monkeypatch, caplog
 ):
     bot = Passivbot.__new__(Passivbot)
+    bot.balance = 100.0
     cycle = {"n": 0}
     executes = []
     sleeps = []
@@ -11724,6 +11738,7 @@ async def test_refresh_market_state_updates_trailing_after_candles():
 @pytest.mark.asyncio
 async def test_run_execution_loop_stops_before_execute_when_signal_arrives_after_refresh():
     bot = Passivbot.__new__(Passivbot)
+    bot.balance = 100.0
     executes = []
 
     bot.stop_signal_received = False
@@ -11770,6 +11785,7 @@ async def test_run_execution_loop_stops_before_execute_when_signal_arrives_after
 @pytest.mark.asyncio
 async def test_run_execution_loop_suppresses_inflight_shutdown_refresh_error(caplog):
     bot = Passivbot.__new__(Passivbot)
+    bot.balance = 100.0
 
     bot.stop_signal_received = False
     bot.execution_scheduled = False
@@ -11817,6 +11833,7 @@ async def test_run_execution_loop_records_nonshutdown_cancelled_error(
     caplog, monkeypatch
 ):
     bot = Passivbot.__new__(Passivbot)
+    bot.balance = 100.0
 
     bot.exchange = "gateio"
     bot.stop_signal_received = False
@@ -11887,6 +11904,7 @@ async def test_run_execution_loop_records_nonshutdown_cancelled_error(
 @pytest.mark.asyncio
 async def test_run_execution_loop_treats_shutdown_cancelled_error_as_clean_stop(caplog):
     bot = Passivbot.__new__(Passivbot)
+    bot.balance = 100.0
 
     bot.stop_signal_received = False
     bot.execution_scheduled = False
@@ -12217,6 +12235,7 @@ def test_exchange_time_sync_warning_stays_within_full_console_line_budget():
 @pytest.mark.asyncio
 async def test_run_execution_loop_recovers_timestamp_error_without_traceback(caplog):
     bot = Passivbot.__new__(Passivbot)
+    bot.balance = 100.0
     bot.exchange = "binance"
     bot.stop_signal_received = False
     bot.execution_scheduled = False
@@ -12271,6 +12290,7 @@ async def test_run_execution_loop_recovers_timestamp_error_without_traceback(cap
 @pytest.mark.asyncio
 async def test_run_execution_loop_error_log_includes_type_status_and_action(caplog, monkeypatch):
     bot = Passivbot.__new__(Passivbot)
+    bot.balance = 100.0
     bot.exchange = "kucoin"
     bot.stop_signal_received = False
     bot.execution_scheduled = False
@@ -13292,6 +13312,7 @@ async def test_staged_account_refresh_request_counts_missing_self_order_escalate
 @pytest.mark.asyncio
 async def test_run_execution_loop_propagates_fatal_bot_exception():
     bot = Passivbot.__new__(Passivbot)
+    bot.balance = 100.0
 
     bot.stop_signal_received = False
     bot.execution_scheduled = False
@@ -13502,6 +13523,7 @@ async def test_execution_loop_defers_unavailable_hsl_boundaries_and_keeps_protec
     from live.state_refresh import AuthoritativeSurfaceUnavailable
 
     bot = Passivbot.__new__(Passivbot)
+    bot.balance = 100.0
     bot.stop_signal_received = False
     bot.execution_scheduled = False
     bot.state_change_detected_by_symbol = set()
@@ -13532,3 +13554,111 @@ async def test_execution_loop_defers_unavailable_hsl_boundaries_and_keeps_protec
     bot.execute_to_exchange.assert_not_awaited()
     assert bot._equity_hard_stop_run_coin_red_supervisor.await_count == int(latched)
     assert bot._sleep_unless_shutdown.await_count == int(not latched)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure", ["current_balance", "history", "late_balance"])
+async def test_execution_loop_risk_inputs_wait_without_planning_or_restart(monkeypatch, failure):
+    from live import risk_input_recovery as recovery
+    bot = Passivbot.__new__(Passivbot)
+    bot.balance = bot.balance_raw = 100.0
+    bot.stop_signal_received = False
+    bot.debug_mode = True
+    bot._equity_hard_stop_enabled = lambda *a, **k: failure == "history"
+    bot._equity_hard_stop_check = AsyncMock()
+    bot._set_log_silence_watchdog_context = lambda **k: None
+    bot._maybe_log_health_summary = lambda: None
+    bot._maybe_log_unstuck_status = lambda: None
+    bot._monitor_flush_snapshot = AsyncMock()
+    bot.restart_bot_on_too_many_errors = AsyncMock()
+    bot._run_halted_hsl_protection_if_active = AsyncMock(return_value=False)
+    bot._run_latched_hsl_supervisor_if_active = AsyncMock(return_value=False)
+    bot._authoritative_execution_barrier_state = lambda: (False, {})
+    bot._staged_execution_ready_state = lambda **kwargs: (True, {})
+    bot._handle_execution_loop_failure = AsyncMock(side_effect=AssertionError("unexpected failure"))
+    bot.live_value = lambda key: 0.0 if key == "execution_delay_seconds" else False
+    clock = [1000.0]
+    cycle = [0]
+    monkeypatch.setattr(recovery, "monotonic", lambda: clock[0])
+
+    async def refresh():
+        cycle[0] += 1
+        bot.balance = bot.balance_raw = 0.0 if failure == "current_balance" and cycle[0] < 4 else 100.0
+        return True
+
+    async def check():
+        if cycle[0] < 4:
+            recovery.validate_history_balances([60_000], [-1.0], current_balance=100.0)
+
+    async def sleep(seconds, *, stage):
+        clock[0] += seconds
+        assert cycle[0] < 6
+
+    async def execute(*, prepare_cycle):
+        if failure == "late_balance" and cycle[0] == 1:
+            # Models a refreshed account losing its positive balance during planning.
+            recovery.validate_balances(0.0, 0.0)
+        assert cycle[0] >= (2 if failure == "late_balance" else 4)
+        return {"executed_cycle": cycle[0]}
+
+    bot.refresh_authoritative_state = refresh
+    bot._equity_hard_stop_check.side_effect = check
+    bot._sleep_unless_shutdown = AsyncMock(side_effect=sleep)
+    bot.prepare_planning_universe = AsyncMock()
+    bot.refresh_market_state_if_needed = AsyncMock(return_value=True)
+    bot.execute_to_exchange = AsyncMock(side_effect=execute)
+    result = await asyncio.wait_for(bot.run_execution_loop(), timeout=10)
+    assert result == {"executed_cycle": 2 if failure == "late_balance" else 4}
+    assert bot.prepare_planning_universe.await_count == (2 if failure == "late_balance" else 1)
+    bot.restart_bot_on_too_many_errors.assert_not_awaited()
+    assert bot._risk_input_recovery is None
+
+
+@pytest.mark.asyncio
+async def test_start_bot_waits_for_risk_before_ready_and_maintainers(monkeypatch):
+    from live import risk_input_recovery as recovery
+    bot = Passivbot.__new__(Passivbot)
+    bot.runtime_identity = TEST_RUNTIME_IDENTITY
+    bot._runtime_manifest_written = True
+    bot.exchange, bot.user, bot.quote = "fake", "test", "USDT"
+    bot.start_time_ms = 1_000_000
+    bot.config = {"live": {"boot_stagger_seconds": 0}}
+    bot.user_info = {"exchange": "fake"}
+    bot.stop_signal_received = False
+    bot.debug_mode = True
+    bot._log_startup_banner = lambda: None
+    bot._log_memory_snapshot = lambda: None
+    bot._monitor_record_event = MagicMock()
+    bot._monitor_flush_snapshot = AsyncMock()
+    bot.init_markets = AsyncMock()
+    bot.warmup_trading_ready_candles = AsyncMock()
+    bot._equity_hard_stop_enabled = lambda: True
+    bot._equity_hard_stop_signal_mode = lambda: "coin"
+    bot._equity_hard_stop_start_coin_history_replay = AsyncMock()
+    bot.start_data_maintainers = AsyncMock()
+    bot.start_background_candle_warmup = AsyncMock()
+    bot.run_execution_loop = AsyncMock()
+    bot._run_halted_hsl_protection_if_active = AsyncMock(return_value=False)
+    bot._run_latched_hsl_supervisor_if_active = AsyncMock(return_value=False)
+    clock, refreshes = [1000.0], [0]
+    monkeypatch.setattr(recovery, "monotonic", lambda: clock[0])
+    monkeypatch.setattr(passivbot_module, "format_approved_ignored_coins", AsyncMock())
+
+    async def refresh():
+        refreshes[0] += 1
+        assert not bot._bot_ready
+        bot.start_data_maintainers.assert_not_awaited()
+        bot.balance = bot.balance_raw = 0.0 if refreshes[0] == 1 else 100.0
+        return True
+
+    async def sleep(seconds, *, stage):
+        clock[0] += seconds
+
+    bot.refresh_authoritative_state = AsyncMock(side_effect=refresh)
+    bot._sleep_unless_shutdown = AsyncMock(side_effect=sleep)
+    await bot.start_bot()
+    assert refreshes[0] == 2
+    assert bot._bot_ready
+    bot.start_data_maintainers.assert_awaited_once()
+    bot._equity_hard_stop_start_coin_history_replay.assert_awaited_once()
+    bot.run_execution_loop.assert_not_awaited()  # debug mode

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -5888,6 +5888,12 @@ async def test_start_bot_records_startup_error_stop_and_early_snapshot(
         def _log_startup_banner(self):
             return None
 
+        get_raw_balance = staticmethod(lambda: 100.0)
+        get_hysteresis_snapped_balance = staticmethod(lambda: 100.0)
+
+        async def refresh_authoritative_state(self):
+            return True
+
         async def init_markets(self):
             return None
 

--- a/tests/test_risk_input_recovery.py
+++ b/tests/test_risk_input_recovery.py
@@ -1,0 +1,310 @@
+import logging
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import numpy as np
+import pytest
+
+from live import risk_input_recovery as recovery
+from live.event_bus import EventTypes, ListEventSink, LiveEventPipeline
+
+
+def make_bot(monkeypatch, *, hsl=True):
+    clock = [1000.0]
+    monkeypatch.setattr(recovery, "monotonic", lambda: clock[0])
+    bot = SimpleNamespace(
+        balance=100.0,
+        balance_raw=100.0,
+        stop_signal_received=False,
+        _equity_hard_stop_enabled=lambda: hsl,
+        _equity_hard_stop_signal_mode=lambda: "coin",
+        _equity_hard_stop_start_coin_history_replay=AsyncMock(),
+        _equity_hard_stop_initialize_from_history=AsyncMock(),
+        _equity_hard_stop_check=AsyncMock(),
+        _run_halted_hsl_protection_if_active=AsyncMock(return_value=False),
+        _run_latched_hsl_supervisor_if_active=AsyncMock(return_value=False),
+        _monitor_flush_snapshot=AsyncMock(),
+        refresh_authoritative_state=AsyncMock(return_value=True),
+    )
+    bot.get_raw_balance = lambda: bot.balance_raw
+    bot.get_hysteresis_snapped_balance = lambda: bot.balance
+
+    async def sleep(seconds, *, stage):
+        assert stage == "risk_inputs_waiting"
+        clock[0] += seconds
+
+    bot._sleep_unless_shutdown = AsyncMock(side_effect=sleep)
+    return bot, clock
+
+
+def invalid_history():
+    recovery.validate_history_balances([60_000, 120_000], [-10.0, 100.0], current_balance=100.0)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("hsl", [True, False])
+@pytest.mark.parametrize("field", ["balance", "balance_raw"])
+@pytest.mark.parametrize("value", [0.0, -1.0, float("nan"), float("inf")])
+async def test_current_balance_blocks_risk_until_valid(monkeypatch, hsl, field, value):
+    bot, clock = make_bot(monkeypatch, hsl=hsl)
+    setattr(bot, field, value)
+    assert not await recovery.ensure_ready(bot)
+    bot._equity_hard_stop_check.assert_not_awaited()
+    await recovery.protect_and_wait(bot)
+    bot._run_halted_hsl_protection_if_active.assert_not_awaited()
+    bot._run_latched_hsl_supervisor_if_active.assert_not_awaited()
+    setattr(bot, field, 100.0)
+    assert await recovery.ensure_ready(bot)
+    assert bot._risk_input_recovery is None
+    assert bot._equity_hard_stop_check.await_count == int(hsl)
+
+
+@pytest.mark.asyncio
+async def test_startup_refreshes_zero_to_funded_without_restart(monkeypatch, caplog):
+    bot, clock = make_bot(monkeypatch)
+    bot.balance = bot.balance_raw = 0.0
+    refreshes = []
+
+    async def refresh():
+        refreshes.append(clock[0])
+        if len(refreshes) == 4:
+            bot.balance = bot.balance_raw = 100.0
+        return True
+
+    bot.refresh_authoritative_state.side_effect = refresh
+    with caplog.at_level(logging.INFO):
+        await recovery.wait_for_startup(bot)
+    assert len(refreshes) == 4
+    bot._equity_hard_stop_start_coin_history_replay.assert_awaited_once()
+    assert bot._risk_input_recovery is None
+    assert len([r for r in caplog.records if r.levelno == logging.WARNING]) == 1
+    assert "current_balance_unavailable" in caplog.text
+    assert "resume_readiness_checks" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_startup_does_not_replay_on_failed_refresh_and_stops_cleanly(monkeypatch):
+    bot, clock = make_bot(monkeypatch)
+    async def refresh():
+        if clock[0] >= 1010.0:
+            bot.stop_signal_received = True
+        return False
+    bot.refresh_authoritative_state.side_effect = refresh
+    await recovery.wait_for_startup(bot)
+    bot._equity_hard_stop_start_coin_history_replay.assert_not_awaited()
+    assert clock[0] == 1010.0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("startup", [True, False])
+async def test_bad_history_backoff_diagnostics_protection_and_recovery(monkeypatch, caplog, startup):
+    bot, clock = make_bot(monkeypatch)
+    check = (bot._equity_hard_stop_start_coin_history_replay if startup
+             else bot._equity_hard_stop_check)
+    check.side_effect = invalid_history
+    sink = ListEventSink()
+    bot._live_event_pipeline = LiveEventPipeline(structured_sinks=[sink], monitor_sinks=[])
+    try:
+        delays = []
+        with caplog.at_level(logging.INFO):
+            for i in range(10):
+                assert not await recovery.ensure_ready(bot, startup=startup)
+                state = bot._risk_input_recovery
+                delays.append(state.retry_at - clock[0])
+                # Retry pacing must not reconstruct unchanged history on each refresh.
+                assert not await recovery.ensure_ready(bot, startup=startup)
+                assert check.await_count == i + 1
+                await recovery.protect_and_wait(bot)
+                clock[0] = state.retry_at
+            check.side_effect = None
+            assert await recovery.ensure_ready(bot, startup=startup)
+        assert delays == [5, 10, 20, 40, 80, 160, 300, 300, 300, 300]
+        assert bot._run_halted_hsl_protection_if_active.await_count == 10
+        assert bot._run_latched_hsl_supervisor_if_active.await_count == 10
+        assert bot._risk_input_recovery is None
+        assert bot._live_event_pipeline.flush(timeout=2.0)
+        events = [e for e in sink.events if e.event_type == EventTypes.RISK_INPUT_STATUS]
+        assert events[0].data["balance_raw"] == 100.0
+        assert events[0].data["first_invalid_balance"] == -10.0
+        assert events[0].data["first_invalid_timestamp_ms"] == 60_000
+        assert events[0].data["invalid_rows"] == 1
+        assert events[-1].status == "succeeded"
+        assert len(events) < check.await_count
+    finally:
+        assert bot._live_event_pipeline.close(timeout=2.0)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("exc", [ValueError("malformed payload"), TypeError("bad config")])
+async def test_contract_errors_propagate_without_recovery_state(monkeypatch, exc):
+    bot, _ = make_bot(monkeypatch)
+    bot._equity_hard_stop_start_coin_history_replay.side_effect = exc
+    with pytest.raises(type(exc)):
+        await recovery.ensure_ready(bot, startup=True)
+    assert not hasattr(bot, "_risk_input_recovery")
+
+
+@pytest.mark.parametrize("values", [[0, 1], [-1, 1], [np.nan, 1], [np.inf, 1]])
+def test_history_unavailability_is_explicit_and_bounded(values):
+    with pytest.raises(recovery.RiskInputUnavailable) as raised:
+        recovery.validate_history_balances([0, 60_000], values, current_balance=100)
+    details = raised.value.details
+    assert details["invalid_rows"] == 1
+    assert details["first_invalid_balance"] is None or np.isfinite(details["first_invalid_balance"])
+    assert len(details) == 6
+
+
+@pytest.mark.parametrize("times,values", [([1], [1, 2]), ([[1]], [[1]]), ([1], ["secret=invalid"])])
+def test_malformed_history_shape_and_types_remain_contract_errors(times, values):
+    with pytest.raises((ValueError, TypeError)):
+        recovery.validate_history_balances(times, values, current_balance=100)
+
+
+def test_valid_empty_and_positive_history():
+    recovery.validate_history_balances([], [], current_balance=100)
+    recovery.validate_history_balances([60_000], [100], current_balance=100)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("compact", [True, False])
+async def test_coin_invalid_history_preserves_live_protection(compact):
+    from test_hsl_coin_mode import make_coin_bot
+    bot = make_coin_bot()
+    state = bot._hsl_coin_state("long", "A")
+    state["halted"] = True
+    bot._runtime_forced_modes["long"]["A"] = "panic"
+    states = bot._equity_hard_stop_coin
+    modes = bot._runtime_forced_modes
+    bot._equity_hard_stop_coin_protective_ready = True
+    bot._equity_hard_stop_coin_replay_ready_pairs = {("long", "A")}
+    payload = ({"hsl_coin_compact_replay": {
+        "timestamps": [60_000, 120_000], "balances": [-10.0, 100.0],
+        "realized_pnl": [0.0, 0.0], "pair_values": {},
+    }} if compact else {"timeline": [
+        {"timestamp": 60_000, "balance": -10.0},
+        {"timestamp": 120_000, "balance": 100.0},
+    ]})
+    bot.get_balance_equity_history = AsyncMock(return_value=payload)
+    with pytest.raises(recovery.RiskInputUnavailable):
+        await bot._equity_hard_stop_initialize_coin_from_history()
+    assert bot._equity_hard_stop_coin is states
+    assert bot._hsl_coin_state("long", "A") is state
+    assert state["halted"]
+    assert bot._runtime_forced_modes is modes
+    assert modes["long"]["A"] == "panic"
+    assert bot._equity_hard_stop_coin_protective_ready
+    assert bot._equity_hard_stop_coin_replay_ready_pairs == {("long", "A")}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["coin", "pside", "unified"])
+async def test_scoped_restart_respects_retry_deadline_and_preserves_state(monkeypatch, mode):
+    from test_hsl_live_restart_replay import _live_restart_bot
+    import passivbot_hsl as hsl
+    bot, state = _live_restart_bot(mode, "expiry")
+    clock = [1000.0]
+    monkeypatch.setattr(recovery, "monotonic", lambda: clock[0])
+    monkeypatch.setattr(hsl, "time", SimpleNamespace(monotonic=lambda: clock[0]))
+    bot._risk_input_recovery = recovery.RecoveryState(
+        reason="hsl_history_balance_unavailable", retry_at=1005.0,
+    )
+    bot.get_balance_equity_history = AsyncMock()
+    assert not await hsl._equity_hard_stop_replay_live_restart(
+        bot, "long", "A" if mode == "coin" else None,
+    )
+    bot.get_balance_equity_history.assert_not_awaited()
+    assert state["halted"]
+
+
+@pytest.mark.asyncio
+async def test_real_coin_startup_replay_recovers_from_invalid_history(monkeypatch):
+    from test_hsl_coin_mode import make_coin_bot
+    bot = make_coin_bot()
+    clock = [1000.0]
+    monkeypatch.setattr(recovery, "monotonic", lambda: clock[0])
+    payload = {"hsl_coin_compact_replay": {
+        "timestamps": [60_000, 120_000], "balances": [-1.0, 100.0],
+        "realized_pnl": [0.0, 0.0], "pair_values": {},
+    }}
+    bot.get_balance_equity_history = AsyncMock(return_value=payload)
+    assert not await recovery.ensure_ready(bot, startup=True)
+    assert not bot._equity_hard_stop_coin_protective_ready
+    payload["hsl_coin_compact_replay"]["balances"] = [100.0, 100.0]
+    clock[0] = bot._risk_input_recovery.retry_at
+    assert await recovery.ensure_ready(bot, startup=True)
+    await bot._equity_hard_stop_coin_replay_task
+    assert bot._equity_hard_stop_coin_protective_ready
+    assert bot._equity_hard_stop_coin_initialized
+    assert bot._risk_input_recovery is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["pside", "unified"])
+async def test_aggregate_invalid_history_preserves_protection(mode):
+    from test_hsl_live_restart_replay import _live_restart_bot
+    bot, state = _live_restart_bot(mode, "expiry")
+    original = bot.get_balance_equity_history
+    async def invalid(**kwargs):
+        history = await original(**kwargs)
+        history["timeline"][0]["balance"] = -1.0
+        return history
+    bot.get_balance_equity_history = invalid
+    with pytest.raises(recovery.RiskInputUnavailable):
+        await bot._equity_hard_stop_initialize_from_history()
+    assert bot._hsl_state("long") is state
+    assert state["halted"]
+
+
+@pytest.mark.asyncio
+async def test_current_balance_failure_supersedes_history_retry_immediately(monkeypatch):
+    bot, clock = make_bot(monkeypatch)
+    bot._equity_hard_stop_check.side_effect = invalid_history
+    assert not await recovery.ensure_ready(bot)
+    bot._risk_input_recovery.retry_at = clock[0] + 300.0
+    bot.balance_raw = 0.0
+    assert not await recovery.ensure_ready(bot)
+    assert bot._risk_input_recovery.reason == "current_balance_unavailable"
+    assert bot._risk_input_recovery.retry_at == clock[0] + 5.0
+    bot._equity_hard_stop_check.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["coin", "pside", "unified"])
+async def test_red_supervisor_returns_to_recovery_when_refresh_invalidates_balance(mode):
+    from test_hsl_coin_mode import make_coin_bot
+    import passivbot_hsl as hsl
+    bot = make_coin_bot()
+    bot.config["live"]["hsl_signal_mode"] = mode
+    bot.stop_signal_received = False
+    bot._equity_hard_stop_supervisor_running = False
+    state = bot._hsl_coin_state("long", "A") if mode == "coin" else bot._hsl_state("long")
+    bot._equity_hard_stop_coin_needs_panic_supervision = lambda *args: True
+    bot._equity_hard_stop_runtime_red_latched = lambda pside: pside == "long"
+    bot.balance_raw = 100.0
+    bot.get_raw_balance = lambda: bot.balance_raw
+    async def refresh():
+        bot.balance_raw = 0.0
+        return True
+    bot.refresh_protective_authoritative_state = AsyncMock(side_effect=refresh)
+    bot.calc_protective_panic_orders_to_cancel_and_create = AsyncMock()
+    supervisor = (hsl._equity_hard_stop_run_coin_red_supervisor if mode == "coin"
+                  else hsl._equity_hard_stop_run_red_supervisor)
+    with pytest.raises(recovery.RiskInputUnavailable):
+        await supervisor(bot)
+    bot.calc_protective_panic_orders_to_cancel_and_create.assert_not_awaited()
+    assert not state["halted"]
+    assert not bot._equity_hard_stop_supervisor_running
+
+
+@pytest.mark.asyncio
+async def test_risk_event_sink_failure_cannot_change_recovery_or_leak_secrets(monkeypatch, caplog):
+    bot, _ = make_bot(monkeypatch)
+    bot.balance_raw = 0.0
+    def fail(*args, **kwargs):
+        raise RuntimeError("api_key=should-never-appear")
+    bot._live_event_pipeline = SimpleNamespace(emit=fail, console_sink=object())
+    bot.live_event_console_enabled = True
+    with caplog.at_level(logging.DEBUG):
+        assert not await recovery.ensure_ready(bot)
+    assert bot._risk_input_recovery.reason == "current_balance_unavailable"
+    assert "should-never-appear" not in caplog.text


### PR DESCRIPTION
A non-positive current balance or an invalid reconstructed historical balance can stop live startup in HSL replay; the Rust planner independently rejects invalid current balances. These numeric observations now enter an explicit readiness wait instead of crashing or exhausting the restart budget.

- Keep startup unready and pause ordinary runtime planning until required balances and HSL evaluation succeed. Refresh authoritative account/fill state and resume automatically, with retry delays capped at 60 seconds for current balances and five minutes for history reconstruction.
- Validate replay balances before replacing existing HSL protection. Existing cooldown/RED protection can continue only with its own valid inputs, and protective replay cannot bypass the retry deadline.
- Emit bounded warnings that distinguish current balances from historical replay failures, with replay timestamp/value/count/window, retry information, and recovery. Coalesce unchanged warnings for five minutes.
- Preserve strict Rust/HSL sample validation and malformed configuration/payload errors. No positive balance substitutes, discarded required history, or disabled-HSL fallback.

Validation: 1,313 focused HSL, execution, lifecycle, orchestration, migration, event, and documentation tests passed on the integrated branch. Rust-backed tests used a rebuilt and source-verified extension. The offline fake exchange RED-stop/restart smoke passed. AI documentation and generated event registry checks passed; `git diff --check` passed.

This handles the failure mode without claiming that the underlying balance/account extraction or history issue has been identified. An account with persistently unusable inputs remains visibly waiting.
