### PR TITLE
Move trailing-martingale EMA spans under entry with schema migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Trailing-martingale price EMA spans now live at
+  `bot.<side>.strategy.trailing_martingale.entry.ema_span_0/1` (schema v8.4.0).
+  Existing configs, bounds, coin files/inline overrides, and scenario paths migrate without
+  changing their horizons. Explicit new paths win on conflicts, with warnings. Previous CLI
+  paths and optimizer selectors remain accepted. Entry-only optimizer selectors now include
+  these spans; coupled unstuck search, CPU/GPU execution, and warmup use the new paths.
+  Shared volatility spans and other strategies keep their existing locations.
+
 - Coin HSL no longer clears live protection or repeatedly reconstructs history when a delayed
   ordinary flatten falls before the bounded replay window. Successful empty-window replays now
   establish the proven episode boundary before calculating current risk, preventing discarded

--- a/configs/examples/BTC_ETH_XRP_SOL_ADA_long.json
+++ b/configs/examples/BTC_ETH_XRP_SOL_ADA_long.json
@@ -138,11 +138,11 @@
             },
             "strategy": {
                 "trailing_martingale": {
-                    "ema_span_0": 770,
-                    "ema_span_1": 210,
                     "volatility_ema_span_1h": 1690,
                     "volatility_ema_span_1m": 60.0,
                     "entry": {
+                        "ema_span_0": 770,
+                        "ema_span_1": 210,
                         "double_down_factor": 0.73,
                         "initial_ema_dist": 0.0097,
                         "initial_qty_pct": 0.0276,
@@ -213,11 +213,11 @@
             },
             "strategy": {
                 "trailing_martingale": {
-                    "ema_span_0": 100,
-                    "ema_span_1": 100,
                     "volatility_ema_span_1h": 672,
                     "volatility_ema_span_1m": 60.0,
                     "entry": {
+                        "ema_span_0": 100,
+                        "ema_span_1": 100,
                         "double_down_factor": 0.5,
                         "initial_ema_dist": -0.01,
                         "initial_qty_pct": 0.01,
@@ -254,7 +254,7 @@
         }
     },
     "coin_overrides": {},
-    "config_version": "v8.3.0",
+    "config_version": "v8.4.0",
     "live": {
         "approved_coins": {
             "long": [
@@ -427,16 +427,6 @@
                 },
                 "strategy": {
                     "trailing_martingale": {
-                        "ema_span_0": [
-                            200,
-                            1440,
-                            10
-                        ],
-                        "ema_span_1": [
-                            200,
-                            1440,
-                            10
-                        ],
                         "volatility_ema_span_1h": [
                             672,
                             2016,
@@ -448,6 +438,16 @@
                             1
                         ],
                         "entry": {
+                            "ema_span_0": [
+                                200,
+                                1440,
+                                10
+                            ],
+                            "ema_span_1": [
+                                200,
+                                1440,
+                                10
+                            ],
                             "double_down_factor": [
                                 0.5,
                                 1,
@@ -656,16 +656,6 @@
                 },
                 "strategy": {
                     "trailing_martingale": {
-                        "ema_span_0": [
-                            200,
-                            1440,
-                            10
-                        ],
-                        "ema_span_1": [
-                            200,
-                            1440,
-                            10
-                        ],
                         "volatility_ema_span_1h": [
                             672,
                             2016,
@@ -677,6 +667,16 @@
                             1
                         ],
                         "entry": {
+                            "ema_span_0": [
+                                200,
+                                1440,
+                                10
+                            ],
+                            "ema_span_1": [
+                                200,
+                                1440,
+                                10
+                            ],
                             "double_down_factor": [
                                 0.5,
                                 1,

--- a/configs/examples/btc_long.json
+++ b/configs/examples/btc_long.json
@@ -73,11 +73,11 @@
             },
             "strategy": {
                 "trailing_martingale": {
-                    "ema_span_0": 770,
-                    "ema_span_1": 210,
                     "volatility_ema_span_1h": 1690,
                     "volatility_ema_span_1m": 60.0,
                     "entry": {
+                        "ema_span_0": 770,
+                        "ema_span_1": 210,
                         "double_down_factor": 0.73,
                         "initial_ema_dist": 0.0097,
                         "initial_qty_pct": 0.0276,
@@ -148,11 +148,11 @@
             },
             "strategy": {
                 "trailing_martingale": {
-                    "ema_span_0": 100,
-                    "ema_span_1": 100,
                     "volatility_ema_span_1h": 672,
                     "volatility_ema_span_1m": 60.0,
                     "entry": {
+                        "ema_span_0": 100,
+                        "ema_span_1": 100,
                         "double_down_factor": 0.5,
                         "initial_ema_dist": -0.01,
                         "initial_qty_pct": 0.01,
@@ -189,7 +189,7 @@
         }
     },
     "coin_overrides": {},
-    "config_version": "v8.3.0",
+    "config_version": "v8.4.0",
     "live": {
         "approved_coins": {
             "long": [
@@ -355,16 +355,6 @@
                 },
                 "strategy": {
                     "trailing_martingale": {
-                        "ema_span_0": [
-                            200,
-                            1440,
-                            10
-                        ],
-                        "ema_span_1": [
-                            200,
-                            1440,
-                            10
-                        ],
                         "volatility_ema_span_1h": [
                             672,
                             2016,
@@ -376,6 +366,16 @@
                             1
                         ],
                         "entry": {
+                            "ema_span_0": [
+                                200,
+                                1440,
+                                10
+                            ],
+                            "ema_span_1": [
+                                200,
+                                1440,
+                                10
+                            ],
                             "double_down_factor": [
                                 0.5,
                                 1,
@@ -584,16 +584,6 @@
                 },
                 "strategy": {
                     "trailing_martingale": {
-                        "ema_span_0": [
-                            200,
-                            1440,
-                            10
-                        ],
-                        "ema_span_1": [
-                            200,
-                            1440,
-                            10
-                        ],
                         "volatility_ema_span_1h": [
                             672,
                             2016,
@@ -605,6 +595,16 @@
                             1
                         ],
                         "entry": {
+                            "ema_span_0": [
+                                200,
+                                1440,
+                                10
+                            ],
+                            "ema_span_1": [
+                                200,
+                                1440,
+                                10
+                            ],
                             "double_down_factor": [
                                 0.5,
                                 1,

--- a/configs/examples/default_trailing_martingale_long.json
+++ b/configs/examples/default_trailing_martingale_long.json
@@ -201,9 +201,9 @@
                         "threshold_volatility_1m_weight": 3.22,
                         "threshold_we_weight": -0.0001
                     },
-                    "ema_span_0": 790.0,
-                    "ema_span_1": 1080.0,
                     "entry": {
+                        "ema_span_0": 790.0,
+                        "ema_span_1": 1080.0,
                         "double_down_factor": 0.94,
                         "ema_gate_mode": "all",
                         "initial_ema_dist": 0.0028,
@@ -275,9 +275,9 @@
                         "threshold_volatility_1m_weight": 0.01,
                         "threshold_we_weight": -0.1
                     },
-                    "ema_span_0": 60.0,
-                    "ema_span_1": 60.0,
                     "entry": {
+                        "ema_span_0": 60.0,
+                        "ema_span_1": 60.0,
                         "double_down_factor": 0.2,
                         "ema_gate_mode": "all",
                         "initial_ema_dist": -0.1,
@@ -308,7 +308,7 @@
         }
     },
     "coin_overrides": {},
-    "config_version": "v8.3.0",
+    "config_version": "v8.4.0",
     "live": {
         "approved_coins": {
             "long": [
@@ -522,9 +522,9 @@
                             "threshold_volatility_1m_weight": [0.01, 80, 0.01],
                             "threshold_we_weight": [-0.05, 0.05, 0.0001]
                         },
-                        "ema_span_0": [100.0, 2880.0, 10.0],
-                        "ema_span_1": [100.0, 2880.0, 10.0],
                         "entry": {
+                            "ema_span_0": [100.0, 2880.0, 10.0],
+                            "ema_span_1": [100.0, 2880.0, 10.0],
                             "double_down_factor": [0.2, 1.2, 0.01],
                             "initial_ema_dist": [-0.05, 0.005, 0.0001],
                             "initial_qty_pct": [0.005, 0.1, 0.0001],
@@ -584,9 +584,9 @@
                             "threshold_volatility_1m_weight": [0.01, 70, 0.01],
                             "threshold_we_weight": [-0.1, 0.1, 0.0001]
                         },
-                        "ema_span_0": [100.0, 1440.0, 10.0],
-                        "ema_span_1": [100.0, 1440.0, 10.0],
                         "entry": {
+                            "ema_span_0": [100.0, 1440.0, 10.0],
+                            "ema_span_1": [100.0, 1440.0, 10.0],
                             "double_down_factor": [0.2, 2, 0.01],
                             "initial_ema_dist": [-0.1, 0.02, 0.0001],
                             "initial_qty_pct": [0.005, 0.1, 0.0001],

--- a/configs/examples/ema_anchor.json
+++ b/configs/examples/ema_anchor.json
@@ -156,7 +156,7 @@
         }
     },
     "coin_overrides": {},
-    "config_version": "v8.3.0",
+    "config_version": "v8.4.0",
     "live": {
         "approved_coins": {"long":["SOL"],"short":["SOL"]},
         "auto_gs": true,

--- a/configs/examples/hsl_npos1.json
+++ b/configs/examples/hsl_npos1.json
@@ -177,11 +177,11 @@
             },
             "strategy": {
                 "trailing_martingale": {
-                    "ema_span_0": 770,
-                    "ema_span_1": 210,
                     "volatility_ema_span_1h": 1690,
                     "volatility_ema_span_1m": 60.0,
                     "entry": {
+                        "ema_span_0": 770,
+                        "ema_span_1": 210,
                         "double_down_factor": 0.73,
                         "initial_ema_dist": 0.0097,
                         "initial_qty_pct": 0.0276,
@@ -252,11 +252,11 @@
             },
             "strategy": {
                 "trailing_martingale": {
-                    "ema_span_0": 100,
-                    "ema_span_1": 100,
                     "volatility_ema_span_1h": 672,
                     "volatility_ema_span_1m": 60.0,
                     "entry": {
+                        "ema_span_0": 100,
+                        "ema_span_1": 100,
                         "double_down_factor": 0.5,
                         "initial_ema_dist": -0.01,
                         "initial_qty_pct": 0.01,
@@ -293,7 +293,7 @@
         }
     },
     "coin_overrides": {},
-    "config_version": "v8.3.0",
+    "config_version": "v8.4.0",
     "live": {
         "approved_coins": {
             "long": [
@@ -496,16 +496,6 @@
                 },
                 "strategy": {
                     "trailing_martingale": {
-                        "ema_span_0": [
-                            200,
-                            1440,
-                            10
-                        ],
-                        "ema_span_1": [
-                            200,
-                            1440,
-                            10
-                        ],
                         "volatility_ema_span_1h": [
                             672,
                             2016,
@@ -517,6 +507,16 @@
                             1
                         ],
                         "entry": {
+                            "ema_span_0": [
+                                200,
+                                1440,
+                                10
+                            ],
+                            "ema_span_1": [
+                                200,
+                                1440,
+                                10
+                            ],
                             "double_down_factor": [
                                 0.5,
                                 1,
@@ -725,16 +725,6 @@
                 },
                 "strategy": {
                     "trailing_martingale": {
-                        "ema_span_0": [
-                            200,
-                            1440,
-                            10
-                        ],
-                        "ema_span_1": [
-                            200,
-                            1440,
-                            10
-                        ],
                         "volatility_ema_span_1h": [
                             672,
                             2016,
@@ -746,6 +736,16 @@
                             1
                         ],
                         "entry": {
+                            "ema_span_0": [
+                                200,
+                                1440,
+                                10
+                            ],
+                            "ema_span_1": [
+                                200,
+                                1440,
+                                10
+                            ],
                             "double_down_factor": [
                                 0.5,
                                 1,

--- a/configs/examples/suite_example.json
+++ b/configs/examples/suite_example.json
@@ -105,11 +105,11 @@
             },
             "strategy": {
                 "trailing_martingale": {
-                    "ema_span_0": 770,
-                    "ema_span_1": 210,
                     "volatility_ema_span_1h": 1690,
                     "volatility_ema_span_1m": 60.0,
                     "entry": {
+                        "ema_span_0": 770,
+                        "ema_span_1": 210,
                         "double_down_factor": 0.73,
                         "initial_ema_dist": 0.0097,
                         "initial_qty_pct": 0.0276,
@@ -180,11 +180,11 @@
             },
             "strategy": {
                 "trailing_martingale": {
-                    "ema_span_0": 100,
-                    "ema_span_1": 100,
                     "volatility_ema_span_1h": 672,
                     "volatility_ema_span_1m": 60.0,
                     "entry": {
+                        "ema_span_0": 100,
+                        "ema_span_1": 100,
                         "double_down_factor": 0.5,
                         "initial_ema_dist": -0.01,
                         "initial_qty_pct": 0.01,
@@ -221,7 +221,7 @@
         }
     },
     "coin_overrides": {},
-    "config_version": "v8.3.0",
+    "config_version": "v8.4.0",
     "live": {
         "approved_coins": {
             "long": [
@@ -385,16 +385,6 @@
                 },
                 "strategy": {
                     "trailing_martingale": {
-                        "ema_span_0": [
-                            200,
-                            1440,
-                            10
-                        ],
-                        "ema_span_1": [
-                            200,
-                            1440,
-                            10
-                        ],
                         "volatility_ema_span_1h": [
                             672,
                             2016,
@@ -406,6 +396,16 @@
                             1
                         ],
                         "entry": {
+                            "ema_span_0": [
+                                200,
+                                1440,
+                                10
+                            ],
+                            "ema_span_1": [
+                                200,
+                                1440,
+                                10
+                            ],
                             "double_down_factor": [
                                 0.5,
                                 1,
@@ -614,16 +614,6 @@
                 },
                 "strategy": {
                     "trailing_martingale": {
-                        "ema_span_0": [
-                            200,
-                            1440,
-                            10
-                        ],
-                        "ema_span_1": [
-                            200,
-                            1440,
-                            10
-                        ],
                         "volatility_ema_span_1h": [
                             672,
                             2016,
@@ -635,6 +625,16 @@
                             1
                         ],
                         "entry": {
+                            "ema_span_0": [
+                                200,
+                                1440,
+                                10
+                            ],
+                            "ema_span_1": [
+                                200,
+                                1440,
+                                10
+                            ],
                             "double_down_factor": [
                                 0.5,
                                 1,

--- a/configs/examples/xmr_long_short.json
+++ b/configs/examples/xmr_long_short.json
@@ -102,11 +102,11 @@
             },
             "strategy": {
                 "trailing_martingale": {
-                    "ema_span_0": 770,
-                    "ema_span_1": 210,
                     "volatility_ema_span_1h": 1690,
                     "volatility_ema_span_1m": 60.0,
                     "entry": {
+                        "ema_span_0": 770,
+                        "ema_span_1": 210,
                         "double_down_factor": 0.73,
                         "initial_ema_dist": 0.0097,
                         "initial_qty_pct": 0.0276,
@@ -177,11 +177,11 @@
             },
             "strategy": {
                 "trailing_martingale": {
-                    "ema_span_0": 100,
-                    "ema_span_1": 100,
                     "volatility_ema_span_1h": 672,
                     "volatility_ema_span_1m": 60.0,
                     "entry": {
+                        "ema_span_0": 100,
+                        "ema_span_1": 100,
                         "double_down_factor": 0.5,
                         "initial_ema_dist": -0.01,
                         "initial_qty_pct": 0.01,
@@ -218,7 +218,7 @@
         }
     },
     "coin_overrides": {},
-    "config_version": "v8.3.0",
+    "config_version": "v8.4.0",
     "live": {
         "approved_coins": {
             "long": [
@@ -383,16 +383,6 @@
                 },
                 "strategy": {
                     "trailing_martingale": {
-                        "ema_span_0": [
-                            200,
-                            1440,
-                            10
-                        ],
-                        "ema_span_1": [
-                            200,
-                            1440,
-                            10
-                        ],
                         "volatility_ema_span_1h": [
                             672,
                             2016,
@@ -404,6 +394,16 @@
                             1
                         ],
                         "entry": {
+                            "ema_span_0": [
+                                200,
+                                1440,
+                                10
+                            ],
+                            "ema_span_1": [
+                                200,
+                                1440,
+                                10
+                            ],
                             "double_down_factor": [
                                 0.5,
                                 1,
@@ -612,16 +612,6 @@
                 },
                 "strategy": {
                     "trailing_martingale": {
-                        "ema_span_0": [
-                            200,
-                            1440,
-                            10
-                        ],
-                        "ema_span_1": [
-                            200,
-                            1440,
-                            10
-                        ],
                         "volatility_ema_span_1h": [
                             672,
                             2016,
@@ -633,6 +623,16 @@
                             1
                         ],
                         "entry": {
+                            "ema_span_0": [
+                                200,
+                                1440,
+                                10
+                            ],
+                            "ema_span_1": [
+                                200,
+                                1440,
+                                10
+                            ],
                             "double_down_factor": [
                                 0.5,
                                 1,

--- a/docs/ai/features/strategy_runtime.md
+++ b/docs/ai/features/strategy_runtime.md
@@ -113,6 +113,13 @@ shared span cannot leak a projected strategy value into coin ranking.
 
 ## Trailing Martingale Semantics
 
+Trailing-martingale price spans belong to `entry.ema_span_0/1`. Schema v8.4.0 migrates
+old strategy-root leaves before hydration and before file/inline override merges; explicit
+new leaves win with warnings on conflicting values. Public optimizer bounds share the nested
+paths; internal optimizer keys and Metal columns retain `ema_span_0/1`. Entry subtree selectors
+include the horizons. EMA-anchor and trailing-grid-v7 paths are unchanged. Volatility horizons
+remain shared by entries and closes.
+
 Entries and closes use threshold/retracement fields.
 
 - `retracement_base_pct <= 0.0`: trailing disabled, use passive recursive limit-order behavior.

--- a/docs/config.bot.md
+++ b/docs/config.bot.md
@@ -30,6 +30,19 @@ Throughout:
 
 ## Trailing Martingale Entries
 
+Price EMA horizons are `bot.<side>.strategy.trailing_martingale.entry.ema_span_0`
+and `entry.ema_span_1`. They govern entry gating, forager entry readiness, and the one-way
+entry tie-break. Ordinary closes do not consume this band. The shared
+`volatility_ema_span_1m/1h` remain at strategy level because both entries and closes use them.
+
+Schema v8.4.0 moves the old strategy-root spans into `entry`, including optimizer bounds
+and coin/scenario overrides. Values and floating-point precision are preserved. Within one
+source, explicit new paths win over conflicting old paths with a warning; normal file/inline
+coin precedence is preserved. Old CLI paths and dotted optimizer selectors still work.
+Selecting `long.strategy.entry` now includes the entry EMA horizons. Other strategies retain
+their existing schema. `couple_unstuck_ema_spans` continues to derive unstuck horizons from
+each coin's effective entry spans during optimization.
+
 ```text
 alpha(span)         = 2 / (span + 1)
 entry_threshold_vol_term =

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -235,14 +235,16 @@ Key HSL analysis metrics:
 
 ### General Parameters for Long and Short
 
-- **ema_span_0**, **ema_span_1**:
+- **strategy.trailing_martingale.entry.ema_span_0**, **entry.ema_span_1**:
   - Spans are given in minutes.
   - Formula: `next_EMA = prev_EMA * (1 - alpha) + new_val * alpha`, where `alpha = 2 / (span + 1)`.
   - An additional EMA span is calculated as `(ema_span_0 * ema_span_1)**0.5`.
   - The three EMAs form an upper and lower EMA band:
     - `ema_band_lower = min(emas)`
     - `ema_band_upper = max(emas)`
-  - These bands are used for initial entries and auto unstuck closes.
+  - These bands govern entry gating, forager entry readiness, and one-way entry arbitration.
+  - Auto-unstuck uses its own `unstuck.ema_span_0/1`; ordinary trailing-martingale closes do not use the entry price band.
+  - Schema v8.4.0 migrates old strategy-root spans into `entry`; conflicting explicit new values win with warnings.
 - **n_positions**: Maximum number of positions to open. Set to `0` to disable long/short.
 - **total_wallet_exposure_limit**: Maximum exposure allowed.
   - Example: `total_wallet_exposure_limit = 0.75` means 75% of (unleveraged) wallet balance is used.
@@ -389,7 +391,7 @@ See [docs/forager.md](forager.md) for a full description of motivation, ranking 
     - `config.bot.long/short.strategy.trailing_martingale`:
       ```
       [
-        ema_span_0, ema_span_1, volatility_ema_span_1h, volatility_ema_span_1m,
+        entry.ema_span_0, entry.ema_span_1, volatility_ema_span_1h, volatility_ema_span_1m,
         entry.double_down_factor, entry.initial_ema_dist, entry.initial_qty_pct,
         entry.threshold_base_pct, entry.threshold_we_weight,
         entry.threshold_volatility_1h_weight, entry.threshold_volatility_1m_weight,

--- a/passivbot-rust/src/backtest.rs
+++ b/passivbot-rust/src/backtest.rs
@@ -951,11 +951,11 @@ fn parse_strategy_params_pair(
 #[cfg(test)]
 fn test_trailing_martingale_params_value_from_flat(bot_params: &BotParams) -> serde_json::Value {
     crate::strategies::TrailingMartingaleParams {
-        ema_span_0: bot_params.ema_span_0,
-        ema_span_1: bot_params.ema_span_1,
         volatility_ema_span_1h: bot_params.entry_volatility_ema_span_1h,
         volatility_ema_span_1m: bot_params.entry_volatility_ema_span_1m,
         entry: crate::strategies::TrailingMartingaleEntryParams {
+            ema_span_0: bot_params.ema_span_0,
+            ema_span_1: bot_params.ema_span_1,
             double_down_factor: bot_params.entry_grid_double_down_factor,
             ema_gate_mode: crate::strategies::EmaGateMode::Initial,
             initial_ema_dist: bot_params.entry_initial_ema_dist,
@@ -6487,11 +6487,11 @@ mod tests {
 
     fn tm_params_for_ema_tests(bot_params: &BotParams) -> TrailingMartingaleParams {
         TrailingMartingaleParams {
-            ema_span_0: bot_params.ema_span_0,
-            ema_span_1: bot_params.ema_span_1,
             volatility_ema_span_1h: bot_params.entry_volatility_ema_span_1h,
             volatility_ema_span_1m: bot_params.entry_volatility_ema_span_1m,
             entry: TrailingMartingaleEntryParams {
+                ema_span_0: bot_params.ema_span_0,
+                ema_span_1: bot_params.ema_span_1,
                 double_down_factor: bot_params.entry_grid_double_down_factor,
                 ema_gate_mode: crate::strategies::EmaGateMode::Initial,
                 initial_ema_dist: bot_params.entry_initial_ema_dist,

--- a/passivbot-rust/src/entries.rs
+++ b/passivbot-rust/src/entries.rs
@@ -1495,6 +1495,8 @@ mod tests {
 
     fn make_entry_params() -> TrailingMartingaleEntryParams {
         TrailingMartingaleEntryParams {
+            ema_span_0: 0.0,
+            ema_span_1: 0.0,
             double_down_factor: 1.0,
             ema_gate_mode: EmaGateMode::Initial,
             threshold_base_pct: 0.01,

--- a/passivbot-rust/src/orchestrator.rs
+++ b/passivbot-rust/src/orchestrator.rs
@@ -4569,11 +4569,11 @@ mod core {
             bot_params: &BotParams,
         ) -> crate::strategies::TrailingMartingaleParams {
             crate::strategies::TrailingMartingaleParams {
-                ema_span_0: bot_params.ema_span_0,
-                ema_span_1: bot_params.ema_span_1,
                 volatility_ema_span_1h: bot_params.entry_volatility_ema_span_1h,
                 volatility_ema_span_1m: bot_params.entry_volatility_ema_span_1m,
                 entry: crate::strategies::TrailingMartingaleEntryParams {
+                    ema_span_0: bot_params.ema_span_0,
+                    ema_span_1: bot_params.ema_span_1,
                     double_down_factor: bot_params.entry_grid_double_down_factor,
                     ema_gate_mode: crate::strategies::EmaGateMode::Initial,
                     initial_ema_dist: bot_params.entry_initial_ema_dist,

--- a/passivbot-rust/src/python.rs
+++ b/passivbot-rust/src/python.rs
@@ -2184,11 +2184,12 @@ fn trailing_martingale_strategy_params_from_dict(dict: &PyDict) -> PyResult<Valu
     let entry = extract_value::<&PyDict>(dict, "entry")?;
     let close = extract_value::<&PyDict>(dict, "close")?;
     Ok(serde_json::json!({
-        "ema_span_0": extract_value::<f64>(dict, "ema_span_0")?,
-        "ema_span_1": extract_value::<f64>(dict, "ema_span_1")?,
+
         "volatility_ema_span_1h": extract_value::<f64>(dict, "volatility_ema_span_1h")?,
         "volatility_ema_span_1m": extract_value::<f64>(dict, "volatility_ema_span_1m")?,
         "entry": {
+            "ema_span_0": extract_value::<f64>(entry, "ema_span_0")?,
+            "ema_span_1": extract_value::<f64>(entry, "ema_span_1")?,
             "double_down_factor": extract_value::<f64>(entry, "double_down_factor")?,
             "ema_gate_mode": extract_optional_string(entry, "ema_gate_mode", "initial")?,
             "initial_ema_dist": extract_value::<f64>(entry, "initial_ema_dist")?,
@@ -2941,6 +2942,8 @@ fn make_trailing_martingale_entry_params(
         entry_trailing_threshold_pct,
     );
     TrailingMartingaleEntryParams {
+        ema_span_0: 0.0,
+        ema_span_1: 0.0,
         double_down_factor: entry_grid_double_down_factor,
         ema_gate_mode: EmaGateMode::Initial,
         initial_ema_dist: entry_initial_ema_dist,

--- a/passivbot-rust/src/strategies/mod.rs
+++ b/passivbot-rust/src/strategies/mod.rs
@@ -44,8 +44,6 @@ impl EmaGateMode {
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Default)]
 #[serde(default, deny_unknown_fields)]
 pub struct TrailingMartingaleParams {
-    pub ema_span_0: f64,
-    pub ema_span_1: f64,
     pub volatility_ema_span_1h: f64,
     pub volatility_ema_span_1m: f64,
     pub entry: TrailingMartingaleEntryParams,
@@ -55,6 +53,8 @@ pub struct TrailingMartingaleParams {
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Default)]
 #[serde(default, deny_unknown_fields)]
 pub struct TrailingMartingaleEntryParams {
+    pub ema_span_0: f64,
+    pub ema_span_1: f64,
     pub double_down_factor: f64,
     pub ema_gate_mode: EmaGateMode,
     pub initial_ema_dist: f64,
@@ -256,7 +256,7 @@ pub fn parse_strategy_params(
 
 pub fn strategy_ema_spans(params: &StrategyParams) -> (f64, f64) {
     match params {
-        StrategyParams::TrailingMartingale(params) => (params.ema_span_0, params.ema_span_1),
+        StrategyParams::TrailingMartingale(params) => (params.entry.ema_span_0, params.entry.ema_span_1),
         StrategyParams::EmaAnchor(params) => (params.ema_span_0, params.ema_span_1),
         StrategyParams::TrailingGridV7(params) => (params.ema_span_0, params.ema_span_1),
     }

--- a/passivbot-rust/src/strategies/spec.rs
+++ b/passivbot-rust/src/strategies/spec.rs
@@ -51,7 +51,7 @@ struct NestedParamSeed {
 const TRAILING_MARTINGALE_PARAM_SEEDS: &[NestedParamSeed] = &[
     NestedParamSeed {
         name: "ema_span_0",
-        path: &["ema_span_0"],
+        path: &["entry", "ema_span_0"],
         long_default: 790.0,
         short_default: 60.0,
         long_bounds: &[100.0, 2880.0, 10.0],
@@ -59,7 +59,7 @@ const TRAILING_MARTINGALE_PARAM_SEEDS: &[NestedParamSeed] = &[
     },
     NestedParamSeed {
         name: "ema_span_1",
-        path: &["ema_span_1"],
+        path: &["entry", "ema_span_1"],
         long_default: 1080.0,
         short_default: 60.0,
         long_bounds: &[100.0, 2880.0, 10.0],

--- a/src/config/bot.py
+++ b/src/config/bot.py
@@ -1080,7 +1080,10 @@ def format_bot_config(
     for path in ("bot.long", "bot.short"):
         require_config_dict(result, path)
     apply_backward_compatibility_renames(result, verbose=verbose, tracker=tracker)
+    from .migrations.entry_ema import migrate_entry_ema_spans
     from .migrations.unstuck_ema import migrate_unstuck_ema_spans
+
+    migrate_entry_ema_spans(result, tracker=tracker)
 
     migrate_unstuck_ema_spans(result, verbose=verbose, tracker=tracker)
     ensure_bot_defaults(result, verbose=verbose, tracker=tracker)

--- a/src/config/migrations/entry_ema.py
+++ b/src/config/migrations/entry_ema.py
@@ -1,0 +1,118 @@
+"""Move trailing-martingale price horizons to their entry-owned config paths."""
+
+import logging
+from copy import deepcopy
+
+SPANS = ("ema_span_0", "ema_span_1")
+KIND = "trailing_martingale"
+
+
+def _move(mapping, old, new, *, path, tracker=None):
+    value = mapping.pop(old)
+    if new in mapping:
+        if mapping[new] != value:
+            logging.warning(
+                "[config] Cannot preserve conflicting EMA values at %s: discarded legacy %s=%r; "
+                "explicit %s=%r wins. Review this config before use.",
+                path,
+                old,
+                value,
+                new,
+                mapping[new],
+            )
+    else:
+        mapping[new] = value
+    if tracker is not None:
+        tracker.rename([*path.split("."), old], [*path.split("."), new], mapping[new])
+
+
+def migrate_entry_ema_tree(document, *, path="config", tracker=None):
+    """Migrate explicit leaves only, including partial and external coin patches.
+
+    Called before merging independently authored patches, so ordinary file/inline
+    precedence is retained. Metadata and unrelated strategies are left alone.
+    """
+    if isinstance(document, list):
+        for index, item in enumerate(document):
+            migrate_entry_ema_tree(item, path=f"{path}.{index}", tracker=tracker)
+        return
+    if not isinstance(document, dict):
+        return
+    for key, value in list(document.items()):
+        if not isinstance(key, str) or key.startswith("_"):
+            continue
+        child_path = f"{path}.{key}"
+        if key.split(".")[-1] == KIND and isinstance(value, dict):
+            for span in SPANS:
+                if span not in value:
+                    continue
+                entry = value.setdefault("entry", {})
+                if not isinstance(entry, dict):
+                    raise TypeError(f"{child_path}.entry must be a mapping")
+                old = value.pop(span)
+                if span in entry and entry[span] != old:
+                    logging.warning(
+                        "[config] Cannot preserve conflicting EMA values: %s.%s=%r is discarded; "
+                        "explicit %s.entry.%s=%r wins. Review this config before use.",
+                        child_path,
+                        span,
+                        old,
+                        child_path,
+                        span,
+                        entry[span],
+                    )
+                else:
+                    entry.setdefault(span, old)
+                if tracker is not None:
+                    tracker.rename(
+                        child_path.split(".")[1:] + [span],
+                        child_path.split(".")[1:] + ["entry", span],
+                        entry[span],
+                    )
+        migrate_entry_ema_tree(value, path=child_path, tracker=tracker)
+        for span in SPANS:
+            suffix = f"{KIND}.{span}"
+            if key == suffix or key.endswith("." + suffix):
+                new = key[: -len(span)] + "entry." + span
+                _move(document, key, new, path=path, tracker=tracker)
+                break
+
+
+def migrate_entry_ema_spans(config, *, tracker=None):
+    # Scenario mappings can mix nested paths, dotted paths, and active-strategy
+    # aliases. Resolve leaf collisions before any defaults/overrides are applied.
+    from ..param_paths import resolve_dotted_config_path
+    from suite_runner import _normalize_scenario_overrides
+
+    for scenario in config.get("backtest", {}).get("scenarios", []):
+        if not isinstance(scenario, dict) or not isinstance(
+            scenario.get("overrides"), dict
+        ):
+            continue
+        overrides = _normalize_scenario_overrides(scenario["overrides"])
+        migrated = {}
+        # Canonical keys win independently of input insertion order.
+        items = []
+        for key, value in overrides.items():
+            resolved = resolve_dotted_config_path(config, key)
+            canonical = (
+                ".".join(resolved)
+                if resolved[-3:] in [(KIND, "entry", span) for span in SPANS]
+                else key
+            )
+            items.append((key, canonical, value))
+        if not any(key != canonical for key, canonical, _ in items):
+            continue
+        for key, canonical, value in sorted(
+            items, key=lambda item: (".entry.ema_span_" in item[0], item[0] == item[1])
+        ):
+            if canonical in migrated and migrated[canonical] != value:
+                logging.warning(
+                    "[config] Cannot preserve conflicting scenario EMA/override values for %s "
+                    "in %r; explicit canonical path wins. Review this config before use.",
+                    canonical,
+                    scenario.get("label", "<unnamed>"),
+                )
+            migrated[canonical] = deepcopy(value)
+        scenario["overrides"] = migrated
+    migrate_entry_ema_tree(config, tracker=tracker)

--- a/src/config/migrations/unstuck_ema.py
+++ b/src/config/migrations/unstuck_ema.py
@@ -4,6 +4,7 @@ import logging
 from copy import deepcopy
 
 from optimization.bounds import Bound
+from .entry_ema import migrate_entry_ema_tree
 
 from ..strategy_spec import (
     get_strategy_defaults,
@@ -12,6 +13,10 @@ from ..strategy_spec import (
 )
 from ..shared_bot import canonicalize_shared_bot_side
 from ..optimize_bounds import flatten_optimize_bounds, set_flat_optimize_bound
+
+
+def _price_spans(strategy, kind):
+    return strategy.get("entry", {}) if kind == "trailing_martingale" else strategy
 
 
 def _migrate_inactive_zero_span(value, bot, default, path):
@@ -42,14 +47,17 @@ def migrate_unstuck_ema_spans(
     explicit_bounds=None,
 ) -> None:
     kind = normalize_strategy_kind(config.get("live", {}).get("strategy_kind"))
-    defaults = get_strategy_defaults(kind)
+    defaults = {
+        side: _price_spans(value, kind)
+        for side, value in get_strategy_defaults(kind).items()
+    }
     migrated = {}
     for side, bot in config.get("bot", {}).items():
         if side not in ("long", "short") or not isinstance(bot, dict):
             continue
         canonicalize_shared_bot_side(bot)
         unstuck = bot.setdefault("unstuck", {})
-        strategy = bot.get("strategy", {}).get(kind, {})
+        strategy = _price_spans(bot.get("strategy", {}).get(kind, {}), kind)
         for key in ("ema_span_0", "ema_span_1"):
             if key in unstuck:
                 continue
@@ -106,12 +114,13 @@ def migrate_unstuck_ema_spans(
             effective_patch = deepcopy(
                 _unwrap_override_document(source, source=f"coin_overrides.{coin}")
             )
+        migrate_entry_ema_tree(effective_patch)
         nested_update(effective_patch, deepcopy(override))
         for side, keys in migrated.items():
             patch_side = effective_patch.get("bot", {}).get(side, {})
             canonicalize_shared_bot_side(patch_side)
             patch_unstuck = patch_side.get("unstuck", {})
-            strategy = patch_side.get("strategy", {}).get(kind, {})
+            strategy = _price_spans(patch_side.get("strategy", {}).get(kind, {}), kind)
             for key in keys:
                 if key in patch_unstuck or key not in strategy:
                     continue
@@ -141,11 +150,16 @@ def migrate_unstuck_ema_spans(
     bounds = config.get("optimize", {}).get("bounds")
     coupled_search = []
     if isinstance(bounds, dict):
-        default_strategy_bounds = get_strategy_optimize_bounds(kind)
+        default_strategy_bounds = {
+            side: _price_spans(value, kind)
+            for side, value in get_strategy_optimize_bounds(kind).items()
+        }
         for side, keys in migrated.items():
             side_bounds = bounds.setdefault(side, {})
             unstuck_bounds = side_bounds.setdefault("unstuck", {})
-            strategy_bounds = side_bounds.get("strategy", {}).get(kind, {})
+            strategy_bounds = _price_spans(
+                side_bounds.get("strategy", {}).get(kind, {}), kind
+            )
             for key in keys:
                 old_bound = Bound.from_config(
                     f"{side}_{key}",
@@ -223,7 +237,9 @@ def migrate_unstuck_ema_spans(
             canonicalize_shared_bot_side(effective_side)
             for key in keys:
                 for old_path in (
-                    f"bot.{side}.strategy.{kind}.{key}",
+                    f"bot.{side}.strategy.{kind}."
+                    + ("entry." if kind == "trailing_martingale" else "")
+                    + key,
                     f"bot.{side}.{key}",
                 ):
                     new_path = f"bot.{side}.unstuck.{key}"

--- a/src/config/normalize.py
+++ b/src/config/normalize.py
@@ -95,9 +95,15 @@ def normalize_config(
             "optimize": deepcopy(raw_optimize_snapshot),
         }
         apply_backward_compatibility_renames(raw_optimize_compat, verbose=False, tracker=None)
+        from .migrations.entry_ema import migrate_entry_ema_tree
+
+        migrate_entry_ema_tree(raw_optimize_compat)
         raw_optimize_snapshot = raw_optimize_compat["optimize"]
 
+    from .migrations.entry_ema import migrate_entry_ema_spans
     from .migrations.unstuck_ema import migrate_unstuck_ema_spans
+
+    migrate_entry_ema_spans(result, tracker=tracker)
 
     migrate_unstuck_ema_spans(
         result,

--- a/src/config/optimize_bounds.py
+++ b/src/config/optimize_bounds.py
@@ -6,6 +6,7 @@ from .strategy_spec import (
     get_supported_strategy_kinds,
     get_strategy_optimize_bounds,
     normalize_strategy_kind,
+    strategy_optimize_key_path_map,
 )
 
 
@@ -139,6 +140,10 @@ def get_optimize_bounds_defaults() -> dict:
 def flatten_optimize_bounds(bounds: dict | None, *, strategy_kind: str) -> dict:
     normalized_kind = normalize_strategy_kind(strategy_kind)
     flat = {}
+    strategy_keys = {
+        "_".join(path[4:]): key.split("_", 1)[1]
+        for key, path in strategy_optimize_key_path_map(normalized_kind).items()
+    }
     if not isinstance(bounds, dict):
         return flat
     if any(
@@ -155,7 +160,7 @@ def flatten_optimize_bounds(bounds: dict | None, *, strategy_kind: str) -> dict:
                 strategy_bounds = group_bounds.get(normalized_kind, {}) if isinstance(group_bounds, dict) else {}
                 if isinstance(strategy_bounds, dict):
                     for key, value in _flatten_strategy_bound_items(strategy_bounds):
-                        flat[f"{pside}_{key}"] = deepcopy(value)
+                        flat[f"{pside}_{strategy_keys.get(key, key)}"] = deepcopy(value)
                 continue
             if not isinstance(group_bounds, dict):
                 continue
@@ -175,6 +180,12 @@ def set_flat_optimize_bound(bounds: dict, strategy_kind: str, flat_key: str, val
     if group is None:
         strategy_root = side_bounds.setdefault("strategy", {})
         current = strategy_root.setdefault(normalized_kind, {})
+        canonical_path = strategy_optimize_key_path_map(normalized_kind).get(flat_key)
+        if canonical_path is not None:
+            for part in canonical_path[4:-1]:
+                current = current.setdefault(part, {})
+            current[canonical_path[-1]] = deepcopy(value)
+            return
         parts = key.split("_")
         if parts[0] in {"entry", "close"} and len(parts) > 1:
             current = current.setdefault(parts[0], {})

--- a/src/config/overrides.py
+++ b/src/config/overrides.py
@@ -280,7 +280,10 @@ def _extract_allowed_patch(
 ) -> dict:
     """Extract explicitly supplied allowed leaves without hydrating defaults."""
 
-    source_doc = _unwrap_override_document(document, source=source)
+    source_doc = deepcopy(_unwrap_override_document(document, source=source))
+    from .migrations.entry_ema import migrate_entry_ema_tree
+
+    migrate_entry_ema_tree(source_doc, path=source)
     _reject_flat_strategy_coin_overrides(source_doc, coin=coin)
     source_live = source_doc.get("live")
     if isinstance(source_live, dict) and "strategy_kind" in source_live:

--- a/src/config/param_paths.py
+++ b/src/config/param_paths.py
@@ -141,6 +141,19 @@ def resolve_dotted_config_path(config: dict, selector_or_path: str) -> tuple[str
         and parts[3] != "*"
     ):
         parts = (*parts[:3], active_strategy_kind(config), *parts[3:])
+    if (
+        len(parts) >= 2
+        and (
+            parts[-2] == "trailing_martingale"
+            or (
+                len(parts) >= 3
+                and parts[-3:-1] == ("strategy", "*")
+                and active_strategy_kind(config) == "trailing_martingale"
+            )
+        )
+        and parts[-1] in ("ema_span_0", "ema_span_1")
+    ):
+        parts = (*parts[:-1], "entry", parts[-1])
     return tuple(parts)
 
 

--- a/src/config/schema.py
+++ b/src/config/schema.py
@@ -4,8 +4,10 @@ from .optimize_bounds import get_optimize_bounds_defaults
 from .strategy import get_all_strategy_defaults
 
 
-CONFIG_SCHEMA_VERSION = "v8.3.0"
-SUPPORTED_PREVIOUS_CONFIG_SCHEMA_VERSIONS = frozenset({"v8.0.0", "v8.1.0", "v8.2.0"})
+CONFIG_SCHEMA_VERSION = "v8.4.0"
+SUPPORTED_PREVIOUS_CONFIG_SCHEMA_VERSIONS = frozenset(
+    {"v8.0.0", "v8.1.0", "v8.2.0", "v8.3.0"}
+)
 DEFAULT_EXAMPLE_CONFIG_PATH = "configs/examples/default_trailing_martingale_long.json"
 # A symbol suspension is temporary policy, not an indefinite timestamp. This
 # generous bound also keeps hours-to-milliseconds conversion finite and well

--- a/src/config_utils.py
+++ b/src/config_utils.py
@@ -2198,6 +2198,19 @@ def add_arguments_recursively(
                 else parser
             )
             hidden_names = [f"--{full_name.replace('.', '_')}"]
+            if full_name.endswith(
+                tuple(f"trailing_martingale.entry.ema_span_{i}" for i in (0, 1))
+            ):
+                old_name = full_name.replace(
+                    "trailing_martingale.entry.ema_span_",
+                    "trailing_martingale.ema_span_",
+                )
+                hidden_names.extend(
+                    [f"--{old_name}", f"--{old_name.replace('.', '_')}"]
+                )
+                old_acronym = create_acronym(old_name, acronyms)
+                hidden_names.append(f"-{old_acronym}")
+                acronyms.add(old_acronym)
             if command is None or len(acronym) > 1:
                 hidden_names.append(f"-{acronym}")
             _register_argument(

--- a/src/optimization/gpu/model.py
+++ b/src/optimization/gpu/model.py
@@ -395,8 +395,8 @@ TRAILING_MARTINGALE_MULTICOIN_PARAM_KEYS = (
 )
 
 TRAILING_MARTINGALE_COIN_OVERRIDE_PATHS = (
-    ("ema_span_0", ("ema_span_0",)),
-    ("ema_span_1", ("ema_span_1",)),
+    ("ema_span_0", ("entry", "ema_span_0")),
+    ("ema_span_1", ("entry", "ema_span_1")),
     ("volatility_ema_span_1h", ("volatility_ema_span_1h",)),
     ("volatility_ema_span_1m", ("volatility_ema_span_1m",)),
     ("entry_double_down_factor", ("entry", "double_down_factor")),
@@ -519,8 +519,8 @@ def flatten_trailing_martingale_params(strategy: dict, risk: dict) -> dict:
     if mode not in {"disabled", "all", "initial", "reentry"}:
         raise ValueError(f"unsupported trailing_martingale entry.ema_gate_mode={mode!r}")
     flattened = {
-        "ema_span_0": strategy.get("ema_span_0"),
-        "ema_span_1": strategy.get("ema_span_1"),
+        "ema_span_0": entry.get("ema_span_0"),
+        "ema_span_1": entry.get("ema_span_1"),
         "volatility_ema_span_1h": strategy.get("volatility_ema_span_1h"),
         "volatility_ema_span_1m": strategy.get("volatility_ema_span_1m"),
         "entry_cooldown_minutes": float(
@@ -530,9 +530,7 @@ def flatten_trailing_martingale_params(strategy: dict, risk: dict) -> dict:
             )
             or 0.0
         ),
-        "total_wallet_exposure_limit": float(
-            risk["total_wallet_exposure_limit"]
-        ),
+        "total_wallet_exposure_limit": float(risk["total_wallet_exposure_limit"]),
         "gate_initial": float(mode in {"all", "initial"}),
         "gate_reentry": float(mode in {"all", "reentry"}),
     }

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -2751,7 +2751,7 @@ def _build_multicoin_tm_coin_overrides(
                 matrix[coin_index, column] = matrix[
                     coin_index,
                     TRAILING_MARTINGALE_COIN_OVERRIDE_PATHS.index(
-                        (strategy_key, (strategy_key,))
+                        (strategy_key, ("entry", strategy_key))
                     ),
                 ]
             elif strategy_key in unstuck_patch:

--- a/src/optimizer_overrides.py
+++ b/src/optimizer_overrides.py
@@ -67,10 +67,15 @@ def couple_unstuck_ema_spans(config, pside):
         ]
     base = config["bot"][pside]
     strategy = base["strategy"][kind]
+    if kind == DEFAULT_STRATEGY_KIND:
+        strategy = strategy["entry"]
     targets = [("global", base, strategy)]
     for coin, patch in (config.get("coin_overrides") or {}).items():
         side_patch = patch.setdefault("bot", {}).setdefault(pside, {})
-        effective = {**strategy, **side_patch.get("strategy", {}).get(kind, {})}
+        patch_strategy = side_patch.get("strategy", {}).get(kind, {})
+        if kind == DEFAULT_STRATEGY_KIND:
+            patch_strategy = patch_strategy.get("entry", {})
+        effective = {**strategy, **patch_strategy}
         targets.append((coin, side_patch, effective))
     for coin, target, source in targets:
         for key in ("ema_span_0", "ema_span_1"):

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -17323,13 +17323,18 @@ class Passivbot:
                 strategy_getter = getattr(self, "_strategy_params_to_rust_dict", None)
                 if callable(strategy_getter):
                     strategy_params = strategy_getter(pside, symbol)
+                    price_ema_params = (
+                        strategy_params["entry"]
+                        if strategy_kind == "trailing_martingale"
+                        else strategy_params
+                    )
                     span0 = Passivbot._positive_finite_warmup_value(
-                        strategy_params["ema_span_0"],
+                        price_ema_params["ema_span_0"],
                         context=f"strategy {pside}.ema_span_0",
                         symbol=symbol,
                     )
                     span1 = Passivbot._positive_finite_warmup_value(
-                        strategy_params["ema_span_1"],
+                        price_ema_params["ema_span_1"],
                         context=f"strategy {pside}.ema_span_1",
                         symbol=symbol,
                     )

--- a/src/strategy_warmup.py
+++ b/src/strategy_warmup.py
@@ -36,8 +36,8 @@ STRATEGY_WARMUP_H1_BOUND_LOCAL_KEYS = (
 )
 
 STRATEGY_WARMUP_PROBE_PATHS = {
-    "ema_span_0": (("ema_span_0",),),
-    "ema_span_1": (("ema_span_1",),),
+    "ema_span_0": (("entry", "ema_span_0"), ("ema_span_0",)),
+    "ema_span_1": (("entry", "ema_span_1"), ("ema_span_1",)),
     "volatility_ema_span_1m": (
         ("volatility_ema_span_1m",),
         ("entry_volatility_ema_span_1m",),

--- a/tests/optimization/test_config_adapter.py
+++ b/tests/optimization/test_config_adapter.py
@@ -162,17 +162,23 @@ class TestConfigAdapter:
         bot_template = template["bot"]
 
         assert spec["strategy_kind"] == "trailing_martingale"
-        assert spec["defaults"]["long"]["ema_span_0"] == bot_template["long"][
-            "strategy"
-        ]["trailing_martingale"]["ema_span_0"]
+        assert (
+            spec["defaults"]["long"]["ema_span_0"]
+            == bot_template["long"]["strategy"]["trailing_martingale"]["entry"][
+                "ema_span_0"
+            ]
+        )
         assert spec["defaults"]["short"]["entry_threshold_base_pct"] == bot_template[
             "short"
         ]["strategy"]["trailing_martingale"]["entry"]["threshold_base_pct"]
-        assert spec["optimize_bounds"]["long_ema_span_0"] == template["optimize"][
-            "bounds"
-        ]["long"]["strategy"]["trailing_martingale"]["ema_span_0"]
+        assert (
+            spec["optimize_bounds"]["long_ema_span_0"]
+            == template["optimize"]["bounds"]["long"]["strategy"][
+                "trailing_martingale"
+            ]["entry"]["ema_span_0"]
+        )
         assert any(
-            param["config_path"] == ["strategy", "long", "ema_span_0"]
+            param["config_path"] == ["strategy", "long", "entry", "ema_span_0"]
             and param["legacy_config_paths"] == []
             for param in spec["parameters"]
         )
@@ -244,7 +250,7 @@ class TestConfigAdapter:
 
         assert (
             "long_ema_span_0",
-            ("bot", "long", "strategy", "trailing_martingale", "ema_span_0"),
+            ("bot", "long", "strategy", "trailing_martingale", "entry", "ema_span_0"),
         ) in key_paths
         assert (
             "short_entry_threshold_base_pct",

--- a/tests/optimization/test_coupled_unstuck_ema.py
+++ b/tests/optimization/test_coupled_unstuck_ema.py
@@ -23,9 +23,11 @@ def config_for(kind="trailing_martingale"):
     config["optimize"]["enable_overrides"] = ["couple_unstuck_ema_spans"]
     config = parse_overrides(prepare_config(config, verbose=False), verbose=False)
     for side in ("long", "short"):
-        config["bot"][side]["strategy"][kind].update(
-            ema_span_0=17.25, ema_span_1=211.75
-        )
+        (
+            config["bot"][side]["strategy"][kind]["entry"]
+            if kind == "trailing_martingale"
+            else config["bot"][side]["strategy"][kind]
+        ).update(ema_span_0=17.25, ema_span_1=211.75)
         config["bot"][side]["unstuck"].update(ema_span_0=9999.5, ema_span_1=8888.5)
     return config
 
@@ -41,7 +43,13 @@ def test_coupled_candidates_drop_redundant_genes_and_materialize_effective_coin_
         "BTC": {
             "bot": {
                 "long": {
-                    "strategy": {kind: {"ema_span_0": 71.5}},
+                    "strategy": {
+                        kind: (
+                            {"entry": {"ema_span_0": 71.5}}
+                            if kind == "trailing_martingale"
+                            else {"ema_span_0": 71.5}
+                        )
+                    },
                     "unstuck": {"ema_span_0": 1.0, "ema_span_1": 2.0},
                 }
             }
@@ -131,7 +139,9 @@ def test_coupling_contract_ignores_derived_coin_values_but_tracks_mode_and_sourc
         "BTC": {"bot": {"long": {"unstuck": {"ema_span_0": 4.5}}}}
     }
     first = build_evaluation_contract(config)
-    config["bot"]["long"]["strategy"]["trailing_martingale"]["ema_span_0"] = 501.25
+    config["bot"]["long"]["strategy"]["trailing_martingale"]["entry"][
+        "ema_span_0"
+    ] = 501.25
     assert build_evaluation_contract(config) == first
     config["coin_overrides"]["BTC"]["bot"]["long"]["strategy"] = {
         "trailing_martingale": {"ema_span_0": 71.5}
@@ -196,14 +206,22 @@ def test_gpu_coin_packing_preserves_dependency_when_only_one_strategy_span_is_pi
         "BTC": {
             "bot": {
                 side: {
-                    "strategy": {kind: {"ema_span_0": 71.5}},
+                    "strategy": {
+                        kind: (
+                            {"entry": {"ema_span_0": 71.5}}
+                            if kind == "trailing_martingale"
+                            else {"ema_span_0": 71.5}
+                        )
+                    },
                     "unstuck": {"ema_span_0": 4.0, "ema_span_1": 5.0},
                 }
             }
         }
     }
     strategy = deepcopy(config["bot"][side]["strategy"][kind])
-    strategy["ema_span_0"] = 71.5
+    (strategy["entry"] if kind == "trailing_martingale" else strategy)[
+        "ema_span_0"
+    ] = 71.5
     payload = SimpleNamespace(
         strategy_params_list=[{side: strategy}],
         bot_params_list=[
@@ -236,7 +254,7 @@ def test_coupled_warmup_tracks_strategy_bounds_and_ignores_migrated_unstuck_pins
     config["coin_overrides"] = {
         "BTC": {"bot": {"long": {"unstuck": {"ema_span_0": 900_000.5}}}}
     }
-    config["optimize"]["bounds"]["long"]["strategy"]["trailing_martingale"][
+    config["optimize"]["bounds"]["long"]["strategy"]["trailing_martingale"]["entry"][
         "ema_span_0"
     ] = [17.25, 80_000.5]
     coupled = compute_optimizer_per_coin_warmup_minutes(config)
@@ -249,13 +267,17 @@ def test_anchored_search_derives_spans_from_selected_anchor_and_tunable_strategy
     from optimization.shape import build_optimization_shape
 
     config = config_for()
-    config["optimize"]["bounds"]["long"]["strategy"]["trailing_martingale"][
+    config["optimize"]["bounds"]["long"]["strategy"]["trailing_martingale"]["entry"][
         "ema_span_0"
     ] = [1.0, 1000.0]
     config["optimize"]["round_to_n_significant_digits"] = 6
     anchors = [deepcopy(config), deepcopy(config)]
-    anchors[0]["bot"]["long"]["strategy"]["trailing_martingale"]["ema_span_0"] = 101.25
-    anchors[1]["bot"]["long"]["strategy"]["trailing_martingale"]["ema_span_0"] = 401.75
+    anchors[0]["bot"]["long"]["strategy"]["trailing_martingale"]["entry"][
+        "ema_span_0"
+    ] = 101.25
+    anchors[1]["bot"]["long"]["strategy"]["trailing_martingale"]["entry"][
+        "ema_span_0"
+    ] = 401.75
     install_anchored_fine_tune_plan(
         config, ["long.ema_span_1"], "<memory>", starting_configs_override=anchors
     )
@@ -294,7 +316,9 @@ def test_exact_suite_finalization_couples_after_context_overrides_without_mutati
 @pytest.mark.parametrize("bad", [0, -1, float("nan"), float("inf")])
 def test_coupling_fails_explicitly_for_invalid_strategy_spans(bad):
     config = config_for()
-    config["bot"]["long"]["strategy"]["trailing_martingale"]["ema_span_0"] = bad
+    config["bot"]["long"]["strategy"]["trailing_martingale"]["entry"][
+        "ema_span_0"
+    ] = bad
     with pytest.raises(
         ValueError, match="couple_unstuck_ema_spans requires positive finite"
     ):
@@ -308,7 +332,7 @@ def test_scenario_override_file_is_resolved_before_materializing_coupled_spans(
 
     config = config_for()
     file_config = clean_config(config)
-    file_config["bot"]["long"]["strategy"]["trailing_martingale"].update(
+    file_config["bot"]["long"]["strategy"]["trailing_martingale"]["entry"].update(
         ema_span_0=71.25, ema_span_1=99.5
     )
     path = tmp_path / "coin.json"
@@ -381,6 +405,7 @@ def test_coupled_saved_scenarios_normalize_nested_and_legacy_aliases(overrides):
     saved["optimize"]["enable_overrides"] = []
     _apply_config_overrides(saved, saved["backtest"]["scenarios"][0]["overrides"])
     assert (
-        saved["bot"]["long"]["strategy"]["trailing_martingale"]["ema_span_0"] == 71.25
+        saved["bot"]["long"]["strategy"]["trailing_martingale"]["entry"]["ema_span_0"]
+        == 71.25
     )
     assert saved["bot"]["long"]["unstuck"]["ema_span_0"] == 71.25

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -7761,7 +7761,9 @@ def test_gpu_suite_unstuck_scope_validates_effective_scenario_bounds(shadow):
     prepared = _gpu_suite_scenario_inputs(config, Suite())
     for path, value in overrides.items():
         family = prepared[0]["config"]["optimize"]["bounds"]
-        for part in path.split(".")[1:-1]:
+        from config.param_paths import resolve_dotted_config_path
+
+        for part in resolve_dotted_config_path(config, path)[1:-1]:
             family = family[part]
         assert family[path.split(".")[-1]] == [value, value]
     suite_cfg["scenarios"].append({"label": "unshadowed", "overrides": {}})

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -4667,8 +4667,8 @@ def test_mps_single_coin_service_dispatches_forced_delist_tail(
         )
     else:
         strategy = config["bot"]["long"]["strategy"]["trailing_martingale"]
-        strategy["ema_span_0"] = 2.0
-        strategy["ema_span_1"] = 3.0
+        strategy["entry"]["ema_span_0"] = 2.0
+        strategy["entry"]["ema_span_1"] = 3.0
         strategy["entry"]["initial_qty_pct"] = 0.1
         strategy["entry"]["initial_ema_dist"] = 0.01
 
@@ -4857,8 +4857,8 @@ def test_mps_single_coin_overrides_shadow_candidates_and_track_exact(
             strategy = config["bot"][side]["strategy"][
                 "trailing_martingale"
             ]
-            strategy["ema_span_0"] = 2.0
-            strategy["ema_span_1"] = 3.0
+            strategy["entry"]["ema_span_0"] = 2.0
+            strategy["entry"]["ema_span_1"] = 3.0
             strategy["entry"]["initial_qty_pct"] = 0.1
             strategy["entry"]["initial_ema_dist"] = 0.4
             strategy["entry"]["double_down_factor"] = 0.0
@@ -5064,8 +5064,8 @@ def test_mps_multicoin_service_dispatches_forced_delist_tail(
             strategy = config["bot"][side]["strategy"][
                 "trailing_martingale"
             ]
-            strategy["ema_span_0"] = 2.0
-            strategy["ema_span_1"] = 3.0
+            strategy["entry"]["ema_span_0"] = 2.0
+            strategy["entry"]["ema_span_1"] = 3.0
             strategy["entry"]["initial_qty_pct"] = 1.0
             strategy["entry"]["initial_ema_dist"] = 0.1
             strategy["entry"]["double_down_factor"] = 0.0
@@ -5271,8 +5271,8 @@ def test_mps_multicoin_service_matches_exact_declared_all_invalid_time(
             strategy = config["bot"][side]["strategy"][
                 "trailing_martingale"
             ]
-            strategy["ema_span_0"] = 2.0
-            strategy["ema_span_1"] = 3.0
+            strategy["entry"]["ema_span_0"] = 2.0
+            strategy["entry"]["ema_span_1"] = 3.0
             strategy["entry"]["initial_qty_pct"] = 1.0
             strategy["entry"]["initial_ema_dist"] = 0.1
             strategy["entry"]["double_down_factor"] = 0.0
@@ -6114,8 +6114,8 @@ def test_mps_multicoin_forced_normal_service_matches_exact_active_symbols(
             strategy = config["bot"][side]["strategy"][
                 "trailing_martingale"
             ]
-            strategy["ema_span_0"] = 2.0
-            strategy["ema_span_1"] = 3.0
+            strategy["entry"]["ema_span_0"] = 2.0
+            strategy["entry"]["ema_span_1"] = 3.0
             strategy["entry"]["initial_qty_pct"] = 1.0
             strategy["entry"]["initial_ema_dist"] = 0.1
             strategy["entry"]["double_down_factor"] = 0.0

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -1610,9 +1610,21 @@ def test_multicoin_proxy_constructs_fused_shared_account_runner(
         config["bot"][side]["unstuck"]["enabled"] = True
         config["bot"][side]["hsl"]["enabled"] = True
         for key in ("ema_span_0", "ema_span_1"):
-            span = config["bot"][side]["strategy"][strategy_kind][key]
+            strategy = config["bot"][side]["strategy"][strategy_kind]
+            span = (
+                strategy["entry"]
+                if strategy_kind == "trailing_martingale"
+                else strategy
+            )[key]
             config["bot"][side]["unstuck"][key] = span
-            config["optimize"]["bounds"][side]["strategy"][strategy_kind][key] = [
+            strategy_bounds = config["optimize"]["bounds"][side]["strategy"][
+                strategy_kind
+            ]
+            (
+                strategy_bounds["entry"]
+                if strategy_kind == "trailing_martingale"
+                else strategy_bounds
+            )[key] = [
                 span,
                 span,
             ]
@@ -3109,11 +3121,11 @@ def test_multicoin_tm_coin_overrides_pack_only_explicit_exact_values():
         key for key, _path in TRAILING_MARTINGALE_COIN_OVERRIDE_PATHS
     ) == TRAILING_MARTINGALE_PARAM_KEYS[:23]
     strategy_base = {
-        "ema_span_0": 10.0,
-        "ema_span_1": 20.0,
         "volatility_ema_span_1h": 30.0,
         "volatility_ema_span_1m": 40.0,
         "entry": {
+            "ema_span_0": 10.0,
+            "ema_span_1": 20.0,
             "ema_gate_mode": "all",
             "double_down_factor": 1.1,
             "initial_ema_dist": 0.01,
@@ -3329,11 +3341,11 @@ def test_trailing_martingale_flattening_preserves_nested_params_and_gates(
     mode, expected
 ):
     strategy = {
-        "ema_span_0": 10.0,
-        "ema_span_1": 20.0,
         "volatility_ema_span_1h": 30.0,
         "volatility_ema_span_1m": 40.0,
         "entry": {
+            "ema_span_0": 10.0,
+            "ema_span_1": 20.0,
             "ema_gate_mode": mode,
             "double_down_factor": 1.1,
             "initial_ema_dist": 0.01,
@@ -3382,11 +3394,9 @@ def test_trailing_martingale_flattening_rejects_unknown_gate_mode():
 
 def test_trailing_martingale_flattening_reads_canonical_payload_cooldown():
     strategy = {
-        "ema_span_0": 10.0,
-        "ema_span_1": 20.0,
         "volatility_ema_span_1h": 30.0,
         "volatility_ema_span_1m": 40.0,
-        "entry": {"ema_gate_mode": "all"},
+        "entry": {"ema_span_0": 10.0, "ema_span_1": 20.0, "ema_gate_mode": "all"},
         "close": {},
     }
     for key in TRAILING_MARTINGALE_COIN_OVERRIDE_PATHS:

--- a/tests/optimization/test_optimizer_warmup.py
+++ b/tests/optimization/test_optimizer_warmup.py
@@ -40,16 +40,16 @@ def _make_optimizer_config() -> dict:
     config["backtest"]["coins"] = {"combined": ["HYPE"]}
 
     long_bot = config["bot"]["long"]
-    long_bot["strategy"]["trailing_martingale"]["ema_span_0"] = 770.0
-    long_bot["strategy"]["trailing_martingale"]["ema_span_1"] = 210.0
+    long_bot["strategy"]["trailing_martingale"]["entry"]["ema_span_0"] = 770.0
+    long_bot["strategy"]["trailing_martingale"]["entry"]["ema_span_1"] = 210.0
     long_bot["forager"]["volume_ema_span_1m"] = 520.0
     long_bot["forager"]["volatility_ema_span_1m"] = 225.0
     long_bot["strategy"]["trailing_martingale"]["volatility_ema_span_1h"] = 1690.0
     long_bot["strategy"]["trailing_martingale"]["volatility_ema_span_1m"] = 60.0
 
     short_bot = config["bot"]["short"]
-    short_bot["strategy"]["trailing_martingale"]["ema_span_0"] = 1.0
-    short_bot["strategy"]["trailing_martingale"]["ema_span_1"] = 1.0
+    short_bot["strategy"]["trailing_martingale"]["entry"]["ema_span_0"] = 1.0
+    short_bot["strategy"]["trailing_martingale"]["entry"]["ema_span_1"] = 1.0
     short_bot["forager"]["volume_ema_span_1m"] = 0.0
     short_bot["forager"]["volatility_ema_span_1m"] = 0.0
     short_bot["strategy"]["trailing_martingale"]["volatility_ema_span_1h"] = 0.0

--- a/tests/test_backtest_maker_fee_override.py
+++ b/tests/test_backtest_maker_fee_override.py
@@ -336,7 +336,9 @@ def test_prep_backtest_args_matches_exact_override_to_active_alias(tmp_path, mon
 
 def test_prep_backtest_args_uses_canonical_strategy_params_for_runtime_payload():
     config = _base_config()
-    config["bot"]["long"]["strategy"]["trailing_martingale"]["ema_span_0"] = 321.0
+    config["bot"]["long"]["strategy"]["trailing_martingale"]["entry"][
+        "ema_span_0"
+    ] = 321.0
     config["bot"]["short"]["strategy"]["trailing_martingale"]["entry"]["threshold_base_pct"] = 0.0123
     mss = _base_mss()
 
@@ -345,7 +347,7 @@ def test_prep_backtest_args_uses_canonical_strategy_params_for_runtime_payload()
     assert len(bot_params_list) == 1
     assert "ema_span_0" not in bot_params_list[0]["long"]
     assert "entry_grid_spacing_pct" not in bot_params_list[0]["short"]
-    assert strategy_params_list[0]["long"]["ema_span_0"] == 321.0
+    assert strategy_params_list[0]["long"]["entry"]["ema_span_0"] == 321.0
     assert strategy_params_list[0]["short"]["entry"]["threshold_base_pct"] == 0.0123
 
 

--- a/tests/test_config_cleaning.py
+++ b/tests/test_config_cleaning.py
@@ -40,8 +40,10 @@ def test_clean_config_removes_internal_sections_and_keeps_user_values():
         "volume_ema_span_1m"
     ]
     assert (
-        cleaned["bot"]["long"]["strategy"]["trailing_martingale"]["ema_span_0"]
-        == template["bot"]["long"]["strategy"]["trailing_martingale"]["ema_span_0"]
+        cleaned["bot"]["long"]["strategy"]["trailing_martingale"]["entry"]["ema_span_0"]
+        == template["bot"]["long"]["strategy"]["trailing_martingale"]["entry"][
+            "ema_span_0"
+        ]
     )
     assert "BTC" in cleaned["coin_overrides"]
     assert "_meta" not in cleaned["coin_overrides"]["BTC"]

--- a/tests/test_config_pipeline.py
+++ b/tests/test_config_pipeline.py
@@ -158,7 +158,13 @@ def test_rust_strategy_spec_matches_generated_strategy_optimize_bounds(strategy_
     for pside in ("long", "short"):
         strategy_bounds = generated[pside]["strategy"][strategy_kind]
         for local_key, value in _flatten_strategy_bound_items(strategy_bounds):
-            flat_generated[f"{pside}_{local_key}"] = value
+            flat_key = (
+                local_key.removeprefix("entry_")
+                if strategy_kind == "trailing_martingale"
+                and local_key in ("entry_ema_span_0", "entry_ema_span_1")
+                else local_key
+            )
+            flat_generated[f"{pside}_{flat_key}"] = value
 
     assert flat_generated == expected
 
@@ -1509,9 +1515,12 @@ def test_prepare_config_canonical_omits_runtime_aliases():
     assert prepared["live"]["strategy_kind"] == "trailing_martingale"
     assert "ema_span_0" not in get_template_config()["bot"]["long"]
     assert "entry_grid_spacing_pct" not in get_template_config()["bot"]["short"]
-    assert _strategy_side(prepared, "long")["ema_span_0"] == _strategy_side(
-        get_template_config(), "long", "trailing_martingale"
-    )["ema_span_0"]
+    assert (
+        _strategy_side(prepared, "long")["entry"]["ema_span_0"]
+        == _strategy_side(get_template_config(), "long", "trailing_martingale")[
+            "entry"
+        ]["ema_span_0"]
+    )
 
 
 def test_prepare_config_rejects_v7_flat_trailing_grid_fields_with_trailing_martingale():
@@ -1653,21 +1662,26 @@ def test_compile_runtime_config_adds_runtime_aliases_without_removing_canonical_
     ]["volatility_ema_span_1m"]
     assert compiled["bot"]["long"]["filter_volatility_drop_pct"] == pytest.approx(0.0)
     assert compiled["optimize"]["bounds"] == canonical["optimize"]["bounds"]
-    assert _strategy_side(compiled, "long")["ema_span_0"] == _strategy_side(canonical, "long")[
-        "ema_span_0"
-    ]
+    assert (
+        _strategy_side(compiled, "long")["entry"]["ema_span_0"]
+        == _strategy_side(canonical, "long")["entry"]["ema_span_0"]
+    )
 
 
 def test_prepare_config_preserves_nested_strategy_namespace():
     source = get_template_config()
-    source["bot"]["long"]["strategy"]["trailing_martingale"]["ema_span_0"] = 321.0
+    source["bot"]["long"]["strategy"]["trailing_martingale"]["entry"][
+        "ema_span_0"
+    ] = 321.0
     source["bot"]["short"]["strategy"]["trailing_martingale"]["entry"]["threshold_base_pct"] = 0.0123
     source["live"].pop("strategy_kind", None)
 
     prepared = prepare_config(source, verbose=False, target="canonical", runtime=None)
 
     assert prepared["live"]["strategy_kind"] == "trailing_martingale"
-    assert _strategy_side(prepared, "long")["ema_span_0"] == pytest.approx(321.0)
+    assert _strategy_side(prepared, "long")["entry"]["ema_span_0"] == pytest.approx(
+        321.0
+    )
     assert _strategy_side(prepared, "short")["entry"]["threshold_base_pct"] == pytest.approx(0.0123)
 
 
@@ -1887,9 +1901,12 @@ def test_load_prepared_config_without_path_uses_schema_defaults_pipeline():
     assert prepared["bot"]["long"]["filter_volume_ema_span_1m"] == template["bot"]["long"]["forager"][
         "volume_ema_span_1m"
     ]
-    assert _strategy_side(prepared, "long")["ema_span_0"] == _strategy_side(
-        template, "long", "trailing_martingale"
-    )["ema_span_0"]
+    assert (
+        _strategy_side(prepared, "long")["entry"]["ema_span_0"]
+        == _strategy_side(template, "long", "trailing_martingale")["entry"][
+            "ema_span_0"
+        ]
+    )
     assert prepared["backtest"]["visible_metrics"] == template["backtest"]["visible_metrics"]
     assert prepared["_raw"] == template
     assert prepared["_raw_effective"] == template

--- a/tests/test_config_utils_helpers.py
+++ b/tests/test_config_utils_helpers.py
@@ -1152,7 +1152,10 @@ def test_compile_runtime_config_adds_internal_forager_aliases():
     assert compiled["bot"]["long"]["filter_volatility_ema_span_1m"] == config["bot"]["long"][
         "forager"
     ]["volatility_ema_span_1m"]
-    assert _strategy_side(compiled, "long")["ema_span_0"] == _strategy_side(config, "long")["ema_span_0"]
+    assert (
+        _strategy_side(compiled, "long")["entry"]["ema_span_0"]
+        == _strategy_side(config, "long")["entry"]["ema_span_0"]
+    )
 
 
 def test_project_config_prunes_unrelated_sections():

--- a/tests/test_entry_ema_migration.py
+++ b/tests/test_entry_ema_migration.py
@@ -1,0 +1,216 @@
+from copy import deepcopy
+import json
+
+import pytest
+
+from config import get_template_config, prepare_config, compile_runtime_config
+from config.overrides import parse_overrides
+from config.optimize_bounds import flatten_optimize_bounds
+from config.param_paths import resolve_bound_selectors, require_existing_config_path
+from config_utils import clean_config
+from optimizer_overrides import apply_coupled_unstuck_ema_spans
+from warmup_utils import compute_per_coin_warmup_minutes
+
+KIND = "trailing_martingale"
+SPANS = ("ema_span_0", "ema_span_1")
+
+
+def legacy_config():
+    config = clean_config(get_template_config())
+    config["config_version"] = "v8.3.0"
+    for root in (config["bot"], config["optimize"]["bounds"]):
+        for side in ("long", "short"):
+            strategy = root[side]["strategy"][KIND]
+            for key in SPANS:
+                strategy[key] = strategy["entry"].pop(key)
+    return config
+
+
+def test_lossless_migration_runtime_warmup_and_roundtrip():
+    old = legacy_config()
+    old["bot"]["long"]["strategy"][KIND].update(ema_span_0=123.75, ema_span_1=998.125)
+    old["optimize"]["bounds"]["long"]["strategy"][KIND]["ema_span_0"] = [
+        12.5,
+        321.75,
+        0.25,
+    ]
+    prepared = prepare_config(old, verbose=False)
+    strategy = prepared["bot"]["long"]["strategy"][KIND]
+    assert strategy["entry"]["ema_span_0"] == 123.75
+    assert strategy["entry"]["ema_span_1"] == 998.125
+    assert not any(key in strategy for key in SPANS)
+    assert prepared["bot"]["long"]["unstuck"] == old["bot"]["long"]["unstuck"]
+    bounds = flatten_optimize_bounds(prepared["optimize"]["bounds"], strategy_kind=KIND)
+    assert bounds["long_ema_span_0"] == [12.5, 321.75, 0.25]
+    saved = clean_config(prepared)
+    reloaded = prepare_config(saved, verbose=False)
+    assert clean_config(reloaded) == saved
+    assert (
+        compile_runtime_config(reloaded)["bot"]
+        == compile_runtime_config(prepared)["bot"]
+    )
+    assert compute_per_coin_warmup_minutes(reloaded) == compute_per_coin_warmup_minutes(
+        prepared
+    )
+
+
+@pytest.mark.parametrize(
+    "file_old,inline_old", [(True, False), (False, True), (True, True)]
+)
+def test_external_inline_precedence_and_partial_coupling(
+    tmp_path, file_old, inline_old
+):
+    config = get_template_config()
+
+    def patch(old, **values):
+        return {
+            "bot": {"long": {"strategy": {KIND: values if old else {"entry": values}}}}
+        }
+
+    source = tmp_path / "coin.json"
+    source.write_text(json.dumps(patch(file_old, ema_span_0=41.25, ema_span_1=81.5)))
+    config["coin_overrides"] = {
+        "BTC": {
+            "override_config_path": str(source),
+            **patch(inline_old, ema_span_0=17.125),
+        }
+    }
+    config = parse_overrides(prepare_config(config, verbose=False), verbose=False)
+    entry = config["coin_overrides"]["BTC"]["bot"]["long"]["strategy"][KIND]["entry"]
+    assert entry == {"ema_span_0": 17.125, "ema_span_1": 81.5}
+    config["optimize"]["enable_overrides"] = ["couple_unstuck_ema_spans"]
+    apply_coupled_unstuck_ema_spans(config)
+    assert config["coin_overrides"]["BTC"]["bot"]["long"]["unstuck"] == entry
+
+
+def test_conflicting_paths_warn_and_new_value_wins(caplog):
+    config = get_template_config()
+    strategy = config["bot"]["long"]["strategy"][KIND]
+    strategy["ema_span_0"] = 17.5
+    strategy["entry"]["ema_span_0"] = 123.5
+    prepared = prepare_config(config, verbose=False)
+    assert prepared["bot"]["long"]["strategy"][KIND]["entry"]["ema_span_0"] == 123.5
+    assert "Cannot preserve conflicting EMA values" in caplog.text
+    assert "explicit" in caplog.text and "wins" in caplog.text
+
+
+def test_old_selectors_and_entry_group_select_the_same_genes():
+    config = prepare_config(get_template_config(), verbose=False)
+    bounds = flatten_optimize_bounds(config["optimize"]["bounds"], strategy_kind=KIND)
+    for selector in [
+        "long.strategy.ema_span_0",
+        "bot.long.strategy.trailing_martingale.ema_span_0",
+    ]:
+        assert require_existing_config_path(config, selector)[-2:] == (
+            "entry",
+            "ema_span_0",
+        )
+        assert set(resolve_bound_selectors(config, [selector], bounds)) == {
+            "long_ema_span_0"
+        }
+    selected = resolve_bound_selectors(config, ["long.strategy.entry"], bounds)
+    assert {"long_ema_span_0", "long_ema_span_1"} <= set(selected)
+    assert not any(key.startswith("long_close") for key in selected)
+
+
+def test_nested_and_dotted_scenario_conflict_is_deterministic(caplog):
+    config = legacy_config()
+    config["backtest"]["scenarios"] = [
+        {
+            "label": "mixed",
+            "overrides": {
+                "bot": {"long": {"strategy": {KIND: {"ema_span_0": 17.5}}}},
+                "bot.long.strategy.trailing_martingale.entry.ema_span_0": 51.25,
+            },
+        }
+    ]
+    prepared = prepare_config(config, verbose=False)
+    overrides = prepared["backtest"]["scenarios"][0]["overrides"]
+    assert overrides["bot.long.strategy.trailing_martingale.entry.ema_span_0"] == 51.25
+    assert "bot.long.strategy.trailing_martingale.ema_span_0" not in overrides
+    assert "conflicting scenario" in caplog.text
+
+
+@pytest.mark.parametrize("side", ["long", "short"])
+@pytest.mark.parametrize("suffix", ["", "_underscores", "_short"])
+def test_legacy_cli_paths_apply_to_canonical_entry(side, suffix):
+    import argparse
+    from config_utils import (
+        add_config_arguments,
+        create_acronym,
+        update_config_with_args,
+    )
+
+    config = get_template_config()
+    parser = argparse.ArgumentParser()
+    allowed = add_config_arguments(
+        parser, config, command="backtest", help_all=True, group_map={}
+    )
+    old = f"bot.{side}.strategy.trailing_martingale.ema_span_0"
+    flag = "--" + old
+    if suffix == "_underscores":
+        flag = "--" + old.replace(".", "_")
+    elif suffix == "_short":
+        flag = "-" + create_acronym(old, set())
+    args = parser.parse_args([flag, "123.75"])
+    update_config_with_args(config, args, verbose=False, allowed_keys=allowed)
+    prepared = prepare_config(config, verbose=False)
+    assert prepared["bot"][side]["strategy"][KIND]["entry"]["ema_span_0"] == 123.75
+
+
+@pytest.mark.parametrize("reverse", [False, True])
+def test_new_scenario_alias_wins_over_old_fully_qualified_path(reverse, caplog):
+    config = legacy_config()
+    items = [
+        ("long.strategy.entry.ema_span_0", 91.5),
+        ("bot.long.strategy.trailing_martingale.ema_span_0", 17.5),
+    ]
+    if reverse:
+        items.reverse()
+    config["backtest"]["scenarios"] = [{"label": "alias", "overrides": dict(items)}]
+    prepared = prepare_config(config, verbose=False)
+    assert (
+        prepared["backtest"]["scenarios"][0]["overrides"][
+            "bot.long.strategy.trailing_martingale.entry.ema_span_0"
+        ]
+        == 91.5
+    )
+    assert "conflicting scenario" in caplog.text
+
+
+def test_scenario_strategy_replacement_and_atomic_coin_patch_migrate():
+    from config.migrations.entry_ema import migrate_entry_ema_spans
+
+    config = legacy_config()
+    config["backtest"]["scenarios"] = [
+        {
+            "label": "replace",
+            "overrides": {
+                "bot.long.strategy.trailing_martingale": {"ema_span_0": 71.25},
+                "coin_overrides": {
+                    "BTC": {
+                        "bot": {"long": {"strategy": {KIND: {"ema_span_1": 33.125}}}}
+                    }
+                },
+            },
+        }
+    ]
+    migrate_entry_ema_spans(config)
+    overrides = config["backtest"]["scenarios"][0]["overrides"]
+    assert overrides["bot.long.strategy.trailing_martingale"] == {
+        "entry": {"ema_span_0": 71.25}
+    }
+    assert overrides["coin_overrides"]["BTC"]["bot"]["long"]["strategy"][KIND] == {
+        "entry": {"ema_span_1": 33.125}
+    }
+
+
+@pytest.mark.parametrize("kind", [KIND, "ema_anchor", "trailing_grid_v7"])
+def test_legacy_wildcard_leaf_selector_preserves_active_strategy_genes(kind):
+    config = get_template_config()
+    config["live"]["strategy_kind"] = kind
+    bounds = flatten_optimize_bounds(config["optimize"]["bounds"], strategy_kind=kind)
+    selected = resolve_bound_selectors(config, ["*.strategy.*.ema_span_0"], bounds)
+    assert set(selected) == {"long_ema_span_0", "short_ema_span_0"}
+    for path in selected.values():
+        assert ("entry" in path) == (kind == KIND)

--- a/tests/test_live_candle_budget.py
+++ b/tests/test_live_candle_budget.py
@@ -1087,11 +1087,11 @@ async def test_orchestrator_ema_bundle_tracks_missing_required_forager_ema_by_si
 
         def _strategy_params_to_rust_dict(self, pside, symbol):
             return {
-                "ema_span_0": 10.0,
-                "ema_span_1": 20.0,
                 "volatility_ema_span_1m": 5.0,
                 "volatility_ema_span_1h": 0.0,
                 "entry": {
+                    "ema_span_0": 10.0,
+                    "ema_span_1": 20.0,
                     "threshold_volatility_1m_weight": 0.0,
                     "retracement_volatility_1m_weight": 0.0,
                 },
@@ -1228,11 +1228,11 @@ async def test_orchestrator_ema_bundle_marks_flat_forager_candidate_required_m1_
 
         def _strategy_params_to_rust_dict(self, pside, symbol):
             return {
-                "ema_span_0": 10.0,
-                "ema_span_1": 20.0,
                 "volatility_ema_span_1m": 5.0,
                 "volatility_ema_span_1h": 0.0,
                 "entry": {
+                    "ema_span_0": 10.0,
+                    "ema_span_1": 20.0,
                     "threshold_volatility_1m_weight": 1.0,
                     "retracement_volatility_1m_weight": 0.0,
                     "threshold_volatility_1h_weight": 0.0,
@@ -1431,11 +1431,11 @@ async def test_orchestrator_ema_bundle_projection_context_summary_is_debug(
 
         def _strategy_params_to_rust_dict(self, pside, symbol):
             return {
-                "ema_span_0": 10.0,
-                "ema_span_1": 20.0,
                 "volatility_ema_span_1m": 5.0,
                 "volatility_ema_span_1h": 0.0,
                 "entry": {
+                    "ema_span_0": 10.0,
+                    "ema_span_1": 20.0,
                     "threshold_volatility_1m_weight": 1.0,
                     "retracement_volatility_1m_weight": 0.0,
                     "threshold_volatility_1h_weight": 0.0,

--- a/tests/test_missing_ema_fix.py
+++ b/tests/test_missing_ema_fix.py
@@ -110,11 +110,11 @@ def _rust_bot_params(**overrides):
 
 def _rust_strategy_params(**overrides):
     params = {
-        "ema_span_0": 10.0,
-        "ema_span_1": 20.0,
         "volatility_ema_span_1h": 0.0,
         "volatility_ema_span_1m": 60.0,
         "entry": {
+            "ema_span_0": 10.0,
+            "ema_span_1": 20.0,
             "double_down_factor": 1.0,
             "initial_ema_dist": 0.0,
             "initial_qty_pct": 0.1,
@@ -2950,11 +2950,11 @@ async def test_trailing_martingale_weight_group_uses_later_nonzero_path():
 
     def trailing_martingale_params(_pside, _symbol=None):
         return {
-            "ema_span_0": 10.0,
-            "ema_span_1": 20.0,
             "volatility_ema_span_1m": 6.0,
             "volatility_ema_span_1h": 0.0,
             "entry": {
+                "ema_span_0": 10.0,
+                "ema_span_1": 20.0,
                 "threshold_volatility_1m_weight": 0.0,
                 "retracement_volatility_1m_weight": 1.0,
                 "threshold_volatility_1h_weight": 0.0,

--- a/tests/test_orchestrator_integration.py
+++ b/tests/test_orchestrator_integration.py
@@ -77,11 +77,11 @@ LEGACY_STRATEGY_KEY_MAP = {
 def adaptive_strategy_params(**overrides):
     """Create trailing_martingale strategy params for direct JSON orchestrator tests."""
     base = {
-        "ema_span_0": 10.0,
-        "ema_span_1": 20.0,
         "volatility_ema_span_1h": 0.0,
         "volatility_ema_span_1m": 60.0,
         "entry": {
+            "ema_span_0": 10.0,
+            "ema_span_1": 20.0,
             "double_down_factor": 1.0,
             "initial_ema_dist": 0.0,
             "initial_qty_pct": 0.1,

--- a/tests/test_orchestrator_json_api.py
+++ b/tests/test_orchestrator_json_api.py
@@ -98,11 +98,11 @@ LEGACY_STRATEGY_KEY_MAP = {
 
 def adaptive_strategy_params(**overrides):
     base = {
-        "ema_span_0": 10.0,
-        "ema_span_1": 20.0,
         "volatility_ema_span_1h": 0.0,
         "volatility_ema_span_1m": 60.0,
         "entry": {
+            "ema_span_0": 10.0,
+            "ema_span_1": 20.0,
             "double_down_factor": 1.0,
             "ema_gate_mode": "initial",
             "initial_ema_dist": 0.0,

--- a/tests/test_unstuck_ema_backtest.py
+++ b/tests/test_unstuck_ema_backtest.py
@@ -10,6 +10,11 @@ from backtest import run_backtest
 def _legacy_replay_config():
     c = get_template_config()
     c["config_version"] = "v8.2.0"
+    for root in (c["bot"], c["optimize"]["bounds"]):
+        for side in ("long", "short"):
+            strategy = root[side]["strategy"]["trailing_martingale"]
+            for key in ("ema_span_0", "ema_span_1"):
+                strategy[key] = strategy["entry"].pop(key)
     for side in ("long", "short"):
         for key in ("ema_span_0", "ema_span_1"):
             c["bot"][side]["unstuck"].pop(key)

--- a/tests/test_unstuck_ema_spans.py
+++ b/tests/test_unstuck_ema_spans.py
@@ -20,6 +20,11 @@ from warmup_utils import compute_per_coin_warmup_minutes
 def legacy_config(kind="trailing_martingale"):
     c = get_template_config()
     c["config_version"] = "v8.2.0"
+    for root in (c["bot"], c["optimize"]["bounds"]):
+        for side in ("long", "short"):
+            strategy = root[side]["strategy"]["trailing_martingale"]
+            for key in ("ema_span_0", "ema_span_1"):
+                strategy[key] = strategy["entry"].pop(key)
     c["live"]["strategy_kind"] = kind
     for side in ("long", "short"):
         for key in ("ema_span_0", "ema_span_1"):
@@ -214,6 +219,7 @@ def test_optimizer_paths_keep_strategy_and_unstuck_spans_separate():
         "long",
         "strategy",
         "trailing_martingale",
+        "entry",
         "ema_span_0",
     )
 
@@ -254,7 +260,7 @@ def test_legacy_coin_flags_file_spans_are_preserved(tmp_path):
 
 def test_zero_span_on_disabled_legacy_side_warns_and_gets_positive_default(caplog):
     c = legacy_config()
-    c["bot"]["short"]["strategy"]["trailing_martingale"]["ema_span_0"] = 0
+    c["bot"]["short"]["strategy"]["trailing_martingale"]["entry"]["ema_span_0"] = 0
     prepared = prepare_config(c, verbose=False)
     assert prepared["bot"]["short"]["unstuck"]["ema_span_0"] > 0
     assert "Cannot copy zero strategy span" in caplog.text

--- a/tests/test_warmup_utils.py
+++ b/tests/test_warmup_utils.py
@@ -37,8 +37,10 @@ def base_config():
                 "forager_volatility_ema_span_1m": 100.0,
                 "strategy": {
                     "trailing_martingale": {
-                        "ema_span_0": 1000.0,
-                        "ema_span_1": 1500.0,
+                        "entry": {
+                            "ema_span_0": 1000.0,
+                            "ema_span_1": 1500.0,
+                        },
                         "volatility_ema_span_1h": 1.0,
                     }
                 },
@@ -48,8 +50,10 @@ def base_config():
                 "forager_volatility_ema_span_1m": 100.0,
                 "strategy": {
                     "trailing_martingale": {
-                        "ema_span_0": 1000.0,
-                        "ema_span_1": 1500.0,
+                        "entry": {
+                            "ema_span_0": 1000.0,
+                            "ema_span_1": 1500.0,
+                        },
                         "volatility_ema_span_1h": 1.0,
                     }
                 },
@@ -75,8 +79,10 @@ def config_with_coin_overrides(base_config):
                 "long": {
                     "strategy": {
                         "trailing_martingale": {
-                            "ema_span_0": 5000.0,
-                            "ema_span_1": 7000.0,
+                            "entry": {
+                                "ema_span_0": 5000.0,
+                                "ema_span_1": 7000.0,
+                            },
                         }
                     },
                 },
@@ -105,8 +111,10 @@ def config_with_bounds(base_config):
             "forager": {"volume_ema_span_1m": [1000, 5000]},
             "strategy": {
                 "trailing_martingale": {
-                    "ema_span_0": [500, 5000],
-                    "ema_span_1": [1000, 10000],
+                    "entry": {
+                        "ema_span_0": [500, 5000],
+                        "ema_span_1": [1000, 10000],
+                    },
                     "volatility_ema_span_1h": [0.5, 5.0],
                 }
             },
@@ -114,8 +122,10 @@ def config_with_bounds(base_config):
         "short": {
             "strategy": {
                 "trailing_martingale": {
-                    "ema_span_0": [500, 5000],
-                    "ema_span_1": [1000, 10000],
+                    "entry": {
+                        "ema_span_0": [500, 5000],
+                        "ema_span_1": [1000, 10000],
+                    },
                 }
             }
         },
@@ -202,7 +212,9 @@ class TestWarmupCalculation:
 
     def test_extreme_spans_edge_case(self, base_config):
         """Test with very large EMA spans."""
-        base_config["bot"]["long"]["strategy"]["trailing_martingale"]["ema_span_0"] = 1_000_000.0
+        base_config["bot"]["long"]["strategy"]["trailing_martingale"]["entry"][
+            "ema_span_0"
+        ] = 1_000_000.0
 
         warmup_minutes = compute_backtest_warmup_minutes(base_config)
 
@@ -345,18 +357,26 @@ class TestEMASpanExtraction:
         # Modify each field to be the maximum and verify it's used
 
         # Test ema_span_0
-        base_config["bot"]["long"]["strategy"]["trailing_martingale"]["ema_span_0"] = 10000.0
+        base_config["bot"]["long"]["strategy"]["trailing_martingale"]["entry"][
+            "ema_span_0"
+        ] = 10000.0
         warmup = compute_backtest_warmup_minutes(base_config)
         assert warmup == 30000  # 10000 * 3.0
 
         # Reset and test ema_span_1
-        base_config["bot"]["long"]["strategy"]["trailing_martingale"]["ema_span_0"] = 1000.0
-        base_config["bot"]["long"]["strategy"]["trailing_martingale"]["ema_span_1"] = 10000.0
+        base_config["bot"]["long"]["strategy"]["trailing_martingale"]["entry"][
+            "ema_span_0"
+        ] = 1000.0
+        base_config["bot"]["long"]["strategy"]["trailing_martingale"]["entry"][
+            "ema_span_1"
+        ] = 10000.0
         warmup = compute_backtest_warmup_minutes(base_config)
         assert warmup == 30000
 
         # Reset and test forager_volume_ema_span_1m
-        base_config["bot"]["long"]["strategy"]["trailing_martingale"]["ema_span_1"] = 1500.0
+        base_config["bot"]["long"]["strategy"]["trailing_martingale"]["entry"][
+            "ema_span_1"
+        ] = 1500.0
         base_config["bot"]["long"]["forager_volume_ema_span_1m"] = 10000.0
         warmup = compute_backtest_warmup_minutes(base_config)
         assert warmup == 30000
@@ -370,7 +390,9 @@ class TestEMASpanExtraction:
     def test_short_params_also_considered(self, base_config):
         """Test that short-side params are also considered."""
         # Make short side have larger span
-        base_config["bot"]["short"]["strategy"]["trailing_martingale"]["ema_span_0"] = 15000.0
+        base_config["bot"]["short"]["strategy"]["trailing_martingale"]["entry"][
+            "ema_span_0"
+        ] = 15000.0
 
         warmup = compute_backtest_warmup_minutes(base_config)
 
@@ -429,7 +451,11 @@ class TestWarmupEdgeCases:
         """Test handling of missing warmup_ratio."""
         config = {
             "bot": {
-                "long": {"strategy": {"trailing_martingale": {"ema_span_0": 1000.0}}},
+                "long": {
+                    "strategy": {
+                        "trailing_martingale": {"entry": {"ema_span_0": 1000.0}}
+                    }
+                },
                 "short": {},
             },
             "live": {"strategy_kind": "trailing_martingale"},  # Missing warmup_ratio
@@ -444,7 +470,11 @@ class TestWarmupEdgeCases:
         """Test handling of missing max_warmup_minutes."""
         config = {
             "bot": {
-                "long": {"strategy": {"trailing_martingale": {"ema_span_0": 1000.0}}},
+                "long": {
+                    "strategy": {
+                        "trailing_martingale": {"entry": {"ema_span_0": 1000.0}}
+                    }
+                },
                 "short": {},
             },
             "live": {"strategy_kind": "trailing_martingale", "warmup_ratio": 3.0},
@@ -472,10 +502,18 @@ class TestWarmupEdgeCases:
         """Test that infinite strategy spans fail loudly."""
         config = {
             "bot": {
-                "long": {"strategy": {"trailing_martingale": {"ema_span_0": math.inf}}},
+                "long": {
+                    "strategy": {
+                        "trailing_martingale": {"entry": {"ema_span_0": math.inf}}
+                    }
+                },
                 "short": {},
             },
-            "live": {"strategy_kind": "trailing_martingale", "warmup_ratio": 3.0, "max_warmup_minutes": 0.0},
+            "live": {
+                "strategy_kind": "trailing_martingale",
+                "warmup_ratio": 3.0,
+                "max_warmup_minutes": 0.0,
+            },
             "optimize": {"bounds": {}},
         }
 
@@ -486,10 +524,18 @@ class TestWarmupEdgeCases:
         """Test that NaN strategy spans fail loudly."""
         config = {
             "bot": {
-                "long": {"strategy": {"trailing_martingale": {"ema_span_0": math.nan}}},
+                "long": {
+                    "strategy": {
+                        "trailing_martingale": {"entry": {"ema_span_0": math.nan}}
+                    }
+                },
                 "short": {},
             },
-            "live": {"strategy_kind": "trailing_martingale", "warmup_ratio": 3.0, "max_warmup_minutes": 0.0},
+            "live": {
+                "strategy_kind": "trailing_martingale",
+                "warmup_ratio": 3.0,
+                "max_warmup_minutes": 0.0,
+            },
             "optimize": {"bounds": {}},
         }
 


### PR DESCRIPTION
Trailing-martingale price EMA spans now belong to `bot.<side>.strategy.trailing_martingale.entry.ema_span_0/1`, alongside the entry behavior they control. Ordinary close logic and the shared volatility horizons are unchanged; other strategies retain their existing paths.

Schema v8.4.0 migrates existing strategy values and optimizer bounds before hydration, including partial coin files, inline overrides, and nested/dotted scenario overrides. Explicit new paths win on conflicts with informative warnings, while file/inline precedence and fractional spans are preserved. Old CLI paths/acronyms and dotted optimizer leaf selectors remain accepted. Entry subtree selectors now include price horizons.

Rust metadata, runtime payloads, live/backtest warmup, coupled unstuck optimization, GPU packing, hard-coded defaults, public examples, and documentation use the new paths. Internal optimizer keys and Metal column layout stay stable.

Validation:
- 295 Rust tests and default-feature test-target compile check; rebuilt Python extension with verified source fingerprint.
- 8,297 Python tests passed (122 skipped), excluding the large Metal-only test file; final selector/migration slice: 224 passed.
- Focused real Apple MPS parity and shared-memory checks: 87 passed; additional single/multicoin GPU service parity cases: 48 passed.
- Bounded offline CPU and GPU optimizer CLI runs with cached candles, checking migrated saved candidates and coupled horizons; EMA-anchor control runs also passed. These are integration checks, not performance claims.
- AI documentation and generated-registry checks passed.
