### PR TITLE
Reuse initial GPU results and preserve performance for small batches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ All notable user-facing changes will be documented in this file.
   per-dispatch work limits, and interruption checkpoints.
 
 - GPU optimization reuses full-history screened seed metrics in the initial population, including
-  after checkpoint resume, avoiding duplicate replay while preserving exact validation.
+  after checkpoint resume, avoiding duplicate replay while preserving exact validation. Small
+  two-sided MPS batches use unchunked replay when they fit the dispatch work limit.
 
 - Risk-input recovery now stops after `live.risk_input_max_attempts` failed attempts (default 10)
   per recovery episode, without entering the full-bot restart loop. Each failed attempt logs its

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable user-facing changes will be documented in this file.
   with both sides enabled, allowing more concurrent candidates while preserving replay state,
   per-dispatch work limits, and interruption checkpoints.
 
+- GPU optimization reuses full-history screened seed metrics in the initial population, including
+  after checkpoint resume, avoiding duplicate replay while preserving exact validation.
+
 - Risk-input recovery now stops after `live.risk_input_max_attempts` failed attempts (default 10)
   per recovery episode, without entering the full-bot restart loop. Each failed attempt logs its
   count, limit, safe balance diagnostics, and retry delay; the first and final failures include

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -755,6 +755,8 @@ duplicate-elimination controls as the ordinary pymoo optimizer.
   Long-history, single-coin Trailing Martingale with both sides enabled can instead split history
   into chunks of at most 96,000 candles and run up to 1,024 candidates concurrently. The complete
   replay state remains on the GPU between chunks; metrics are finalized only after the last chunk.
+  Small actual batches that fit the work envelope use unchunked replay, even when the configured
+  batch ceiling requires temporal chunks.
   The same work envelope applies to each chunk, and interruption is checked between chunks.
   Topologies without temporal replay fail closed when even one candidate exceeds the envelope,
   with guidance to shorten the date range or reduce the coin count.

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -773,7 +773,12 @@ duplicate-elimination controls as the ordinary pymoo optimizer.
   active-volatility kernels, nor to kernels with optional metric feature paths enabled.
 - `seed_bootstrap.mode` controls `-t/--start` handling. `auto` exact-evaluates all deduplicated seeds
   up to `seed_bootstrap.max_exact`, then switches to full-history proxy screening plus capped exact
-  validation for larger pools. `exact` forces exact evaluation of every seed even above the cap;
+  validation for larger pools. With successive halving disabled, screened seeds reuse their
+  full-history proxy metrics in the initial population. This bounded cache survives resume and is
+  released after the initial population completes; exact validation still runs normally. The
+  initial base-config candidate is screened alongside the seeds, without entering seed ranking
+  or drift calibration, so a fully seeded population can avoid replay entirely.
+  `exact` forces exact evaluation of every seed even above the cap;
   `screened` always performs proxy screening and validates at most the cap; and `legacy` restores
   the former behavior of copying seeds directly into the first proxy population without an
   authoritative bootstrap archive. Bootstrap exact evaluations are recorded in `all_results.bin`

--- a/src/optimization/backends/gpu_backend.py
+++ b/src/optimization/backends/gpu_backend.py
@@ -2655,6 +2655,45 @@ def _select_validation_indices(
     return selected
 
 
+def _seed_proxy_key(candidate: dict) -> tuple:
+    # Match the exact effective proxy input, including inactive parameters.
+    # Canonical vector hashes serve exact-result deduplication and may collapse
+    # inputs that must not share proxy evidence.
+    return tuple(sorted((name, float(value).hex()) for name, value in candidate.items()))
+
+
+def _screen_seed_proxy_candidates(seed_candidates, base_candidate, evaluate_proxy):
+    """Include the population base in the screen without changing seed ranking."""
+    base_key = _seed_proxy_key(base_candidate) if base_candidate is not None else None
+    base_index = next(
+        (i for i, candidate in enumerate(seed_candidates)
+         if _seed_proxy_key(candidate) == base_key),
+        None,
+    ) if base_key is not None else None
+    extra = int(base_key is not None and base_index is None)
+    candidates = seed_candidates + [base_candidate] if extra else seed_candidates
+    rows = evaluate_proxy(candidates)
+    if len(rows) != len(candidates):
+        raise RuntimeError("GPU seed screen received misaligned proxy results")
+    base_row = rows[-1] if extra else (rows[base_index] if base_index is not None else None)
+    return rows[:len(seed_candidates)], base_row, extra
+
+
+def _evaluate_with_seed_proxy_reuse(candidates, cached_rows, evaluate_proxy):
+    """Reuse full-history seed evidence without changing row order or fitness."""
+    keys = [_seed_proxy_key(candidate) for candidate in candidates]
+    missing = [i for i, key in enumerate(keys) if key not in cached_rows]
+    fresh = evaluate_proxy([candidates[i] for i in missing]) if missing else []
+    if len(fresh) != len(missing):
+        raise RuntimeError("GPU seed reuse received misaligned proxy results")
+    fresh_rows = iter(fresh)
+    rows = [
+        deepcopy(cached_rows[key]) if key in cached_rows else next(fresh_rows)
+        for key in keys
+    ]
+    return rows, len(candidates) - len(missing)
+
+
 def _effective_seed_bootstrap_mode(policy: dict, seed_count: int) -> str:
     """Resolve auto without silently weakening an explicit exact request."""
 
@@ -4777,6 +4816,7 @@ def run_backend(
     sampling[0] = normalize_vector(base_vector)
     seed_policy = options["seed_bootstrap"]
     objective_scale = _ObjectiveScale()
+    initial_seed_proxy_rows = {}
     seed_proxy_metrics = None
     seed_proxy_objectives = None
     seed_proxy_violations = None
@@ -5009,6 +5049,17 @@ def run_backend(
         algorithm = checkpoint["algorithm"]
         seed = int(checkpoint.get("seed", seed))
         generation = int(checkpoint["generation"])
+        # The surrounding evaluation contract binds this evidence to the data,
+        # proxy implementation, metrics, overrides, and search configuration.
+        if generation == 0:
+            initial_seed_proxy_rows = dict(
+                checkpoint.get("initial_seed_proxy_rows", {})
+            )
+            cache_bound = population_size + int(seed_policy["max_exact"])
+            if len(initial_seed_proxy_rows) > cache_bound:
+                raise RuntimeError(
+                    "GPU checkpoint seed proxy cache exceeds its population bound"
+                )
         exact_done = int(checkpoint["exact_done"])
         seed_exact_done = int(checkpoint.get("seed_exact_done", 0))
         seed_bootstrap_complete = bool(
@@ -5192,6 +5243,7 @@ def run_backend(
             ),
             "seed_bootstrap_contract": deepcopy(seed_bootstrap_contract),
             "seed_bootstrap_plan": seed_plan,
+            "initial_seed_proxy_rows": initial_seed_proxy_rows,
             "anchor_plan": deepcopy(get_anchor_plan(config)),
             "completed_hashes": sorted(completed_hashes),
             "scale_median": objective_scale.median,
@@ -5263,13 +5315,20 @@ def run_backend(
             [normalize_vector(vector) for vector in starting_vectors],
             dtype=np.float64,
         )
-        proxy_metric_rows = evaluate_proxy(parameter_dicts(seed_rows))
+        seed_candidates = parameter_dicts(seed_rows)
+        base_candidate = (
+            parameter_dicts(sampling[:1])[0] if not halving_policy["enabled"] else None
+        )
+        proxy_metric_rows, base_proxy_row, extra_base = _screen_seed_proxy_candidates(
+            seed_candidates, base_candidate, evaluate_proxy
+        )
         seed_proxy_seconds = time.perf_counter() - seed_proxy_started
         logging.info(
-            "GPU seed proxy screen complete | seeds=%d wall=%.2fs rate=%.1f/s",
+            "GPU seed proxy screen complete | seeds=%d wall=%.2fs rate=%.1f/s base_extra=%d",
             len(starting_vectors),
             seed_proxy_seconds,
-            len(starting_vectors) / max(seed_proxy_seconds, 1.0e-9),
+            (len(starting_vectors) + extra_base) / max(seed_proxy_seconds, 1.0e-9),
+            extra_base,
         )
         seed_proxy_objectives, seed_proxy_violations = proxy_fitness(
             proxy_metric_rows
@@ -5292,9 +5351,20 @@ def run_backend(
             seed_proxy_violations,
             count=min(len(starting_vectors), population_size - 1),
         )
-        # Keep only compact objective arrays and the selected exact-validation
-        # metric rows. Full per-seed metrics and normalized screen inputs can be
-        # substantial for large seed archives.
+        if not halving_policy["enabled"]:
+            # Exact preference can reorder the initial population, so retain
+            # the union of both bounded selection sets, never the whole archive.
+            reuse_indices = set(seed_population_indices) | set(seed_proxy_metrics)
+            initial_seed_proxy_rows[_seed_proxy_key(base_candidate)] = base_proxy_row
+            initial_seed_proxy_rows.update(
+                {
+                    _seed_proxy_key(seed_candidates[index]): proxy_metric_rows[index]
+                    for index in reuse_indices
+                }
+            )
+        del seed_candidates
+        # Retain bounded selected metric rows and compact objective arrays;
+        # release the full archive's metrics and normalized screen inputs.
         del proxy_metric_rows
         del seed_rows
         seed_screen_complete = True
@@ -5670,6 +5740,7 @@ def run_backend(
                     )
                     proxy_profile_records.append(record)
 
+            seed_proxy_reused = 0
             if halving_policy["enabled"]:
                 (
                     metric_rows,
@@ -5686,7 +5757,16 @@ def run_backend(
                     stage_callback=capture_halving_profile,
                 )
             else:
-                metric_rows = evaluate_proxy(proxy_candidates)
+                if initial_seed_proxy_rows:
+                    metric_rows, seed_proxy_reused = _evaluate_with_seed_proxy_reuse(
+                        proxy_candidates, initial_seed_proxy_rows, evaluate_proxy
+                    )
+                    logging.info(
+                        "GPU initial population seed reuse | reused=%d evaluated=%d",
+                        seed_proxy_reused, len(proxy_candidates) - seed_proxy_reused,
+                    )
+                else:
+                    metric_rows = evaluate_proxy(proxy_candidates)
                 proxy_objectives, proxy_violations = proxy_fitness(metric_rows)
                 full_rung_indices = np.arange(len(rows), dtype=np.int64)
                 halving_trace = []
@@ -5696,7 +5776,7 @@ def run_backend(
             proxy_evaluations += (
                 sum(int(item["candidate_count"]) for item in halving_trace)
                 if halving_trace
-                else len(rows)
+                else len(rows) - seed_proxy_reused
             )
             if halving_trace:
                 logging.info(
@@ -5734,6 +5814,7 @@ def run_backend(
             )
             generation_in_progress = False
             generation += 1
+            initial_seed_proxy_rows.clear()
             # PyTorch MPS may consume KeyboardInterrupt while waiting for a
             # Metal dispatch. Finish the in-progress ask/tell transaction, then
             # honor the latched signal before exact work is submitted. This is
@@ -5813,7 +5894,7 @@ def run_backend(
                 generation_wall_seconds = (
                     time.perf_counter() - generation_profile_started
                 )
-                if not halving_policy["enabled"]:
+                if not halving_policy["enabled"] and seed_proxy_reused < len(rows):
                     proxy_profile_records = [
                         deepcopy(getattr(item, "last_profile", {}))
                         for item in profile_proxies
@@ -5832,6 +5913,7 @@ def run_backend(
                     "generation",
                     generation=generation,
                     population_size=len(rows),
+                    seed_proxy_reused=seed_proxy_reused,
                     successive_halving=halving_trace,
                     full_history_candidate_count=len(full_rung_indices),
                     proxy_profiles=proxy_profile_records,

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -3031,6 +3031,8 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
         dispatch_features: tuple[
             bool, bool, bool, bool, bool, bool, bool
         ] | None = None,
+        *,
+        temporal_chunking: bool | None = None,
     ):
         if dispatch_features is None:
             dispatch_features = (
@@ -3092,7 +3094,8 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
             self.equity_balance_diff_enabled,
             self.entry_interval_enabled,
             self.hsl_diagnostics_enabled,
-            self.max_dispatch_candidate_bars is not None,
+            (self.max_dispatch_candidate_bars is not None)
+            if temporal_chunking is None else temporal_chunking,
         )
 
     def _entry_interval_buffers(self, batch_size: int):
@@ -3312,7 +3315,17 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
                 device="mps",
             )
         prepared = time.perf_counter() if profile else 0.0
-        loader, library_args = self._shader_library_cache_call(dispatch_features)
+        # A small seed pool, cache miss, or final batch may fit the full-history
+        # work envelope even when the configured batch ceiling needs chunking.
+        # Preserve the cheaper unchunked shader for those actual dispatches.
+        temporal_chunking = (
+            self.max_dispatch_candidate_bars is not None
+            and batch_size * 2 * (effective_end_step - max(0, effective_history_start))
+            > self.max_dispatch_candidate_bars
+        )
+        loader, library_args = self._shader_library_cache_call(
+            dispatch_features, temporal_chunking=temporal_chunking
+        )
         library, cold = _cached_library_with_miss(loader, *library_args)
         compiled = time.perf_counter() if profile else 0.0
         if profile:
@@ -3343,9 +3356,11 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
             )
             if self.recovery_distribution_enabled:
                 kernel_args += (recovery_samples,)
-            if self.max_dispatch_candidate_bars is None:
+            if not temporal_chunking:
                 library.passivbot_trailing_martingale(
-                    *kernel_args, threads=(batch_size, 1, 1)
+                    *kernel_args, threads=(batch_size, 1, 1),
+                    **({"group_size": (min(batch_size, 64), 1, 1)}
+                       if self.max_dispatch_candidate_bars is not None else {}),
                 )
                 return {"dispatch_count": 1}
             chunk_bars = min(

--- a/tests/optimization/test_gpu_backend.py
+++ b/tests/optimization/test_gpu_backend.py
@@ -7771,3 +7771,108 @@ def test_gpu_suite_unstuck_scope_validates_effective_scenario_bounds(shadow):
         config, suite_cfg, torch_module=_fake_torch_with_mps()
     )
     assert config == original
+
+
+@pytest.mark.parametrize("roundtrip", [False, True])
+def test_seed_proxy_reuse_preserves_order_and_nested_metric_evidence(roundtrip):
+    import pickle
+    from optimization.backends.gpu_backend import _seed_proxy_key, _evaluate_with_seed_proxy_reuse
+
+    seed = {"long_span": 17.25, "short_span": 42.5}
+    evidence = {"adg": 0.125, "suite_objectives": [1.0, 2.0]}
+    cached = {_seed_proxy_key(seed): evidence}
+    if roundtrip:
+        cached = pickle.loads(pickle.dumps(cached))
+    changed = dict(seed, short_span=42.50001)
+    requested = [changed, dict(reversed(list(seed.items()))), seed]
+    calls = []
+    def evaluate(candidates):
+        calls.append(candidates)
+        return [{"adg": 0.25} for _ in candidates]
+    rows, reused = _evaluate_with_seed_proxy_reuse(requested, cached, evaluate)
+    assert calls == [[changed]]
+    assert reused == 2
+    assert rows == [{"adg": 0.25}, evidence, evidence]
+    rows[1]["suite_objectives"][0] = 99.0
+    assert cached[_seed_proxy_key(seed)]["suite_objectives"] == [1.0, 2.0]
+    assert rows[2]["suite_objectives"] == [1.0, 2.0]
+
+
+def test_seed_proxy_reuse_all_hits_avoids_dispatch_and_handles_absent_cache():
+    from optimization.backends.gpu_backend import _seed_proxy_key, _evaluate_with_seed_proxy_reuse
+
+    candidate = {"span": 17.25}
+    evidence = {"adg": 0.125}
+    cached = {_seed_proxy_key(candidate): evidence}
+    def unexpected(_candidates):
+        pytest.fail("cached seed should not be dispatched again")
+    assert _evaluate_with_seed_proxy_reuse([candidate], cached, unexpected) == ([evidence], 1)
+    assert _evaluate_with_seed_proxy_reuse([candidate], {}, lambda c: [evidence]) == ([evidence], 0)
+
+
+def test_seed_proxy_reuse_interrupted_misses_do_not_commit_partial_evidence():
+    from optimization.backends.gpu_backend import _seed_proxy_key, _evaluate_with_seed_proxy_reuse
+
+    candidate = {"span": 17.25}
+    evidence = {"adg": 0.125}
+    cached = {_seed_proxy_key(candidate): evidence}
+    def interrupt(_candidates):
+        raise KeyboardInterrupt
+    with pytest.raises(KeyboardInterrupt):
+        _evaluate_with_seed_proxy_reuse([candidate, {"span": 99.0}], cached, interrupt)
+    assert cached == {_seed_proxy_key(candidate): evidence}
+    with pytest.raises(RuntimeError, match="misaligned"):
+        _evaluate_with_seed_proxy_reuse([{"span": 99.0}], cached, lambda c: [])
+
+
+def test_seed_proxy_reuse_preserves_nsga_next_population_after_resume():
+    import pickle
+    from pymoo.algorithms.moo.nsga2 import NSGA2
+    from pymoo.core.problem import Problem
+    from optimization.backends.gpu_backend import _seed_proxy_key, _evaluate_with_seed_proxy_reuse
+
+    sampling = np.linspace(0.05, 0.95, 8).reshape(-1, 1)
+    algorithm = NSGA2(pop_size=8, sampling=sampling)
+    algorithm.setup(Problem(n_var=1, n_obj=2, n_ieq_constr=1, xl=0.0, xu=1.0), seed=19)
+    def evaluate(candidates):
+        return [{"F": [c["x"] ** 2, (1.0 - c["x"]) ** 2], "G": c["x"] - 0.7}
+                for c in candidates]
+    seeds = [{"x": float(x)} for x in sampling[1:, 0]]
+    cache = {_seed_proxy_key(c): m for c, m in zip(seeds, evaluate(seeds))}
+    checkpoint = pickle.dumps({"algorithm": algorithm, "initial_seed_proxy_rows": cache})
+    populations = []
+    for reuse in (False, True):
+        restored = pickle.loads(checkpoint)
+        algorithm = restored["algorithm"]
+        population = algorithm.ask()
+        candidates = [{"x": float(x)} for x in population.get("X")[:, 0]]
+        if reuse:
+            rows, count = _evaluate_with_seed_proxy_reuse(
+                candidates, restored["initial_seed_proxy_rows"], evaluate
+            )
+            assert count == 7
+        else:
+            rows = evaluate(candidates)
+        population.set("F", np.asarray([row["F"] for row in rows]))
+        population.set("G", np.asarray([[row["G"]] for row in rows]))
+        algorithm.tell(infills=population)
+        populations.append((algorithm.pop.get("F"), algorithm.pop.get("G"), algorithm.ask().get("X")))
+    for before, after in zip(*populations):
+        np.testing.assert_array_equal(before, after)
+
+
+@pytest.mark.parametrize("base", [{"x": 0.5}, {"x": 0.25}, None])
+def test_seed_screen_includes_population_base_without_changing_seed_rows(base):
+    from optimization.backends.gpu_backend import _screen_seed_proxy_candidates
+
+    seeds = [{"x": 0.25}, {"x": 0.75}]
+    calls = []
+    def evaluate(candidates):
+        calls.append(list(candidates))
+        return [{"score": c["x"]} for c in candidates]
+    rows, base_row, extra = _screen_seed_proxy_candidates(seeds, base, evaluate)
+    assert seeds == [{"x": 0.25}, {"x": 0.75}]
+    assert rows == [{"score": 0.25}, {"score": 0.75}]
+    assert base_row == (None if base is None else {"score": base["x"]})
+    assert extra == int(base == {"x": 0.5})
+    assert calls == [seeds + [base] if extra else seeds]

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -22034,3 +22034,23 @@ def test_tm_directional_temporal_preserves_early_liquidation_outputs():
             torch.testing.assert_close(value.cpu(), expected[key], rtol=0, atol=0, equal_nan=True)
         else:
             assert value == expected[key]
+
+
+@pytest.mark.skipif(not torch.backends.mps.is_available(), reason="Apple MPS unavailable")
+def test_tm_directional_chunking_uses_actual_batch_work_and_switches_safely():
+    market, run, data, row, kwargs = _tm_directional_temporal_fixture(True)
+    original = MpsTrailingMartingaleRunner(market, run, data, **kwargs)
+    runner = MpsTrailingMartingaleRunner(
+        market, run, data, max_dispatch_candidate_bars=2 * 1513, **kwargs
+    )
+    for count in (1, 3, 1):
+        matrix = np.asarray([row + row] * count, dtype=np.float64)
+        expected = {k: v.cpu().clone() if isinstance(v, torch.Tensor) else v
+                    for k, v in original.run(matrix).items()}
+        for key, value in runner.run(matrix, profile=True).items():
+            if isinstance(value, torch.Tensor):
+                torch.testing.assert_close(value.cpu(), expected[key], rtol=0, atol=0, equal_nan=True)
+            else:
+                assert value == expected[key]
+        assert runner.last_profile["dispatch_count"] == (1 if count == 1 else 3)
+        assert ("temporal_chunk_bars" in runner.last_profile) == (count == 3)


### PR DESCRIPTION
A screened seed can be replayed twice: once during bootstrap selection and again when it enters the initial GPU population. Retain the bounded union of population-selected and exact-selected seed metrics and reuse them when the effective proxy parameter input matches exactly.

The base-config candidate is screened alongside the seed pool without entering seed ranking or calibration, allowing a fully seeded initial population to avoid replay entirely.

The cache is scoped to the current run, saved with its existing evaluation-contract-bound checkpoint, and released after the initial ask/tell transaction. Missing evidence is evaluated normally. Successive-halving runs retain their existing partial-history behavior, and exact Rust validation remains unchanged. Profiling counts newly evaluated candidates separately from reused seeds.

Small seed pools, cache misses, and final candidate batches use the unchunked shader when their actual work fits the dispatch envelope. Larger batches retain temporal replay. Both paths use bounded explicit threadgroups when temporal replay is configured.

Validation:
- 1,680 actual-MPS, service, backend, and calibration tests pass, including actual-batch scheduling switches, replay parity, mixed hits/misses, input identity, nested evidence isolation, interrupted misses, checkpoint serialization, and identical NSGA fitness and next offspring after resume.
- Offline CLI smoke checkpoints a completed screened bootstrap, resumes without the seed input, reuses the initial population's screened rows, and records exact results; its final population matches the preceding replaying run.
- Documentation checks and diff checks pass.
