### PR TITLE
Reduce GPU optimizer parameter packing overhead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ since the latest release tag; these features may already be available when insta
 
 ## Unreleased
 
+- Reduce GPU optimizer candidate-packing overhead by assembling parameter columns directly,
+  preserving side-specific values, fixed coin overrides, and EMA coupling.
+
 - Add experimental NVIDIA CUDA GPU optimization on Linux and Windows WSL2 with the
   `gpu-cuda` install extra, sharing the existing GPU strategy kernels and exact Rust validation.
 

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -147,6 +147,22 @@ Start with a small batch and few exact workers, then increase after measuring me
 throughput. CUDA multi-coin input preparation limits invariant tensors to 45% of currently
 free GPU memory. Native Windows Python is not supported by this installation profile.
 
+For NVIDIA throughput tuning, use the deterministic proxy benchmark to hold candidate work
+fixed while varying dispatch batch size:
+
+```bash
+PYTHONPATH=src python src/tools/gpu_proxy_benchmark.py --case tm-single-long \
+  --candidates 1024 --dispatch-batch-size 1024 --single-bars 23040 --warm-runs 5
+```
+
+Compare `--dispatch-batch-size 16`, `256`, and `1024` using the same candidate count and seed.
+Small setup-test batches can spend much of their time on repeated launches and host processing.
+For a modest dataset, a population and batch of 1024 are a useful starting point; retain the
+existing dispatch and memory limits, and reduce the batch if the workload approaches VRAM capacity.
+Increasing population size changes the search workload, whereas increasing batch size alone only
+changes how a fixed population is dispatched. Measure complete optimization runs separately,
+including exact Rust workers, startup, and checkpointing; proxy throughput is not end-to-end speedup.
+
 Select it with `--backend gpu` or `optimize.backend: "gpu"`. Normal live operation, backtesting,
 and the DEAP/pymoo CPU optimizers do not import or require PyTorch.
 

--- a/src/optimization/gpu/service.py
+++ b/src/optimization/gpu/service.py
@@ -1826,6 +1826,45 @@ def _combine_hedged_multicoin_outputs(
     return combined
 
 
+def _candidate_parameter_matrix(
+    candidates: list[dict],
+    param_keys,
+    base_params: dict,
+    *,
+    static_overrides: dict | None = None,
+    couple_unstuck_emas: bool = False,
+) -> np.ndarray:
+    """Pack columns directly, preserving base < candidate < fixed override precedence."""
+    if not candidates:
+        return np.asarray([], dtype=np.float64)
+    matrix = np.empty(
+        (len(candidates), len(base_params) * len(param_keys)), dtype=np.float64
+    )
+    for side_index, (side, base) in enumerate(base_params.items()):
+        overrides = (static_overrides or {}).get(side, {})
+        for column, key in enumerate(param_keys):
+            source_key = (
+                key.removeprefix("unstuck_")
+                if couple_unstuck_emas
+                and key in ("unstuck_ema_span_0", "unstuck_ema_span_1")
+                else key
+            )
+            target = side_index * len(param_keys) + column
+            if source_key in overrides:
+                matrix[:, target] = float(overrides[source_key])
+            else:
+                candidate_key = f"{side}_{source_key}"
+                matrix[:, target] = [
+                    float(
+                        candidate[candidate_key]
+                        if candidate_key in candidate
+                        else base[source_key]
+                    )
+                    for candidate in candidates
+                ]
+    return matrix
+
+
 class MpsSingleCoinProxy:
     """Batched directional screening proxy for supported single-coin strategies."""
 
@@ -2235,27 +2274,13 @@ class MpsSingleCoinProxy:
             )
 
     def _parameter_matrix(self, candidates: list[dict]) -> np.ndarray:
-        rows = []
-        for candidate in candidates:
-            row = []
-            for side in ("long", "short"):
-                merged = dict(self.base_params[side])
-                merged.update(
-                    {
-                        key.removeprefix(f"{side}_"): value
-                        for key, value in candidate.items()
-                        if key.startswith(f"{side}_")
-                    }
-                )
-                merged.update(
-                    getattr(self, "static_coin_override_params", {}).get(side, {})
-                )
-                if getattr(self, "couple_unstuck_emas", False):
-                    for i in (0, 1):
-                        merged[f"unstuck_ema_span_{i}"] = merged[f"ema_span_{i}"]
-                row.extend(float(merged[key]) for key in self.param_keys)
-            rows.append(row)
-        return np.asarray(rows, dtype=np.float64)
+        return _candidate_parameter_matrix(
+            candidates,
+            self.param_keys,
+            {side: self.base_params[side] for side in ("long", "short")},
+            static_overrides=getattr(self, "static_coin_override_params", None),
+            couple_unstuck_emas=getattr(self, "couple_unstuck_emas", False),
+        )
 
     def recent_window_for_history_fraction(
         self, history_fraction: float
@@ -3535,21 +3560,12 @@ class MpsMulticoinProxy:
                 raise ValueError("side is required for dual-side multicoin parameters")
             side = self.sides[0]
         param_keys = getattr(self, "param_keys", EMA_ANCHOR_MULTICOIN_PARAM_KEYS)
-        rows = []
-        for candidate in candidates:
-            merged = dict(self.base_params[side])
-            merged.update(
-                {
-                    key.removeprefix(f"{side}_"): value
-                    for key, value in candidate.items()
-                    if key.startswith(f"{side}_")
-                }
-            )
-            if getattr(self, "couple_unstuck_emas", False):
-                for i in (0, 1):
-                    merged[f"unstuck_ema_span_{i}"] = merged[f"ema_span_{i}"]
-            rows.append([float(merged[key]) for key in param_keys])
-        return np.asarray(rows, dtype=np.float64)
+        return _candidate_parameter_matrix(
+            candidates,
+            param_keys,
+            {side: self.base_params[side]},
+            couple_unstuck_emas=getattr(self, "couple_unstuck_emas", False),
+        )
 
     def evaluate(self, candidates: list[dict]) -> list[dict]:
         results: list[dict] = []

--- a/tests/optimization/test_gpu_service.py
+++ b/tests/optimization/test_gpu_service.py
@@ -3430,3 +3430,55 @@ def test_mps_single_coin_temporal_plan_preserves_work_limit(strategy, batch, bar
     plan = _mps_single_coin_dispatch_plan(strategy, batch, n_bars=bars, n_sides=sides, max_candidate_bars=cap)
     assert plan == expected
     assert plan[1] * plan[2] * sides <= cap
+
+
+@pytest.mark.parametrize("coupled", [False, True])
+def test_parameter_columns_preserve_fixed_override_then_ema_coupling(coupled):
+    proxy = MpsEmaAnchorProxy.__new__(MpsEmaAnchorProxy)
+    proxy.param_keys = (
+        "ema_span_0",
+        "ema_span_1",
+        "unstuck_ema_span_0",
+        "unstuck_ema_span_1",
+        "offset",
+    )
+    proxy.base_params = {
+        "short": dict(zip(proxy.param_keys, [6.0, 7.0, 8.0, 9.0, 0.1])),
+        "long": dict(zip(proxy.param_keys, [1.0, 2.0, 3.0, 4.0, 0.2])),
+    }
+    proxy.static_coin_override_params = {
+        "long": {"ema_span_0": 10.25, "unstuck_ema_span_0": 999.0},
+        "short": {"offset": 0.125},
+    }
+    proxy.couple_unstuck_emas = coupled
+    candidate = {
+        "long_ema_span_0": 12.5,
+        "long_ema_span_1": 2.5,
+        "long_unstuck_ema_span_1": 13.5,
+        "long_offset": 0.5,
+        "short_offset": 0.75,
+        "unrelated": -999.0,
+    }
+    original = dict(candidate)
+    expected = (
+        [10.25, 2.5, 10.25, 2.5, 0.5, 6.0, 7.0, 6.0, 7.0, 0.125]
+        if coupled
+        else [10.25, 2.5, 999.0, 13.5, 0.5, 6.0, 7.0, 8.0, 9.0, 0.125]
+    )
+    matrix = proxy._parameter_matrix([candidate, candidate])
+    np.testing.assert_array_equal(matrix, [expected, expected])
+    assert matrix.dtype == np.float64
+    assert matrix.flags.c_contiguous
+    assert candidate == original
+
+
+def test_parameter_columns_keep_candidate_fallback_and_missing_key_failure():
+    proxy = MpsMulticoinEmaProxy.__new__(MpsMulticoinEmaProxy)
+    proxy.param_keys = ("offset",)
+    proxy.sides = ["short"]
+    proxy.base_params = {"short": {}}
+    np.testing.assert_array_equal(proxy._parameter_matrix([{"short_offset": 0.125}]), [[0.125]])
+    with pytest.raises(KeyError, match="offset"):
+        proxy._parameter_matrix([{}])
+    with pytest.raises((TypeError, ValueError)):
+        proxy._parameter_matrix([{"short_offset": None}])


### PR DESCRIPTION
GPU screening repeatedly builds merged parameter dictionaries for every candidate and side. Assemble float64 parameter columns directly instead, retaining candidate/base precedence, fixed coin overrides, coupled EMA spans, and side ordering.

Add regression coverage for fractional EMA values, override/coupling precedence, immutable candidate inputs, and missing/invalid parameters. Document fixed-work NVIDIA batch-size benchmarking and the distinction between proxy throughput and complete optimizer performance.

Follows NVIDIA support in #1730. CUDA kernels, dispatch limits, memory limits, and Rust trading behavior are unchanged.

Validation: focused GPU orchestration suite (888 passed, 7 CUDA-only skips on macOS); actual Apple GPU parity slice (68 passed); documentation tests (6 passed). NVIDIA GPU regression matrix (1,842 passed, 77 skipped); exact before/after proxy outputs for both strategies on single-coin and multi-coin fixtures; repeated bounded offline optimizer runs for both strategies. Direct parameter-packing microbenchmarks improve both sparse and dense candidate inputs; complete proxy gains depend on workload and CPU threading.
