### PR TITLE
Reduce CUDA multi-coin scratch storage by dataset capacity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ since the latest release tag; these features may already be available when insta
 
 ## Unreleased
 
+- Reduce NVIDIA multi-coin GPU optimizer memory and screening overhead by compiling
+  per-candidate coin storage to a capacity matched to the dataset. Apple GPU compilation is unchanged.
+
 - Reduce GPU optimizer candidate-packing overhead by assembling parameter columns directly,
   preserving side-specific values, fixed coin overrides, and EMA coupling.
 

--- a/src/optimization/gpu/cuda_kernel.py
+++ b/src/optimization/gpu/cuda_kernel.py
@@ -1,7 +1,8 @@
 """Compile the repository's scalar Metal kernel dialect as CUDA C++.
 
 Only address-space qualifiers, the grid index, and the few Metal vector operations
-used by these kernels differ. Strategy expressions remain in the Rust-owned source.
+used by these kernels differ. Multi-coin private arrays may use a smaller validated
+capacity. Strategy expressions remain in the Rust-owned source.
 CuPy compiles with NVRTC and shares PyTorch tensors and its current CUDA stream.
 """
 
@@ -59,8 +60,25 @@ __device__ inline PBFloat3 fma(PBFloat3 a, PBFloat3 b, PBFloat3 c) {
 """
 
 
-def cuda_source(source: str) -> str:
+def cuda_source(source: str, *, coin_capacity: int | None = None) -> str:
     """Lower only the explicitly supported scalar shader dialect."""
+    if coin_capacity is not None:
+        declarations = list(re.finditer(
+            r"\bconstant\s+int\s+MAX_COINS\s*=\s*(\d+)\s*;", source
+        ))
+        if len(declarations) != 1:
+            raise ValueError("CUDA coin specialization requires one MAX_COINS declaration")
+        declaration = declarations[0]
+        if (
+            type(coin_capacity) is not int
+            or not 1 <= coin_capacity <= int(declaration[1])
+        ):
+            raise ValueError("CUDA coin capacity must fit the shader's MAX_COINS limit")
+        source = (
+            source[:declaration.start(1)]
+            + str(coin_capacity)
+            + source[declaration.end(1):]
+        )
     for signature in re.findall(r"kernel\s+void\s+\w+\((.*?)\)\s*\{", source, re.S):
         for position, argument in enumerate(signature.split(",")):
             slot = re.search(r"\[\[buffer\((\d+)\)\]\]", argument)
@@ -103,7 +121,7 @@ def cuda_source(source: str) -> str:
 
 
 class CudaShaderLibrary:
-    def __init__(self, source: str):
+    def __init__(self, source: str, *, coin_capacity: int | None = None):
         import cupy
 
         self._cupy = cupy
@@ -115,7 +133,7 @@ class CudaShaderLibrary:
                 if (match := re.search(r"\bconstant\s+(\w+)\s*&", argument))
             }
         self._module = cupy.RawModule(
-            code=cuda_source(source),
+            code=cuda_source(source, coin_capacity=coin_capacity),
             options=("--std=c++17", "--fmad=false"),
         )
         self._module.compile()

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -19,6 +19,7 @@ from optimization.gpu.model import (
     EMA_ANCHOR_MULTICOIN_PARAM_KEYS,
     EMA_ANCHOR_SINGLE_COIN_PARAM_KEYS,
     GAP_BINS,
+    MPS_MULTICOIN_MAX_COINS,
     MPS_TM_MULTICOIN_CHUNK_BARS,
     MPS_TM_SINGLE_COIN_CHUNK_BARS,
     MPS_TM_MULTICOIN_CHUNK_CANDIDATE_STEPS,
@@ -946,6 +947,7 @@ def _ema_anchor_multicoin_shader_library(
     dynamic_wel_by_tradability: bool = True,
     btc_risk_enabled: bool = False,
     equity_balance_diff_enabled: bool = False,
+    cuda_coin_capacity: int | None = None,
 ):
     gpu_device(torch)
     import passivbot_rust
@@ -962,7 +964,7 @@ def _ema_anchor_multicoin_shader_library(
     )
     source = _with_btc_risk(source, btc_risk_enabled)
     source = _with_equity_balance_diff(source, equity_balance_diff_enabled)
-    return compile_shader(source)
+    return compile_shader(source, cuda_coin_capacity=cuda_coin_capacity)
 
 
 @lru_cache(maxsize=32)
@@ -976,6 +978,7 @@ def _trailing_martingale_multicoin_shader_library(
     equity_balance_diff_enabled: bool = False,
     entry_interval_enabled: bool = False,
     temporal_chunking: bool = False,
+    cuda_coin_capacity: int | None = None,
 ):
     gpu_device(torch)
     import passivbot_rust
@@ -997,7 +1000,7 @@ def _trailing_martingale_multicoin_shader_library(
         if "#if PASSIVBOT_TM_MULTICOIN_CHUNKED" not in source:
             raise RuntimeError("MPS source is missing the multicoin replay-state contract")
         source = "#define PASSIVBOT_TM_MULTICOIN_CHUNKED 1\n" + source
-    return compile_shader(source)
+    return compile_shader(source, cuda_coin_capacity=cuda_coin_capacity)
 
 
 @lru_cache(maxsize=1)
@@ -1917,6 +1920,12 @@ class MpsEmaAnchorMulticoinRunner:
             else 1
         )
         self.bars = data["bars"]
+        self.cuda_coin_capacity = None
+        if self.bars.device.type == "cuda":
+            if not 1 <= self.n_coins <= MPS_MULTICOIN_MAX_COINS:
+                raise ValueError("CUDA coin count exceeds the multicoin shader limit")
+            # Bound CUDA private arrays while sharing compiled variants within buckets.
+            self.cuda_coin_capacity = 1 << (self.n_coins - 1).bit_length()
         self.fill_ticks = data["fill_ticks"]
         self.touch_ticks = data["touch_ticks"]
         self.touch_nearest_ticks = data["touch_nearest_ticks"]
@@ -2135,7 +2144,7 @@ class MpsEmaAnchorMulticoinRunner:
         return loader(*args)
 
     def _library_cache_call(self):
-        return _ema_anchor_multicoin_shader_library, (
+        args = (
             self.hsl_ema_tail_enabled,
             self.hsl_raw_drawdown_enabled,
             self.hsl_raw_tail_enabled,
@@ -2144,6 +2153,9 @@ class MpsEmaAnchorMulticoinRunner:
             self.btc_risk_enabled,
             self.equity_balance_diff_enabled,
         )
+        if self.cuda_coin_capacity is not None:
+            args += (self.cuda_coin_capacity,)
+        return _ema_anchor_multicoin_shader_library, args
 
     def _decode(self, daily, scalars, gaps) -> dict:
         return _decode_outputs(daily, scalars, gaps)
@@ -2619,7 +2631,7 @@ class MpsTrailingMartingaleMulticoinRunner(MpsEmaAnchorMulticoinRunner):
         return loader(*args)
 
     def _library_cache_call(self):
-        return _trailing_martingale_multicoin_shader_library, (
+        args = (
             self.hsl_ema_tail_enabled,
             self.hsl_raw_drawdown_enabled,
             self.hsl_raw_tail_enabled,
@@ -2630,6 +2642,9 @@ class MpsTrailingMartingaleMulticoinRunner(MpsEmaAnchorMulticoinRunner):
             self.entry_interval_enabled,
             self.max_dispatch_candidate_bars is not None,
         )
+        if self.cuda_coin_capacity is not None:
+            args += (self.cuda_coin_capacity,)
+        return _trailing_martingale_multicoin_shader_library, args
 
     def _dispatch(
         self,

--- a/src/optimization/gpu/runtime.py
+++ b/src/optimization/gpu/runtime.py
@@ -26,14 +26,14 @@ def synchronize() -> None:
         torch.cuda.synchronize()
 
 
-def compile_shader(source: str):
+def compile_shader(source: str, *, cuda_coin_capacity: int | None = None):
     import torch
 
     if gpu_device(torch) == "mps":
         return torch.mps.compile_shader(source)
     from optimization.gpu.cuda_kernel import CudaShaderLibrary
 
-    return CudaShaderLibrary(source)
+    return CudaShaderLibrary(source, coin_capacity=cuda_coin_capacity)
 
 
 def checkpoint_runtime(torch_module) -> dict:

--- a/tests/optimization/test_gpu_cuda.py
+++ b/tests/optimization/test_gpu_cuda.py
@@ -138,3 +138,75 @@ def test_cuda_constant_reference_buffer(cuda):
     for value in [factor, 3]:
         library.scale(value, output, threads=5)
         np.testing.assert_array_equal(output.cpu().numpy(), [3, 6, 9, 12, 15])
+
+
+@pytest.mark.parametrize("capacity", [1, 2, 8, 64])
+def test_cuda_coin_capacity_specializes_only_the_declared_limit(capacity):
+    source = """constant int MAX_COINS = 64;
+        kernel void size(device int* output, uint i [[thread_position_in_grid]]) {
+            output[i] = MAX_COINS;
+        }"""
+    assert f"constexpr int MAX_COINS = {capacity};" in cuda_source(
+        source, coin_capacity=capacity
+    )
+    assert "constexpr int MAX_COINS = 64;" in cuda_source(source)
+
+
+@pytest.mark.parametrize("capacity", [0, -1, 65, 8.5, True])
+def test_cuda_coin_capacity_rejects_invalid_limits(capacity):
+    with pytest.raises(ValueError, match="coin capacity"):
+        cuda_source("constant int MAX_COINS = 64;", coin_capacity=capacity)
+
+
+@pytest.mark.parametrize("source", ["", "constant int MAX_COINS = 64;" * 2])
+def test_cuda_coin_capacity_requires_one_known_declaration(source):
+    with pytest.raises(ValueError, match="one MAX_COINS declaration"):
+        cuda_source(source, coin_capacity=8)
+
+
+def test_mps_compilation_does_not_apply_cuda_coin_specialization(monkeypatch):
+    import sys
+    from optimization.gpu.runtime import compile_shader
+
+    sources = []
+    torch = SimpleNamespace(
+        backends=SimpleNamespace(mps=SimpleNamespace(is_available=lambda: True)),
+        mps=SimpleNamespace(compile_shader=lambda source: sources.append(source)),
+    )
+    monkeypatch.setitem(sys.modules, "torch", torch)
+    source = "constant int MAX_COINS = 64;"
+    compile_shader(source, cuda_coin_capacity=8)
+    assert sources == [source]
+
+
+@pytest.mark.parametrize("case", ["ema-multicoin-overhead", "tm-multicoin-overhead"])
+@pytest.mark.parametrize("coins", [2, 3, 5, 9, 17, 33, 64])
+def test_cuda_coin_capacity_matches_full_capacity_outputs(cuda, case, coins):
+    torch, _library_cls = cuda
+    from tools.gpu_proxy_benchmark import _build_case
+
+    def evaluate(full_capacity):
+        proxy, candidates, *_ = _build_case(
+            case, candidates=4, dispatch_batch_size=4, single_bars=256,
+            multicoin_bars=256, coins=coins, seed=7,
+        )
+        runner = proxy.runners["long"]
+        expected_capacity = 1 << (coins - 1).bit_length()
+        assert runner.cuda_coin_capacity == expected_capacity
+        assert runner._library_cache_call()[1][-1] == expected_capacity
+        if full_capacity:
+            runner.cuda_coin_capacity = 64
+        if case.startswith("tm-"):
+            # Exercise the variant-specific replay-state ABI across temporal chunks.
+            runner.max_dispatch_candidate_bars = 4 * coins * 31
+        output = runner.run(proxy._parameter_matrix(candidates, "long"))
+        return {
+            key: value.cpu().numpy().copy()
+            for key, value in output.items() if isinstance(value, torch.Tensor)
+        }
+
+    specialized = evaluate(False)
+    baseline = evaluate(True)
+    assert specialized.keys() == baseline.keys()
+    for key in baseline:
+        np.testing.assert_array_equal(specialized[key], baseline[key], err_msg=key)


### PR DESCRIPTION
NVIDIA multi-coin screening allocates private arrays for the maximum 64 coins even when a dataset uses only a few. Select a power-of-two coin capacity for CUDA compilation and include it in the shader cache key, reducing unused per-candidate storage and initialization work.

The capacity stays within the existing shader limit. The CUDA adapter rejects missing or ambiguous declarations and invalid capacities. Apple Metal retains its original shader source and cache keys; strategy expressions, precision settings, dispatch limits, and Rust behavior are unchanged. Each new capacity/feature variant has a one-time CUDA compilation cost and is subsequently cached.

Validation:
- Actual NVIDIA GPU matrix: 1,868 passed, 77 skipped.
- Actual Apple GPU matrix: 1,924 passed, 21 skipped; exact before/after outputs for both strategies in single-coin and multi-coin fixtures.
- Exact full-capacity versus specialized CUDA outputs across 2, 3, 5, 9, 17, 33, and 64 coins, including Trailing Martingale temporal replay-state sizing.
- Alternating warm fixed-input comparisons for both strategies at 2, 8, and 16 coins, 1,024 candidates, and 8,000 bars retained exact outputs.
- Bounded offline optimizer integration runs passed for both strategies, including exact evaluation and clean shutdown.
- Documentation and generated registry checks passed; no Rust sources changed.
