### PR TITLE
Reduce host CPU usage during long CUDA screening waits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ since the latest release tag; these features may already be available when insta
 
 ## Unreleased
 
+- Reduce CPU usage during long NVIDIA GPU optimizer screening waits,
+  preserving GPU calculations and Apple GPU synchronization behavior.
+
 - Reduce NVIDIA multi-coin GPU optimizer memory and screening overhead by compiling
   per-candidate coin storage to a capacity matched to the dataset. Apple GPU compilation is unchanged.
 

--- a/src/optimization/gpu/mps_kernel.py
+++ b/src/optimization/gpu/mps_kernel.py
@@ -7,7 +7,9 @@ import time
 import numpy as np
 import torch
 
-from optimization.gpu.runtime import gpu_device, compile_shader, synchronize
+from optimization.gpu.runtime import (
+    gpu_device, compile_shader, synchronize, wait_for_cuda_stream,
+)
 
 from optimization.gpu.model import (
     EMA_ANCHOR_COIN_OVERRIDE_UNSTUCK_EMA_START_COLUMN,
@@ -1785,6 +1787,7 @@ class MpsEmaAnchorRunner:
             }
         else:
             self.last_profile = {}
+            wait_for_cuda_stream()
         output = _decode_directional_outputs(daily, scalars, gaps)
         output.update(_decode_equity_balance_diff_outputs(equity_balance_diff))
         if self.recovery_distribution_enabled:
@@ -2296,6 +2299,7 @@ class MpsEmaAnchorMulticoinRunner:
             }
         else:
             self.last_profile = {}
+            wait_for_cuda_stream()
         output = self._decode(daily, scalars, gaps)
         output.update(_decode_equity_balance_diff_outputs(equity_balance_diff))
         output.update(
@@ -3454,6 +3458,7 @@ class MpsTrailingMartingaleRunner(MpsEmaAnchorRunner):
             }
         else:
             self.last_profile = {}
+            wait_for_cuda_stream()
         output = _decode_directional_outputs(daily, scalars, gaps)
         output.update(_decode_equity_balance_diff_outputs(equity_balance_diff))
         output.update(

--- a/src/optimization/gpu/runtime.py
+++ b/src/optimization/gpu/runtime.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import time
+
 
 def gpu_device(torch_module=None) -> str:
     if torch_module is None:
@@ -17,12 +19,30 @@ def gpu_device(torch_module=None) -> str:
     )
 
 
+def wait_for_cuda_stream() -> None:
+    """Yield host CPU time during long waits for the current CUDA stream."""
+    import torch
+
+    if gpu_device(torch) != "cuda":
+        return
+    completed = torch.cuda.Event()
+    completed.record()
+    # Keep short kernels on the active-wait path to avoid host wake-up latency.
+    # Longer waits yield so CUDA screening does not occupy an exact-worker core.
+    active_until = time.perf_counter() + 0.5
+    while not completed.query():
+        if time.perf_counter() >= active_until:
+            time.sleep(0.001)
+
+
 def synchronize() -> None:
     import torch
 
     if gpu_device(torch) == "mps":
         torch.mps.synchronize()
     else:
+        wait_for_cuda_stream()
+        # Preserve this helper's device-wide contract, including other streams.
         torch.cuda.synchronize()
 
 

--- a/tests/optimization/test_gpu_cuda.py
+++ b/tests/optimization/test_gpu_cuda.py
@@ -210,3 +210,115 @@ def test_cuda_coin_capacity_matches_full_capacity_outputs(cuda, case, coins):
     assert specialized.keys() == baseline.keys()
     for key in baseline:
         np.testing.assert_array_equal(specialized[key], baseline[key], err_msg=key)
+
+
+@pytest.mark.parametrize("pending_queries", [0, 2])
+def test_cuda_completion_wait_yields_until_ready(monkeypatch, pending_queries):
+    import sys
+    from optimization.gpu import runtime
+
+    calls = []
+    ready = iter([False] * pending_queries + [True])
+    event = SimpleNamespace(
+        record=lambda: calls.append("record"),
+        query=lambda: next(ready),
+    )
+    torch = SimpleNamespace(
+        backends=SimpleNamespace(mps=SimpleNamespace(is_available=lambda: False)),
+        cuda=SimpleNamespace(
+            is_available=lambda: True,
+            Event=lambda: event,
+            synchronize=lambda: calls.append("device_sync"),
+        ),
+    )
+    monkeypatch.setitem(sys.modules, "torch", torch)
+    ticks = iter([0.0] + [0.5] * pending_queries)
+    monkeypatch.setattr(
+        runtime, "time", SimpleNamespace(
+            perf_counter=lambda: next(ticks),
+            sleep=lambda seconds: calls.append(seconds),
+        )
+    )
+    runtime.synchronize()
+    assert calls == ["record", *([0.001] * pending_queries), "device_sync"]
+
+
+def test_cuda_completion_error_propagates(monkeypatch):
+    import sys
+    from optimization.gpu import runtime
+
+    def failed_query():
+        raise RuntimeError("asynchronous kernel failure")
+
+    torch = SimpleNamespace(
+        backends=SimpleNamespace(mps=SimpleNamespace(is_available=lambda: False)),
+        cuda=SimpleNamespace(
+            is_available=lambda: True,
+            Event=lambda: SimpleNamespace(record=lambda: None, query=failed_query),
+        ),
+    )
+    monkeypatch.setitem(sys.modules, "torch", torch)
+    with pytest.raises(RuntimeError, match="asynchronous kernel failure"):
+        runtime.synchronize()
+
+
+def test_mps_completion_keeps_existing_synchronization(monkeypatch):
+    import sys
+    from optimization.gpu import runtime
+
+    calls = []
+    torch = SimpleNamespace(
+        backends=SimpleNamespace(mps=SimpleNamespace(is_available=lambda: True)),
+        mps=SimpleNamespace(synchronize=lambda: calls.append("mps_sync")),
+    )
+    monkeypatch.setitem(sys.modules, "torch", torch)
+    runtime.wait_for_cuda_stream()
+    runtime.synchronize()
+    assert calls == ["mps_sync"]
+
+
+def test_cuda_completion_waits_for_current_stream(cuda):
+    torch, _library_cls = cuda
+    from optimization.gpu.runtime import wait_for_cuda_stream
+
+    stream = torch.cuda.Stream()
+    with torch.cuda.stream(stream):
+        output = torch.empty(16, device="cuda")
+        torch.cuda._sleep(10_000_000)
+        output.fill_(42)
+        wait_for_cuda_stream()
+        assert stream.query()
+    np.testing.assert_array_equal(output.cpu().numpy(), np.full(16, 42))
+
+
+def test_cuda_synchronize_still_waits_for_other_streams(cuda):
+    torch, _library_cls = cuda
+    from optimization.gpu.runtime import synchronize
+
+    other = torch.cuda.Stream()
+    with torch.cuda.stream(other):
+        torch.cuda._sleep(10_000_000)
+    synchronize()
+    assert other.query()
+
+
+def test_cuda_completion_keeps_short_wait_active(monkeypatch):
+    import sys
+    from optimization.gpu import runtime
+
+    calls = []
+    ready = iter([False, False, True])
+    ticks = iter([0.0, 0.1, 0.49])
+    torch = SimpleNamespace(
+        backends=SimpleNamespace(mps=SimpleNamespace(is_available=lambda: False)),
+        cuda=SimpleNamespace(
+            is_available=lambda: True,
+            Event=lambda: SimpleNamespace(record=lambda: None, query=lambda: next(ready)),
+        ),
+    )
+    monkeypatch.setitem(sys.modules, "torch", torch)
+    monkeypatch.setattr(runtime, "time", SimpleNamespace(
+        perf_counter=lambda: next(ticks), sleep=lambda seconds: calls.append(seconds),
+    ))
+    runtime.wait_for_cuda_stream()
+    assert calls == []


### PR DESCRIPTION
CUDA screening can spend a CPU core waiting for a long-running kernel, competing with exact optimizer workers. Record completion on the current CUDA stream; preserve active waiting for up to 0.5 seconds, then yield between event queries before decoding results. The initial active window avoids wake-up overhead for short screening kernels. Keep the existing device-wide synchronization contract and Apple synchronization behavior.

No shader, precision, launch, or strategy calculations change. GPU failures still propagate. Regression coverage checks event polling, asynchronous errors, current-stream completion, the device-wide barrier, and Apple routing.

Validation: 1,875 NVIDIA GPU/optimizer regression tests passed, 77 skipped. Paired fixed-input replay retained exact output equality while substantially reducing host CPU time. Apple hardware validation was not rerun for this change; its routing is covered by tests.

Four paired synthetic EMA/TM, single/multi-coin benchmark cases retained exact outputs and showed less than 0.3% wall-time difference. A bounded optimizer CLI integration also completed successfully on the final implementation.
