### PR TITLE
Fix GPU HSL episode resets and trailing-close price parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ since the latest release tag; these features may already be available when insta
 
 ## Unreleased
 
+- Clear completed coin-HSL rolling PnL windows when GPU replay finalizes a RED stop at
+  a closing fill, preventing old losses from triggering another stop after cooldown.
+- Quantize single trailing-martingale close prices before backtest fill peeks, matching
+  expanded close bundles and preventing off-tick simulated fills.
+
 - Reduce CPU usage during long NVIDIA GPU optimizer screening waits,
   preserving GPU calculations and Apple GPU synchronization behavior.
 

--- a/passivbot-rust/src/closes.rs
+++ b/passivbot-rust/src/closes.rs
@@ -463,6 +463,18 @@ pub fn calc_trailing_close_long(
     }
 }
 
+// Size against the selected raw price first, then normalize executable intent.
+// Single-order backtest peeks must use the same price as expanded close bundles.
+fn quantize_close_price(mut order: Order, exchange_params: &ExchangeParams) -> Order {
+    order.price = quantize_price(
+        order.price,
+        exchange_params.price_step,
+        RoundingMode::Nearest,
+        "calc_next_close::price",
+    );
+    order
+}
+
 pub fn calc_next_close_long(
     exchange_params: &ExchangeParams,
     state_params: &StateParams,
@@ -490,9 +502,9 @@ pub fn calc_next_close_long(
         position,
         wallet_exposure,
     ) {
-        return order;
+        return quantize_close_price(order, exchange_params);
     }
-    if close_params.retracement_base_pct > 0.0 {
+    let order = if close_params.retracement_base_pct > 0.0 {
         calc_trailing_close_long(
             exchange_params,
             state_params,
@@ -511,7 +523,8 @@ pub fn calc_next_close_long(
             close_params,
             position,
         )
-    }
+    };
+    quantize_close_price(order, exchange_params)
 }
 
 pub fn calc_grid_close_short(
@@ -701,9 +714,9 @@ pub fn calc_next_close_short(
         position,
         wallet_exposure,
     ) {
-        return order;
+        return quantize_close_price(order, exchange_params);
     }
-    if close_params.retracement_base_pct > 0.0 {
+    let order = if close_params.retracement_base_pct > 0.0 {
         calc_trailing_close_short(
             exchange_params,
             state_params,
@@ -722,7 +735,8 @@ pub fn calc_next_close_short(
             close_params,
             position,
         )
-    }
+    };
+    quantize_close_price(order, exchange_params)
 }
 
 pub fn calc_trailing_martingale_close_diagnostic(

--- a/passivbot-rust/src/gpu/mps_hsl_common.metal
+++ b/passivbot-rust/src/gpu/mps_hsl_common.metal
@@ -889,7 +889,10 @@ inline bool finish_hsl_episode_at_flat(
     update_hsl_from_signal(h, signal, realized_pnl, false, false, kf, interval_ms, true);
     if (h.red_latched) {
         update_hsl_from_signal(h, signal, realized_pnl, false, false, kf, interval_ms);
-        return false;
+        // Finalization at this fill already increments the trigger counter.
+        // The later per-bar transition check cannot detect it, so the caller
+        // must clear the completed coin episode's rolling PnL window now.
+        return h.halted;
     }
     // Prime the next episode at the exact flat baseline. Another closing fill
     // in this minute must include its entry fee and closing loss in its signal.

--- a/passivbot-rust/src/strategies/trailing_martingale.rs
+++ b/passivbot-rust/src/strategies/trailing_martingale.rs
@@ -508,4 +508,66 @@ mod tests {
         assert_eq!(generated.closes[0].price, 98.9);
         assert_eq!(generated.closes[9].price, 98.0);
     }
+
+    #[test]
+    fn trailing_close_touch_is_quantized_before_every_peek_path() {
+        use crate::strategies::PeekBehavior;
+        for side in [StrategySide::Long, StrategySide::Short] {
+            let long = matches!(side, StrategySide::Long);
+            // A raw touch would fill the next candle, but its nearest tick would not.
+            let touch = if long { 101.006 } else { 98.994 };
+            let tick = if long { 101.01 } else { 98.99 };
+            let exchange = ExchangeParams {
+                qty_step: 0.01, price_step: 0.01, min_qty: 0.01,
+                min_cost: 0.0, c_mult: 1.0, ..Default::default()
+            };
+            let state = StateParams {
+                balance: 1000.0,
+                order_book: OrderBook { ask: touch, bid: touch },
+                ..Default::default()
+            };
+            let bot = BotParams {
+                wallet_exposure_limit: 1.0, total_wallet_exposure_limit: 1.0,
+                risk_wel_enforcer_enabled: false, ..Default::default()
+            };
+            let params = StrategyParams::TrailingMartingale(TrailingMartingaleParams {
+                close: TrailingMartingaleCloseParams {
+                    qty_pct: 1.0, threshold_base_pct: 0.001,
+                    retracement_base_pct: 0.001, ..Default::default()
+                },
+                ..Default::default()
+            });
+            let position = Position { size: if long { 1.0 } else { -1.0 }, price: 100.0 };
+            let trailing = TrailingPriceBundle {
+                min_since_open: 98.0, max_since_min: 99.0,
+                max_since_open: 102.0, min_since_max: 101.0,
+            };
+            let next_low = if long { 100.0 } else { 98.992 };
+            let next_high = if long { 101.008 } else { 100.0 };
+            let mut prices = Vec::new();
+            for mode in 0..5 {
+                let mut request = recursive_close_request(
+                    &exchange, &state, &bot, &params, &position, &trailing,
+                    next_low, next_high,
+                );
+                match mode {
+                    0 => request.next_candle = None, // live/full generation
+                    1 => {}, // next-candle fallback
+                    2 => request.next_candle.as_mut().unwrap().tradable = false,
+                    3 | 4 => request.peek = Some(PeekBehavior {
+                        expand_entries: false, expand_closes: mode == 4,
+                    }),
+                    _ => unreachable!(),
+                }
+                let orders = generate_orders(side, request);
+                assert_eq!(orders.closes.len(), 1, "mode {mode}");
+                let order = &orders.closes[0];
+                assert_eq!(order.price, tick, "side {side:?}, mode {mode}");
+                assert!(!would_fill_next_candle(next_low, next_high, order.qty, order.price));
+                prices.push(order.price);
+            }
+            assert!(prices.iter().all(|price| *price == prices[0]));
+        }
+    }
+
 }

--- a/tests/optimization/test_gpu_hsl_episode_boundary.py
+++ b/tests/optimization/test_gpu_hsl_episode_boundary.py
@@ -1,0 +1,94 @@
+"""Coin HSL must discard completed episodes before replaying a new one."""
+
+from functools import lru_cache
+
+import numpy as np
+import pytest
+
+
+torch = pytest.importorskip("torch")
+from optimization.gpu.runtime import compile_shader, gpu_device
+
+pytestmark = pytest.mark.skipif(
+    not (torch.backends.mps.is_available() or torch.cuda.is_available()),
+    reason="Apple MPS and NVIDIA CUDA unavailable",
+)
+
+
+@lru_cache(maxsize=4)
+def _boundary_library(strategy, side):
+    import passivbot_rust
+
+    source = getattr(
+        passivbot_rust, f"mps_{strategy}_{side}_hsl_source_py"
+    )() if strategy == "trailing_martingale" else passivbot_rust.mps_ema_anchor_source_py()
+    return compile_shader(source + r"""
+kernel void coin_episode_boundary(
+    constant float* params [[buffer(0)]],
+    device float2* values [[buffer(1)]],
+    device int2* indices [[buffer(2)]],
+    device float* output [[buffer(3)]],
+    uint b [[thread_position_in_grid]]
+) {
+    if (b > 0) return;
+    HslState h = load_hsl(params, 0, 0);
+    HslRollingPnlWindow window = init_hsl_rolling_pnl_window();
+    record_hsl_rolling_pnl(window, values, indices, 0, 16, 0, 100, true, 0.0f);
+    record_hsl_rolling_pnl(window, values, indices, 0, 16, 1, 100, true, -200.0f);
+    prepare_coin_hsl_rolling_signal(h, window, values, indices, 0, 16, 1, 100, -200.0f);
+    update_one_side_hsl(h, 800.0f, 1000.0f, -200.0f, 0.0f, true, false, 1.0f, 60000.0f);
+    // The directional replay caller clears its window only on this return value.
+    bool reset = finish_hsl_scoped_episode_at_flat(
+        h, nullptr, params[11] > 0.0f, false,
+        800.0f, 1000.0f, -200.0f, -200.0f, 2.0f, 60000.0f
+    );
+    if (reset) reset_hsl_rolling_pnl_window(window);
+    output[0] = reset;
+    output[1] = window.event_count;
+    output[2] = h.halted;
+    output[3] = h.no_restart_latched;
+    output[4] = h.cooldown_until_k;
+    try_restart_hsl(h, 5.0f, 800.0f);
+    prepare_coin_hsl_rolling_signal(h, window, values, indices, 0, 16, 5, 100, -200.0f);
+    HslSignal signal;
+    bool valid = derive_hsl_signal(h, 800.0f, 1000.0f, -200.0f, 0.0f, signal);
+    output[5] = valid ? signal.drawdown_raw : -1.0f;
+    // Reset must preserve subsequent episode fees/losses, including same-minute fills.
+    record_hsl_rolling_pnl(window, values, indices, 0, 16, 5, 100, true, -8.0f);
+    prepare_coin_hsl_rolling_signal(h, window, values, indices, 0, 16, 5, 100, -208.0f);
+    valid = derive_hsl_signal(h, 792.0f, 1000.0f, -208.0f, 0.0f, signal);
+    output[6] = valid ? signal.drawdown_raw : -1.0f;
+}
+""")
+
+
+@pytest.mark.parametrize("strategy", ["ema_anchor", "trailing_martingale"])
+@pytest.mark.parametrize("side", ["long", "short"])
+@pytest.mark.parametrize("policy", [0, 1, 2])
+@pytest.mark.parametrize("still_held", [False, True])
+def test_coin_red_fill_boundary_resets_window_and_preserves_restart_policy(
+    strategy, side, policy, still_held
+):
+    params = torch.tensor(
+        [1., .1, 1., 3., 1., policy, .5, .75, 0., 2., 1., float(still_held)],
+        dtype=torch.float32, device=gpu_device(),
+    )
+    values = torch.zeros((16, 2), dtype=torch.float32, device=gpu_device())
+    indices = torch.zeros((16, 2), dtype=torch.int32, device=gpu_device())
+    output = torch.zeros(7, dtype=torch.float32, device=gpu_device())
+    _boundary_library(strategy, side).coin_episode_boundary(
+        params, values, indices, output, threads=(1, 1, 1)
+    )
+    actual = output.cpu().numpy()
+    if still_held:
+        np.testing.assert_array_equal(actual[:4], [0, 2, 0, 0])
+        assert actual[5] == pytest.approx(.25)
+        assert actual[6] == pytest.approx(208 / 792)
+    else:
+        np.testing.assert_array_equal(actual[:4], [1, 0, 1, policy == 2])
+        if policy == 2:
+            np.testing.assert_array_equal(actual[5:], [-1, -1])
+        else:
+            assert actual[4] == 5.0
+            assert actual[5] == 0.0
+            assert actual[6] == pytest.approx(8 / 792)

--- a/tests/optimization/test_gpu_mps.py
+++ b/tests/optimization/test_gpu_mps.py
@@ -21493,8 +21493,8 @@ def test_mps_trailing_martingale_entry_cap_uses_rust_nearest_step_rounding():
 @pytest.mark.skipif(
     not GPU_AVAILABLE, reason="Apple MPS and NVIDIA CUDA unavailable"
 )
-def test_mps_trailing_martingale_touch_close_preserves_raw_price():
-    """Match Rust finalization when an off-tick market touch controls a close."""
+def test_mps_trailing_touch_close_uses_nearest_not_directional_tick():
+    """Match nearest-tick finalization when an off-tick touch controls a close."""
 
     from optimization.gpu.mps_kernel import MpsTrailingMartingaleRunner
 
@@ -21567,8 +21567,8 @@ def test_mps_trailing_martingale_touch_close_preserves_raw_price():
     ).run(np.array([row + row], dtype=np.float64))
     synchronize()
 
-    # Exact Rust keeps the raw 100.004 ask, which fills at the next 100.005
-    # high. Rounding the touch up to 100.01 would leave the position open.
+    # Nearest-tick finalization rounds the 100.004 ask to 100.00, which fills
+    # at the next 100.005 high. Rounding up to 100.01 would leave it open.
     assert output["psize"].item() == 0.0
 
 

--- a/tests/test_order_rounding.py
+++ b/tests/test_order_rounding.py
@@ -251,3 +251,28 @@ def test_calc_twel_enforcer_orders_quantizes_results():
     assert ot == order_type
     assert _is_step_aligned(abs(qty), 0.1)
     assert _is_step_aligned(price, 0.0005)
+
+
+@requires_extension
+@pytest.mark.parametrize("side", ["long", "short"])
+def test_single_trailing_close_matches_expanded_price_at_raw_touch(side):
+    is_long = side == "long"
+    params = dict(
+        qty_step=0.01, price_step=0.01, min_qty=0.01, min_cost=0.0, c_mult=1.0,
+        close_grid_qty_pct=1.0, close_trailing_qty_pct=1.0,
+        close_trailing_retracement_pct=0.001, close_trailing_threshold_pct=0.001,
+        wallet_exposure_limit=1.0, risk_we_excess_allowance_pct=0.0,
+        risk_wel_enforcer_threshold=1.0, balance=1000.0,
+        position_size=1.0 if is_long else -1.0, position_price=100.0,
+        min_since_open=98.0, max_since_min=99.0,
+        max_since_open=102.0, min_since_max=101.0,
+    )
+    params["order_book_ask" if is_long else "order_book_bid"] = (
+        101.006 if is_long else 98.994
+    )
+    single = getattr(pbr, f"calc_next_close_{side}_py")(**params)
+    expanded = getattr(pbr, f"calc_closes_{side}_py")(**params)
+    assert single[1] == expanded[0][1] == (101.01 if is_long else 98.99)
+    assert single[0] == expanded[0][0]
+    # Strict fill tests must agree for a candle between the raw touch and tick.
+    assert not (101.008 > single[1] if is_long else 98.992 < single[1])


### PR DESCRIPTION
GPU replay could retain a completed coin-HSL episode's rolling losses when a closing fill finalized a RED stop. After cooldown, those losses could trigger another stop. Return the completed boundary to directional callers so they clear the window, while preserving restart policy and subsequent episode fees and losses.

Single trailing-martingale close calculations could also return an off-tick market touch to backtest fill peeks, even though expanded close bundles normalized that price. Quantize the selected close price after sizing so single and expanded paths use the same executable tick and fill decision.

Validation:
- Rust suite: 296 tests passed; `cargo check --tests` passed.
- Rebuilt and verified the Python extension; focused optimizer, metrics, order-rounding, orchestrator, and trailing-diagnostics tests passed (889 current cases).
- Metal hardware: 283 focused HSL, close, and temporal-replay tests passed, including both strategies, both sides, restart policies, and held/flat boundaries.
- New regressions fail on the previous implementation and pass with the fixes. Rust peek coverage includes live/full generation, next-candle fallback, untradable candles, and explicit expansion settings.
- AI documentation and generated event-registry checks passed. CUDA hardware validation is not included.

The GPU proxy drift safety threshold remains unchanged; these fixes do not claim complete proxy/exact parity.
